### PR TITLE
Domain: move LINQ query cache to StorageNode

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0546_IncorrectCachingOfQueries.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0546_IncorrectCachingOfQueries.cs
@@ -158,7 +158,7 @@ namespace Xtensive.Orm.Tests.Issues
       using (var transaction = session.OpenTransaction()) {
         var upperLimit = 80;
         List<IEnumerable<Location>> queries = new List<IEnumerable<Location>>();
-        var cachedQueriesCountBefore = Domain.QueryCache.Count;
+        var cachedQueriesCountBefore = GetCachedQueryCount();
         for (int i = 0; i < upperLimit; i++) {
           var locations = session.Query.ExecuteDelayed(endpoint => from location in session.Query.All<Location>()
             where location.Active && location.Id.In((
@@ -169,7 +169,7 @@ namespace Xtensive.Orm.Tests.Issues
             select location);
           queries.Add(locations);
         }
-        var cachedQueriesCountAfter = Domain.QueryCache.Count;
+        var cachedQueriesCountAfter = GetCachedQueryCount();
         Assert.Greater(cachedQueriesCountAfter, cachedQueriesCountBefore);
         Assert.AreEqual(1, cachedQueriesCountAfter - cachedQueriesCountBefore);
         var result = session.Query.All<TestEntity>().ToList();
@@ -187,7 +187,7 @@ namespace Xtensive.Orm.Tests.Issues
       using (var transaction = session.OpenTransaction()) {
         var upperLimit = 80;
         List<IEnumerable<Location>> queries = new List<IEnumerable<Location>>();
-        var cachedQueriesCountBefore = Domain.QueryCache.Count;
+        var cachedQueriesCountBefore = GetCachedQueryCount();
         for (int i = 0; i < upperLimit; i++) {
           var locations = Query.ExecuteFuture(() => from location in Query.All<Location>()
             where location.Active && location.Id.In((
@@ -198,7 +198,7 @@ namespace Xtensive.Orm.Tests.Issues
             select location);
           queries.Add(locations);
         }
-        var cachedQueriesCountAfter = Domain.QueryCache.Count;
+        var cachedQueriesCountAfter = GetCachedQueryCount();
         Assert.Greater(cachedQueriesCountAfter, cachedQueriesCountBefore);
         Assert.AreEqual(1, cachedQueriesCountAfter - cachedQueriesCountBefore);
         var result = session.Query.All<TestEntity>().ToList();
@@ -214,7 +214,7 @@ namespace Xtensive.Orm.Tests.Issues
       using (var session = Domain.OpenSession())
       using (session.Activate())
       using (var transaction = session.OpenTransaction()) {
-        var cachedQueriesCountBefore = Domain.QueryCache.Count;
+        var cachedQueriesCountBefore = GetCachedQueryCount();
         var currentValue = 1;
         var iterationsCount = 0;
         var oldValue = currentValue;
@@ -224,11 +224,11 @@ namespace Xtensive.Orm.Tests.Issues
           oldValue = currentValue;
           iterationsCount++;
         }
-        var cachedQueriesCountAfter = Domain.QueryCache.Count;
+        var cachedQueriesCountAfter = GetCachedQueryCount();
         Assert.Greater(cachedQueriesCountAfter, cachedQueriesCountBefore);
         Assert.AreEqual(1, cachedQueriesCountAfter - cachedQueriesCountBefore);
 
-        cachedQueriesCountBefore = Domain.QueryCache.Count;
+        cachedQueriesCountBefore = GetCachedQueryCount();
         currentValue = oldValue = 1;
         iterationsCount = 0;
         while (currentValue < 80) {
@@ -237,7 +237,7 @@ namespace Xtensive.Orm.Tests.Issues
           oldValue = currentValue;
           iterationsCount++;
         }
-        cachedQueriesCountAfter = Domain.QueryCache.Count;
+        cachedQueriesCountAfter = GetCachedQueryCount();
         Assert.Greater(cachedQueriesCountAfter, cachedQueriesCountBefore);
         Assert.AreEqual(1, cachedQueriesCountAfter - cachedQueriesCountBefore);
       }
@@ -249,19 +249,19 @@ namespace Xtensive.Orm.Tests.Issues
       using (session.Activate())
       using (var transaction = session.OpenTransaction()) {
         //ExecuteDelayed API
-        var cachedQueriesCountBefore = Domain.QueryCache.Count;
+        var cachedQueriesCountBefore = GetCachedQueryCount();
         var zone = session.Query.All<Zone>().First();
         for (int i = 0; i < 80; i++)
           GetMinimalIdWithZone(session, zone);
-        var cachedQueriesCountAfter = Domain.QueryCache.Count;
+        var cachedQueriesCountAfter = GetCachedQueryCount();
         Assert.Greater(cachedQueriesCountAfter, cachedQueriesCountBefore);
         Assert.AreEqual(1, cachedQueriesCountAfter - cachedQueriesCountBefore);
 
         //ExecuteFuture API
-        cachedQueriesCountBefore = Domain.QueryCache.Count;
+        cachedQueriesCountBefore = GetCachedQueryCount();
         for (int i = 0; i < 80; i++)
           GetMinimalIdWithZone(zone);
-        cachedQueriesCountAfter = Domain.QueryCache.Count;
+        cachedQueriesCountAfter = GetCachedQueryCount();
         Assert.Greater(cachedQueriesCountAfter, cachedQueriesCountBefore);
         Assert.AreEqual(1, cachedQueriesCountAfter - cachedQueriesCountBefore);
       }
@@ -280,7 +280,7 @@ namespace Xtensive.Orm.Tests.Issues
     private void TaskSequencesGenerator(Session session)
     {
       //ExecuteDelayed API
-      var cachedQueriesCountBefore = Domain.QueryCache.Count;
+      var cachedQueriesCountBefore = GetCachedQueryCount();
       var currentId = 1;
       var iterationsCount = 0;
       while (currentId<80) {
@@ -290,12 +290,12 @@ namespace Xtensive.Orm.Tests.Issues
         Assert.AreEqual(previousId+1, currentId);
         iterationsCount++;
       }
-      var cachedQueriesCountAfter = Domain.QueryCache.Count;
+      var cachedQueriesCountAfter = GetCachedQueryCount();
       Assert.Greater(cachedQueriesCountAfter, cachedQueriesCountBefore);
       Assert.AreEqual(1, cachedQueriesCountAfter - cachedQueriesCountBefore);
 
       //ExecuteFuture API
-      cachedQueriesCountBefore = Domain.QueryCache.Count;
+      cachedQueriesCountBefore = GetCachedQueryCount();
       currentId = 1;
       iterationsCount = 0;
       while (currentId < 80) {
@@ -305,7 +305,7 @@ namespace Xtensive.Orm.Tests.Issues
         Assert.AreEqual(previousId + 1, currentId);
         iterationsCount++;
       }
-      cachedQueriesCountAfter = Domain.QueryCache.Count;
+      cachedQueriesCountAfter = GetCachedQueryCount();
       Assert.Greater(cachedQueriesCountAfter, cachedQueriesCountBefore);
       Assert.AreEqual(1, cachedQueriesCountAfter - cachedQueriesCountBefore);
     }
@@ -361,5 +361,8 @@ namespace Xtensive.Orm.Tests.Issues
       Query.All<Location>();
       return locations.Min(field => field.Id);
     }
+
+    private int GetCachedQueryCount() =>
+      Domain.StorageNodeManager.GetNode(WellKnown.DefaultNodeId)?.LinqQueryCache.Count ?? 0;
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Storage/Multinode/QueryCachingTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Multinode/QueryCachingTest.cs
@@ -217,7 +217,7 @@ namespace Xtensive.Orm.Tests.Storage.Multinode
         }
       }
 
-      initialQueriesCached = Domain.QueryCache.Count;
+      initialQueriesCached = GetCachedQueryCount();
     }
 
     [Test]
@@ -226,7 +226,7 @@ namespace Xtensive.Orm.Tests.Storage.Multinode
       RunTestSimpleQueryTest(WellKnown.DefaultNodeId);
       RunFilterByTypeIdQueryTest(WellKnown.DefaultNodeId);
       RunFilterBySeveralTypeIdsTest(WellKnown.DefaultNodeId);
-      Assert.That(Domain.QueryCache.Count, Is.EqualTo(initialQueriesCached));
+      Assert.That(GetCachedQueryCount(), Is.EqualTo(initialQueriesCached));
     }
 
     [Test]
