### PR TITLE
Lru cache performance test

### DIFF
--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/BitFaster.Lru/Defaults.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/BitFaster.Lru/Defaults.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace BitFaster.Caching.Lru
+{
+    internal static class Defaults
+    {
+        public static int ConcurrencyLevel => Environment.ProcessorCount;
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/BitFaster.Lru/FastConcurrentLru.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/BitFaster.Lru/FastConcurrentLru.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using Xtensive.Caching.Lru;
+
+namespace BitFaster.Caching.Lru
+{
+    ///<inheritdoc/>
+    public sealed class FastConcurrentLru<K, V> : TemplateConcurrentLru<K, V, LruItem<K, V>, LruPolicy<K, V>>
+    {
+        /// <summary>
+        /// Initializes a new instance of the FastConcurrentLru class with the specified capacity that has the default 
+        /// concurrency level, and uses the default comparer for the key type.
+        /// </summary>
+        /// <param name="capacity">The maximum number of elements that the FastConcurrentLru can contain.</param>
+        /// <param name="dictFunc"></param>
+        public FastConcurrentLru(int capacity,
+            Func<int, int, IEqualityComparer<K>, IConcurrentDictionary<K, LruItem<K, V>>> dictFunc)
+            : base(Defaults.ConcurrencyLevel, capacity, EqualityComparer<K>.Default, new LruPolicy<K, V>(), dictFunc)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the FastConcurrentLru class that has the specified concurrency level, has the 
+        /// specified initial capacity, and uses the specified IEqualityComparer<T>.
+        /// </summary>
+        /// <param name="concurrencyLevel">The estimated number of threads that will update the FastConcurrentLru concurrently.</param>
+        /// <param name="capacity">The maximum number of elements that the FastConcurrentLru can contain.</param>
+        /// <param name="comparer">The IEqualityComparer<T> implementation to use when comparing keys.</param>
+        /// <param name="dictFunc"></param>
+        public FastConcurrentLru(int concurrencyLevel, int capacity, IEqualityComparer<K> comparer,
+            Func<int, int, IEqualityComparer<K>, IConcurrentDictionary<K, LruItem<K, V>>> dictFunc)
+            : base(concurrencyLevel, capacity, comparer, new LruPolicy<K, V>(), dictFunc)
+        {
+        }
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/BitFaster.Lru/ICache.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/BitFaster.Lru/ICache.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace BitFaster.Caching
+{
+    /// <summary>
+    /// Represents a generic cache of key/value pairs.
+    /// </summary>
+    /// <typeparam name="K">The type of keys in the cache.</typeparam>
+    /// <typeparam name="V">The type of values in the cache.</typeparam>
+    public interface ICache<K, V>
+    {
+        /// <summary>
+        /// Attempts to get the value associated with the specified key from the cache.
+        /// </summary>
+        /// <param name="key">The key of the value to get.</param>
+        /// <param name="value">When this method returns, contains the object from the cache that has the specified key, or the default value of the type if the operation failed.</param>
+        /// <returns>true if the key was found in the cache; otherwise, false.</returns>
+        bool TryGet(K key, out V value);
+
+        /// <summary>
+        /// Adds a key/value pair to the cache if the key does not already exist. Returns the new value, or the 
+        /// existing value if the key already exists.
+        /// </summary>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="valueFactory">The factory function used to generate a value for the key.</param>
+        /// <returns>The value for the key. This will be either the existing value for the key if the key is already 
+        /// in the cache, or the new value if the key was not in the dictionary.</returns>
+        V GetOrAdd(K key, Func<K, V> valueFactory);
+
+        /// <summary>
+        /// Adds a key/value pair to the cache if the key does not already exist. Returns the new value, or the 
+        /// existing value if the key already exists.
+        /// </summary>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="valueFactory">The factory function used to asynchronously generate a value for the key.</param>
+        /// <returns>A task that represents the asynchronous GetOrAdd operation.</returns>
+        Task<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory);
+
+        /// <summary>
+        /// Attempts to remove and return the value that has the specified key from the cache.
+        /// </summary>
+        /// <param name="key">The key of the element to remove.</param>
+        /// <returns>true if the object was removed successfully; otherwise, false.</returns>
+        bool TryRemove(K key);
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/BitFaster.Lru/IPolicy.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/BitFaster.Lru/IPolicy.cs
@@ -1,0 +1,17 @@
+﻿namespace BitFaster.Caching.Lru
+{
+    public interface IPolicy<in K, in V, I> where I : LruItem<K, V>
+    {
+        I CreateItem(K key, V value);
+
+        void Touch(I item);
+
+        bool ShouldDiscard(I item);
+
+        ItemDestination RouteHot(I item);
+
+        ItemDestination RouteWarm(I item);
+
+        ItemDestination RouteCold(I item);
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/BitFaster.Lru/ItemDestination.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/BitFaster.Lru/ItemDestination.cs
@@ -1,0 +1,9 @@
+﻿namespace BitFaster.Caching.Lru
+{
+    public enum ItemDestination
+    {
+        Warm,
+        Cold,
+        Remove
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/BitFaster.Lru/LruItem.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/BitFaster.Lru/LruItem.cs
@@ -1,0 +1,30 @@
+﻿namespace BitFaster.Caching.Lru
+{
+    public class LruItem<K, V>
+    {
+        private volatile bool wasAccessed;
+        private volatile bool wasRemoved;
+
+        public LruItem(K k, V v)
+        {
+            Key = k;
+            Value = v;
+        }
+
+        public readonly K Key;
+
+        public readonly V Value;
+
+        public bool WasAccessed
+        {
+            get => wasAccessed;
+            set => wasAccessed = value;
+        }
+
+        public bool WasRemoved
+        {
+            get => wasRemoved;
+            set => wasRemoved = value;
+        }
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/BitFaster.Lru/LruPolicy.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/BitFaster.Lru/LruPolicy.cs
@@ -1,0 +1,61 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace BitFaster.Caching.Lru
+{
+    /// <summary>
+    /// Discards the least recently used items first. 
+    /// </summary>
+    public readonly struct LruPolicy<K, V> : IPolicy<K, V, LruItem<K, V>>
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public LruItem<K, V> CreateItem(K key, V value)
+        {
+            return new LruItem<K, V>(key, value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Touch(LruItem<K, V> item)
+        {
+            item.WasAccessed = true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool ShouldDiscard(LruItem<K, V> item)
+        {
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ItemDestination RouteHot(LruItem<K, V> item)
+        {
+            if (item.WasAccessed)
+            {
+                return ItemDestination.Warm;
+            }
+
+            return ItemDestination.Cold;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ItemDestination RouteWarm(LruItem<K, V> item)
+        {
+            if (item.WasAccessed)
+            {
+                return ItemDestination.Warm;
+            }
+
+            return ItemDestination.Cold;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ItemDestination RouteCold(LruItem<K, V> item)
+        {
+            if (item.WasAccessed)
+            {
+                return ItemDestination.Warm;
+            }
+
+            return ItemDestination.Remove;
+        }
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/BitFaster.Lru/TemplateConcurrentLru.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/BitFaster.Lru/TemplateConcurrentLru.cs
@@ -1,0 +1,343 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xtensive.Caching.Lru;
+
+namespace BitFaster.Caching.Lru
+{
+    /// <summary>
+    /// Pseudo LRU implementation where LRU list is composed of 3 segments: hot, warm and cold. Cost of maintaining
+    /// segments is amortized across requests. Items are only cycled when capacity is exceeded. Pure read does
+    /// not cycle items if all segments are within capacity constraints.
+    /// There are no global locks. On cache miss, a new item is added. Tail items in each segment are dequeued,
+    /// examined, and are either enqueued or discarded.
+    /// This scheme of hot, warm and cold is based on the implementation used in MemCached described online here:
+    /// https://memcached.org/blog/modern-lru/
+    /// </summary>
+    /// <remarks>
+    /// Each segment has a capacity. When segment capacity is exceeded, items are moved as follows:
+    /// 1. New items are added to hot, WasAccessed = false
+    /// 2. When items are accessed, update WasAccessed = true
+    /// 3. When items are moved WasAccessed is set to false.
+    /// 4. When hot is full, hot tail is moved to either Warm or Cold depending on WasAccessed. 
+    /// 5. When warm is full, warm tail is moved to warm head or cold depending on WasAccessed.
+    /// 6. When cold is full, cold tail is moved to warm head or removed from dictionary on depending on WasAccessed.
+    /// </remarks>
+    public class TemplateConcurrentLru<K, V, I, P> : ICache<K, V>
+        where I : LruItem<K, V>
+        where P : struct, IPolicy<K, V, I>
+    {
+        private readonly IConcurrentDictionary<K, I> dictionary;
+
+        private readonly ConcurrentQueue<I> hotQueue;
+        private readonly ConcurrentQueue<I> warmQueue;
+        private readonly ConcurrentQueue<I> coldQueue;
+
+        // maintain count outside ConcurrentQueue, since ConcurrentQueue.Count holds a global lock
+        private int hotCount;
+        private int warmCount;
+        private int coldCount;
+
+        private readonly int hotCapacity;
+        private readonly int warmCapacity;
+        private readonly int coldCapacity;
+
+        private readonly P policy;
+
+        public TemplateConcurrentLru(
+            int concurrencyLevel,
+            int capacity,
+            IEqualityComparer<K> comparer,
+            P itemPolicy,
+            Func<int, int, IEqualityComparer<K>, IConcurrentDictionary<K, I>> dictFunc)
+        {
+            if (capacity < 3)
+            {
+                throw new ArgumentOutOfRangeException("Capacity must be greater than or equal to 3.");
+            }
+
+            if (comparer == null)
+            {
+                throw new ArgumentNullException(nameof(comparer));
+            }    
+
+            hotCapacity = capacity / 3;
+            warmCapacity = capacity / 3;
+            coldCapacity = capacity / 3;
+
+            hotQueue = new ConcurrentQueue<I>();
+            warmQueue = new ConcurrentQueue<I>();
+            coldQueue = new ConcurrentQueue<I>();
+
+            int dictionaryCapacity = hotCapacity + warmCapacity + coldCapacity + 1;
+
+            dictionary = dictFunc(concurrencyLevel, dictionaryCapacity, comparer);
+            policy = itemPolicy;
+        }
+
+        public int HotCount => hotCount;
+
+        public int WarmCount => warmCount;
+
+        public int ColdCount => coldCount;
+
+        ///<inheritdoc/>
+        public bool TryGet(K key, out V value)
+        {
+            I item;
+            if (dictionary.TryGetValue(key, out item))
+            {
+                return GetOrDiscard(item, out value);
+            }
+
+            value = default(V);
+            return false;
+        }
+
+        // AggressiveInlining forces the JIT to inline policy.ShouldDiscard(). For LRU policy 
+        // the first branch is completely eliminated due to JIT time constant propogation.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool GetOrDiscard(I item, out V value)
+        {
+            if (policy.ShouldDiscard(item))
+            {
+                Move(item, ItemDestination.Remove);
+                value = default(V);
+                return false;
+            }
+
+            value = item.Value;
+            policy.Touch(item);
+            return true;
+        }
+
+        ///<inheritdoc/>
+        public V GetOrAdd(K key, Func<K, V> valueFactory)
+        {
+            if (TryGet(key, out var value))
+            {
+                return value;
+            }
+
+            // The value factory may be called concurrently for the same key, but the first write to the dictionary wins.
+            // This is identical logic in ConcurrentDictionary.GetOrAdd method.
+            var newItem = policy.CreateItem(key, valueFactory(key));
+
+            if (dictionary.TryAdd(key, newItem))
+            {
+                hotQueue.Enqueue(newItem);
+                Interlocked.Increment(ref hotCount);
+                Cycle();
+                return newItem.Value;
+            }
+
+            return GetOrAdd(key, valueFactory);
+        }
+
+        ///<inheritdoc/>
+        public async Task<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory)
+        {
+            if (TryGet(key, out var value))
+            {
+                return value;
+            }
+
+            // The value factory may be called concurrently for the same key, but the first write to the dictionary wins.
+            // This is identical logic in ConcurrentDictionary.GetOrAdd method.
+            var newItem = policy.CreateItem(key, await valueFactory(key).ConfigureAwait(false));
+
+            if (dictionary.TryAdd(key, newItem))
+            {
+                hotQueue.Enqueue(newItem);
+                Interlocked.Increment(ref hotCount);
+                Cycle();
+                return newItem.Value;
+            }
+
+            return await GetOrAddAsync(key, valueFactory).ConfigureAwait(false);
+        }
+
+        ///<inheritdoc/>
+        public bool TryRemove(K key)
+        {
+            // Possible race condition:
+            // Thread A TryRemove(1), removes LruItem1, has reference to removed item but not yet marked as removed
+            // Thread B GetOrAdd(1) => Adds LruItem1*
+            // Thread C GetOrAdd(2), Cycle, Move(LruItem1, Removed)
+            // 
+            // Thread C can run and remove LruItem1* from this.dictionary before Thread A has marked LruItem1 as removed.
+            // 
+            // In this situation, a subsequent attempt to fetch 1 will be a miss. The queues will still contain LruItem1*, 
+            // and it will not be marked as removed. If key 1 is fetched while LruItem1* is still in the queue, there will 
+            // be two queue entries for key 1, and neither is marked as removed. Thus when LruItem1 * ages out, it will  
+            // incorrectly remove 1 from the dictionary, and this cycle can repeat.
+            if (dictionary.TryGetValue(key, out var existing))
+            {
+                if (existing.WasRemoved)
+                {
+                    return false;
+                }
+
+                lock (existing)
+                {
+                    if (existing.WasRemoved)
+                    {
+                        return false;
+                    }
+
+                    existing.WasRemoved = true;
+                }
+
+                if (dictionary.TryRemove(key, out var removedItem))
+                {
+                    // Mark as not accessed, it will later be cycled out of the queues because it can never be fetched 
+                    // from the dictionary. Note: Hot/Warm/Cold count will reflect the removed item until it is cycled 
+                    // from the queue.
+                    removedItem.WasAccessed = false;
+
+                    if (removedItem.Value is IDisposable d)
+                    {
+                        d.Dispose();
+                    }
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private void Cycle()
+        {
+            // There will be races when queue count == queue capacity. Two threads may each dequeue items.
+            // This will prematurely free slots for the next caller. Each thread will still only cycle at most 5 items.
+            // Since TryDequeue is thread safe, only 1 thread can dequeue each item. Thus counts and queue state will always
+            // converge on correct over time.
+            CycleHot();
+
+            // Multi-threaded stress tests show that due to races, the warm and cold count can increase beyond capacity when
+            // hit rate is very high. Double cycle results in stable count under all conditions. When contention is low, 
+            // secondary cycles have no effect.
+            CycleWarm();
+            CycleWarm();
+            CycleCold();
+            CycleCold();
+        }
+
+        private void CycleHot()
+        {
+            if (hotCount > hotCapacity)
+            {
+                Interlocked.Decrement(ref hotCount);
+
+                if (hotQueue.TryDequeue(out var item))
+                {
+                    var where = policy.RouteHot(item);
+                    Move(item, where);
+                }
+                else
+                {
+                    Interlocked.Increment(ref hotCount);
+                }
+            }
+        }
+
+        private void CycleWarm()
+        {
+            if (warmCount > warmCapacity)
+            {
+                Interlocked.Decrement(ref warmCount);
+
+                if (warmQueue.TryDequeue(out var item))
+                {
+                    var where = policy.RouteWarm(item);
+
+                    // When the warm queue is full, we allow an overflow of 1 item before redirecting warm items to cold.
+                    // This only happens when hit rate is high, in which case we can consider all items relatively equal in
+                    // terms of which was least recently used.
+                    if (where == ItemDestination.Warm && warmCount <= warmCapacity)
+                    {
+                        Move(item, where);
+                    }
+                    else
+                    {
+                        Move(item, ItemDestination.Cold);
+                    }
+                }
+                else
+                {
+                    Interlocked.Increment(ref warmCount);
+                }
+            }
+        }
+
+        private void CycleCold()
+        {
+            if (coldCount > coldCapacity)
+            {
+                Interlocked.Decrement(ref coldCount);
+
+                if (coldQueue.TryDequeue(out var item))
+                {
+                    var where = policy.RouteCold(item);
+
+                    if (where == ItemDestination.Warm && warmCount <= warmCapacity)
+                    {
+                        Move(item, where);
+                    }
+                    else
+                    {
+                        Move(item, ItemDestination.Remove);
+                    }
+                }
+                else
+                {
+                    Interlocked.Increment(ref coldCount);
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void Move(I item, ItemDestination where)
+        {
+            item.WasAccessed = false;
+
+            switch (where)
+            {
+                case ItemDestination.Warm:
+                    warmQueue.Enqueue(item);
+                    Interlocked.Increment(ref warmCount);
+                    break;
+                case ItemDestination.Cold:
+                    coldQueue.Enqueue(item);
+                    Interlocked.Increment(ref coldCount);
+                    break;
+                case ItemDestination.Remove:
+                    if (!item.WasRemoved)
+                    {   
+                        // avoid race where 2 threads could remove the same key - see TryRemove for details.
+                        lock (item)
+                        { 
+                            if (item.WasRemoved)
+                            {
+                                break;
+                            }
+
+                            if (dictionary.TryRemove(item.Key, out var removedItem))
+                            {
+                                item.WasRemoved = true;
+                                if (removedItem.Value is IDisposable d)
+                                {
+                                    d.Dispose();
+                                }
+                            }
+                        }
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/IConcurrentDictionary.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/IConcurrentDictionary.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Xtensive.Caching.Lru
+{
+  public interface IConcurrentDictionary<TKey, TValue>
+  {
+    bool TryGetValue(TKey key, out TValue item);
+    bool TryAdd(TKey key, TValue newItem);
+    bool TryRemove(TKey key, out TValue newItem);
+  }
+
+  public class NonBlockingConcurrentDictionary<TKey, TValue> : IConcurrentDictionary<TKey, TValue>
+  {
+    private readonly NonBlocking.ConcurrentDictionary<TKey, TValue> concurrentDictionaryImplementation;
+
+    public NonBlockingConcurrentDictionary(int concurrencyLevel, int capacity, IEqualityComparer<TKey> comparer)
+    {
+      concurrentDictionaryImplementation =
+        new NonBlocking.ConcurrentDictionary<TKey, TValue>(concurrencyLevel, capacity, comparer);
+    }
+
+    public NonBlockingConcurrentDictionary(int capacity)
+    {
+      concurrentDictionaryImplementation =
+        new NonBlocking.ConcurrentDictionary<TKey, TValue>(capacity);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryGetValue(TKey key, out TValue item) => concurrentDictionaryImplementation.TryGetValue(key, out item);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryAdd(TKey key, TValue newItem) => concurrentDictionaryImplementation.TryAdd(key, newItem);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryRemove(TKey key, out TValue newItem) =>
+      concurrentDictionaryImplementation.TryRemove(key, out newItem);
+  }
+
+  public class SystemConcurrentDictionary<TKey, TValue> : IConcurrentDictionary<TKey, TValue>
+  {
+    private readonly ConcurrentDictionary<TKey, TValue> concurrentDictionaryImplementation;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public SystemConcurrentDictionary(int concurrencyLevel, int capacity, IEqualityComparer<TKey> comparer)
+    {
+      concurrentDictionaryImplementation =
+        new ConcurrentDictionary<TKey, TValue>(concurrencyLevel, capacity, comparer);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryGetValue(TKey key, out TValue item) => concurrentDictionaryImplementation.TryGetValue(key, out item);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryAdd(TKey key, TValue newItem) => concurrentDictionaryImplementation.TryAdd(key, newItem);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryRemove(TKey key, out TValue newItem) =>
+      concurrentDictionaryImplementation.TryRemove(key, out newItem);
+  }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/ConcurrentDictionary.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/ConcurrentDictionary.cs
@@ -1,0 +1,1020 @@
+﻿// Copyright (c) Vladimir Sadov. All rights reserved.
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+
+//
+// Doc comments match, where possible, System.Collection.Concurrent.ConcurrentDictionary in 
+// https://github.com/dotnet/corefx to ensure compatibility.
+//
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using static NonBlocking.DictionaryImpl;
+
+namespace NonBlocking
+{
+    /// <summary>
+    /// Represents a thread-safe and lock-free collection of keys and values.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
+    /// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
+    /// <remarks>
+    /// All public and protected members of <see cref="ConcurrentDictionary{TKey,TValue}"/> are thread-safe and may be used
+    /// concurrently from multiple threads.
+    /// </remarks>
+    public class ConcurrentDictionary<TKey, TValue> :
+        IDictionary<TKey, TValue>,
+        IReadOnlyDictionary<TKey, TValue>,
+        IDictionary,
+        ICollection
+    {
+        internal DictionaryImpl<TKey, TValue> _table;
+        internal uint _lastResizeTickMillis;
+
+        internal readonly bool valueIsValueType = typeof(TValue).GetTypeInfo().IsValueType;
+
+        internal object _sweeperInstance;
+        internal int _sweepRequests;
+
+        // System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue>
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Concurrent.ConcurrentDictionary`2" /> class that is empty, has the default initial capacity, and uses the default comparer for the key type.</summary>
+        public ConcurrentDictionary() : this(31)
+        {
+        }
+
+        // System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue>
+        /// <param name="capacity">The initial number of elements that the <see cref="T:System.Collections.Concurrent.ConcurrentDictionary`2" /> can contain.</param>
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Concurrent.ConcurrentDictionary`2" /> class that is empty and uses the default comparer for the key type.</summary>
+        public ConcurrentDictionary(int capacity) : this(capacity, null)
+        {
+        }
+
+        // System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue>
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Concurrent.ConcurrentDictionary`2" /> class that is empty, has the specified capacity, and uses the default comparer for the key type.</summary>
+        /// <param name="concurrencyLevel">Any number greater than '0'. This parameter is allowed for compatibility reasons and has no effect on the dictionary.</param>
+        /// <param name="capacity">The initial number of elements that the <see cref="T:System.Collections.Concurrent.ConcurrentDictionary`2" /> can contain.</param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        ///   <paramref name="concurrencyLevel" /> is less than 1.-or-<paramref name="capacity" /> is less than 0.</exception>
+        public ConcurrentDictionary(int concurrencyLevel, int capacity) : this(capacity)
+        {
+            if (concurrencyLevel < 1)
+            {
+                throw new ArgumentOutOfRangeException("concurrencyLevel");
+            }
+        }
+
+        // System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue>
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Concurrent.ConcurrentDictionary`2" /> class that contains elements copied from the specified <see cref="T:System.Collections.IEnumerable{KeyValuePair{TKey,TValue}}" />, has the default initial capacity, and uses the default comparer for the key type.</summary>
+        /// <param name="collection">The <see cref="T:System.Collections.IEnumerable{KeyValuePair{TKey,TValue}}" /> whose elements are copied to the new <see cref="T:System.Collections.Concurrent.ConcurrentDictionary`2" />.</param>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///   <paramref name="collection" /> or any of its keys is a null reference (Nothing in Visual Basic)</exception>
+        /// <exception cref="T:System.ArgumentException">
+        ///   <paramref name="collection" /> contains one or more duplicate keys.</exception>
+        public ConcurrentDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection) : this()
+        {
+            if (collection == null)
+            {
+                throw new ArgumentNullException("collection");
+            }
+            this.InitializeFromCollection(collection);
+        }
+
+        // System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue>
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Concurrent.ConcurrentDictionary`2" /> class that is empty, has the default capacity, and uses the specified <see cref="T:System.Collections.Generic.IEqualityComparer{TKey}" />.</summary>
+        /// <param name="comparer">The <see cref="T:System.Collections.Generic.IEqualityComparer{TKey}" /> implementation to use when comparing keys.</param>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///   <paramref name="comparer" /> is a null reference (Nothing in Visual Basic).</exception>
+        public ConcurrentDictionary(IEqualityComparer<TKey> comparer) : this(31, comparer)
+        {
+            if (comparer == null)
+            {
+                throw new ArgumentNullException("comparer");
+            }
+        }
+
+        // System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue>
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Concurrent.ConcurrentDictionary`2" /> class that contains elements copied from the specified <see cref="T:System.Collections.IEnumerable" />, has the default initial capacity, and uses the specified <see cref="T:System.Collections.Generic.IEqualityComparer{TKey}" />.</summary>
+        /// <param name="collection">The <see cref="T:System.Collections.IEnumerable{KeyValuePair{TKey,TValue}}" /> whose elements are copied to the new <see cref="T:System.Collections.Concurrent.ConcurrentDictionary`2" />.</param>
+        /// <param name="comparer">The <see cref="T:System.Collections.Generic.IEqualityComparer{TKey}" /> implementation to use when comparing keys.</param>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///   <paramref name="collection" /> is a null reference (Nothing in Visual Basic). -or- <paramref name="comparer" /> is a null reference (Nothing in Visual Basic).</exception>
+        public ConcurrentDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey> comparer) : this(comparer)
+        {
+            if (collection == null)
+            {
+                throw new ArgumentNullException("collection");
+            }
+            if (comparer == null)
+            {
+                throw new ArgumentNullException("comparer");
+            }
+            this.InitializeFromCollection(collection);
+        }
+
+        // System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue>
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Concurrent.ConcurrentDictionary`2" /> class that contains elements copied from the specified <see cref="T:System.Collections.IEnumerable" />, and uses the specified <see cref="T:System.Collections.Generic.IEqualityComparer{TKey}" />.</summary>
+        /// <param name="concurrencyLevel">Any number greater than '0'. This parameter is allowed for compatibility reasons and has no effect on the dictionary.</param>
+        /// <param name="collection">The <see cref="T:System.Collections.IEnumerable{KeyValuePair{TKey,TValue}}" /> whose elements are copied to the new <see cref="T:System.Collections.Concurrent.ConcurrentDictionary`2" />.</param>
+        /// <param name="comparer">The <see cref="T:System.Collections.Generic.IEqualityComparer{TKey}" /> implementation to use when comparing keys.</param>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///   <paramref name="collection" /> is a null reference (Nothing in Visual Basic). -or- <paramref name="comparer" /> is a null reference (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        ///   <paramref name="concurrencyLevel" /> is less than 1.</exception>
+        /// <exception cref="T:System.ArgumentException">
+        ///   <paramref name="collection" /> contains one or more duplicate keys.</exception>
+        public ConcurrentDictionary(int concurrencyLevel, IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey> comparer) : this(comparer)
+        {
+            if (concurrencyLevel < 1)
+            {
+                throw new ArgumentOutOfRangeException("concurrencyLevel");
+            }
+            if (collection == null)
+            {
+                throw new ArgumentNullException("collection");
+            }
+            if (comparer == null)
+            {
+                throw new ArgumentNullException("comparer");
+            }
+            this.InitializeFromCollection(collection);
+        }
+
+        private void InitializeFromCollection(IEnumerable<KeyValuePair<TKey, TValue>> collection)
+        {
+            foreach (KeyValuePair<TKey, TValue> current in collection)
+            {
+                if (!this.TryAdd(current.Key, current.Value))
+                {
+                    throw new ArgumentException("Collection contains duplicate keys");
+                }
+            }
+        }
+
+        // System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue>
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Concurrent.ConcurrentDictionary`2" /> class that is empty, has the specified initial capacity, and uses the specified <see cref="T:System.Collections.Generic.IEqualityComparer{TKey}" />.</summary>
+        /// <param name="concurrencyLevel">Any number greater than '0'. This parameter is allowed for compatibility reasons and has no effect on the dictionary.</param>
+        /// <param name="capacity">The initial number of elements that the <see cref="T:System.Collections.Concurrent.ConcurrentDictionary`2" /> can contain.</param>
+        /// <param name="comparer">The <see cref="T:System.Collections.Generic.IEqualityComparer{TKey}" /> implementation to use when comparing keys.</param>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///   <paramref name="comparer" /> is a null reference (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        ///   <paramref name="concurrencyLevel" /> is less than 1. -or- <paramref name="capacity" /> is less than 0.</exception>
+        public ConcurrentDictionary(int concurrencyLevel, int capacity, IEqualityComparer<TKey> comparer) : this(capacity, comparer)
+        {
+            if (concurrencyLevel < 1)
+            {
+                throw new ArgumentOutOfRangeException("concurrencyLevel");
+            }
+            if (comparer == null)
+            {
+                throw new ArgumentNullException("comparer");
+            }
+        }
+
+        private ConcurrentDictionary(
+            int capacity,
+            IEqualityComparer<TKey> comparer = null)
+        {
+            if (capacity < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(capacity));
+            }
+
+            if (default(TKey) == null)
+            {
+                if (typeof(TKey) == typeof(ValueType) ||
+                    !(default(TKey) is ValueType))
+                {
+                    _table = DictionaryImpl<TKey, TValue>.CreateRefUnsafe(this, capacity);
+                    _table._keyComparer = comparer ?? EqualityComparer<TKey>.Default;
+                    return;
+                }
+            }
+            else
+            {
+                if (typeof(TKey) == typeof(int))
+                {
+                    if (comparer == null)
+                    {
+                        _table = (DictionaryImpl<TKey, TValue>)(object)new DictionaryImplIntNoComparer<TValue>(capacity, (ConcurrentDictionary<int, TValue>)(object)this);
+                    }
+                    else
+                    {
+                        _table = (DictionaryImpl<TKey, TValue>)(object)new DictionaryImplInt<TValue>(capacity, (ConcurrentDictionary<int, TValue>)(object)this);
+                        _table._keyComparer = comparer;
+                    }
+                    return;
+                }
+
+                if (typeof(TKey) == typeof(long))
+                {
+                    if (comparer == null)
+                    {
+                        _table = (DictionaryImpl<TKey, TValue>)(object)new DictionaryImplLongNoComparer<TValue>(capacity, (ConcurrentDictionary<long, TValue>)(object)this);
+                    }
+                    else
+                    {
+                        _table = (DictionaryImpl<TKey, TValue>)(object)new DictionaryImplLong<TValue>(capacity, (ConcurrentDictionary<long, TValue>)(object)this);
+                        _table._keyComparer = comparer;
+                    }
+                    return ;
+                }
+
+                if (typeof(TKey) == typeof(uint))
+                {
+                    if (comparer == null)
+                    {
+                        _table = (DictionaryImpl<TKey, TValue>)(object)new DictionaryImplUIntNoComparer<TValue>(capacity, (ConcurrentDictionary<uint, TValue>)(object)this);
+                    }
+                    else
+                    {
+                        _table = (DictionaryImpl<TKey, TValue>)(object)new DictionaryImplUInt<TValue>(capacity, (ConcurrentDictionary<uint, TValue>)(object)this);
+                        _table._keyComparer = comparer;
+                    }
+                    return;
+                }
+
+                if (typeof(TKey) == typeof(ulong))
+                {
+                    if (comparer == null)
+                    {
+                        _table = (DictionaryImpl<TKey, TValue>)(object)new DictionaryImplULongNoComparer<TValue>(capacity, (ConcurrentDictionary<ulong, TValue>)(object)this);
+                    }
+                    else
+                    {
+                        _table = (DictionaryImpl<TKey, TValue>)(object)new DictionaryImplULong<TValue>(capacity, (ConcurrentDictionary<ulong, TValue>)(object)this);
+                        _table._keyComparer = comparer;
+                    }
+                    return;
+                }
+
+                if (typeof(TKey) == typeof(IntPtr))
+                {
+                    if (comparer == null)
+                    {
+                        _table = (DictionaryImpl<TKey, TValue>)(object)new DictionaryImplIntPtrNoComparer<TValue>(capacity, (ConcurrentDictionary<IntPtr, TValue>)(object)this);
+                    }
+                    else
+                    {
+                        _table = (DictionaryImpl<TKey, TValue>)(object)new DictionaryImplIntPtr<TValue>(capacity, (ConcurrentDictionary<IntPtr, TValue>)(object)this);
+                        _table._keyComparer = comparer;
+                    }
+                    return;
+                }
+            }
+
+            _table = new DictionaryImplBoxed<TKey, TValue>(capacity, this);
+            _table._keyComparer = comparer ?? EqualityComparer<TKey>.Default;
+        }
+
+        /// <summary>
+        /// Adds the specified key and value to the <see cref="ConcurrentDictionary{TKey,
+        /// TValue}"/>.
+        /// </summary>
+        /// <param name="key">The object to use as the key of the element to add.</param>
+        /// <param name="value">The object to use as the value of the element to add.</param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.OverflowException">The dictionary contains too many
+        /// elements.</exception>
+        /// <exception cref="T:System.ArgumentException">
+        /// An element with the same key already exists in the <see
+        /// cref="ConcurrentDictionary{TKey,TValue}"/>.</exception>
+        public void Add(TKey key, TValue value)
+        {
+            if (!TryAdd(key, value))
+            {
+                throw new ArgumentException("AddingDuplicate");
+            }
+        }
+
+        /// <summary>
+        /// Attempts to add the specified key and value to the <see cref="ConcurrentDictionary{TKey,
+        /// TValue}"/>.
+        /// </summary>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="value">The value of the element to add. The value can be a null reference (Nothing
+        /// in Visual Basic) for reference types.</param>
+        /// <returns>true if the key/value pair was added to the <see cref="ConcurrentDictionary{TKey,
+        /// TValue}"/>
+        /// successfully; otherwise, false.</returns>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.OverflowException">The <see cref="ConcurrentDictionary{TKey, TValue}"/>
+        /// contains too many elements.</exception>
+        public bool TryAdd(TKey key, TValue value)
+        {
+            TValue oldVal = default;
+            return _table.PutIfMatch(key, value, ref oldVal, ValueMatch.NullOrDead);
+        }
+
+        /// <summary>
+        /// Removes the element with the specified key from the         
+        /// <see cref="ConcurrentDictionary{TKey, TValue}"/>.
+        /// </summary>
+        /// <param name="key">The key of the element to remove.</param>
+        /// <returns>true if the element is successfully removed; otherwise false. This method also returns
+        /// false if
+        /// <paramref name="key"/> was not found in the original <see
+        /// cref="T:System.Collections.Generic.IDictionary{TKey,TValue}"/>.
+        /// </returns>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        public bool Remove(TKey key)
+        {
+            TValue oldVal = default;
+            return _table.RemoveIfMatch(key, ref oldVal, ValueMatch.Any);
+        }
+
+        /// <summary>
+        /// Attempts to remove and return the value with the specified key from the
+        /// <see cref="ConcurrentDictionary{TKey, TValue}"/>.
+        /// </summary>
+        /// <param name="key">The key of the element to remove and return.</param>
+        /// <param name="value">When this method returns, <paramref name="value"/> contains the object removed from the
+        /// <see cref="ConcurrentDictionary{TKey,TValue}"/> or the default value of <typeparamref
+        /// name="TValue"/>
+        /// if the operation failed.</param>
+        /// <returns>true if an object was removed successfully; otherwise, false.</returns>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        public bool TryRemove(TKey key, out TValue value)
+        {
+            value = default;
+            return _table.RemoveIfMatch(key, ref value, ValueMatch.NotNullOrDead);
+        }
+
+        /// <summary>
+        /// Attempts to get the value associated with the specified key from the <see
+        /// cref="ConcurrentDictionary{TKey,TValue}"/>.
+        /// </summary>
+        /// <param name="key">The key of the value to get.</param>
+        /// <param name="value">When this method returns, <paramref name="value"/> contains the object from
+        /// the
+        /// <see cref="ConcurrentDictionary{TKey,TValue}"/> with the specified key or the default value of
+        /// <typeparamref name="TValue"/>, if the operation failed.</param>
+        /// <returns>true if the key was found in the <see cref="ConcurrentDictionary{TKey,TValue}"/>;
+        /// otherwise, false.</returns>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            object oldValObj = _table.TryGetValue(key);
+
+            Debug.Assert(!(oldValObj is Prime));
+
+            if (oldValObj != null)
+            {
+                value = FromObjectValue(oldValObj);
+                return true;
+            }
+            else
+            {
+                value = default(TValue);
+                return false;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal TValue FromObjectValue(object obj)
+        {
+            // regular value type
+            if (default(TValue) != null)
+            {
+                return Unsafe.As<Boxed<TValue>>(obj).Value;               
+            }
+
+            // null
+            if (obj == NULLVALUE)
+            {
+                return default(TValue);
+            }
+
+            // ref type
+            if (!valueIsValueType)
+            {
+                return Unsafe.As<object, TValue>(ref obj);
+            }
+
+            // nullable
+            return (TValue)obj;
+        }
+
+        /// <summary>
+        /// Gets or sets the value associated with the specified key.
+        /// </summary>
+        /// <param name="key">The key of the value to get or set.</param>
+        /// <value>The value associated with the specified key. If the specified key is not found, a get
+        /// operation throws a
+        /// <see cref="T:System.Collections.Generic.KeyNotFoundException"/>, and a set operation creates a new
+        /// element with the specified key.</value>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.Collections.Generic.KeyNotFoundException">The property is retrieved and
+        /// <paramref name="key"/>
+        /// does not exist in the collection.</exception>
+        public TValue this[TKey key]
+        {
+            get
+            {
+                object oldValObj = _table.TryGetValue(key);
+
+                Debug.Assert(!(oldValObj is Prime));
+
+                if (oldValObj != null)
+                {
+                    return FromObjectValue(oldValObj);
+                }
+
+                throw new KeyNotFoundException();
+            }
+            set
+            {
+                TValue oldVal = default;
+                _table.PutIfMatch(key, value, ref oldVal, ValueMatch.Any);
+            }
+        }
+
+        /// <summary>
+        /// Determines whether the <see cref="ConcurrentDictionary{TKey, TValue}"/> contains the specified
+        /// key.
+        /// </summary>
+        /// <param name="key">The key to locate in the <see cref="ConcurrentDictionary{TKey,
+        /// TValue}"/>.</param>
+        /// <returns>true if the <see cref="ConcurrentDictionary{TKey, TValue}"/> contains an element with
+        /// the specified key; otherwise, false.</returns>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        public bool ContainsKey(TKey key)
+        {
+            TValue value;
+            return this.TryGetValue(key, out value);
+        }
+
+        /// <summary>
+        /// Adds the specified value to the <see cref="T:System.Collections.Generic.ICollection{TValue}"/>
+        /// with the specified key.
+        /// </summary>
+        /// <param name="keyValuePair">The <see cref="T:System.Collections.Generic.KeyValuePair{TKey,TValue}"/>
+        /// structure representing the key and value to add to the <see
+        /// cref="T:System.Collections.Generic.Dictionary{TKey,TValue}"/>.</param>
+        /// <exception cref="T:System.ArgumentNullException">The <paramref name="keyValuePair"/> of <paramref
+        /// name="keyValuePair"/> is null.</exception>
+        /// <exception cref="T:System.OverflowException">The <see
+        /// cref="T:System.Collections.Generic.Dictionary{TKey,TValue}"/>
+        /// contains too many elements.</exception>
+        /// <exception cref="T:System.ArgumentException">An element with the same key already</exception>
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> keyValuePair)
+        {
+            this.Add(keyValuePair.Key, keyValuePair.Value);
+        }
+
+        /// <summary>
+        /// Determines whether the <see cref="T:System.Collections.Generic.ICollection{TKey,TValue}"/>
+        /// contains a specific key and value.
+        /// </summary>
+        /// <param name="keyValuePair">The <see cref="T:System.Collections.Generic.KeyValuePair{TKey,TValue}"/>
+        /// structure to locate in the <see
+        /// cref="T:System.Collections.Generic.ICollection{TValue}"/>.</param>
+        /// <returns>true if the <paramref name="keyValuePair"/> is found in the <see
+        /// cref="T:System.Collections.Generic.ICollection{TKey,TValue}"/>; otherwise, false.</returns>
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair)
+        {
+            TValue value;
+            return TryGetValue(keyValuePair.Key, out value) && 
+                EqualityComparer<TValue>.Default.Equals(value, keyValuePair.Value);
+        }
+
+        /// <summary>
+        /// Compares the existing value for the specified key with a specified value, and if they're equal,
+        /// updates the key with a third value.
+        /// </summary>
+        /// <param name="key">The key whose value is compared with <paramref name="comparisonValue"/> and
+        /// possibly replaced.</param>
+        /// <param name="newValue">The value that replaces the value of the element with <paramref
+        /// name="key"/> if the comparison results in equality.</param>
+        /// <param name="comparisonValue">The value that is compared to the value of the element with
+        /// <paramref name="key"/>.</param>
+        /// <returns>true if the value with <paramref name="key"/> was equal to <paramref
+        /// name="comparisonValue"/> and replaced with <paramref name="newValue"/>; otherwise,
+        /// false.</returns>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null
+        /// reference.</exception>
+        public bool TryUpdate(TKey key, TValue newValue, TValue comparisonValue)
+        {
+            TValue oldVal = comparisonValue;
+            return _table.PutIfMatch(key, newValue, ref oldVal, ValueMatch.OldValue);
+        }
+
+        /// <summary>
+        /// Adds a key/value pair to the <see cref="ConcurrentDictionary{TKey,TValue}"/> 
+        /// if the key does not already exist.
+        /// </summary>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="value">the value to be added, if the key does not already exist</param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.OverflowException">The dictionary contains too many
+        /// elements.</exception>
+        /// <returns>The value for the key.  This will be either the existing value for the key if the 
+        /// key is already in the dictionary, or the new value if the key was not in the dictionary.</returns>
+        public TValue GetOrAdd(TKey key, TValue value)
+        {
+            TValue oldVal = default;
+            if (_table.PutIfMatch(key, value, ref oldVal, ValueMatch.NullOrDead))
+            {
+                return value;
+            }
+
+            return FromObjectValue(oldVal);
+        }
+
+        /// <summary>
+        /// Adds a key/value pair to the <see cref="ConcurrentDictionary{TKey,TValue}"/> 
+        /// if the key does not already exist.
+        /// </summary>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="valueFactory">The function used to generate a value for the key</param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="valueFactory"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.OverflowException">The dictionary contains too many
+        /// elements.</exception>
+        /// <returns>The value for the key.  This will be either the existing value for the key if the
+        /// key is already in the dictionary, or the new value for the key as returned by valueFactory
+        /// if the key was not in the dictionary.</returns>
+        public TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory)
+        {
+            return _table.GetOrAdd(key, valueFactory);
+        }
+
+        /// <summary>
+        /// Removes a key and value from the dictionary.
+        /// </summary>
+        /// <param name="keyValuePair">The <see
+        /// cref="T:System.Collections.Generic.KeyValuePair{TKey,TValue}"/>
+        /// structure representing the key and value to remove from the <see
+        /// cref="T:System.Collections.Generic.Dictionary{TKey,TValue}"/>.</param>
+        /// <returns>true if the key and value represented by <paramref name="keyValuePair"/> is successfully
+        /// found and removed; otherwise, false.</returns>
+        /// <exception cref="T:System.ArgumentNullException">The Key property of <paramref
+        /// name="keyValuePair"/> is a null reference (Nothing in Visual Basic).</exception>
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair)
+        {
+            TValue oldVal = keyValuePair.Value;
+            return _table.RemoveIfMatch(keyValuePair.Key, ref oldVal, ValueMatch.OldValue);
+        }
+
+        bool IDictionary.IsReadOnly => false;
+        bool IDictionary.IsFixedSize => false;
+
+        /// <summary>
+        /// Gets a value indicating whether access to the <see cref="T:System.Collections.ICollection"/> is
+        /// synchronized with the SyncRoot.
+        /// </summary>
+        /// <value>true if access to the <see cref="T:System.Collections.ICollection"/> is synchronized
+        /// (thread safe); otherwise, false. For <see
+        /// cref="T:System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/>, this property always
+        /// returns false.</value>
+        bool ICollection.IsSynchronized => false;
+
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly => false;
+
+        /// <summary>
+        /// Gets a value that indicates whether the <see cref="ConcurrentDictionary{TKey,TValue}"/> is empty.
+        /// </summary>
+        /// <value>true if the <see cref="ConcurrentDictionary{TKey,TValue}"/> is empty; otherwise,
+        /// false.</value>
+        public bool IsEmpty => _table.Count == 0;
+
+        /// <summary>
+        /// Gets the number of key/value pairs contained in the <see
+        /// cref="ConcurrentDictionary{TKey,TValue}"/>.
+        /// </summary>
+        /// <exception cref="T:System.OverflowException">The dictionary contains too many
+        /// elements.</exception>
+        /// <value>The number of key/value pairs contained in the <see
+        /// cref="ConcurrentDictionary{TKey,TValue}"/>.</value>
+        /// <remarks>Count has snapshot semantics and represents the number of items in the <see
+        /// cref="ConcurrentDictionary{TKey,TValue}"/>
+        /// at the moment when Count was accessed.</remarks>
+        public int Count => _table.Count;
+
+        /// <summary>
+        /// Removes all keys and values from the <see cref="ConcurrentDictionary{TKey,TValue}"/>.
+        /// </summary>
+        public void Clear() => _table.Clear();
+
+        /// <summary>
+        /// Gets an <see cref="T:System.Collections.Generic.IEnumerable{TKey}"/> containing the keys of
+        /// the <see cref="T:System.Collections.Generic.IReadOnlyDictionary{TKey,TValue}"/>.
+        /// </summary>
+        /// <value>An <see cref="T:System.Collections.Generic.IEnumerable{TKey}"/> containing the keys of
+        /// the <see cref="T:System.Collections.Generic.IReadOnlyDictionary{TKey,TValue}"/>.</value>
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => GetKeys();
+
+        /// <summary>
+        /// Gets an <see cref="T:System.Collections.Generic.IEnumerable{TValue}"/> containing the values
+        /// in the <see cref="T:System.Collections.Generic.IReadOnlyDictionary{TKey,TValue}"/>.
+        /// </summary>
+        /// <value>An <see cref="T:System.Collections.Generic.IEnumerable{TValue}"/> containing the
+        /// values in the <see cref="T:System.Collections.Generic.IReadOnlyDictionary{TKey,TValue}"/>.</value>
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => GetValues();
+
+        /// <summary>
+        /// Gets a collection containing the keys in the <see
+        /// cref="T:System.Collections.Generic.Dictionary{TKey,TValue}"/>.
+        /// </summary>
+        /// <value>An <see cref="T:System.Collections.Generic.ICollection{TKey}"/> containing the keys in the
+        /// <see cref="T:System.Collections.Generic.Dictionary{TKey,TValue}"/>.</value>
+        public ICollection<TKey> Keys => GetKeys();
+
+        /// <summary>
+        /// Gets a collection containing the values in the <see
+        /// cref="T:System.Collections.Generic.Dictionary{TKey,TValue}"/>.
+        /// </summary>
+        /// <value>An <see cref="T:System.Collections.Generic.ICollection{TValue}"/> containing the values in
+        /// the
+        /// <see cref="T:System.Collections.Generic.Dictionary{TKey,TValue}"/>.</value>
+        public ICollection<TValue> Values => GetValues();
+
+        ICollection IDictionary.Keys => GetKeys();
+        ICollection IDictionary.Values => GetValues();
+
+        bool IDictionary.Contains(object key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException("key");
+            }
+            return key is TKey && this.ContainsKey((TKey)((object)key));
+        }
+
+        void IDictionary.Add(object key, object value)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException("key");
+            }
+            if (!(key is TKey))
+            {
+                throw new ArgumentException();
+            }
+            TValue value2;
+            try
+            {
+                value2 = (TValue)((object)value);
+            }
+            catch (InvalidCastException)
+            {
+                throw new ArgumentException();
+            }
+            ((IDictionary<TKey, TValue>)this).Add((TKey)((object)key), value2);
+        }
+
+        void IDictionary.Remove(object key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException("key");
+            }
+            if (key is TKey)
+            {
+                TValue tValue;
+                this.TryRemove((TKey)((object)key), out tValue);
+            }
+        }
+
+        /// <summary>
+        /// Copies the elements of the <see cref="T:System.Collections.ICollection"/> to an array, starting
+        /// at the specified array index.
+        /// </summary>
+        /// <param name="array">The one-dimensional array that is the destination of the elements copied from
+        /// the <see cref="T:System.Collections.ICollection"/>. The array must have zero-based
+        /// indexing.</param>
+        /// <param name="index">The zero-based index in <paramref name="array"/> at which copying
+        /// begins.</param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="array"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index"/> is less than
+        /// 0.</exception>
+        /// <exception cref="T:System.ArgumentException"><paramref name="index"/> is equal to or greater than
+        /// the length of the <paramref name="array"/>. -or- The number of elements in the source <see
+        /// cref="T:System.Collections.ICollection"/>
+        /// is greater than the available space from <paramref name="index"/> to the end of the destination
+        /// <paramref name="array"/>.</exception>
+        void ICollection.CopyTo(Array array, int index)
+        {
+            var pairs = array as KeyValuePair<TKey, TValue>[];
+            if (pairs != null)
+            {
+                CopyToPairs(pairs, index);
+                return;
+            }
+
+            var entries = array as DictionaryEntry[];
+            if (entries != null)
+            {
+                CopyToEntries(entries, index);
+                return;
+            }
+
+            var objects = array as object[];
+            if (objects != null)
+            {
+                CopyToObjects(objects, index);
+                return;
+            }
+
+            throw new ArgumentNullException("array");
+        }
+
+        /// <summary>
+        /// Gets an object that can be used to synchronize access to the <see
+        /// cref="T:System.Collections.ICollection"/>. This property is not supported.
+        /// </summary>
+        /// <exception cref="T:System.NotSupportedException">The SyncRoot property is not supported.</exception>
+        object ICollection.SyncRoot
+        {
+            get
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        object IDictionary.this[object key]
+        {
+            get
+            {
+                if (key == null)
+                {
+                    throw new ArgumentNullException("key");
+                }
+                TValue tValue;
+                if (key is TKey && this.TryGetValue((TKey)((object)key), out tValue))
+                {
+                    return tValue;
+                }
+                return null;
+            }
+            set
+            {
+                if (key == null)
+                {
+                    throw new ArgumentNullException("key");
+                }
+                if (!(key is TKey))
+                {
+                    throw new ArgumentException();
+                }
+                if (!(value is TValue))
+                {
+                    throw new ArgumentException();
+                }
+                this[(TKey)((object)key)] = (TValue)((object)value);
+            }
+        }
+
+        /// <summary>
+        /// Adds a key/value pair to the <see cref="ConcurrentDictionary{TKey,TValue}"/> if the key does not already 
+        /// exist, or updates a key/value pair in the <see cref="ConcurrentDictionary{TKey,TValue}"/> if the key 
+        /// already exists.
+        /// </summary>
+        /// <param name="key">The key to be added or whose value should be updated</param>
+        /// <param name="addValueFactory">The function used to generate a value for an absent key</param>
+        /// <param name="updateValueFactory">The function used to generate a new value for an existing key
+        /// based on the key's existing value</param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="addValueFactory"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="updateValueFactory"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.OverflowException">The dictionary contains too many
+        /// elements.</exception>
+        /// <returns>The new value for the key.  This will be either the result of addValueFactory (if the key was 
+        /// absent) or the result of updateValueFactory (if the key was present).</returns>
+        public TValue AddOrUpdate(TKey key, Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory)
+        {
+            if (addValueFactory == null)
+            {
+                throw new ArgumentNullException("addValueFactory");
+            }
+            if (updateValueFactory == null)
+            {
+                throw new ArgumentNullException("updateValueFactory");
+            }
+            TValue tValue2;
+            while (true)
+            {
+                TValue tValue;
+                if (this.TryGetValue(key, out tValue))
+                {
+                    tValue2 = updateValueFactory(key, tValue);
+                    if (this.TryUpdate(key, tValue2, tValue))
+                    {
+                        break;
+                    }
+                }
+                else
+                {
+                    tValue2 = addValueFactory(key);
+                    if (this.TryAdd(key, tValue2))
+                    {
+                        break;
+                    }
+                }
+            }
+            return tValue2;
+        }
+
+        /// <summary>
+        /// Adds a key/value pair to the <see cref="ConcurrentDictionary{TKey,TValue}"/> if the key does not already 
+        /// exist, or updates a key/value pair in the <see cref="ConcurrentDictionary{TKey,TValue}"/> if the key 
+        /// already exists.
+        /// </summary>
+        /// <param name="key">The key to be added or whose value should be updated</param>
+        /// <param name="addValue">The value to be added for an absent key</param>
+        /// <param name="updateValueFactory">The function used to generate a new value for an existing key based on 
+        /// the key's existing value</param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="updateValueFactory"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.OverflowException">The dictionary contains too many
+        /// elements.</exception>
+        /// <returns>The new value for the key.  This will be either the value of addValue (if the key was 
+        /// absent) or the result of updateValueFactory (if the key was present).</returns>
+        public TValue AddOrUpdate(TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory)
+        {
+            if (updateValueFactory == null)
+            {
+                throw new ArgumentNullException("updateValueFactory");
+            }
+            TValue tValue2;
+            while (true)
+            {
+                TValue tValue;
+                if (this.TryGetValue(key, out tValue))
+                {
+                    tValue2 = updateValueFactory(key, tValue);
+                    if (this.TryUpdate(key, tValue2, tValue))
+                    {
+                        return tValue2;
+                    }
+                }
+                else if (this.TryAdd(key, addValue))
+                {
+                    return addValue;
+                }
+            }            
+        }
+
+        /// <summary>
+        /// Copies the elements of the <see cref="T:System.Collections.Generic.ICollection"/> to an array of
+        /// type <see cref="T:System.Collections.Generic.KeyValuePair{TKey,TValue}"/>, starting at the
+        /// specified array index.
+        /// </summary>
+        /// <param name="array">The one-dimensional array of type <see
+        /// cref="T:System.Collections.Generic.KeyValuePair{TKey,TValue}"/>
+        /// that is the destination of the <see
+        /// cref="T:System.Collections.Generic.KeyValuePair{TKey,TValue}"/> elements copied from the <see
+        /// cref="T:System.Collections.ICollection"/>. The array must have zero-based indexing.</param>
+        /// <param name="index">The zero-based index in <paramref name="array"/> at which copying
+        /// begins.</param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="array"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index"/> is less than
+        /// 0.</exception>
+        /// <exception cref="T:System.ArgumentException"><paramref name="index"/> is equal to or greater than
+        /// the length of the <paramref name="array"/>. -or- The number of elements in the source <see
+        /// cref="T:System.Collections.ICollection"/>
+        /// is greater than the available space from <paramref name="index"/> to the end of the destination
+        /// <paramref name="array"/>.</exception>
+        void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int index)
+        {
+            CopyToPairs(array, index);
+        }
+
+        /// <summary>
+        /// Copy dictionary contents to an array - shared implementation between ToArray and CopyTo.
+        /// </summary>
+        private void CopyToPairs(KeyValuePair<TKey, TValue>[] array, int index)
+        {
+            if (array == null)
+            {
+                throw new ArgumentNullException("array");
+            }
+            if (index < 0)
+            {
+                throw new ArgumentOutOfRangeException("index");
+            }
+
+            foreach (var entry in this)
+            {
+                array[index++] = entry;
+            }
+        }
+
+        /// <summary>
+        /// Copy dictionary contents to an array - shared implementation between ToArray and CopyTo.
+        /// </summary>
+        private void CopyToEntries(DictionaryEntry[] array, int arrayIndex)
+        {
+            if (array == null)
+            {
+                throw new ArgumentNullException("array");
+            }
+            if (arrayIndex < 0)
+            {
+                throw new ArgumentOutOfRangeException("index");
+            }
+
+            foreach (var entry in this)
+            {
+                array[arrayIndex++] = new DictionaryEntry(entry.Key, entry.Value);
+            }
+        }
+
+        /// <summary>
+        /// Copy dictionary contents to an array - shared implementation between ToArray and CopyTo.
+        /// </summary>
+        private void CopyToObjects(object[] array, int arrayIndex)
+        {
+            if (array == null)
+            {
+                throw new ArgumentNullException("array");
+            }
+            if (arrayIndex < 0)
+            {
+                throw new ArgumentOutOfRangeException("index");
+            }
+
+            var length = array.Length;
+            foreach (var entry in this)
+            {
+                if ((uint)arrayIndex < (uint)length)
+                {
+                    array[arrayIndex++] = entry;
+                }
+                else
+                {
+                    throw new ArgumentException();
+                }
+            }
+        }
+
+        /// <summary>Returns an enumerator that iterates through the <see
+        /// cref="ConcurrentDictionary{TKey,TValue}"/>.</summary>
+        /// <returns>An enumerator for the <see cref="ConcurrentDictionary{TKey,TValue}"/>.</returns>
+        /// <remarks>
+        /// The enumerator returned from the dictionary is safe to use concurrently with
+        /// reads and writes to the dictionary, however it does not represent a moment-in-time snapshot
+        /// of the dictionary.  The contents exposed through the enumerator may contain modifications
+        /// made to the dictionary after <see cref="GetEnumerator"/> was called.
+        /// </remarks>
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            return _table.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _table.GetEnumerator();
+        }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator()
+        {
+            return _table.GetdIDictEnumerator();
+        }
+
+        internal ReadOnlyCollection<TKey> GetKeys()
+        {
+            var keys = new List<TKey>(Count);
+            foreach (var kv in this)
+            {
+                keys.Add(kv.Key);
+            }
+
+            return new ReadOnlyCollection<TKey>(keys);
+        }
+
+        internal ReadOnlyCollection<TValue> GetValues()
+        {
+            var values = new List<TValue>(Count);
+            foreach (var kv in this)
+            {
+                values.Add(kv.Value);
+            }
+
+            return new ReadOnlyCollection<TValue>(values);
+        }
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/Counter/Counter32.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/Counter/Counter32.cs
@@ -1,0 +1,214 @@
+﻿// Copyright (c) Vladimir Sadov. All rights reserved.
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace NonBlocking
+{
+    /// <summary>
+    /// Scalable 32bit counter that can be used from multiple threads.
+    /// </summary>
+    public sealed class Counter32: CounterBase
+    {
+        private class Cell
+        {
+            [StructLayout(LayoutKind.Explicit, Size = CACHE_LINE * 2 - OBJ_HEADER_SIZE)]
+            public struct SpacedCounter
+            {
+                [FieldOffset(CACHE_LINE - OBJ_HEADER_SIZE)]
+                public int cnt;
+            }
+
+            public SpacedCounter counter;
+        }
+
+        // spaced out counters
+        private Cell[] cells;
+
+        // default counter
+        private int cnt;
+
+        // delayed estimated count
+        private int lastCnt;
+
+        /// <summary>
+        /// Initializes a new instance of the <see
+        /// cref="Counter32"/>
+        /// </summary>
+        public Counter32()
+        {
+        }
+
+        /// <summary>
+        /// Returns the value of the counter at the time of the call.
+        /// </summary>
+        /// <remarks>
+        /// The value may miss in-progress updates if the counter is being concurrently modified.
+        /// </remarks>
+        public int Value
+        {
+            get
+            {
+                var count = this.cnt;
+                var cells = this.cells;
+
+                if (cells != null)
+                {
+                    for (int i = 0; i < cells.Length; i++)
+                    {
+                        var cell = cells[i];
+                        if (cell != null)
+                        {
+                            count += cell.counter.cnt;
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                }
+
+                return count;
+            }
+        }
+
+        /// <summary>
+        /// Returns the approximate value of the counter at the time of the call.
+        /// </summary>
+        /// <remarks>
+        /// EstimatedValue could be significantly cheaper to obtain, but may be slightly delayed.
+        /// </remarks>
+        public int EstimatedValue
+        {
+            get
+            {
+                if (this.cells == null)
+                {
+                    return this.cnt;
+                }
+
+                var curTicks = (uint)Environment.TickCount;
+                // more than a millisecond passed?
+                if (curTicks != lastCntTicks)
+                {
+                    lastCntTicks = curTicks;
+                    lastCnt = Value;
+                }
+
+                return lastCnt;
+            }
+        }
+
+        /// <summary>
+        /// Increments the counter by 1.
+        /// </summary>
+        public void Increment()
+        {
+            int curCellCount = this.cellCount;
+            var drift = increment(ref GetCntRef(curCellCount));
+
+            if (drift != 0)
+            {
+                TryAddCell(curCellCount);
+            }
+        }
+
+        /// <summary>
+        /// Decrements the counter by 1.
+        /// </summary>
+        public void Decrement()
+        {
+            int curCellCount = this.cellCount;
+            var drift = decrement(ref GetCntRef(curCellCount));
+
+            if (drift != 0)
+            {
+                TryAddCell(curCellCount);
+            }
+        }
+
+        /// <summary>
+        /// Increments the counter by 'value'.
+        /// </summary>
+        public void Add(int value)
+        {
+            int curCellCount = this.cellCount;
+            var drift = add(ref GetCntRef(curCellCount), value);
+
+            if (drift != 0)
+            {
+                TryAddCell(curCellCount);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private ref int GetCntRef(int curCellCount)
+        {
+            ref var cntRef = ref cnt;
+
+            Cell[] cells;
+            if ((cells = this.cells) != null && curCellCount > 1)
+            {
+                var cell = cells[GetIndex((uint)curCellCount)];
+                if (cell != null)
+                {
+                    cntRef = ref cell.counter.cnt;
+                }
+            }
+
+            return ref cntRef;
+        }
+
+        private static int increment(ref int val)
+        {
+            return -val - 1 + Interlocked.Increment(ref val);
+        }
+
+        private static int add(ref int val, int inc)
+        {
+            return -val - inc + Interlocked.Add(ref val, inc);
+        }
+
+        private static int decrement(ref int val)
+        {
+            return val - 1 - Interlocked.Decrement(ref val);
+        }
+
+        private void TryAddCell(int curCellCount)
+        {
+            if (curCellCount < s_MaxCellCount)
+            {
+                TryAddCellCore(curCellCount);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void TryAddCellCore(int curCellCount)
+        {
+            var cells = this.cells;
+            if (cells == null)
+            {
+                var newCells = new Cell[s_MaxCellCount];
+                cells = Interlocked.CompareExchange(ref this.cells, newCells, null) ?? newCells;
+            }
+
+            if (cells[curCellCount] == null)
+            {
+                Interlocked.CompareExchange(ref cells[curCellCount], new Cell(), null);
+            }
+
+            if (this.cellCount == curCellCount)
+            {
+                Interlocked.CompareExchange(ref this.cellCount, curCellCount + 1, curCellCount);
+                //if (Interlocked.CompareExchange(ref this.cellCount, curCellCount + 1, curCellCount) == curCellCount)
+                //{
+                //    System.Console.WriteLine(curCellCount + 1);
+                //}
+            }
+        }
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/Counter/Counter64.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/Counter/Counter64.cs
@@ -1,0 +1,213 @@
+﻿// Copyright (c) Vladimir Sadov. All rights reserved.
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace NonBlocking
+{    
+    /// <summary>
+    /// Scalable 64bit counter that can be used from multiple threads.
+    /// </summary>
+    public sealed class Counter64 : CounterBase
+    {
+        private class Cell
+        {
+            [StructLayout(LayoutKind.Explicit, Size = CACHE_LINE * 2 - OBJ_HEADER_SIZE)]
+            public struct SpacedCounter
+            {
+                [FieldOffset(CACHE_LINE - OBJ_HEADER_SIZE)]
+                public long cnt;
+            }
+
+            public SpacedCounter counter;
+        }
+
+        // spaced out counters
+        private Cell[] cells;
+
+        // default counter
+        private long cnt;
+
+        // delayed count
+        private long lastCnt;
+
+        /// <summary>
+        /// Initializes a new instance of the <see
+        /// cref="Counter32"/>
+        /// </summary>
+        public Counter64()
+        {
+        }
+
+        /// <summary>
+        /// Returns the value of the counter at the time of the call.
+        /// </summary>
+        /// <remarks>
+        /// The value may miss in-progress updates if the counter is being concurrently modified.
+        /// </remarks>
+        public long Value
+        {
+            get
+            {
+                var count = this.cnt;
+                var cells = this.cells;
+
+                if (cells != null)
+                {
+                    for (int i = 0; i < cells.Length; i++)
+                    {
+                        var cell = cells[i];
+                        if (cell != null)
+                        {
+                            count += cell.counter.cnt;
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                }
+
+                return count;
+            }
+        }
+
+        /// <summary>
+        /// Returns the approximate value of the counter at the time of the call.
+        /// </summary>
+        /// <remarks>
+        /// EstimatedValue could be significantly cheaper to obtain, but may be slightly delayed.
+        /// </remarks>
+        public long EstimatedValue
+        {
+            get
+            {
+                if (this.cellCount == 0)
+                {
+                    return Value;
+                }
+
+                var curTicks = (uint)Environment.TickCount;
+                // more than a millisecond passed?
+                if (curTicks != lastCntTicks)
+                {
+                    lastCntTicks = curTicks;
+                    lastCnt = Value;
+                }
+
+                return lastCnt;
+            }
+        }
+
+        /// <summary>
+        /// Increments the counter by 1.
+        /// </summary>
+        public void Increment()
+        {
+            int curCellCount = this.cellCount;
+            var drift = increment(ref GetCntRef(curCellCount));
+
+            if (drift != 0)
+            {
+                TryAddCell(curCellCount);
+            }
+        }
+
+        /// <summary>
+        /// Decrements the counter by 1.
+        /// </summary>
+        public void Decrement()
+        {
+            int curCellCount = this.cellCount;
+            var drift = decrement(ref GetCntRef(curCellCount));
+
+            if (drift != 0)
+            {
+                TryAddCell(curCellCount);
+            }
+        }
+
+        /// <summary>
+        /// Increments the counter by 'value'.
+        /// </summary>
+        public void Add(int value)
+        {
+            int curCellCount = this.cellCount;
+            var drift = add(ref GetCntRef(curCellCount), value);
+
+            if (drift != 0)
+            {
+                TryAddCell(curCellCount);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private ref long GetCntRef(int curCellCount)
+        {
+            ref var cntRef = ref cnt;
+
+            Cell[] cells;
+            if ((cells = this.cells) != null && curCellCount > 1)
+            {
+                var cell = cells[GetIndex((uint)curCellCount)];
+                if (cell != null)
+                {
+                    cntRef = ref cell.counter.cnt;
+                }
+            }
+
+            return ref cntRef;
+        }
+
+        private static long increment(ref long val)
+        {
+            return -val - 1 + Interlocked.Increment(ref val);
+        }
+
+        private static long add(ref long val, int inc)
+        {
+            return -val - inc + Interlocked.Add(ref val, inc);
+        }
+
+        private static long decrement(ref long val)
+        {
+            return val - 1 - Interlocked.Decrement(ref val);
+        }
+
+        private void TryAddCell(int curCellCount)
+        {
+            if (curCellCount < s_MaxCellCount)
+            {
+                TryAddCellCore(curCellCount);
+            }
+        }
+
+        private void TryAddCellCore(int curCellCount)
+        {
+            var cells = this.cells;
+            if (cells == null)
+            {
+                var newCells = new Cell[s_MaxCellCount];
+                cells = Interlocked.CompareExchange(ref this.cells, newCells, null) ?? newCells;
+            }
+
+            if (cells[curCellCount] == null)
+            {
+                Interlocked.CompareExchange(ref cells[curCellCount], new Cell(), null);
+            }
+
+            if (this.cellCount == curCellCount)
+            {
+                Interlocked.CompareExchange(ref this.cellCount, curCellCount + 1, curCellCount);
+                //if (Interlocked.CompareExchange(ref this.cellCount, curCellCount + 1, curCellCount) == curCellCount)
+                //{
+                //    System.Console.WriteLine(curCellCount + 1);
+                //}
+            }
+        }
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/Counter/CounterBase.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/Counter/CounterBase.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Vladimir Sadov. All rights reserved.
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace NonBlocking
+{
+    /// <summary>
+    /// Scalable counter base.
+    /// </summary>
+    public class CounterBase
+    {
+        private protected const int CACHE_LINE = 64;
+        private protected const int OBJ_HEADER_SIZE = 8;
+
+        private protected static readonly int s_MaxCellCount = Util.AlignToPowerOfTwo(Environment.ProcessorCount) + 1;
+
+        // how many cells we have
+        private protected int cellCount;
+
+        // delayed count time
+        private protected uint lastCntTicks;
+
+        private protected CounterBase()
+        {
+            // touch static
+            _ = s_MaxCellCount;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private protected unsafe static int GetIndex(uint cellCount)
+        {
+            if (IntPtr.Size == 4)
+            {
+                uint addr = (uint)&cellCount;
+                return (int)(addr % cellCount);
+            }
+            else
+            {
+                ulong addr = (ulong)&cellCount;
+                return (int)(addr % cellCount);
+            }
+        }
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImpl.Enumerators.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImpl.Enumerators.cs
@@ -1,0 +1,172 @@
+﻿// Copyright (c) Vladimir Sadov. All rights reserved.
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace NonBlocking
+{
+    internal abstract partial class DictionaryImpl<TKey, TKeyStore, TValue>
+        : DictionaryImpl<TKey, TValue>
+    {
+
+        internal override IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            return new SnapshotKV(this);
+        }
+
+        internal override IDictionaryEnumerator GetdIDictEnumerator()
+        {
+            return new SnapshotIDict(this);
+        }
+
+        private class Snapshot : IDisposable
+        {
+            private readonly DictionaryImpl<TKey, TKeyStore, TValue> _table;
+            private int _idx;
+            protected TKey _curKey, _nextK;
+            protected object _curValue, _nextV;
+
+            public Snapshot(DictionaryImpl<TKey, TKeyStore, TValue> dict)
+            {
+                this._table = dict;
+
+                // linearization point.
+                // if table is quiescent and has no copy in progress,
+                // we can simply iterate over its table.
+                while (true)
+                {
+                    if (_table._newTable == null)
+                    {
+                        break;
+                    }
+
+                    // there is a copy in progress, finish it and try again
+                    _table.HelpCopy(copy_all: true);
+                    this._table = (DictionaryImpl<TKey, TKeyStore, TValue>)(this._table._topDict._table);
+                }
+
+                // Warm-up the iterator
+                MoveNext();
+            }
+
+            public bool MoveNext()
+            {
+                if (_nextV == NULLVALUE)
+                {
+                    return false;
+                }
+
+                _curKey = _nextK;
+                _curValue = _nextV;
+                _nextV = NULLVALUE;
+
+                var entries = this._table._entries;
+                while (_idx < entries.Length)
+                {  // Scan array
+                    var nextEntry = entries[_idx++];
+
+                    if (nextEntry.value != null)
+                    {
+                        var nextKstore = nextEntry.key;
+                        if (nextKstore == null)
+                        {
+                            // slot was deleted.
+                            continue;
+                        }
+
+                        var nextK = _table.keyFromEntry(nextKstore);
+
+                        object nextV = _table.TryGetValue(nextK);
+                        if (nextV != null)
+                        {
+                            _nextK = nextK;
+
+                            // PERF: this would be nice to have as a helper, 
+                            // but it does not get inlined
+                            if (default(TValue) == null && nextV == NULLVALUE)
+                            {
+                                _nextV = default(TValue);
+                            }
+                            else
+                            {
+                                _nextV = nextV;
+                            }
+
+
+                            break;
+                        }
+                    }
+                }
+
+                return _curValue != NULLVALUE;
+            }
+
+            public void Reset()
+            {
+                _idx = 0;
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+
+        private sealed class SnapshotKV : Snapshot, IEnumerator<KeyValuePair<TKey, TValue>>
+        {
+            public SnapshotKV(DictionaryImpl<TKey, TKeyStore, TValue> dict) : base(dict) { }
+
+            public KeyValuePair<TKey, TValue> Current
+            {
+                get
+                {
+                    var curValue = this._curValue;
+                    if (curValue == NULLVALUE)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    var curValueUnboxed = default(TValue) != null ?
+                                            Unsafe.As<Boxed<TValue>>(curValue).Value :
+                                            (TValue)curValue;
+
+                    return new KeyValuePair<TKey, TValue>(this._curKey, curValueUnboxed);
+                }
+            }
+
+            object IEnumerator.Current => Current;
+        }
+
+        private sealed class SnapshotIDict : Snapshot, IDictionaryEnumerator
+        {
+            public SnapshotIDict(DictionaryImpl<TKey, TKeyStore, TValue> dict) : base(dict) { }
+
+            public DictionaryEntry Entry
+            {
+                get
+                {
+                    var curValue = this._curValue;
+                    if (curValue == NULLVALUE)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    var curValueUnboxed = default(TValue) != null ?
+                        Unsafe.As<Boxed<TValue>>(curValue).Value :
+                        (TValue)curValue;
+
+                    return new DictionaryEntry(this._curKey, curValueUnboxed);
+                }
+            }
+
+            public object Key => Entry.Key;
+
+            public object Value => Entry.Value;
+
+            object IEnumerator.Current => Entry;
+        }
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImpl.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImpl.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Vladimir Sadov. All rights reserved.
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+
+using System.Runtime.CompilerServices;
+
+namespace NonBlocking
+{
+    internal abstract class DictionaryImpl
+    {
+        internal DictionaryImpl() { }
+
+        internal enum ValueMatch
+        {
+            Any,            // sets new value unconditionally, used by index set and TryRemove(key)
+            NullOrDead,     // set value if original value is null or dead, used by Add/TryAdd
+            NotNullOrDead,  // set value if original value is alive, used by Remove
+            OldValue,       // sets new value if old value matches
+        }
+
+        internal sealed class Prime
+        {
+            internal object originalValue;
+
+            public Prime(object originalValue)
+            {
+                this.originalValue = originalValue;
+            }
+        }
+
+        internal static readonly object TOMBSTONE = new object();
+        internal static readonly Prime TOMBPRIME = new Prime(TOMBSTONE);
+        internal static readonly object NULLVALUE = new object();
+
+        // represents a trivially copied empty entry
+        // we insert it in the old table during rehashing
+        // to reduce chances that more entries are added
+        protected const int TOMBPRIMEHASH = 1 << 31;
+
+        // we cannot distigush zero keys from uninitialized state
+        // so we force them to have this special hash instead
+        protected const int ZEROHASH = 1 << 30;
+
+        // all regular hashes have both these bits set
+        // to be different from either 0, TOMBPRIMEHASH or ZEROHASH
+        // having only these bits set in a case of Ref key means that the slot is permanently deleted.
+        protected const int SPECIAL_HASH_BITS = TOMBPRIMEHASH | ZEROHASH;
+
+        protected const int REPROBE_LIMIT = 4;
+        protected const int REPROBE_LIMIT_SHIFT = 1;
+        // Heuristic to decide if we have reprobed toooo many times.  Running over
+        // the reprobe limit on a 'get' call acts as a 'miss'; on a 'put' call it
+        // can trigger a table resize.  Several places must have exact agreement on
+        // what the reprobe_limit is, so we share it here.
+        protected static int ReprobeLimit(int lenMask)
+        {
+            // 1/2 of table with some extra
+            return REPROBE_LIMIT + (lenMask >> REPROBE_LIMIT_SHIFT);
+        }
+
+        protected static bool EntryValueNullOrDead(object entryValue)
+        {
+            return entryValue == null || entryValue == TOMBSTONE;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected static int ReduceHashToIndex(int fullHash, int lenMask)
+        {
+            var h = (uint)fullHash;
+
+            // hashcodes often exhibit clustering behavior (i.e. ...,42,43,44,45,46,47...)
+            // unchanged that would cause clustering in the table
+            // some clustering is good, since it improves locality of sequential accesses
+            // excessive clustering may result in long reprobes in case of collisions.
+
+            // we will use lower LBITS bits as-is and mix up other bits to break clusters.
+            const int LBITS = 6;
+
+            uint upper = (h >> LBITS) * 2654435769u;
+            upper &= ~((1u << LBITS) - 1u);
+            h += upper;
+
+            return (int)h & lenMask;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static object ToObjectValue<TValue>(TValue value)
+        {
+            if (default(TValue) != null)
+            {
+                return new Boxed<TValue>(value);
+            }
+
+            return (object)value ?? NULLVALUE;
+        }
+
+        internal static DictionaryImpl<TKey, TValue> CreateRef<TKey, TValue>(ConcurrentDictionary<TKey, TValue> topDict, int capacity)
+            where TKey : class
+        {
+            var result = new DictionaryImplRef<TKey, TKey, TValue>(capacity, topDict);
+            return result;
+        }
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImplBoxed.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImplBoxed.cs
@@ -1,0 +1,132 @@
+﻿// Copyright (c) Vladimir Sadov. All rights reserved.
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace NonBlocking
+{
+    internal sealed class DictionaryImplBoxed<TKey, TValue>
+            : DictionaryImpl<TKey, Boxed<TKey>, TValue>
+    {
+        internal DictionaryImplBoxed(int capacity, ConcurrentDictionary<TKey, TValue> topDict)
+            : base(capacity, topDict)
+        {
+        }
+
+        internal DictionaryImplBoxed(int capacity, DictionaryImplBoxed<TKey, TValue> other)
+            : base(capacity, other)
+        {
+        }
+
+        protected override bool TryClaimSlotForPut(ref Boxed<TKey> entryKey, TKey key)
+        {
+            var entryKeyValue = entryKey;
+            if (entryKeyValue == null)
+            {
+                entryKeyValue = Interlocked.CompareExchange(ref entryKey, new Boxed<TKey>(key), null);
+                if (entryKeyValue == null)
+                {
+                    // claimed a new slot
+                    this.allocatedSlotCount.Increment();
+                    return true;
+                }
+            }
+
+            return _keyComparer.Equals(key, entryKey.Value);
+        }
+
+        protected override bool TryClaimSlotForCopy(ref Boxed<TKey> entryKey,Boxed<TKey> key)
+        {
+            var entryKeyValue = entryKey;
+            if (entryKeyValue == null)
+            {
+                entryKeyValue = Interlocked.CompareExchange(ref entryKey, key, null);
+                if (entryKeyValue == null)
+                {
+                    // claimed a new slot
+                    this.allocatedSlotCount.Increment();
+                    return true;
+                }
+            }
+
+            return _keyComparer.Equals(key.Value, entryKey.Value);
+        }
+
+        protected override bool keyEqual(TKey key, Boxed<TKey> entryKey)
+        {
+            //NOTE: slots are claimed in two stages - claim a hash, then set a key
+            //      it is possible to observe a slot with a null key, but with hash already set
+            //      that is not a match since the key is not yet in the table
+            return entryKey != null && _keyComparer.Equals(key, entryKey.Value);
+        }
+
+        protected override DictionaryImpl<TKey, Boxed<TKey>, TValue> CreateNew(int capacity)
+        {
+            return new DictionaryImplBoxed<TKey, TValue>(capacity, this);
+        }
+
+        protected override TKey keyFromEntry(Boxed<TKey> entryKey)
+        {
+            return entryKey.Value;
+        }
+    }
+
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
+    internal class Boxed<T>
+    {
+        public int writeStatus;
+        public T Value;
+
+        public Boxed(T key)
+        {
+            this.Value = key;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return EqualityComparer<T>.Default.Equals(this.Value, Unsafe.As<Boxed<T>>(obj).Value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryVolatileWrite(T value)
+        {
+            if (Interlocked.CompareExchange(ref writeStatus, 1, 0) == 0)
+            {
+                Value = value;
+                Volatile.Write(ref writeStatus, 0);
+                return true;
+            }
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryCompareExchange(T oldValue, T newValue, out bool changed)
+        {
+            changed = false;
+            if (Interlocked.CompareExchange(ref writeStatus, 1, 0) != 0)
+            {
+                return false;
+            }
+
+            if (EqualityComparer<T>.Default.Equals(Value, oldValue))
+            {
+                Value = newValue;
+                changed = true;
+            }
+
+            Volatile.Write(ref writeStatus, 0);
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void Freeze()
+        {
+            // Wait for writers (1) to leave. Already 2 is ok, or set 0 -> 2.
+            while (Interlocked.CompareExchange(ref writeStatus, 2, 0) == 1);
+        }
+    }
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImplInt.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImplInt.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) Vladimir Sadov. All rights reserved.
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+
+using System.Threading;
+
+namespace NonBlocking
+{
+    internal sealed class DictionaryImplInt<TValue>
+                : DictionaryImpl<int, int, TValue>
+    {
+        internal DictionaryImplInt(int capacity, ConcurrentDictionary<int, TValue> topDict)
+            : base(capacity, topDict)
+        {
+        }
+
+        internal DictionaryImplInt(int capacity, DictionaryImplInt<TValue> other)
+            : base(capacity, other)
+        {
+        }
+
+        protected override bool TryClaimSlotForPut(ref int entryKey, int key)
+        {
+            return TryClaimSlot(ref entryKey, key);
+        }
+
+        protected override bool TryClaimSlotForCopy(ref int entryKey, int key)
+        {
+            return TryClaimSlot(ref entryKey, key);
+        }
+
+        private bool TryClaimSlot(ref int entryKey, int key)
+        {
+            var entryKeyValue = entryKey;
+            //zero keys are claimed via hash
+            if (entryKeyValue == 0 & key != 0)
+            {
+                entryKeyValue = Interlocked.CompareExchange(ref entryKey, key, 0);
+                if (entryKeyValue == 0)
+                {
+                    // claimed a new slot
+                    this.allocatedSlotCount.Increment();
+                    return true;
+                }
+            }
+
+            return key == entryKeyValue || _keyComparer.Equals(key, entryKey);
+        }
+
+        protected override int hash(int key)
+        {
+            if (key == 0)
+            {
+                return ZEROHASH;
+            }
+
+            return base.hash(key);
+        }
+
+        protected override bool keyEqual(int key, int entryKey)
+        {
+            return key == entryKey || _keyComparer.Equals(key, entryKey);
+        }
+
+        protected override DictionaryImpl<int, int, TValue> CreateNew(int capacity)
+        {
+            return new DictionaryImplInt<TValue>(capacity, this);
+        }
+
+        protected override int keyFromEntry(int entryKey)
+        {
+            return entryKey;
+        }
+    }
+
+    internal sealed class DictionaryImplIntNoComparer<TValue>
+            : DictionaryImpl<int, int, TValue>
+    {
+        internal DictionaryImplIntNoComparer(int capacity, ConcurrentDictionary<int, TValue> topDict)
+            : base(capacity, topDict)
+        {
+        }
+
+        internal DictionaryImplIntNoComparer(int capacity, DictionaryImplIntNoComparer<TValue> other)
+            : base(capacity, other)
+        {
+        }
+
+        protected override bool TryClaimSlotForPut(ref int entryKey, int key)
+        {
+            return TryClaimSlot(ref entryKey, key);
+        }
+
+        protected override bool TryClaimSlotForCopy(ref int entryKey, int key)
+        {
+            return TryClaimSlot(ref entryKey, key);
+        }
+
+        private bool TryClaimSlot(ref int entryKey, int key)
+        {
+            var entryKeyValue = entryKey;
+            //zero keys are claimed via hash
+            if (entryKeyValue == 0 & key != 0)
+            {
+                entryKeyValue = Interlocked.CompareExchange(ref entryKey, key, 0);
+                if (entryKeyValue == 0)
+                {
+                    // claimed a new slot
+                    this.allocatedSlotCount.Increment();
+                    return true;
+                }
+            }
+
+            return key == entryKeyValue;
+        }
+
+        protected override int hash(int key)
+        {
+            return (key == 0) ?
+                ZEROHASH :
+                key | SPECIAL_HASH_BITS;
+        }
+
+        protected override bool keyEqual(int key, int entryKey)
+        {
+            return key == entryKey;
+        }
+
+        protected override DictionaryImpl<int, int, TValue> CreateNew(int capacity)
+        {
+            return new DictionaryImplIntNoComparer<TValue>(capacity, this);
+        }
+
+        protected override int keyFromEntry(int entryKey)
+        {
+            return entryKey;
+        }
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImplIntPtr.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImplIntPtr.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) Vladimir Sadov. All rights reserved.
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+
+using System;
+using System.Threading;
+
+namespace NonBlocking
+{
+    internal sealed class DictionaryImplIntPtr<TValue>
+                : DictionaryImpl<IntPtr, IntPtr, TValue>
+    {
+        internal DictionaryImplIntPtr(int capacity, ConcurrentDictionary<IntPtr, TValue> topDict)
+            : base(capacity, topDict)
+        {
+        }
+
+        internal DictionaryImplIntPtr(int capacity, DictionaryImplIntPtr<TValue> other)
+            : base(capacity, other)
+        {
+        }
+
+        protected override bool TryClaimSlotForPut(ref IntPtr entryKey, IntPtr key)
+        {
+            return TryClaimSlot(ref entryKey, key);
+        }
+
+        protected override bool TryClaimSlotForCopy(ref IntPtr entryKey, IntPtr key)
+        {
+            return TryClaimSlot(ref entryKey, key);
+        }
+
+        private bool TryClaimSlot(ref IntPtr entryKey, IntPtr key)
+        {
+            var entryKeyValue = entryKey;
+            //zero keys are claimed via hash
+            if (entryKeyValue == default(IntPtr) & key != default(IntPtr))
+            {
+                entryKeyValue = Interlocked.CompareExchange(ref entryKey, key, default(IntPtr));
+                if (entryKeyValue == default(IntPtr))
+                {
+                    // claimed a new slot
+                    this.allocatedSlotCount.Increment();
+                    return true;
+                }
+            }
+
+            return key == entryKeyValue || _keyComparer.Equals(key, entryKey);
+        }
+
+        protected override int hash(IntPtr key)
+        {
+            if (key == default(IntPtr))
+            {
+                return ZEROHASH;
+            }
+
+            return base.hash(key);
+        }
+
+        protected override bool keyEqual(IntPtr key, IntPtr entryKey)
+        {
+            return key == entryKey || _keyComparer.Equals(key, entryKey);
+        }
+
+        protected override DictionaryImpl<IntPtr, IntPtr, TValue> CreateNew(int capacity)
+        {
+            return new DictionaryImplIntPtr<TValue>(capacity, this);
+        }
+
+        protected override IntPtr keyFromEntry(IntPtr entryKey)
+        {
+            return entryKey;
+        }
+    }
+
+    internal sealed class DictionaryImplIntPtrNoComparer<TValue>
+            : DictionaryImpl<IntPtr, IntPtr, TValue>
+    {
+        internal DictionaryImplIntPtrNoComparer(int capacity, ConcurrentDictionary<IntPtr, TValue> topDict)
+            : base(capacity, topDict)
+        {
+        }
+
+        internal DictionaryImplIntPtrNoComparer(int capacity, DictionaryImplIntPtrNoComparer<TValue> other)
+            : base(capacity, other)
+        {
+        }
+
+        protected override bool TryClaimSlotForPut(ref IntPtr entryKey, IntPtr key)
+        {
+            return TryClaimSlot(ref entryKey, key);
+        }
+
+        protected override bool TryClaimSlotForCopy(ref IntPtr entryKey, IntPtr key)
+        {
+            return TryClaimSlot(ref entryKey, key);
+        }
+
+        private bool TryClaimSlot(ref IntPtr entryKey, IntPtr key)
+        {
+            var entryKeyValue = entryKey;
+            //zero keys are claimed via hash
+            if (entryKeyValue == default(IntPtr) & key != default(IntPtr))
+            {
+                entryKeyValue = Interlocked.CompareExchange(ref entryKey, key, default(IntPtr));
+                if (entryKeyValue == default(IntPtr))
+                {
+                    // claimed a new slot
+                    this.allocatedSlotCount.Increment();
+                    return true;
+                }
+            }
+
+            return key == entryKeyValue;
+        }
+
+        protected override int hash(IntPtr key)
+        {
+            return (key == default(IntPtr)) ?
+                ZEROHASH :
+                key.GetHashCode() | SPECIAL_HASH_BITS;
+        }
+
+        protected override bool keyEqual(IntPtr key, IntPtr entryKey)
+        {
+            return key == entryKey;
+        }
+
+        protected override DictionaryImpl<IntPtr, IntPtr, TValue> CreateNew(int capacity)
+        {
+            return new DictionaryImplIntPtrNoComparer<TValue>(capacity, this);
+        }
+
+        protected override IntPtr keyFromEntry(IntPtr entryKey)
+        {
+            return entryKey;
+        }
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImplLong.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImplLong.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) Vladimir Sadov. All rights reserved.
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+
+using System.Threading;
+
+namespace NonBlocking
+{
+    internal sealed class DictionaryImplLong<TValue>
+                : DictionaryImpl<long, long, TValue>
+    {
+        internal DictionaryImplLong(int capacity, ConcurrentDictionary<long, TValue> topDict)
+            : base(capacity, topDict)
+        {
+        }
+
+        internal DictionaryImplLong(int capacity, DictionaryImplLong<TValue> other)
+            : base(capacity, other)
+        {
+        }
+
+        protected override bool TryClaimSlotForPut(ref long entryKey, long key)
+        {
+            return TryClaimSlot(ref entryKey, key);
+        }
+
+        protected override bool TryClaimSlotForCopy(ref long entryKey, long key)
+        {
+            return TryClaimSlot(ref entryKey, key);
+        }
+
+        private bool TryClaimSlot(ref long entryKey, long key)
+        {
+            var entryKeyValue = entryKey;
+            //zero keys are claimed via hash
+            if (entryKeyValue == 0 & key != 0)
+            {
+                entryKeyValue = Interlocked.CompareExchange(ref entryKey, key, 0);
+                if (entryKeyValue == 0)
+                {
+                    // claimed a new slot
+                    this.allocatedSlotCount.Increment();
+                    return true;
+                }
+            }
+
+            return key == entryKeyValue || _keyComparer.Equals(key, entryKey);
+        }
+
+        protected override int hash(long key)
+        {
+            if (key == 0)
+            {
+                return ZEROHASH;
+            }
+
+            return base.hash(key);
+        }
+
+        protected override bool keyEqual(long key, long entryKey)
+        {
+            return key == entryKey || _keyComparer.Equals(key, entryKey);
+        }
+
+        protected override DictionaryImpl<long, long, TValue> CreateNew(int capacity)
+        {
+            return new DictionaryImplLong<TValue>(capacity, this);
+        }
+
+        protected override long keyFromEntry(long entryKey)
+        {
+            return entryKey;
+        }
+    }
+
+    internal sealed class DictionaryImplLongNoComparer<TValue>
+            : DictionaryImpl<long, long, TValue>
+    {
+        internal DictionaryImplLongNoComparer(int capacity, ConcurrentDictionary<long, TValue> topDict)
+            : base(capacity, topDict)
+        {
+        }
+
+        internal DictionaryImplLongNoComparer(int capacity, DictionaryImplLongNoComparer<TValue> other)
+            : base(capacity, other)
+        {
+        }
+
+        protected override bool TryClaimSlotForPut(ref long entryKey, long key)
+        {
+            return TryClaimSlot(ref entryKey, key);
+        }
+
+        protected override bool TryClaimSlotForCopy(ref long entryKey, long key)
+        {
+            return TryClaimSlot(ref entryKey, key);
+        }
+
+        private bool TryClaimSlot(ref long entryKey, long key)
+        {
+            var entryKeyValue = entryKey;
+            //zero keys are claimed via hash
+            if (entryKeyValue == 0 & key != 0)
+            {
+                entryKeyValue = Interlocked.CompareExchange(ref entryKey, key, 0);
+                if (entryKeyValue == 0)
+                {
+                    // claimed a new slot
+                    this.allocatedSlotCount.Increment();
+                    return true;
+                }
+            }
+
+            return key == entryKeyValue;
+        }
+
+        protected override int hash(long key)
+        {
+            return (key == 0) ?
+                ZEROHASH :
+                key.GetHashCode() | SPECIAL_HASH_BITS;
+        }
+
+        protected override bool keyEqual(long key, long entryKey)
+        {
+            return key == entryKey;
+        }
+
+        protected override DictionaryImpl<long, long, TValue> CreateNew(int capacity)
+        {
+            return new DictionaryImplLongNoComparer<TValue>(capacity, this);
+        }
+
+        protected override long keyFromEntry(long entryKey)
+        {
+            return entryKey;
+        }
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImplRef.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImplRef.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Vladimir Sadov. All rights reserved.
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+
+using System.Threading;
+
+namespace NonBlocking
+{
+    internal sealed class DictionaryImplRef<TKey, TKeyStore, TValue>
+            : DictionaryImpl<TKey, TKey, TValue>
+                    where TKey : class
+    {
+        internal DictionaryImplRef(int capacity, ConcurrentDictionary<TKey, TValue> topDict)
+            : base(capacity, topDict)
+        {
+        }
+
+        internal DictionaryImplRef(int capacity, DictionaryImplRef<TKey, TKeyStore, TValue> other)
+            : base(capacity, other)
+        {
+        }
+
+        protected override bool TryClaimSlotForPut(ref TKey entryKey, TKey key)
+        {
+            return TryClaimSlot(ref entryKey, key);
+        }
+
+        protected override bool TryClaimSlotForCopy(ref TKey entryKey, TKey key)
+        {
+            return TryClaimSlot(ref entryKey, key);
+        }
+
+        private bool TryClaimSlot(ref TKey entryKey, TKey key)
+        {
+            var entryKeyValue = entryKey;
+            if (entryKeyValue == null)
+            {
+                entryKeyValue = Interlocked.CompareExchange(ref entryKey, key, null);
+                if (entryKeyValue == null)
+                {
+                    // claimed a new slot
+                    this.allocatedSlotCount.Increment();
+                    return true;
+                }
+            }
+
+            return key == entryKeyValue || _keyComparer.Equals(key, entryKeyValue);
+        }
+
+        protected override bool keyEqual(TKey key, TKey entryKey)
+        {
+            if (key == entryKey)
+            {
+                return true;
+            }
+           
+            //NOTE: slots are claimed in two stages - claim a hash, then set a key
+            //      it is possible to observe a slot with a null key, but with hash already set
+            //      that is not a match since the key is not yet in the table
+            return entryKey != null && _keyComparer.Equals(entryKey, key);
+        }
+
+        protected override DictionaryImpl<TKey, TKey, TValue> CreateNew(int capacity)
+        {
+            return new DictionaryImplRef<TKey, TKeyStore, TValue>(capacity, this);
+        }
+
+        protected override TKey keyFromEntry(TKey entryKey)
+        {
+            return entryKey;
+        }
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImplUInt.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImplUInt.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) Vladimir Sadov. All rights reserved.
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+
+using System.Threading;
+
+namespace NonBlocking
+{
+    internal sealed class DictionaryImplUInt<TValue>
+                : DictionaryImpl<uint, int, TValue>
+    {
+        internal DictionaryImplUInt(int capacity, ConcurrentDictionary<uint, TValue> topDict)
+            : base(capacity, topDict)
+        {
+        }
+
+        internal DictionaryImplUInt(int capacity, DictionaryImplUInt<TValue> other)
+            : base(capacity, other)
+        {
+        }
+
+        protected override bool TryClaimSlotForPut(ref int entryKey, uint key)
+        {
+            return TryClaimSlot(ref entryKey, (int)key);
+        }
+
+        protected override bool TryClaimSlotForCopy(ref int entryKey, int key)
+        {
+            return TryClaimSlot(ref entryKey, key);
+        }
+
+        private bool TryClaimSlot(ref int entryKey, int key)
+        {
+            var entryKeyValue = entryKey;
+            //zero keys are claimed via hash
+            if (entryKeyValue == 0 & key != 0)
+            {
+                entryKeyValue = Interlocked.CompareExchange(ref entryKey, key, 0);
+                if (entryKeyValue == 0)
+                {
+                    // claimed a new slot
+                    this.allocatedSlotCount.Increment();
+                    return true;
+                }
+            }
+
+            return key == entryKeyValue || _keyComparer.Equals((uint)key, (uint)entryKey);
+        }
+
+        protected override int hash(uint key)
+        {
+            if (key == 0)
+            {
+                return ZEROHASH;
+            }
+
+            return base.hash(key);
+        }
+
+        protected override bool keyEqual(uint key, int entryKey)
+        {
+            return key == (uint)entryKey || _keyComparer.Equals(key, (uint)entryKey);
+        }
+
+        protected override DictionaryImpl<uint, int, TValue> CreateNew(int capacity)
+        {
+            return new DictionaryImplUInt<TValue>(capacity, this);
+        }
+
+        protected override uint keyFromEntry(int entryKey)
+        {
+            return (uint)entryKey;
+        }
+    }
+
+    internal sealed class DictionaryImplUIntNoComparer<TValue>
+            : DictionaryImpl<uint, int, TValue>
+    {
+        internal DictionaryImplUIntNoComparer(int capacity, ConcurrentDictionary<uint, TValue> topDict)
+            : base(capacity, topDict)
+        {
+        }
+
+        internal DictionaryImplUIntNoComparer(int capacity, DictionaryImplUIntNoComparer<TValue> other)
+            : base(capacity, other)
+        {
+        }
+
+        protected override bool TryClaimSlotForPut(ref int entryKey, uint key)
+        {
+            return TryClaimSlot(ref entryKey, (int)key);
+        }
+
+        protected override bool TryClaimSlotForCopy(ref int entryKey, int key)
+        {
+            return TryClaimSlot(ref entryKey, key);
+        }
+
+        private bool TryClaimSlot(ref int entryKey, int key)
+        {
+            var entryKeyValue = entryKey;
+            //zero keys are claimed via hash
+            if (entryKeyValue == 0 & key != 0)
+            {
+                entryKeyValue = Interlocked.CompareExchange(ref entryKey, key, 0);
+                if (entryKeyValue == 0)
+                {
+                    // claimed a new slot
+                    this.allocatedSlotCount.Increment();
+                    return true;
+                }
+            }
+
+            return key == entryKeyValue;
+        }
+
+        protected override int hash(uint key)
+        {
+            return (key == 0) ?
+                ZEROHASH :
+                (int)key | SPECIAL_HASH_BITS;
+        }
+
+        protected override bool keyEqual(uint key, int entryKey)
+        {
+            return key == (uint)entryKey;
+        }
+
+        protected override DictionaryImpl<uint, int, TValue> CreateNew(int capacity)
+        {
+            return new DictionaryImplUIntNoComparer<TValue>(capacity, this);
+        }
+
+        protected override uint keyFromEntry(int entryKey)
+        {
+            return (uint)entryKey;
+        }
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImplULong.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImplULong.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) Vladimir Sadov. All rights reserved.
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+
+using System.Threading;
+
+namespace NonBlocking
+{
+    internal sealed class DictionaryImplULong<TValue>
+                : DictionaryImpl<ulong, long, TValue>
+    {
+        internal DictionaryImplULong(int capacity, ConcurrentDictionary<ulong, TValue> topDict)
+            : base(capacity, topDict)
+        {
+        }
+
+        internal DictionaryImplULong(int capacity, DictionaryImplULong<TValue> other)
+            : base(capacity, other)
+        {
+        }
+
+        protected override bool TryClaimSlotForPut(ref long entryKey, ulong key)
+        {
+            return TryClaimSlot(ref entryKey, (long)key);
+        }
+
+        protected override bool TryClaimSlotForCopy(ref long entryKey, long key)
+        {
+            return TryClaimSlot(ref entryKey, key);
+        }
+
+        private bool TryClaimSlot(ref long entryKey, long key)
+        {
+            var entryKeyValue = entryKey;
+            //zero keys are claimed via hash
+            if (entryKeyValue == 0 & key != 0)
+            {
+                entryKeyValue = Interlocked.CompareExchange(ref entryKey, key, 0);
+                if (entryKeyValue == 0)
+                {
+                    // claimed a new slot
+                    this.allocatedSlotCount.Increment();
+                    return true;
+                }
+            }
+
+            return key == entryKeyValue || _keyComparer.Equals((ulong)key, (ulong)entryKey);
+        }
+
+        protected override int hash(ulong key)
+        {
+            if (key == 0)
+            {
+                return ZEROHASH;
+            }
+
+            return base.hash(key);
+        }
+
+        protected override bool keyEqual(ulong key, long entryKey)
+        {
+            return key == (ulong)entryKey || _keyComparer.Equals(key, (ulong)entryKey);
+        }
+
+        protected override DictionaryImpl<ulong, long, TValue> CreateNew(int capacity)
+        {
+            return new DictionaryImplULong<TValue>(capacity, this);
+        }
+
+        protected override ulong keyFromEntry(long entryKey)
+        {
+            return (ulong)entryKey;
+        }
+    }
+
+    internal sealed class DictionaryImplULongNoComparer<TValue>
+            : DictionaryImpl<ulong, long, TValue>
+    {
+        internal DictionaryImplULongNoComparer(int capacity, ConcurrentDictionary<ulong, TValue> topDict)
+            : base(capacity, topDict)
+        {
+        }
+
+        internal DictionaryImplULongNoComparer(int capacity, DictionaryImplULongNoComparer<TValue> other)
+            : base(capacity, other)
+        {
+        }
+
+        protected override bool TryClaimSlotForPut(ref long entryKey, ulong key)
+        {
+            return TryClaimSlot(ref entryKey, (long)key);
+        }
+
+        protected override bool TryClaimSlotForCopy(ref long entryKey, long key)
+        {
+            return TryClaimSlot(ref entryKey, key);
+        }
+
+        private bool TryClaimSlot(ref long entryKey, long key)
+        {
+            var entryKeyValue = entryKey;
+            //zero keys are claimed via hash
+            if (entryKeyValue == 0 & key != 0)
+            {
+                entryKeyValue = Interlocked.CompareExchange(ref entryKey, key, 0);
+                if (entryKeyValue == 0)
+                {
+                    // claimed a new slot
+                    this.allocatedSlotCount.Increment();
+                    return true;
+                }
+            }
+
+            return key == entryKeyValue;
+        }
+
+        protected override int hash(ulong key)
+        {
+            return (key == 0) ?
+                ZEROHASH :
+                key.GetHashCode() | SPECIAL_HASH_BITS;
+        }
+
+        protected override bool keyEqual(ulong key, long entryKey)
+        {
+            return key == (ulong)entryKey;
+        }
+
+        protected override DictionaryImpl<ulong, long, TValue> CreateNew(int capacity)
+        {
+            return new DictionaryImplULongNoComparer<TValue>(capacity, this);
+        }
+
+        protected override ulong keyFromEntry(long entryKey)
+        {
+            return (ulong)entryKey;
+        }
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImpl`2.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImpl`2.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Vladimir Sadov. All rights reserved.
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace NonBlocking
+{
+    internal abstract class DictionaryImpl<TKey, TValue>
+        : DictionaryImpl
+    {
+        // TODO: move to leafs
+        internal IEqualityComparer<TKey> _keyComparer;
+
+        internal static Func<ConcurrentDictionary<TKey, TValue>, int, DictionaryImpl<TKey, TValue>> CreateRefUnsafe =
+            (ConcurrentDictionary <TKey, TValue> topDict, int capacity) =>
+            {
+                var mObj = new Func<ConcurrentDictionary<object, object>, int, DictionaryImpl<object, object>> (DictionaryImpl.CreateRef);
+                var method = mObj.GetMethodInfo().GetGenericMethodDefinition().MakeGenericMethod(new Type[] { typeof(TKey), typeof(TValue) });
+                var del = (Func<ConcurrentDictionary<TKey, TValue>, int, DictionaryImpl<TKey, TValue>>)method
+                    .CreateDelegate(typeof(Func<ConcurrentDictionary<TKey, TValue>, int, DictionaryImpl<TKey, TValue>>));
+
+                var result = del(topDict, capacity);
+                CreateRefUnsafe = del;
+
+                return result;
+            };
+
+        internal DictionaryImpl() { }         
+
+        internal abstract void Clear();
+        internal abstract int Count { get; }
+
+        internal abstract object TryGetValue(TKey key);
+        internal abstract bool PutIfMatch(TKey key, TValue newVal, ref TValue oldValue, ValueMatch match);
+        internal abstract bool RemoveIfMatch(TKey key, ref TValue oldValue, ValueMatch match);
+        internal abstract TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory);
+
+        internal abstract IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator();
+        internal abstract IDictionaryEnumerator GetdIDictEnumerator();
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImpl`3.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/DictionaryImpl`3.cs
@@ -1,0 +1,1457 @@
+﻿// Copyright (c) Vladimir Sadov. All rights reserved.
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+
+//
+// Core algorithms are based on NonBlockingHashMap, 
+// written and released to the public domain by Dr.Cliff Click.
+// A good overview is here https://www.youtube.com/watch?v=HJ-719EGIts
+//
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NonBlocking
+{
+    internal abstract partial class DictionaryImpl<TKey, TKeyStore, TValue>
+        : DictionaryImpl<TKey, TValue>
+    {
+        private readonly Entry[] _entries;
+        internal DictionaryImpl<TKey, TKeyStore, TValue> _newTable;
+
+        protected readonly ConcurrentDictionary<TKey, TValue> _topDict;
+        protected readonly Counter32 allocatedSlotCount = new Counter32();
+        private Counter32 _size;
+
+        internal static readonly bool valueIsAtomic = IsValueAtomicPrimitive();
+        internal readonly bool valueIsValueType = typeof(TValue).GetTypeInfo().IsValueType;
+
+        // Sometimes many threads race to create a new very large table.  Only 1
+        // wins the race, but the losers all allocate a junk large table with
+        // hefty allocation costs.  Attempt to control the overkill here by
+        // throttling attempts to create a new table.  I cannot really block here
+        // (lest I lose the non-blocking property) but late-arriving threads can
+        // give the initial resizing thread a little time to allocate the initial
+        // new table.
+        //
+        // count of threads attempting an initial resize
+        private int _resizers;
+
+        // The next part of the table to copy.  It monotonically transits from zero
+        // to table.length.  Visitors to the table can claim 'work chunks' by
+        // CAS'ing this field up, then copying the indicated indices from the old
+        // table to the new table.  Workers are not required to finish any chunk;
+        // the counter simply wraps and work is copied duplicately until somebody
+        // somewhere completes the count.
+        private int _claimedChunk = 0;
+
+        // Work-done reporting.  Used to efficiently signal when we can move to
+        // the new table.  From 0 to length of old table refers to copying from the old
+        // table to the new.
+        private int _copyDone = 0;
+
+        [DebuggerDisplay("key = {key}; hash = {hash}; value = {value};")]
+        [StructLayout(LayoutKind.Sequential)]
+        public struct Entry
+        {
+            internal int hash;
+            internal TKeyStore key;
+            internal object value;
+        }
+
+        private const int MIN_SIZE = 8;
+
+        // targeted time span between resizes.
+        // if resizing more often than this, try expanding.
+        const uint RESIZE_MILLIS_TARGET = (uint)1000;
+
+        // create an empty dictionary
+        protected abstract DictionaryImpl<TKey, TKeyStore, TValue> CreateNew(int capacity);
+
+        // convert key from its storage form (noop or unboxing) used in Key enumarators
+        protected abstract TKey keyFromEntry(TKeyStore entryKey);
+
+        // compares key with another in its storage form
+        protected abstract bool keyEqual(TKey key, TKeyStore entryKey);
+
+        // claiming (by writing atomically to the entryKey location) 
+        // or getting existing slot suitable for storing a given key.
+        protected abstract bool TryClaimSlotForPut(ref TKeyStore entryKey, TKey key);
+
+        // claiming (by writing atomically to the entryKey location) 
+        // or getting existing slot suitable for storing a given key in its store form (could be boxed).
+        protected abstract bool TryClaimSlotForCopy(ref TKeyStore entryKey, TKeyStore key);
+
+        internal DictionaryImpl(int capacity, ConcurrentDictionary<TKey, TValue> topDict)
+        {
+            capacity = Math.Max(capacity, MIN_SIZE);
+
+            capacity = Util.AlignToPowerOfTwo(capacity);
+            this._entries = new Entry[capacity];
+            this._size = new Counter32();
+            this._topDict = topDict;
+
+            if (!typeof(TKeyStore).GetTypeInfo().IsValueType)
+            {
+                topDict._sweeperInstance = new Sweeper();
+            }
+
+            _ = valueIsAtomic;
+        }
+
+        protected DictionaryImpl(int capacity, DictionaryImpl<TKey, TKeyStore, TValue> other)
+        {
+            capacity = Util.AlignToPowerOfTwo(capacity);
+            this._entries = new Entry[capacity];
+            this._size = other._size;
+            this._topDict = other._topDict;
+            this._keyComparer = other._keyComparer;
+        }
+
+        /// <summary>
+        /// Determines whether type TValue can be written atomically
+        /// </summary>
+        private static bool IsValueAtomicPrimitive()
+        {
+            // only intereste in primitive value types here.
+            if (default(TValue) == null)
+            {
+                return false;
+            }
+
+            //
+            // Section 12.6.6 of ECMA CLI explains which types can be read and written atomically without
+            // the risk of tearing.
+            //
+            // See http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-335.pdf
+            //
+            if (typeof(TValue) == typeof(Boolean) ||
+                typeof(TValue) == typeof(Byte) ||
+                typeof(TValue) == typeof(Char) ||
+                typeof(TValue) == typeof(Int16) ||
+                typeof(TValue) == typeof(Int32) ||
+                typeof(TValue) == typeof(SByte) ||
+                typeof(TValue) == typeof(Single) ||
+                typeof(TValue) == typeof(UInt16) ||
+                typeof(TValue) == typeof(UInt32) ||
+                typeof(TValue) == typeof(IntPtr) ||
+                typeof(TValue) == typeof(UIntPtr))
+            {
+                return true;
+            }
+
+            if (typeof(TValue) == typeof(Int64) ||
+                typeof(TValue) == typeof(Double) ||
+                typeof(TValue) == typeof(UInt64))
+            {
+                return IntPtr.Size == 8;
+            }
+
+            return false;
+        }
+
+        private static uint CurrentTickMillis()
+        {
+            return (uint)Environment.TickCount;
+        }
+
+        protected virtual int hash(TKey key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException("key");
+            }
+
+            int h = _keyComparer.GetHashCode(key);
+
+            // ensure that hash never matches 0, TOMBPRIMEHASH, ZEROHASH or REGULAR_HASH_BITS
+            return h | (SPECIAL_HASH_BITS | 1);
+        }
+
+        internal sealed override int Count => this.Size;
+
+        internal sealed override void Clear()
+        {
+            var newTable = CreateNew(MIN_SIZE);
+            newTable._size = new Counter32();
+            _topDict._table = newTable;
+        }
+
+        /// <summary>
+        /// returns null if value is not present in the table
+        /// otherwise returns the actual value or NULLVALUE if null is the actual value 
+        /// </summary>
+        internal sealed override object TryGetValue(TKey key)
+        {
+            int fullHash = this.hash(key);
+            var curTable = this;
+
+        tryWithNewTable:
+
+            var lenMask = curTable._entries.Length - 1;
+            int idx = ReduceHashToIndex(fullHash, lenMask);
+
+            // Main spin/reprobe loop
+            int reprobeCount = 0;
+            while (true)
+            {
+                ref var entry = ref curTable._entries[idx];
+
+                // an entry is never reused for a different key 
+                // key/value/hash all read atomically and order of reads is unimportant
+
+                // is this our slot?
+                if (fullHash == entry.hash && curTable.keyEqual(key, entry.key))
+                {
+                    // read the value before the _newTable.
+                    // if the new table is null later, then the value cannot be forwarded
+                    // this also orders reads from the table.
+                    var entryValue = Volatile.Read(ref entry.value);
+                    if (EntryValueNullOrDead(entryValue))
+                    {
+                        break;
+                    }
+
+                    // if no new table, no need to check for primed value, 
+                    // but TOMBPRIME is possible when sweeping, check for that
+                    if ((curTable._newTable == null && entryValue != TOMBPRIME) ||
+                        entryValue.GetType() != typeof(Prime))
+                    {
+                        return entryValue;
+                    }
+
+                    // found a prime, that means the copying or sweeping has started 
+                    // help and retry in the new table
+                    curTable = curTable.CopySlotAndGetNewTable(ref entry, shouldHelp: true);
+                    goto tryWithNewTable;
+                }
+
+                if (entry.hash == 0)
+                {
+                    // the slot has not been claimed - the rest of the bucket is empty
+                    break;
+                }
+
+                // get, put and remove must have the same key lookup logic.
+                // But only 'put' needs to force a table-resize for a too-long key-reprobe sequence
+                // hitting reprobe limit or finding TOMBPRIMEHASH here means that the key is not in this table, 
+                // but there could be more in the new table
+                if (entry.hash == TOMBPRIMEHASH || reprobeCount >= ReprobeLimit(lenMask))
+                {
+                    if (curTable._newTable != null)
+                    {
+                        curTable.HelpCopy();
+                        curTable = curTable._newTable;
+                        goto tryWithNewTable;
+                    }
+
+                    // no new table, so this is a miss
+                    break;
+                }
+
+                // quadratic reprobe
+                reprobeCount++;
+                curTable.ResizeOnReprobeCheck(reprobeCount);
+                idx = (idx + reprobeCount) & lenMask;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// returns true if value was removed from the table.
+        /// oldVal contains original value or default(TValue), if it was not present in the table
+        /// </summary>
+        internal sealed override bool RemoveIfMatch(TKey key, ref TValue oldVal, ValueMatch match)
+        {
+            Debug.Assert(
+                match == ValueMatch.NotNullOrDead ||
+                match == ValueMatch.OldValue ||
+                match == ValueMatch.Any);   // same as NotNullOrDead, but not reporting the old value
+
+            var curTable = this;
+            int fullHash = curTable.hash(key);
+
+        tryWithNewTable:
+
+            var lenMask = curTable._entries.Length - 1;
+            int idx = ReduceHashToIndex(fullHash, lenMask);
+            ref Entry entry = ref curTable._entries[idx];
+
+            // Main spin/reprobe loop
+            int reprobeCount = 0;
+            while (true)
+            {
+                // an entry is never reused for a different key 
+                // key/value/hash all read atomically and order of reads is unimportant
+                var entryHash = entry.hash;
+
+                // is this our slot?
+                if (fullHash == entryHash && curTable.keyEqual(key, entry.key))
+                {
+                    break;
+                }
+
+                if (entryHash == 0)
+                {
+                    // Found an unassigned slot - which means this 
+                    // key has never been in this table.
+                    oldVal = default;
+                    goto FAILED;
+                }
+
+                // get, put and remove must have the same key lookup logic.
+                // But only 'put' needs to force a table-resize for a too-long key-reprobe sequence
+                // hitting reprobe limit or finding TOMBPRIMEHASH here means that the key is not in this table, 
+                // but there could be more in the new table
+                if (entryHash == TOMBPRIMEHASH || reprobeCount >= ReprobeLimit(lenMask))
+                {
+                    if (curTable._newTable != null)
+                    {
+                        curTable.HelpCopy();
+                        curTable = curTable._newTable;
+                        goto tryWithNewTable;
+                    }
+
+                    // no new table, so this is a miss
+                    break;
+                }
+
+                // quadratic reprobing
+                reprobeCount++;
+                curTable.ResizeOnReprobeCheck(reprobeCount);
+                idx = (idx + reprobeCount) & lenMask;
+                entry = ref curTable._entries[idx];
+            }
+
+            // Found the proper Key slot, now update the Value.  
+            // We never put a null, so Value slots monotonically move from null to
+            // not-null (deleted Values use Tombstone).
+
+            // volatile read to make sure we read the element before we read the _newTable
+            // that would guarantee that as long as _newTable == null, entryValue cannot be forwarded.
+            var entryValue = Volatile.Read(ref entry.value);
+            var newTable = curTable._newTable;
+
+            // See if we are moving to a new table.
+            // If so, copy our slot and retry in the new table.
+            // Seeing TOMBPRIME entry while no newTable means the slot is in a process of being deleted
+            // Let CopySlotAndGetNewTable handle that case too.
+            if (newTable != null || entryValue == TOMBPRIME)
+            {
+                var newTable1 = curTable.CopySlotAndGetNewTable(ref entry, shouldHelp: true);
+                Debug.Assert(newTable == newTable1 || (newTable == null && newTable1 == this));
+                curTable = newTable1;
+                goto tryWithNewTable;
+            }
+
+            // We are finally prepared to update the existing table
+            while (true)
+            {
+                Debug.Assert(!(entryValue is Prime));
+
+                // can't remove if nothing is there
+                if (EntryValueNullOrDead(entryValue))
+                {
+                    oldVal = default;
+                    goto FAILED;
+                }
+
+                if (ValueIsAtomicPrimitive() && match != ValueMatch.Any)
+                {
+                    // must freeze before removing or before checking for value match
+                    // unless it is "Any" case where we have no witnesses of the old value
+                    // and can assume all writes in the current box "happened before" the remove.
+                    Unsafe.As<Boxed<TValue>>(entryValue).Freeze();
+                }
+
+                if (match == ValueMatch.OldValue)
+                {
+                    TValue unboxedEntryValue = FromObjectValue(entryValue);
+                    if (!EqualityComparer<TValue>.Default.Equals(oldVal, unboxedEntryValue))
+                    {
+                        oldVal = unboxedEntryValue;
+                        goto FAILED;
+                    }
+                }
+
+                // Actually change the Value 
+                var prev = Interlocked.CompareExchange(ref entry.value, TOMBSTONE, entryValue);
+                if (prev == entryValue)
+                {
+                    // CAS succeeded - we removed!
+                    if (match == ValueMatch.NotNullOrDead)
+                    {
+                        oldVal = FromObjectValue(prev);
+                    }
+
+                    // Adjust the size
+                    curTable._size.Decrement();
+                    SweepCheck();
+
+                    return true;
+                }
+
+                // If a Prime'd value got installed, we need to re-run on the new table. 
+                Debug.Assert(prev != null);
+                if (prev.GetType() == typeof(Prime))
+                {
+                    curTable = curTable.CopySlotAndGetNewTable(ref entry, shouldHelp: true);
+                    goto tryWithNewTable;
+                }
+
+                // Otherwise we lost the CAS to another racing put/remove.
+                // Simply retry from the start.
+                entryValue = prev;
+            }
+
+        FAILED:
+            return false;
+        }
+
+        // 1) finds or creates a slot for the key
+        // 2) sets the slot value to the newVal if original value meets oldVal and match condition
+        // 3) returns true if the value was actually changed 
+        // Note that pre-existence of the slot is irrelevant 
+        // since slot without a value is as good as no slot at all
+        internal sealed override bool PutIfMatch(TKey key, TValue newVal, ref TValue oldVal, ValueMatch match)
+        {
+            Debug.Assert(
+                match == ValueMatch.NullOrDead || 
+                match == ValueMatch.OldValue ||
+                match == ValueMatch.Any);
+
+
+            var curTable = this;
+            int fullHash = curTable.hash(key);
+
+        tryWithNewTable:
+
+            var lenMask = curTable._entries.Length - 1;
+            int idx = ReduceHashToIndex(fullHash, lenMask);
+            ref Entry entry = ref curTable._entries[idx];
+
+            // Spin till we get a slot for the key or force a resizing.
+            int reprobeCount = 0;
+            while (true)
+            {
+                // an entry is never reused for a different key 
+                // key/value/hash all read atomically and order of reads is unimportant
+                var entryHash = entry.hash;
+                if (entryHash == 0)
+                {
+                    // Found an unassigned slot - which means this key has never been in this table.
+                    // claim the hash first
+                    Debug.Assert(fullHash != 0);
+                    entryHash = Interlocked.CompareExchange(ref entry.hash, fullHash, 0);
+                    if (entryHash == 0)
+                    {
+                        entryHash = fullHash;
+                        if (entryHash == ZEROHASH)
+                        {
+                            // "added" entry for zero key
+                            curTable.allocatedSlotCount.Increment();
+                            break;
+                        }
+                    }
+                }
+
+                if (entryHash == fullHash)
+                {
+                    // hash is good, one way or another, 
+                    // try claiming the slot for the key
+                    if (curTable.TryClaimSlotForPut(ref entry.key, key))
+                    {
+                        break;
+                    }
+                }
+
+                // here we know that this slot does not map to our key and must reprobe or resize
+                // hitting reprobe limit or finding TOMBPRIMEHASH here means that the key is not in this table, 
+                // but there could be more in the new table
+                if (entryHash == TOMBPRIMEHASH || reprobeCount >= ReprobeLimit(lenMask))
+                {
+                    // start resize or get new table if resize is already in progress
+                    var newTable1 = curTable.Resize();
+                    // help along an existing copy
+                    curTable.HelpCopy();
+                    curTable = newTable1;
+                    goto tryWithNewTable;
+                }
+
+                // quadratic reprobing
+                reprobeCount++;
+                curTable.ResizeOnReprobeCheck(reprobeCount);
+                idx = (idx + reprobeCount) & lenMask;
+                entry = ref curTable._entries[idx];
+            }
+
+            // Found the proper Key slot, now update the Value.  
+            // We never put a null, so Value slots monotonically move from null to
+            // not-null (deleted Values use Tombstone).
+
+            // volatile read to make sure we read the element before we read the _newTable
+            // that would guarantee that as long as _newTable == null, entryValue cannot be forwarded.
+            var entryValue = Volatile.Read(ref entry.value);
+
+            // See if we want to move to a new table (to avoid high average re-probe counts).  
+            // We only check on the initial set of a Value from null to
+            // not-null (i.e., once per key-insert).
+            var newTable = curTable._newTable;
+
+            // newTable == entryValue only when both are nulls
+                if ((object)newTable == (object)entryValue &&
+                curTable.TableIsCrowded())
+            {
+                // Force the new table copy to start
+                newTable = curTable.Resize();
+                Debug.Assert(curTable._newTable != null && newTable == curTable._newTable);
+            }
+
+            // See if we are moving to a new table.
+            // If so, copy our slot and retry in the new table.
+            // Seeing TOMBPRIME entry while no newTable means the slot is in a process of being deleted
+            // Let CopySlotAndGetNewTable handle that case too.
+            if (newTable != null || entryValue == TOMBPRIME)
+            {
+                var newTable1 = curTable.CopySlotAndGetNewTable(ref entry, shouldHelp: true);
+                Debug.Assert(newTable == newTable1 || (newTable == null && newTable1 == this));
+                curTable = newTable1;
+                goto tryWithNewTable;
+            }
+
+            // We are finally prepared to update the existing table
+            while (true)
+            {
+                Debug.Assert(!(entryValue is Prime));
+                var entryValueNullOrDead = EntryValueNullOrDead(entryValue);
+
+                switch (match)
+                {
+                    case ValueMatch.Any:
+                        if (ValueIsAtomicPrimitive() &&
+                            !entryValueNullOrDead &&
+                            Unsafe.As<Boxed<TValue>>(entryValue).TryVolatileWrite(newVal))
+                        {
+                            return true;
+                        }
+                        break;
+
+                    case ValueMatch.OldValue:
+                        if (entryValueNullOrDead)
+                        {
+                            goto FAILED;
+                        }
+
+                        if (ValueIsAtomicPrimitive() &&
+                            Unsafe.As<Boxed<TValue>>(entryValue).TryCompareExchange(oldVal, newVal, out var changed))
+                        {
+                            return changed;
+                        }
+
+                        if (ValueIsAtomicPrimitive())
+                        {
+                            // we could not change the value in place (this is rare), fallback to replacing the whole box.
+                            Unsafe.As<Boxed<TValue>>(entryValue).Freeze();
+                        }
+
+                        TValue unboxedEntryValue = FromObjectValue(entryValue);
+                        if (!EqualityComparer<TValue>.Default.Equals(oldVal, unboxedEntryValue))
+                        {
+                            goto FAILED;
+                        }
+                        break;
+
+                    default:
+                        Debug.Assert(match == ValueMatch.NullOrDead);
+                        if (!entryValueNullOrDead)
+                        {
+                            // this is the only case where caller expects to see oldVal
+                            // NB: No need to freeze here. This is keyed on mere presence of the value. 
+                            oldVal = FromObjectValue(entryValue);
+                            goto FAILED;
+                        }
+                        break;
+                }
+
+                // Actually change the Value
+                object newValObj = ToObjectValue(newVal);
+                var prev = Interlocked.CompareExchange(ref entry.value, newValObj, entryValue);
+                if (prev == entryValue)
+                {
+                    // CAS succeeded - we did the update!
+                    // Adjust sizes
+                    if (entryValueNullOrDead)
+                    {
+                        curTable._size.Increment();
+                    }
+
+                    return true;
+                }
+                // Else CAS failed
+
+                // If a Prime'd value got installed, we need to re-run the put on the new table. 
+                Debug.Assert(prev != null);
+                if (prev.GetType() == typeof(Prime))
+                {
+                    curTable = curTable.CopySlotAndGetNewTable(ref entry, shouldHelp: true);
+                    goto tryWithNewTable;
+                }
+
+                // Otherwise we lost the CAS to another racing put.
+                // Simply retry from the start.
+                entryValue = prev;
+            }
+
+        FAILED:
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool ValueIsAtomicPrimitive()
+        {
+            return default(TValue) != null && valueIsAtomic;
+        }
+
+        internal sealed override TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory)
+        {
+            if (valueFactory == null)
+            {
+                throw new ArgumentNullException("valueFactory");
+            }
+
+            object newValObj = null;
+            TValue result = default(TValue);
+
+            var curTable = this;
+            int fullHash = curTable.hash(key);
+
+        TRY_WITH_NEW_TABLE:
+
+            var lenMask = curTable._entries.Length - 1;
+            int idx = ReduceHashToIndex(fullHash, lenMask);
+            ref Entry entry = ref curTable._entries[idx];
+
+            // Spin till we get a slot for the key or force a resizing.
+            int reprobeCount = 0;
+            while (true)
+            {
+                // hash and key are CAS-ed down and follow a specific sequence of states.
+                // hence the order of their reads is irrelevant and they do not need to be volatile    
+                var entryHash = entry.hash;
+                if (entryHash == 0)
+                {
+                    // Found an unassigned slot - which means this 
+                    // key has never been in this table.
+                    // Slot is completely clean, claim the hash first
+                    Debug.Assert(fullHash != 0);
+                    entryHash = Interlocked.CompareExchange(ref entry.hash, fullHash, 0);
+                    if (entryHash == 0)
+                    {
+                        entryHash = fullHash;
+                        if (entryHash == ZEROHASH)
+                        {
+                            // "added" entry for zero key
+                            curTable.allocatedSlotCount.Increment();
+                            break;
+                        }
+                    }
+                }
+
+                if (entryHash == fullHash)
+                {
+                    // hash is good, one way or another, 
+                    // try claiming the slot for the key
+                    if (curTable.TryClaimSlotForPut(ref entry.key, key))
+                    {
+                        break;
+                    }
+                }
+
+                // here we know that this slot does not map to our key
+                // and must reprobe or resize
+                // hitting reprobe limit or finding TOMBPRIMEHASH here means that the key is not in this table, 
+                // but there could be more in the new table
+                if (entryHash == TOMBPRIMEHASH || reprobeCount >= ReprobeLimit(lenMask))
+                {
+                    // start resize or get new table if resize is already in progress
+                    var newTable1 = curTable.Resize();
+                    // help along an existing copy
+                    curTable.HelpCopy();
+                    curTable = newTable1;
+                    goto TRY_WITH_NEW_TABLE;
+                }
+
+                // quadratic reprobing
+                reprobeCount++;
+                curTable.ResizeOnReprobeCheck(reprobeCount);
+                idx = (idx + reprobeCount) & lenMask;
+                entry = ref curTable._entries[idx];
+            }
+
+            // Found the proper Key slot, now update the Value.  
+            // We never put a null, so Value slots monotonically move from null to
+            // not-null (deleted Values use Tombstone).
+
+            // volatile read to make sure we read the element before we read the _newTable
+            // that would guarantee that as long as _newTable == null, entryValue cannot be forwarded.
+            var entryValue = Volatile.Read(ref entry.value);
+
+            // See if we want to move to a new table (to avoid high average re-probe counts).  
+            // We only check on the initial set of a Value from null to
+            // not-null (i.e., once per key-insert).
+            var newTable = curTable._newTable;
+
+            // newTable == entryValue only when both are nulls
+            if ((object)newTable == (object)entryValue &&
+                curTable.TableIsCrowded())
+            {
+                // Force the new table copy to start
+                newTable = curTable.Resize();
+                Debug.Assert(curTable._newTable != null && curTable._newTable == newTable);
+            }
+
+            // See if we are moving to a new table.
+            // If so, copy our slot and retry in the new table.
+            // Seeing TOMBPRIME entry while no newTable means the slot is in a process of being deleted
+            // Let CopySlotAndGetNewTable handle that case too.
+            if (newTable != null || entryValue == TOMBPRIME)
+            {
+                var newTable1 = curTable.CopySlotAndGetNewTable(ref entry, shouldHelp: true);
+                Debug.Assert(newTable == newTable1);
+                curTable = newTable;
+                goto TRY_WITH_NEW_TABLE;
+            }
+
+            if (!EntryValueNullOrDead(entryValue))
+            {
+                goto GOT_PREV_VALUE;
+            }
+
+            // prev value is null or dead.
+            // let's try install new value
+            newValObj = newValObj ?? ToObjectValue(result = valueFactory(key));
+            while (true)
+            {
+                Debug.Assert(!(entryValue is Prime));
+
+                // Actually change the Value 
+                var prev = Interlocked.CompareExchange(ref entry.value, newValObj, entryValue);
+                if (prev == entryValue)
+                {
+                    // CAS succeeded - we did the update!
+                    // Adjust sizes
+                    curTable._size.Increment();
+                    goto DONE;
+                }
+                // Else CAS failed
+
+                // If a Prime'd value got installed, we need to re-run on the new table.
+                Debug.Assert(prev != null);
+                if (prev.GetType() == typeof(Prime))
+                {
+                    curTable = curTable.CopySlotAndGetNewTable(ref entry, shouldHelp: true);
+                    goto TRY_WITH_NEW_TABLE;
+                }
+
+                // Otherwise we lost the CAS to another racing put.
+                entryValue = prev;
+                if (entryValue != TOMBSTONE)
+                {
+                    goto GOT_PREV_VALUE;
+                }
+            }
+
+        GOT_PREV_VALUE:
+            result = FromObjectValue(entryValue);
+
+        DONE:
+            return result;
+        }
+
+        private bool PutSlotCopy(TKeyStore key, object value, int fullHash)
+        {
+            Debug.Assert(key != null);
+            Debug.Assert(value != TOMBSTONE);
+            Debug.Assert(value != null);
+            Debug.Assert(!(value is Prime));
+
+            var curTable = this;
+
+        TRY_WITH_NEW_TABLE:
+
+            var lenMask = curTable._entries.Length - 1;
+            int idx = ReduceHashToIndex(fullHash, lenMask);
+            ref Entry entry = ref curTable._entries[idx];
+
+            // Spin till we get a slot for the key or force a resizing.
+            int reprobeCount = 0;
+            while (true)
+            {
+                var entryHash = entry.hash;
+                if (entryHash == 0)
+                {
+                    // Slot is completely clean, claim the hash
+                    Debug.Assert(fullHash != 0);
+                    entryHash = Interlocked.CompareExchange(ref entry.hash, fullHash, 0);
+                    if (entryHash == 0)
+                    {
+                        entryHash = fullHash;
+                        if (entryHash == ZEROHASH)
+                        {
+                            // "added" entry for zero key
+                            curTable.allocatedSlotCount.Increment();
+                            break;
+                        }
+                    }
+                }
+
+                if (entryHash == fullHash)
+                {
+                    // hash is good, one way or another, claim the key
+                    if (curTable.TryClaimSlotForCopy(ref entry.key, key))
+                    {
+                        break;
+                    }
+                }
+
+                // this slot contains a different key
+
+                // here we know that this slot does not map to our key
+                // and must reprobe or resize
+                // hitting reprobe limit or finding TOMBPRIMEHASH here means that 
+                // we will not find an appropriate slot in this table
+                // but there could be more in the new one
+                if (entryHash == TOMBPRIMEHASH || reprobeCount >= ReprobeLimit(lenMask))
+                {
+                    var resized = curTable.Resize();
+                    curTable = resized;
+                    goto TRY_WITH_NEW_TABLE;
+                }
+
+                // quadratic reprobing
+                reprobeCount++;
+                // no resize check on reprobe needed. 
+                // we always insert a new value (or somebody else inserts)
+                idx = (idx + reprobeCount) & lenMask;
+                entry = ref curTable._entries[idx];
+            }
+
+            // Found the proper Key slot, now update the Value. 
+
+            // volatile read to make sure we read the element before we read the _newTable
+            // that would guarantee that as long as _newTable == null, entryValue cannot be forwarded.
+            var entryValue = Volatile.Read(ref entry.value);
+
+            // See if we want to move to a new table (to avoid high average re-probe counts).  
+            // We only check on the initial set of a Value from null to
+            // not-null (i.e., once per key-insert).
+            var newTable = curTable._newTable;
+
+            // newTable == entryValue only when both are nulls
+            if ((object)newTable == (object)entryValue &&
+                curTable.TableIsCrowded())
+            {
+                // Force the new table copy to start
+                newTable = curTable.Resize();
+                Debug.Assert(curTable._newTable != null && curTable._newTable == newTable);
+            }
+
+            // See if we are moving to a new table.
+            // If so, copy our slot and retry in the new table.
+            // Seeing TOMBPRIME entry while no newTable means the slot is in a process of being deleted
+            // Let CopySlotAndGetNewTable handle that case too.
+            if (newTable != null || entryValue == TOMBPRIME)
+            {
+                var newTable1 = curTable.CopySlotAndGetNewTable(ref entry, shouldHelp: false);
+                Debug.Assert(newTable == newTable1);
+                curTable = newTable;
+                goto TRY_WITH_NEW_TABLE;
+            }
+
+            // We are finally prepared to update the existing table
+            // if entry value is null and our CAS succeeds - we did the update!
+            // otherwise someone else copied the value.
+            // table-copy does not (effectively) increase the number of live k/v pairs
+            // so no need to update size
+            return entry.value == null &&
+                   Interlocked.CompareExchange(ref entry.value, value, null) == null;
+        }
+
+        // check once in a while if a table might benefit from resizing.
+        // one reason for this is that crowdedness check uses estimated counts 
+        // so we do not always catch this on key inserts.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ResizeOnReprobeCheck(int reprobeCount)
+        {
+            // must be ^2 - 1
+            const int reprobeCheckPeriod = 16 - 1;
+
+            // once per reprobeCheckPeriod, check if the table is crowded
+            // and initiale a resize
+            if ((reprobeCount & reprobeCheckPeriod) == 0)
+            {
+                ReprobeResizeCheckSlow();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void ReprobeResizeCheckSlow()
+        {
+            if (this.TableIsCrowded())
+            {
+                this.Resize();
+                this.HelpCopy();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal TValue FromObjectValue(object obj)
+        {
+            // regular value type
+            if (default(TValue) != null)
+            {
+                return Unsafe.As<Boxed<TValue>>(obj).Value;
+            }
+
+            // null
+            if (obj == NULLVALUE)
+            {
+                return default(TValue);
+            }
+
+            // ref type
+            if (!valueIsValueType)
+            {
+                return Unsafe.As<object, TValue>(ref obj);
+            }
+
+            // nullable
+            return (TValue)obj;
+        }
+
+        ///////////////////////////////////////////////////////////
+        // Resize support
+        ///////////////////////////////////////////////////////////
+
+        internal int Size
+        {
+            get
+            {
+                // counter does not lose counts, but reports of increments/decrements can be delayed
+                // it might be confusing if we ever report negative size.
+                var size = _size.Value;
+                var negMask = ~(size >> 31);
+                return size & negMask;
+            }
+        }
+
+        internal int EstimatedSlotsUsed
+        {
+            get
+            {
+                return (int)allocatedSlotCount.EstimatedValue;
+            }
+        }
+
+        internal bool TableIsCrowded()
+        {
+            // 80% utilization, switch to a bigger table
+            return EstimatedSlotsUsed > (_entries.Length >> 2) * 3;
+        }
+
+
+        // Help along an existing resize operation.  This is just a fast cut-out
+        // wrapper, to encourage inlining for the fast no-copy-in-progress case.
+        private void HelpCopyIfNeeded()
+        {
+            if (this._newTable != null)
+            {
+                this.HelpCopy(copy_all: false);
+            }
+        }
+
+        // Help along an existing resize operation.
+        internal void HelpCopy(bool copy_all = false)
+        {
+            var newTable = this._newTable;
+            var oldEntries = this._entries;
+            int toCopy = oldEntries.Length;
+
+#if DEBUG
+            const int CHUNK_SIZE = 16;
+#else
+            const int CHUNK_SIZE = 1024;
+#endif
+            int MIN_COPY_WORK = Math.Min(toCopy, CHUNK_SIZE); // Limit per-thread work
+
+            bool panic = false;
+            int claimedChunk = -1;
+
+            while (this._copyDone < toCopy)
+            {
+                // Still needing to copy?
+                // Carve out a chunk of work.
+                if (!panic)
+                {
+                    claimedChunk = this._claimedChunk;
+
+                    while (true)
+                    {
+                        // panic check
+                        // We "panic" if we have tried TWICE to copy every slot - and it still
+                        // has not happened.  i.e., twice some thread somewhere claimed they
+                        // would copy 'slot X' (by bumping _copyIdx) but they never claimed to
+                        // have finished (by bumping _copyDone).  Our choices become limited:
+                        // we can wait for the work-claimers to finish (and become a blocking
+                        // algorithm) or do the copy work ourselves.  Tiny tables with huge
+                        // thread counts trying to copy the table often 'panic'. 
+                        if (claimedChunk > (toCopy / (CHUNK_SIZE / 2)))
+                        {
+                            panic = true;
+                            //System.Console.WriteLine("panic");
+                            break;
+                        }
+
+                        var alreadyClaimed = Interlocked.CompareExchange(ref this._claimedChunk, claimedChunk + 1, claimedChunk);
+                        if (alreadyClaimed == claimedChunk)
+                        {
+                            break;
+                        }
+
+                        claimedChunk = alreadyClaimed;
+                    }
+                }
+                else
+                {
+                    // we went through the whole table in panic mode
+                    // there cannot be possibly anything left to copy.
+                    if (claimedChunk > ((toCopy / (CHUNK_SIZE / 2)) + toCopy / CHUNK_SIZE))
+                    {
+                        _copyDone = toCopy;
+                        PromoteNewTable();
+                        return;
+                    }
+
+                    claimedChunk++;
+                }
+
+                // We now know what to copy.  Try to copy.
+                int workdone = 0;
+                int copyStart = claimedChunk * CHUNK_SIZE;
+                for (int i = 0; i < MIN_COPY_WORK; i++)
+                {
+                    if (this._copyDone >= toCopy)
+                    {
+                        PromoteNewTable();
+                        return;
+                    }
+
+                    if (CopySlot(ref oldEntries[(copyStart + i) & (toCopy - 1)], newTable))
+                    {
+                        workdone++;
+                    }
+                }
+
+                if (workdone > 0)
+                {
+                    // See if we can promote
+                    var copyDone = Interlocked.Add(ref this._copyDone, workdone);
+
+                    // Check for copy being ALL done, and promote.  
+                    if (copyDone >= toCopy)
+                    {
+                        PromoteNewTable();
+                    }
+                }
+
+                if (!(copy_all | panic))
+                {
+                    return;
+                }
+            }
+
+            // Extra promotion check, in case another thread finished all copying
+            // then got stalled before promoting.
+            PromoteNewTable();
+        }
+
+        private void PromoteNewTable()
+        {
+            // Looking at the top-level table?
+            // Note that we might have
+            // nested in-progress copies and manage to finish a nested copy before
+            // finishing the top-level copy.  We only promote top-level copies.
+            if (_topDict._table == this)
+            {
+                // Attempt to promote
+                if (Interlocked.CompareExchange(ref _topDict._table, this._newTable, this) == this)
+                {
+                    // System.Console.WriteLine("size: " + _newTable.Length);
+                    _topDict._lastResizeTickMillis = CurrentTickMillis();
+                }
+            }
+        }
+
+        // Copy slot 'idx' from the old table to the new table.  If this thread
+        // confirmed the copy, update the counters and check for promotion.
+        //
+        // Returns the result of reading the new table, mostly as a
+        // convenience to callers.  We come here with 1-shot copy requests
+        // typically because the caller has found a Prime, and has not yet read
+        // the new table - which must have changed from null-to-not-null
+        // before any Prime appears.  So the caller needs to read the new table
+        // field to retry his operation in the new table, but probably has not
+        // read it yet.
+        internal DictionaryImpl<TKey, TKeyStore, TValue> CopySlotAndGetNewTable(ref Entry entry, bool shouldHelp)
+        {
+            // However this could be just an entry partially swept.
+            // In such case treat the value as being copied (into oblivion) and return the same table back to retry.
+            var newTable = this._newTable;
+
+            // We're here because the caller saw a Prime or new table, which implies copying or sweeping is in progress.
+            Debug.Assert(entry.value is Prime || newTable != null);
+
+            if (newTable == null)
+            {
+                Debug.Assert(!typeof(TKeyStore).GetTypeInfo().IsValueType);
+                // help with sweeping in case the sweeper thread is stuck. We do not want to come here again.
+                // we write unconditionally though, since this is a relatively rare case.
+                entry.hash = SPECIAL_HASH_BITS;
+                entry.key = default(TKeyStore);
+
+                return this;
+            }
+
+            if (CopySlot(ref entry, newTable))
+            {
+                // Record the slot copied
+                var copyDone = Interlocked.Increment(ref this._copyDone);
+
+                // Check for copy being ALL done, and promote.  
+                if (copyDone >= this._entries.Length)
+                {
+                    PromoteNewTable();
+                    return newTable;
+                }
+            }
+
+            // Generically help along any copy (except if called recursively from a helper)
+            if (shouldHelp)
+            {
+                this.HelpCopy();
+            }
+
+            return newTable;
+        }
+
+        // Copy one K/V pair from old table to new table. 
+        // Returns true if we actually did the copy.
+        // Regardless, once this returns, the copy is available in the new table and 
+        // slot in the old table is no longer usable.
+        private static bool CopySlot(ref Entry oldEntry, DictionaryImpl<TKey, TKeyStore, TValue> newTable)
+        {
+            Debug.Assert(newTable != null);
+
+            // Blindly set the hash from 0 to TOMBPRIMEHASH, to eagerly stop
+            // fresh put's from claiming new slots in the old table when the old
+            // table is mid-resize.
+            var hash = oldEntry.hash;
+            if (hash == 0)
+            {
+                hash = Interlocked.CompareExchange(ref oldEntry.hash, TOMBPRIMEHASH, 0);
+                if (hash == 0)
+                {
+                    // slot was not claimed, copy is done here
+                    return true;
+                }
+            }
+
+            if (hash == TOMBPRIMEHASH)
+            {
+                // slot was trivially copied, but not by us
+                return false;
+            }
+
+            // Prevent new values from appearing in the old table.
+            // Put a forwarding entry, to prevent further updates.
+            // NOTE: Read of the value below must happen before reading of the key, 
+            // however this read does not need to be volatile since we will have 
+            // some fences in between reads.
+            object oldval = oldEntry.value;
+
+            // already boxed?
+            Prime box = oldval as Prime;
+            if (box != null)
+            {
+                // volatile read here since we need to make sure 
+                // that the key read below happens after we have read oldval above
+                // (this read is a dependednt read after oldval, and reading the key is after)
+                Volatile.Read(ref box.originalValue);
+            }
+            else
+            {
+                do
+                {
+                    box = EntryValueNullOrDead(oldval) ?
+                        TOMBPRIME :
+                        new Prime(oldval);
+
+                    // CAS down a box'd version of oldval
+                    // also works as a complete fence between reading the value and the key
+                    object prev = Interlocked.CompareExchange(ref oldEntry.value, box, oldval);
+
+                    if (prev == oldval)
+                    {
+                        // If we made the Value slot hold a TOMBPRIME, then we both
+                        // prevented further updates here but also the (absent)
+                        // oldval is vacuously available in the new table.  We
+                        // return with true here: any thread looking for a value for
+                        // this key can correctly go straight to the new table and
+                        // skip looking in the old table.
+                        if (box == TOMBPRIME)
+                        {
+                            return true;
+                        }
+
+                        // Break loop; oldval is now boxed by us
+                        // it still needs to be copied into the new table.
+                        break;
+                    }
+
+                    oldval = prev;
+                    box = oldval as Prime;
+                }
+                while (box == null);
+            }
+
+            if (box == TOMBPRIME)
+            {
+                // Copy already complete here, but not by us.
+                return false;
+            }
+
+            // Copy the value into the new table, but only if we overwrite a null.
+            // If another value is already in the new table, then somebody else
+            // wrote something there and that write is happens-after any value that
+            // appears in the old table.  If putIfMatch does not find a null in the
+            // new table - somebody else should have recorded the null-not_null
+            // transition in this copy.
+            object originalValue = box.originalValue;
+            Debug.Assert(originalValue != TOMBSTONE);
+
+            // since we have a real value, there must be a nontrivial key in the table.
+            // regular read is ok because value is always CASed down after the key
+            // and we ensured that we read the key after the value with fences above
+            var key = oldEntry.key;
+            bool copiedIntoNew = newTable.PutSlotCopy(key, originalValue, hash);
+
+            // Finally, now that any old value is exposed in the new table, we can
+            // forever hide the old-table value by gently inserting TOMBPRIME value.  
+            // This will stop other threads from uselessly attempting to copy this slot
+            // (i.e., it's a speed optimization not a correctness issue).
+            if (oldEntry.value != TOMBPRIME)
+            {
+                oldEntry.value = TOMBPRIME;
+            }
+
+            // if we failed to copy, it means something has already appeared in
+            // the new table and old value should have been copied before that (not by us).
+            return copiedIntoNew;
+        }
+
+        // kick off resizing, if not started already, and return the new table.
+        private DictionaryImpl<TKey, TKeyStore, TValue> Resize()
+        {
+            // Check for resize already in progress, probably triggered by another thread.
+            // reads of this._newTable in Resize are not volatile
+            // we are just opportunistically checking if a new table has arrived.
+            return this._newTable ?? ResizeImpl();
+        }
+
+        // Resizing after too many probes.  "How Big???" heuristics are here.
+        // Callers will (not this routine) help any in-progress copy.
+        // Since this routine has a fast cutout for copy-already-started, callers
+        // MUST 'help_copy' lest we have a path which forever runs through
+        // 'resize' only to discover a copy-in-progress which never progresses.
+        private DictionaryImpl<TKey, TKeyStore, TValue> ResizeImpl()
+        {
+            // No copy in-progress, so start one.  
+            // First up: compute new table size.
+            int oldlen = this._entries.Length;
+
+            const int MAX_SIZE = 1 << 30;
+            const int MAX_CHURN_SIZE = 1 << 15;
+
+            // First size estimate is roughly inverse of ProbeLimit
+            int sz = Size + (MIN_SIZE >> REPROBE_LIMIT_SHIFT);
+            int newsz = sz < (MAX_SIZE >> REPROBE_LIMIT_SHIFT) ?
+                                            sz << REPROBE_LIMIT_SHIFT :
+                                            sz;
+
+            // if new table would shrink or hold steady, 
+            // we must be resizing because of churn.
+            // target churn based resize rate to be about 1 per RESIZE_TICKS_TARGET
+            if (newsz <= oldlen)
+            {
+                var resizeSpan = CurrentTickMillis() - _topDict._lastResizeTickMillis;
+
+                // note that CurrentTicks() will wrap around every 50 days.
+                // For our purposes that is tolerable since it just 
+                // adds a possibility that in some rare cases a churning resize will not be 
+                // considered a churning one.
+                if (resizeSpan < RESIZE_MILLIS_TARGET)
+                {
+                    // last resize too recent, expand
+                    newsz = oldlen < MAX_CHURN_SIZE ? oldlen << 1 : oldlen;
+                }
+                else
+                {
+                    // do not allow shrink too fast
+                    newsz = Math.Max(newsz, (int)((long)oldlen * RESIZE_MILLIS_TARGET / resizeSpan));
+                }
+            }
+
+            // Align up to a power of 2
+            newsz = Util.AlignToPowerOfTwo(newsz);
+
+            // Size calculation: 2 words (K+V) per table entry, plus a handful.  We
+            // guess at 32-bit pointers; 64-bit pointers screws up the size calc by
+            // 2x but does not screw up the heuristic very much.
+            int kBs4 = (((newsz << 1) + 4) << 3/*word to bytes*/) >> 12/*kBs4*/;
+
+            var newTable = this._newTable;
+
+            // Now, if allocation is big enough,
+            // limit the number of threads actually allocating memory to a
+            // handful - lest we have 750 threads all trying to allocate a giant
+            // resized array.
+            // conveniently, Increment is also a full fence
+            if (kBs4 > 0 && Interlocked.Increment(ref _resizers) >= 2)
+            {
+                // Already 2 guys trying; wait and see
+                // See if resize is already in progress
+                if (newTable != null)
+                {
+                    return newTable;         // Use the new table already
+                }
+
+                SpinWait.SpinUntil(() => this._newTable != null, 8 * kBs4);
+            }
+
+            // Last check, since the 'new' below is expensive and there is a chance
+            // that another thread slipped in a new table while we ran the heuristic.
+            newTable = this._newTable;
+            // See if resize is already in progress
+            if (newTable != null)
+            {
+                return newTable;          // Use the new table already
+            }
+
+            newTable = this.CreateNew(newsz);
+
+            // The new table must be CAS'd in to ensure only 1 winner
+            var prev = this._newTable ??
+                        Interlocked.CompareExchange(ref this._newTable, newTable, null);
+
+            if (prev != null)
+            {
+                return prev;
+            }
+            else
+            {
+                //Console.WriteLine("resized: " + newsz);
+                return newTable;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void SweepCheck()
+        {
+            if (_topDict._sweepRequests == 0)
+            {
+                _topDict._sweepRequests = 1;
+                Sweeper.TryRearm(this);
+            }
+        }
+
+        private class Sweeper
+        {
+            private DictionaryImpl<TKey, TKeyStore, TValue> _dict;
+
+            public static void TryRearm(DictionaryImpl<TKey, TKeyStore, TValue> dict)
+            {
+                ref var sweeperLocation = ref dict._topDict._sweeperInstance;
+                var sweeperInst = sweeperLocation as Sweeper;
+                if (sweeperInst != null && Interlocked.CompareExchange(ref sweeperLocation, null, sweeperInst) == sweeperInst)
+                {
+                    sweeperInst._dict = dict;
+                    GC.ReRegisterForFinalize(sweeperInst);
+                }
+            }
+
+            ~Sweeper()
+            {
+                Task.Run(() => Sweep());
+            }
+
+            private void Sweep()
+            {
+                var dict = _dict;
+                this._dict = null;
+
+                if (dict == null)
+                {
+                    // this could happen when table is destroyed
+                    return;
+                }
+
+                // any key removed after we start sweeping may not be swept
+                // signal to future removers that they need another request.
+                // note that remove is a CAS, so remover will see this value 
+                // after removing.
+                Interlocked.Exchange(ref dict._topDict._sweepRequests, 0);
+
+                var entries = dict._entries;
+                for (int i = 0; i < entries.Length; i++)
+                {
+                    // if resizing, just help to resize instead
+                    if (dict._newTable != null)
+                    {
+                        do
+                        {
+                            dict.HelpCopy(copy_all: true);
+                            dict = dict._newTable;
+                        } while (dict._newTable != null);
+                        break;
+                    }
+
+                    ref var e = ref entries[i];
+                    if (e.value == TOMBSTONE)
+                    {
+                        if (Interlocked.CompareExchange(ref e.value, TOMBPRIME, TOMBSTONE) == TOMBSTONE)
+                        {
+                            e.hash = SPECIAL_HASH_BITS;
+                            e.key = default(TKeyStore);
+                            Interlocked.Increment(ref dict._copyDone);
+                        }
+                    }
+
+                }
+
+                // got new requests while sweeping. revisit after next GC.
+                dict._topDict._sweeperInstance = this;
+                if (dict._topDict._sweepRequests != 0)
+                {
+                    TryRearm(dict);
+                }
+            }
+        }
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/Util.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/Lru/NonBlocking/Util.cs
@@ -1,0 +1,21 @@
+﻿using System.Diagnostics;
+
+namespace NonBlocking
+{
+    internal static class Util
+    {
+        // returns 2^x >= size
+        internal static int AlignToPowerOfTwo(int size)
+        {
+            Debug.Assert(size > 0);
+
+            size--;
+            size |= size >> 1;
+            size |= size >> 2;
+            size |= size >> 4;
+            size |= size >> 8;
+            size |= size >> 16;
+            return size + 1;
+        }
+    }
+}

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/LruConcurrentPerformanceTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/LruConcurrentPerformanceTest.cs
@@ -1,0 +1,242 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using BitFaster.Caching.Lru;
+using NonBlocking;
+using NUnit.Framework;
+using Xtensive.Caching;
+using Xtensive.Caching.Lru;
+
+namespace Xtensive.Orm.Tests.Core.Caching
+{
+  [TestFixture]
+  [Explicit]
+  public class LruConcurrentPerformanceTest
+  {
+    private static int[] samples;
+    private static object[] items;
+
+    private static int itemsNumber = 1_000_000;
+    private static int samplesNumber = 2_000_000;
+
+    [Test]
+    public void RunTests()
+    {
+      Initialize();
+
+      // big lru, high hit rate (expected load)
+      var lruSize = 20_000;
+      Console.WriteLine($@"lruSize {lruSize} itemsNumber {itemsNumber} high hit rate by Zipf law");
+      GetOrAddBenchLruFastSystemConcurrentDictionary(lruSize);
+      GetOrAddBenchLruFastNonBlockingDictionary(lruSize);
+      GetOrAddBenchDataObjectsLRU_Pair(lruSize);
+
+      // small lru, high hit rate
+      lruSize = 256;
+      Console.WriteLine($@"lruSize {lruSize} itemsNumber {itemsNumber} high hit rate by Zipf");
+      GetOrAddBenchLruFastSystemConcurrentDictionary(lruSize);
+      GetOrAddBenchLruFastNonBlockingDictionary(lruSize);
+      GetOrAddBenchDataObjectsLRU_Pair(lruSize);
+
+      // small lru, low hit rate (current load)
+      lruSize = 256;
+
+      var random = new Random();
+      for (var i = 0; i < samples.Length; i++) {
+        samples[i] = random.Next(0, itemsNumber);
+      }
+
+      Console.WriteLine($@"lruSize {lruSize} itemsNumber {itemsNumber} low hit rate - random");
+      GetOrAddBenchLruFastSystemConcurrentDictionary(lruSize);
+      GetOrAddBenchLruFastNonBlockingDictionary(lruSize);
+      GetOrAddBenchDataObjectsLRU_Pair(lruSize);
+    }
+
+    public static double GeneralHarmonic(int n, double m)
+    {
+      var num = 0.0;
+      for (var index = 0; index < n; ++index) {
+        num += Math.Pow(index + 1, -m);
+      }
+
+      return num;
+    }
+
+    private static void Initialize()
+    {
+      samples = new int[samplesNumber];
+      items = new object[itemsNumber];
+      for (var i = 0; i < items.Length; i++) {
+        items[i] = new object();
+      }
+
+      var random = new Random();
+      var num4 = 1.0 / GeneralHarmonic(itemsNumber, 1);
+      Parallel.For(0, samplesNumber, i => {
+        int val;
+        do {
+          val = GetZipfSample(random, itemsNumber, num4);
+        } while (val < 0 || val > itemsNumber);
+
+        samples[i] = val;
+      });
+    }
+    
+    private static int GetZipfSample(Random rnd, int n, double num2)
+    {
+      var num1 = 0.0;
+      while (num1 == 0.0) {
+        num1 = rnd.NextDouble();
+      }
+
+      // double num2 = 1.0 / SpecialFunctions.GeneralHarmonic(n, s);
+      var num3 = 0.0;
+      int num4;
+      for (num4 = 1; num4 <= n; ++num4)
+      {
+        num3 += num2 / (num4);
+        if (num3 >= num1) {
+          break;
+        }
+      }
+      return num4;
+    }
+
+    private static void GetOrAddBenchLruFastSystemConcurrentDictionary(int lruSize)
+    {
+      var dict = new FastConcurrentLru<object, object>(lruSize,
+        (c, p, e) => new SystemConcurrentDictionary<object, LruItem<object, object>>(c, p, e));
+
+      var benchmarkName = "======== GetOrAdd FastConcurrentLru ConcurrentDictionary object->object 1M Ops/sec:";
+
+      void Act(int i, int threadNumber)
+      {
+        var dummy = dict.GetOrAdd(GetItem(i, threadNumber), j => j);
+      }
+
+      WarmUpLru(dict);
+
+      RunBench(benchmarkName, Act);
+    }
+
+    private static void WarmUpLru(FastConcurrentLru<object, object> dict)
+    {
+      for (int i = 0; i < samplesNumber; i++) {
+        dict.GetOrAdd(GetItem(i, 0), j => j);
+      }
+    }
+
+    private static void GetOrAddBenchLruFastNonBlockingDictionary(int lruSize)
+    {
+      var dict = new FastConcurrentLru<object, object>(lruSize,
+        (c, p, e) => new NonBlockingConcurrentDictionary<object, LruItem<object, object>>(c, p, e));
+
+      var benchmarkName = "======== GetOrAdd FastConcurrentLru NonBlockingDictionary object->object 1M Ops/sec:";
+
+      void Act(int i, int threadNumber)
+      {
+        var dummy = dict.GetOrAdd(GetItem(i, threadNumber), j => j);
+      }
+
+      WarmUpLru(dict);
+
+      RunBench(benchmarkName, Act);
+    }
+
+    private static void GetOrAddBenchDataObjectsLRU_Pair(int lruSize)
+    {
+      var dict = new LruCache<object, (object key, object value)>(lruSize, i => i.key);
+
+      var benchmarkName = "======== GetOrAdd DataObjectsLRU Pair object->object 1M Ops/sec:";
+
+      void Act(int i, int threadNumber)
+      {
+        object val;
+        var item = GetItem(i, threadNumber);
+        lock (dict) {
+          val = dict.TryGetItem(item, true, out var result) ? result.value : null;
+        }
+
+        if (val == null) {
+          lock (dict) {
+            dict.Add((item, item), false);
+          }
+        }
+      }
+
+      for (var i = 0; i < itemsNumber; i++) {
+        dict.Add((items[i], items[i]), false);
+      }
+
+      RunBench(benchmarkName, Act);
+    }
+
+    private static long RunBenchmark(Action<int, int> action, int threads, int time)
+    {
+      var cnt = new Counter64();
+      var workers = new Task[threads];
+      var sw = Stopwatch.StartNew();
+      var e = new ManualResetEventSlim();
+      long stopTime = 0;
+
+      Func<int, Action> createBody = worker => () => {
+        var iteration = 0;
+        e.Wait();
+        while (sw.ElapsedMilliseconds < stopTime) {
+          const int batch = 10000;
+          for (int i = 0; i < batch; i++) {
+            action(iteration++, worker);
+          }
+
+          cnt.Add(batch);
+        }
+      };
+
+      for (int i = 0; i < workers.Length; i++) {
+        var threanDumber = i;
+        workers[i] = Task.Factory.StartNew(createBody(threanDumber), TaskCreationOptions.LongRunning);
+      }
+
+      stopTime = sw.ElapsedMilliseconds + time;
+      e.Set();
+
+      Task.WaitAll(workers);
+      return cnt.Value;
+    }
+
+    private static void RunBench(string benchmarkName, Action<int, int> action)
+    {
+      Console.WriteLine(benchmarkName);
+      var maxThreads = Environment.ProcessorCount;
+      for (int i = 1; i <= maxThreads; i++) {
+        var mOps = RunBenchmark(action, i, 2000) / 2000000.0;
+        if (mOps > 1000) {
+          Console.Write(@"{0:f0} ", mOps);
+        }
+        else if (mOps > 100) {
+          Console.Write(@"{0:f1} ", mOps);
+        }
+        else if (mOps > 10) {
+          Console.Write(@"{0:f2} ", mOps);
+        }
+        else if (mOps > 1) {
+          Console.Write(@"{0:f3} ", mOps);
+        }
+        else {
+          Console.Write(@"{0:f4} ", mOps);
+        }
+      }
+
+      Console.WriteLine();
+      GC.Collect();
+      GC.Collect();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static object GetItem(int i, int threadNumber) =>
+      items[samples[(i + 1) * threadNumber % samplesNumber]];
+  }
+
+}

--- a/Orm/Xtensive.Orm.Tests.Framework/TestInfo.cs
+++ b/Orm/Xtensive.Orm.Tests.Framework/TestInfo.cs
@@ -69,7 +69,7 @@ namespace Xtensive.Orm.Tests
       StackFrame[] stackFrames = new StackTrace().GetFrames();
       foreach (StackFrame frame in stackFrames) {
         MethodBase method = frame.GetMethod();
-        // Ïî÷åìó ñðàçó íå âçÿòü íóæíûå àòðèáóòû, íàïðèìåð, CategoryAttribute?
+        // Why not immediately take the necessary attributes, CategoryAttribute for example?
         Attribute[] methodAttributes = Attribute.GetCustomAttributes(method, typeof (TestAttribute), false);
         if (methodAttributes==null || methodAttributes.Length==0)
           continue;

--- a/Orm/Xtensive.Orm.Tests.Framework/TestInfo.cs
+++ b/Orm/Xtensive.Orm.Tests.Framework/TestInfo.cs
@@ -69,7 +69,7 @@ namespace Xtensive.Orm.Tests
       StackFrame[] stackFrames = new StackTrace().GetFrames();
       foreach (StackFrame frame in stackFrames) {
         MethodBase method = frame.GetMethod();
-        // Почему сразу не взять нужные атрибуты, например, CategoryAttribute?
+        // ГЏГ®Г·ГҐГ¬Гі Г±Г°Г Г§Гі Г­ГҐ ГўГ§ГїГІГј Г­ГіГ¦Г­Г»ГҐ Г ГІГ°ГЁГЎГіГІГ», Г­Г ГЇГ°ГЁГ¬ГҐГ°, CategoryAttribute?
         Attribute[] methodAttributes = Attribute.GetCustomAttributes(method, typeof (TestAttribute), false);
         if (methodAttributes==null || methodAttributes.Length==0)
           continue;


### PR DESCRIPTION
I checked the performance of LRU caches. What has been tested: 
* Original LRU cache from DataObjects
* FastLru cache from https://github.com/bitfaster/BitFaster.Caching with ConcurrentDictionary
* FastLru cache from https://github.com/bitfaster/BitFaster.Caching with https://github.com/VSadov/NonBlocking dictionary

There were also 3 types of load
* a rather large cache (20,000), a large number of keys (1,000,000), distribution of key frequencies according to the Zipf law. This type of load is likely to be close to reality after the node id is no longer part of the key and the cache size is increased. 

* small cache (256), a large number of keys (1,000,000), distribution of key frequencies according to the Zipf law. This type of load will be if the node id is no longer part of the key, but the cache size is left at the default.

* small cache (256), a large number of keys (1,000,000), distribution of keys is uniform. We have this type of load now (due to the fact that the node id is part of the key and the number of nodes is large)

I also compared the performance in net core 3.1 and 5.

So, there are (3*3*2) 18 tests. Each test is executed in 1,2,3...16 threads to have a better understanding of how it works concurrently. 
Tested on  
```
AMD Ryzen 4900HS 3.0GHz (~4.0Ghz boost), 1 CPU, 16 logical and 8 physical cores
Microsoft Windows 10 Pro 10.0.19042
```
Results: 
```
Runtime=.NET Core 3.1.9 
lruSize 20000 itemsNumber 1000000 high hit rate by Zipf law
======== GetOrAdd FastConcurrentLru ConcurrentDictionary object->object 1M Ops/sec:
28.10; 26.17; 25.01; 21.00; 18.24; 17.12; 16.26; 15.65; 15.38; 15.21; 14.67; 14.97; 14.83; 14.57; 15.48; 14.45;
======== GetOrAdd FastConcurrentLru NonBlockingDictionary object->object 1M Ops/sec:
26.46; 26.40; 26.01; 23.79; 22.79; 21.51; 20.47; 19.77; 19.45; 19.25; 18.90; 18.50; 17.83; 17.81; 17.71; 17.14;
======== GetOrAdd DataObjectsLRU Pair object->object 1M Ops/sec:
14.03; 6.802; 4.362; 3.928; 3.490; 3.242; 3.020; 2.824; 2.768; 2.694; 2.362; 2.358; 2.298; 2.298; 2.242; 2.270;
lruSize 256 itemsNumber 1000000 high hit rate by Zipf
======== GetOrAdd FastConcurrentLru ConcurrentDictionary object->object 1M Ops/sec:
27.53; 25.40; 19.87; 17.39; 15.58; 14.95; 14.63; 14.22; 13.32; 13.09; 12.56; 12.39; 12.24; 12.04; 11.92; 11.88;
======== GetOrAdd FastConcurrentLru NonBlockingDictionary object->object 1M Ops/sec:
26.61; 23.55; 22.36; 19.35; 17.46; 16.37; 15.45; 12.76; 15.66; 14.77; 14.60; 13.88; 12.98; 12.52; 11.93; 12.63;
======== GetOrAdd DataObjectsLRU Pair object->object 1M Ops/sec:
14.03; 7.314; 4.574; 3.900; 3.504; 3.364; 3.210; 3.006; 3.012; 2.962; 2.912; 2.876; 2.852; 2.832; 2.812; 2.804;
lruSize 256 itemsNumber 1000000 low hit rate - random
======== GetOrAdd FastConcurrentLru ConcurrentDictionary object->object 1M Ops/sec:
27.61; 26.10; 20.52; 17.73; 16.00; 13.76; 12.47; 11.56; 11.30; 10.53; 9.020; 10.00; 9.510; 8.944; 8.850; 8.580;
======== GetOrAdd FastConcurrentLru NonBlockingDictionary object->object 1M Ops/sec:
26.95; 22.20; 18.46; 17.40; 16.85; 15.01; 14.07; 13.36; 12.93; 12.24; 12.03; 12.51; 14.36; 13.33; 12.72; 11.33;
======== GetOrAdd DataObjectsLRU Pair object->object 1M Ops/sec:
14.14; 6.582; 3.802; 3.298; 2.912; 2.650; 2.448; 2.282; 2.144; 2.022; 1.958; 1.898; 1.852; 1.818; 1.780; 1.766;

Runtime=.NET Core 5.0
lruSize 20000 itemsNumber 1000000 high hit rate by Zipf law
======== GetOrAdd FastConcurrentLru ConcurrentDictionary object->object 1M Ops/sec:
39.26; 37.89; 32.75; 25.05; 21.94; 20.29; 17.63; 16.84; 16.59; 15.64; 15.93; 14.95; 15.21; 15.17; 15.57; 15.36;
======== GetOrAdd FastConcurrentLru NonBlockingDictionary object->object 1M Ops/sec:
30.77; 28.92; 28.36; 25.40; 23.92; 23.13; 22.26; 21.79; 19.49; 20.96; 19.32; 18.87; 19.03; 18.17; 17.78; 17.31;
======== GetOrAdd DataObjectsLRU Pair object->object 1M Ops/sec:
17.34; 7.296; 5.158; 4.224; 3.478; 3.466; 3.292; 3.246; 3.040; 2.808; 2.696; 2.822; 2.730; 2.728; 2.766; 2.752;
lruSize 256 itemsNumber 1000000 high hit rate by Zipf
======== GetOrAdd FastConcurrentLru ConcurrentDictionary object->object 1M Ops/sec:
38.73; 32.86; 23.78; 16.72; 14.52; 12.66; 13.55; 15.68; 14.59; 14.16; 13.28; 12.19; 11.82; 12.11; 11.73; 11.41;
======== GetOrAdd FastConcurrentLru NonBlockingDictionary object->object 1M Ops/sec:
29.72; 22.32; 21.66; 22.13; 17.68; 17.25; 16.90; 14.05; 17.03; 15.03; 15.07; 14.49; 13.86; 13.12; 13.28; 14.66;
======== GetOrAdd DataObjectsLRU Pair object->object 1M Ops/sec:
17.53; 6.960; 3.878; 3.584; 3.394; 3.288; 3.208; 3.110; 3.082; 3.092; 3.060; 3.028; 2.886; 2.976; 3.056; 3.082;
lruSize 256 itemsNumber 1000000 low hit rate - random
======== GetOrAdd FastConcurrentLru ConcurrentDictionary object->object 1M Ops/sec:
38.69; 28.10; 22.08; 18.07; 14.25; 15.93; 14.68; 12.48; 11.90; 11.29; 10.44; 11.34; 11.32; 11.13; 10.79; 10.51;
======== GetOrAdd FastConcurrentLru NonBlockingDictionary object->object 1M Ops/sec:
31.30; 26.92; 20.32; 15.70; 14.90; 12.24; 11.13; 14.16; 15.70; 15.54; 15.28; 16.11; 14.12; 13.78; 13.61; 13.27;
======== GetOrAdd DataObjectsLRU Pair object->object 1M Ops/sec:
17.28; 7.182; 3.688; 3.054; 2.720; 2.606; 2.500; 2.406; 2.334; 2.366; 2.330; 2.258; 2.262; 2.272; 2.238; 2.204;
```
Conclusions: 
1. .net 5 improves performance dramatically 
2. DataObjectsLRU slows down even on two threads. Also, I checked the Performance profile, and see very high lock contention with periodic lock-convoys 
3. About NonBlockingDictionary. It's clearly faster with a large number of threads (4 and more) and parallels well. 
But in 1-3  thread ConcurrentDictionary is better. 

Thus I recommend `BitFaster.Caching` with default ConcurrentDictionary as a DataObjectsLRU replacement as QueryCache. 
This replacement will be useful even without removing node id from the query key. This will solve the problem of convoy lock in Query Cache. See the difference: 

```
lruSize 256 itemsNumber 1000000 low hit rate - random
======== GetOrAdd FastConcurrentLru ConcurrentDictionary object->object 1M Ops/sec:
38.69; 28.10; 22.08; 18.07; 14.25; 15.93; 14.68; 12.48; 11.90; 11.29; 10.44; 11.34; 11.32; 11.13; 10.79; 10.51;
======== GetOrAdd DataObjectsLRU Pair object->object 1M Ops/sec:
17.28; 7.182; 3.688; 3.054; 2.720; 2.606; 2.500; 2.406; 2.334; 2.366; 2.330; 2.258; 2.262; 2.272; 2.238; 2.204;
```
