### PR TITLE
Remove enumerator boxing

### DIFF
--- a/Orm/Xtensive.Orm/Collections/CollectionBaseSlim.cs
+++ b/Orm/Xtensive.Orm/Collections/CollectionBaseSlim.cs
@@ -168,16 +168,18 @@ namespace Xtensive.Collections
 
     /// <inheritdoc/>
     [DebuggerStepThrough]
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-      return GetEnumerator();
-    }
+    public List<TItem>.Enumerator GetEnumerator()
+      => items.GetEnumerator();
 
     /// <inheritdoc/>
-    public virtual IEnumerator<TItem> GetEnumerator()
-    {
-      return Items.GetEnumerator();
-    }
+    [DebuggerStepThrough]
+    IEnumerator<TItem> IEnumerable<TItem>.GetEnumerator()
+      => items.GetEnumerator();
+    
+    /// <inheritdoc/>
+    [DebuggerStepThrough]
+    IEnumerator IEnumerable.GetEnumerator()
+      => items.GetEnumerator();
 
     #endregion
 


### PR DESCRIPTION
Subj, this helps to save the memory traffic during a upgrade.
I think it's ok to expose original `List<T>.Enumerator` struct without boxing.