@@ -235,7 +235,7 @@ namespace Xtensive.Orm.Tests.Storage.Multinode
       RunTestSimpleQueryTest(TestNodeId2);
       RunFilterByTypeIdQueryTest(TestNodeId2);
       RunFilterBySeveralTypeIdsTest(TestNodeId2);
-      Assert.That(Domain.QueryCache.Count, Is.EqualTo(initialQueriesCached));
+      Assert.That(GetCachedQueryCount(), Is.EqualTo(initialQueriesCached));
     }
 
     [Test]
@@ -244,7 +244,7 @@ namespace Xtensive.Orm.Tests.Storage.Multinode
       RunTestSimpleQueryTest(TestNodeId3);
       RunFilterByTypeIdQueryTest(TestNodeId3);
       RunFilterBySeveralTypeIdsTest(TestNodeId3);
-      Assert.That(Domain.QueryCache.Count, Is.EqualTo(initialQueriesCached));
+      Assert.That(GetCachedQueryCount(), Is.EqualTo(initialQueriesCached));
     }
 
     private void RunTestSimpleQueryTest(string nodeId)
@@ -456,6 +456,12 @@ namespace Xtensive.Orm.Tests.Storage.Multinode
     private List<BaseTestEntity> ExecuteFilterBySeveralTypeIdsNoCache(Session session, int[] typeIds)
     {
       return session.Query.All<BaseTestEntity>().Where(e => e.TypeId.In(typeIds)).ToList();
+    }
+
+    private int GetCachedQueryCount()
+    {
+      return new[] {WellKnown.DefaultNodeId, TestNodeId2, TestNodeId3}
+        .Sum(n => Domain.StorageNodeManager.GetNode(n)?.LinqQueryCache.Count ?? 0);
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Domain.cs
+++ b/Orm/Xtensive.Orm/Orm/Domain.cs
@@ -121,8 +121,6 @@ namespace Xtensive.Orm
     internal KeyGeneratorRegistry KeyGenerators { get; private set; }
 
     internal ConcurrentDictionary<TypeInfo, ReadOnlyList<PrefetchFieldDescriptor>> PrefetchFieldDescriptorCache { get; private set; }
-    
-    internal ICache<object, Pair<object, TranslatedQuery>> QueryCache { get; private set; }
 
     internal ICache<Key, Key> KeyCache { get; private set; }
 
@@ -295,7 +293,6 @@ namespace Xtensive.Orm
       KeyGenerators = new KeyGeneratorRegistry();
       PrefetchFieldDescriptorCache = new ConcurrentDictionary<TypeInfo, ReadOnlyList<PrefetchFieldDescriptor>>();
       KeyCache = new LruCache<Key, Key>(Configuration.KeyCacheSize, k => k);
-      QueryCache = new LruCache<object, Pair<object, TranslatedQuery>>(Configuration.QueryCacheSize, k => k.First);
       PrefetchActionMap = new Dictionary<TypeInfo, Action<SessionHandler, IEnumerable<Key>>>();
       Extensions = new ExtensionCollection();
       UpgradeContextCookie = upgradeContextCookie;

--- a/Orm/Xtensive.Orm/Orm/Linq/TranslatedQuery.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/TranslatedQuery.cs
@@ -6,7 +6,7 @@
 
 using System;
 using System.Collections.Generic;
-
+using Xtensive.Core;
 using Xtensive.Tuples;
 using Xtensive.Orm.Rse.Providers;
 using Tuple = Xtensive.Tuples.Tuple;
@@ -24,11 +24,28 @@ namespace Xtensive.Orm.Linq
     /// </summary>
     public readonly ExecutableProvider DataSource;
 
+    private object cacheKey;
+
     /// <summary>
     /// Gets the untyped materializer.
     /// </summary>
     public abstract Delegate UntypedMaterializer { get; }
 
+    /// <summary>
+    /// Gets or tests cache key for this query.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Cache key is already set</exception>
+    public object CacheKey
+    {
+      get => cacheKey;
+      set {
+        if (cacheKey != null) {
+          throw new InvalidOperationException("Internal error: CacheKey is already set.");
+        }
+
+        cacheKey = value;
+      }
+    }
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Linq/TranslatedQuery.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/TranslatedQuery.cs
@@ -32,7 +32,7 @@ namespace Xtensive.Orm.Linq
     public abstract Delegate UntypedMaterializer { get; }
 
     /// <summary>
-    /// Gets or tests cache key for this query.
+    /// Gets or sets cache key for this query.
     /// </summary>
     /// <exception cref="InvalidOperationException">Cache key is already set</exception>
     public object CacheKey

--- a/Orm/Xtensive.Orm/Orm/StorageNode.cs
+++ b/Orm/Xtensive.Orm/Orm/StorageNode.cs
@@ -6,8 +6,10 @@
 
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using Xtensive.Caching;
 using Xtensive.Core;
 using Xtensive.Orm.Configuration;
+using Xtensive.Orm.Linq;
 using Xtensive.Orm.Model;
 using Xtensive.Orm.Providers;
 
@@ -44,11 +46,14 @@ namespace Xtensive.Orm
 
     internal ConcurrentDictionary<PersistRequestBuilderTask, ICollection<PersistRequest>> PersistRequestCache { get; private set; }
 
+    internal ICache<object, TranslatedQuery> LinqQueryCache { get; }
 
     // Constructors
 
-    internal StorageNode(NodeConfiguration configuration, ModelMapping mapping, TypeIdRegistry typeIdRegistry)
+    internal StorageNode(DomainConfiguration domainConfiguration, NodeConfiguration configuration, ModelMapping mapping,
+      TypeIdRegistry typeIdRegistry)
     {
+      ArgumentValidator.EnsureArgumentNotNull(domainConfiguration, nameof(domainConfiguration));
       ArgumentValidator.EnsureArgumentNotNull(configuration, "configuration");
       ArgumentValidator.EnsureArgumentNotNull(mapping, "mapping");
       ArgumentValidator.EnsureArgumentNotNull(typeIdRegistry, "typeIdRegistry");
@@ -60,6 +65,7 @@ namespace Xtensive.Orm
       KeySequencesCache = new ConcurrentDictionary<SequenceInfo, object>();
       PersistRequestCache = new ConcurrentDictionary<PersistRequestBuilderTask, ICollection<PersistRequest>>();
       InternalQueryCache = new ConcurrentDictionary<object, object>();
+      LinqQueryCache = new LruCache<object, TranslatedQuery>(domainConfiguration.QueryCacheSize, k => k.CacheKey);
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
@@ -328,7 +328,8 @@ namespace Xtensive.Orm.Upgrade
       var modelMapping = ModelMappingBuilder.Build(
         domain.Handlers, schemaExtractionResult,
         context.Services.MappingResolver, context.NodeConfiguration, context.UpgradeMode.IsLegacy());
-      var result = new StorageNode(context.NodeConfiguration, modelMapping, new TypeIdRegistry());
+      var result = new StorageNode(context.Configuration, context.NodeConfiguration, modelMapping,
+        new TypeIdRegistry());
 
       // Register default storage node immediately,
       // non-default nodes are registered in NodeManager after everything completes successfully.


### PR DESCRIPTION
This reduces contention under high load.

Additionally `CacheKey` is added to `TranslatedQuery`, this simplifies interfaces.