### PR TITLE
Improve performance of KeyExpression.Create method

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
@@ -18,32 +18,36 @@ namespace Xtensive.Orm.Linq.Expressions
   {
     private IPersistentExpression owner;
 
-    public new FieldInfo Field { get; private set; }
+    public new FieldInfo Field { get; }
 
     public virtual IPersistentExpression Owner
     {
-      get { return owner; }
+      get => owner;
       internal set
       {
-        if (owner!=null)
+        if (owner!=null) {
           throw Exceptions.AlreadyInitialized("Owner");
+        }
+
         owner = value;
       }
     }
 
     public override Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions)
     {
-      if (!CanRemap)
+      if (!CanRemap) {
         return this;
+      }
 
-      Expression result;
-      if (processedExpressions.TryGetValue(this, out result))
+      if (processedExpressions.TryGetValue(this, out var result)) {
         return result;
+      }
 
       var mapping = new Segment<int>(Mapping.Offset + offset, Mapping.Length);
       result = new FieldExpression(ExtendedExpressionType.Field, Field, mapping, OuterParameter, DefaultIfEmpty);
-      if (owner == null)
+      if (owner == null) {
         return result;
+      }
 
       processedExpressions.Add(this, result);
       Owner.Remap(offset, processedExpressions);


### PR DESCRIPTION
This PR is to improve performance of `KeyExpression.Create` method.
Original implementation always looks for key columns in the full column collection then it calls `Sort` method to get key columns in correct order. However when type model is locked it already contains pre-calculated collection of key columns in correct order. We can leverage this fact to improve performance because model is locked after domain building process is completed.

In addition to the described change this PR contains few minor changed.  Those are mostly formatting improvements and also few places where we avoiding memory reallocation by allocating an array of needed length before filling it with data.