### PR TITLE
ARCH-1235: Optimizations: Memoize Attributes in AttributeHelper and ServiceRegistrations

### DIFF
--- a/Orm/Xtensive.Orm/Collections/TypeRegistry.cs
+++ b/Orm/Xtensive.Orm/Collections/TypeRegistry.cs
@@ -11,7 +11,7 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Linq;
 using Xtensive.Core;
-
+using Xtensive.IoC;
 
 namespace Xtensive.Collections
 {
@@ -33,6 +33,7 @@ namespace Xtensive.Collections
     private readonly ITypeRegistrationProcessor processor;
     private bool isProcessingPendingActions = false;
     private readonly Set<Assembly> assemblies = new Set<Assembly>();
+    protected ServiceRegistration[] serviceRegistrations;
 
     /// <summary>
     /// Gets assemblies containing registered types.
@@ -63,6 +64,7 @@ namespace Xtensive.Collections
       else {
         if (typeSet.Contains(type))
           return;
+        serviceRegistrations = null;
         types.Add(type);
         typeSet.Add(type);
         assemblies.Add(type.Assembly);

--- a/Orm/Xtensive.Orm/IoC/Internals/DefaultServiceContainer.cs
+++ b/Orm/Xtensive.Orm/IoC/Internals/DefaultServiceContainer.cs
@@ -38,10 +38,7 @@ namespace Xtensive.IoC
       return containers.GetValue(assembly, _assembly => {
         var typeRegistry = new TypeRegistry(new ServiceTypeRegistrationProcessor());
         typeRegistry.Register(_assembly);
-        return new ServiceContainer(
-          from type in typeRegistry
-          from serviceRegistration in ServiceRegistration.CreateAll(type, true)
-          select serviceRegistration);
+        return new ServiceContainer(typeRegistry.SelectMany(type => ServiceRegistration.CreateAll(type, true)));
       });
     }
   }

--- a/Orm/Xtensive.Orm/IoC/ServiceContainer.cs
+++ b/Orm/Xtensive.Orm/IoC/ServiceContainer.cs
@@ -200,14 +200,16 @@ namespace Xtensive.IoC
         throw new ArgumentException(string.Format(
           Strings.ExContainerTypeMustImplementX, typeof(IServiceContainer).GetShortName()), "containerType");
 
-      return TryConstruct(containerType, configuration, parent)
-        ?? TryConstruct(containerType, configuration)
-        ?? TryConstruct(containerType, parent)
+      Type configurationType = configuration?.GetType(),
+        parentType = parent?.GetType();
+      return TryConstruct(containerType, new[] { configurationType, parentType }, new[] { configuration, parent })
+        ?? TryConstruct(containerType, new[] { configurationType }, new[] { configuration })
+        ?? TryConstruct(containerType, new[] { parentType }, new[] { parent })
         ?? throw new ArgumentException(Strings.ExContainerTypeDoesNotProvideASuitableConstructor, "containerType");
     }
 
-    private static IServiceContainer TryConstruct(Type containerType, params object[] args) =>
-      (IServiceContainer)containerType.GetConstructor(args)?.Invoke(args);
+    private static IServiceContainer TryConstruct(Type containerType, Type[] argumentTypes, object[] args) =>
+      (IServiceContainer)containerType.GetSingleConstructor(argumentTypes)?.Invoke(args);
 
     #endregion
 

--- a/Orm/Xtensive.Orm/IoC/ServiceContainer.cs
+++ b/Orm/Xtensive.Orm/IoC/ServiceContainer.cs
@@ -27,7 +27,7 @@ namespace Xtensive.IoC
   [Serializable]
   public class ServiceContainer : ServiceContainerBase
   {
-    private static Type typeofIServiceContainer = typeof(IServiceContainer);
+    private static Type typeofIServiceContainer =   typeof(IServiceContainer);
 
     private readonly Dictionary<Key, List<ServiceRegistration>> types =
       new Dictionary<Key, List<ServiceRegistration>>();
@@ -200,20 +200,14 @@ namespace Xtensive.IoC
         throw new ArgumentException(string.Format(
           Strings.ExContainerTypeMustImplementX, typeof(IServiceContainer).GetShortName()), "containerType");
 
-      var possibleArgs =
-        Enumerable.Empty<object[]>()
-          .Append(new[] { configuration, parent })
-          .Append(new[] { configuration })
-          .Append(new[] { parent });
-      foreach (var args in possibleArgs) {
-        var ctor = containerType.GetConstructor(args);
-        if (ctor != null)
-          return (IServiceContainer) ctor.Invoke(args);
-      }
-
-      throw new ArgumentException(
-        Strings.ExContainerTypeDoesNotProvideASuitableConstructor, "containerType");
+      return TryConstruct(containerType, configuration, parent)
+        ?? TryConstruct(containerType, configuration)
+        ?? TryConstruct(containerType, parent)
+        ?? throw new ArgumentException(Strings.ExContainerTypeDoesNotProvideASuitableConstructor, "containerType");
     }
+
+    private static IServiceContainer TryConstruct(Type containerType, params object[] args) =>
+      (IServiceContainer)containerType.GetConstructor(args)?.Invoke(args);
 
     #endregion
 

--- a/Orm/Xtensive.Orm/IoC/ServiceContainer.cs
+++ b/Orm/Xtensive.Orm/IoC/ServiceContainer.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
@@ -15,21 +15,23 @@ using Xtensive.Reflection;
 using Xtensive.IoC.Configuration;
 using AttributeSearchOptions = Xtensive.Reflection.AttributeSearchOptions;
 using AppConfiguration = System.Configuration.Configuration;
-using ConfigurationSection=Xtensive.IoC.Configuration.ConfigurationSection;
+using ConfigurationSection = Xtensive.IoC.Configuration.ConfigurationSection;
 
 namespace Xtensive.IoC
 {
+  using Key = ValueTuple<Type, string>;
+
   /// <summary>
   /// Default IoC (inversion of control) container implementation.
   /// </summary>
   [Serializable]
   public class ServiceContainer : ServiceContainerBase
   {
-    private readonly Dictionary<object, List<ServiceRegistration>> types = 
-      new Dictionary<object, List<ServiceRegistration>>();
-    private readonly Dictionary<ServiceRegistration, object> instances = 
+    private readonly Dictionary<Key, List<ServiceRegistration>> types =
+      new Dictionary<Key, List<ServiceRegistration>>();
+    private readonly Dictionary<ServiceRegistration, object> instances =
       new Dictionary<ServiceRegistration, object>();
-    private readonly Dictionary<ServiceRegistration, Pair<ConstructorInfo,ParameterInfo[]>> constructorCache = 
+    private readonly Dictionary<ServiceRegistration, Pair<ConstructorInfo, ParameterInfo[]>> constructorCache =
       new Dictionary<ServiceRegistration, Pair<ConstructorInfo, ParameterInfo[]>>();
     private readonly HashSet<Type> creating = new HashSet<Type>();
     private readonly object _lock = new object();
@@ -42,14 +44,13 @@ namespace Xtensive.IoC
     {
       // Not very optimal, but...
       lock (_lock) {
-        List<ServiceRegistration> list;
-        if (!types.TryGetValue(GetKey(serviceType, name), out list))
+        if (!types.TryGetValue(GetKey(serviceType, name), out var list))
           return null;
-        if (list.Count==0)
-          return null;
-        if (list.Count > 1)
-          throw new AmbiguousMatchException(Strings.ExMultipleServicesMatchToTheSpecifiedArguments);
-        return GetOrCreateInstances(list).Single();
+        return list.Count switch {
+          0 => null,
+          1 => GetOrCreateInstances(list).Single(),
+          _ => throw new AmbiguousMatchException(Strings.ExMultipleServicesMatchToTheSpecifiedArguments)
+        };
       }
     }
 
@@ -58,10 +59,9 @@ namespace Xtensive.IoC
     {
       // Not very optimal, but...
       lock (_lock) {
-        List<ServiceRegistration> list;
-        if (!types.TryGetValue(GetKey(serviceType, null), out list))
-          return EnumerableUtils<object>.Empty;
-        return GetOrCreateInstances(list);
+        return types.TryGetValue(GetKey(serviceType, null), out var list)
+          ? GetOrCreateInstances(list)
+          : Array.Empty<object>();
       }
     }
 
@@ -75,25 +75,25 @@ namespace Xtensive.IoC
     {
       if (creating.Contains(serviceInfo.Type))
         throw new ActivationException(Strings.ExRecursiveConstructorParemeterDependencyIsDetected);
-      Pair<ConstructorInfo,ParameterInfo[]> cachedInfo;
+      Pair<ConstructorInfo, ParameterInfo[]> cachedInfo;
       var mappedType = serviceInfo.MappedType;
       if (!constructorCache.TryGetValue(serviceInfo, out cachedInfo)) {
         var @ctor = (
           from c in mappedType.GetConstructors()
-          where c.GetAttribute<ServiceConstructorAttribute>(AttributeSearchOptions.InheritNone)!=null
+          where c.GetAttribute<ServiceConstructorAttribute>(AttributeSearchOptions.InheritNone) != null
           select c
           ).SingleOrDefault();
-        if (@ctor==null)
+        if (@ctor == null)
           @ctor = mappedType.GetConstructor(ArrayUtils<Type>.EmptyArray);
-        var @params = @ctor==null ? null : @ctor.GetParameters();
+        var @params = @ctor == null ? null : @ctor.GetParameters();
         cachedInfo = new Pair<ConstructorInfo, ParameterInfo[]>(@ctor, @params);
         constructorCache[serviceInfo] = cachedInfo;
       }
       var cInfo = cachedInfo.First;
-      if (cInfo==null)
+      if (cInfo == null)
         return null;
       var pInfos = cachedInfo.Second;
-      if (pInfos.Length==0)
+      if (pInfos.Length == 0)
         return Activator.CreateInstance(mappedType);
       var args = new object[pInfos.Length];
       creating.Add(serviceInfo.Type);
@@ -111,13 +111,8 @@ namespace Xtensive.IoC
 
     #region Private \ internal methods
 
-    private static object GetKey(Type serviceType, string name)
-    {
-      if (name.IsNullOrEmpty())
-        return serviceType;
-      else
-        return new ObjectPair(serviceType, name);
-    }
+    private static Key GetKey(Type serviceType, string name) =>
+      new Key(serviceType, string.IsNullOrEmpty(name) ? null : name);
 
     private IEnumerable<object> GetOrCreateInstances(IEnumerable<ServiceRegistration> services)
     {
@@ -128,7 +123,7 @@ namespace Xtensive.IoC
           continue;
         }
 
-        if (registration.MappedInstance!=null)
+        if (registration.MappedInstance != null)
           result = registration.MappedInstance;
         else
           result = CreateInstance(registration);
@@ -141,11 +136,9 @@ namespace Xtensive.IoC
 
     private void Register(ServiceRegistration serviceRegistration)
     {
-      List<ServiceRegistration> list;
       var key = GetKey(serviceRegistration.Type, serviceRegistration.Name);
-      if (!types.TryGetValue(key, out list)) {
-        list = new List<ServiceRegistration>();
-        types[key] = list;
+      if (!types.TryGetValue(key, out var list)) {
+        types[key] = list = new List<ServiceRegistration>();
       }
       list.Add(serviceRegistration);
     }
@@ -207,12 +200,12 @@ namespace Xtensive.IoC
 
       var possibleArgs =
         Enumerable.Empty<object[]>()
-          .Append(new[] {configuration, parent})
-          .Append(new[] {configuration})
-          .Append(new[] {parent});
+          .Append(new[] { configuration, parent })
+          .Append(new[] { configuration })
+          .Append(new[] { parent });
       foreach (var args in possibleArgs) {
         var ctor = containerType.GetConstructor(args);
-        if (ctor!=null)
+        if (ctor != null)
           return (IServiceContainer) ctor.Invoke(args);
       }
 
@@ -270,7 +263,7 @@ namespace Xtensive.IoC
       return Create(section, name, null);
     }
 
-      /// <summary>
+    /// <summary>
     /// Creates <see cref="IServiceContainer"/> by its configuration.
     /// </summary>
     /// <param name="section">IoC configuration section.</param>
@@ -284,10 +277,8 @@ namespace Xtensive.IoC
       if (name.IsNullOrEmpty())
         name = string.Empty;
 
-      ContainerElement configuration = section==null ? null : section.Containers[name];
-
-      if (configuration==null)
-        configuration = new ContainerElement();
+      ContainerElement configuration = section?.Containers[name]
+        ?? new ContainerElement();
 
       var registrations = new List<ServiceRegistration>();
       var typeRegistry = new TypeRegistry(new ServiceTypeRegistrationProcessor());
@@ -299,12 +290,12 @@ namespace Xtensive.IoC
       foreach (var serviceRegistrationElement in configuration.Explicit)
         registrations.Add(serviceRegistrationElement.ToNative());
 
-      var currentParent = configuration.Parent.IsNullOrEmpty() 
-        ? parent 
+      var currentParent = configuration.Parent.IsNullOrEmpty()
+        ? parent
         : Create(section, configuration.Parent, parent);
-      
-      var containerType = configuration.Type.IsNullOrEmpty() ? 
-        typeof(ServiceContainer) : 
+
+      var containerType = configuration.Type.IsNullOrEmpty() ?
+        typeof(ServiceContainer) :
         Type.GetType(configuration.Type);
       return Create(containerType, registrations, currentParent);
     }
@@ -337,7 +328,7 @@ namespace Xtensive.IoC
     public ServiceContainer(IEnumerable<ServiceRegistration> configuration, IServiceContainer parent)
       : base(parent)
     {
-      if (configuration==null)
+      if (configuration == null)
         return;
       foreach (var serviceRegistration in configuration)
         Register(serviceRegistration);
@@ -351,7 +342,7 @@ namespace Xtensive.IoC
         foreach (var pair in instances) {
           var service = pair.Value;
           var disposable = service as IDisposable;
-          if (disposable!=null)
+          if (disposable != null)
             toDispose.Add(disposable);
         }
       }

--- a/Orm/Xtensive.Orm/IoC/ServiceContainer.cs
+++ b/Orm/Xtensive.Orm/IoC/ServiceContainer.cs
@@ -202,14 +202,16 @@ namespace Xtensive.IoC
 
       Type configurationType = configuration?.GetType(),
         parentType = parent?.GetType();
-      return TryConstruct(containerType, new[] { configurationType, parentType }, new[] { configuration, parent })
-        ?? TryConstruct(containerType, new[] { configurationType }, new[] { configuration })
-        ?? TryConstruct(containerType, new[] { parentType }, new[] { parent })
-        ?? throw new ArgumentException(Strings.ExContainerTypeDoesNotProvideASuitableConstructor, "containerType");
+      return (IServiceContainer)(
+        FindConstructor(containerType, configurationType, parentType)?.Invoke(new[] { configuration, parent })
+        ?? FindConstructor(containerType, configurationType)?.Invoke(new[] { configuration })
+        ?? FindConstructor(containerType, parentType)?.Invoke(new[] { parent })
+        ?? throw new ArgumentException(Strings.ExContainerTypeDoesNotProvideASuitableConstructor, "containerType")
+      );
     }
 
-    private static IServiceContainer TryConstruct(Type containerType, Type[] argumentTypes, object[] args) =>
-      (IServiceContainer)containerType.GetSingleConstructor(argumentTypes)?.Invoke(args);
+    private static ConstructorInfo FindConstructor(Type containerType, params Type[] argumentTypes) =>
+      containerType.GetSingleConstructor(argumentTypes);
 
     #endregion
 

--- a/Orm/Xtensive.Orm/IoC/ServiceContainer.cs
+++ b/Orm/Xtensive.Orm/IoC/ServiceContainer.cs
@@ -27,6 +27,8 @@ namespace Xtensive.IoC
   [Serializable]
   public class ServiceContainer : ServiceContainerBase
   {
+    private static Type typeofIServiceContainer = typeof(IServiceContainer);
+
     private readonly Dictionary<Key, List<ServiceRegistration>> types =
       new Dictionary<Key, List<ServiceRegistration>>();
     private readonly Dictionary<ServiceRegistration, object> instances =
@@ -194,7 +196,7 @@ namespace Xtensive.IoC
     public static IServiceContainer Create(Type containerType, object configuration, IServiceContainer parent)
     {
       ArgumentValidator.EnsureArgumentNotNull(containerType, "containerType");
-      if (!typeof(IServiceContainer).IsAssignableFrom(containerType))
+      if (!typeofIServiceContainer.IsAssignableFrom(containerType))
         throw new ArgumentException(string.Format(
           Strings.ExContainerTypeMustImplementX, typeof(IServiceContainer).GetShortName()), "containerType");
 

--- a/Orm/Xtensive.Orm/IoC/ServiceContainer.cs
+++ b/Orm/Xtensive.Orm/IoC/ServiceContainer.cs
@@ -198,7 +198,7 @@ namespace Xtensive.IoC
       ArgumentValidator.EnsureArgumentNotNull(containerType, "containerType");
       if (!typeofIServiceContainer.IsAssignableFrom(containerType))
         throw new ArgumentException(string.Format(
-          Strings.ExContainerTypeMustImplementX, typeof(IServiceContainer).GetShortName()), "containerType");
+          Strings.ExContainerTypeMustImplementX, typeofIServiceContainer.GetShortName()), "containerType");
 
       Type configurationType = configuration?.GetType(),
         parentType = parent?.GetType();

--- a/Orm/Xtensive.Orm/IoC/ServiceRegistration.cs
+++ b/Orm/Xtensive.Orm/IoC/ServiceRegistration.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using Xtensive.Core;
 using Xtensive.Reflection;
 
@@ -84,10 +83,14 @@ namespace Xtensive.IoC
       if (type.IsAbstract)
         return Array.Empty<ServiceRegistration>();
 
-      IEnumerable< ServiceAttribute> attributes = type.GetAttributes<ServiceAttribute>(AttributeSearchOptions.InheritNone);
-      if (defaultOnly)
-        attributes = attributes.Where(a => a.Default);
-      return attributes.Select(sa => new ServiceRegistration(sa.Type, sa.Name.IsNullOrEmpty() ? null : sa.Name, type, sa.Singleton)).ToArray();
+      var attributes = type.GetAttributes<ServiceAttribute>(AttributeSearchOptions.InheritNone);
+      var registrations = new List<ServiceRegistration>(attributes.Length);
+      foreach (var sa in attributes) {
+        if (!defaultOnly || sa.Default) {
+          registrations.Add(new ServiceRegistration(sa.Type, sa.Name.IsNullOrEmpty() ? null : sa.Name, type, sa.Singleton));
+        }
+      }
+      return registrations.ToArray();
     };
 
 

--- a/Orm/Xtensive.Orm/IoC/ServiceRegistration.cs
+++ b/Orm/Xtensive.Orm/IoC/ServiceRegistration.cs
@@ -1,24 +1,29 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
+// Copyright (C) 2003-2021 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Dmitri Maximov
 // Created:    2009.10.12
 
 using System;
-using Xtensive.Collections;
-using Xtensive.Core;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
-
+using Xtensive.Core;
 using Xtensive.Reflection;
 
 namespace Xtensive.IoC
 {
+  using ServiceRegistrationKey = ValueTuple<Type, bool>;
+
   /// <summary>
   /// Describes single service mapping entry for <see cref="ServiceContainer"/>.
   /// </summary>
   [Serializable]
   public sealed class ServiceRegistration
   {
+    private static readonly ConcurrentDictionary<ServiceRegistrationKey, ServiceRegistration[]> serviceRegistrationsByType =
+      new ConcurrentDictionary<ServiceRegistrationKey, ServiceRegistration[]>();
+
     /// <summary>
     /// Gets the type of the service.
     /// </summary>
@@ -56,10 +61,8 @@ namespace Xtensive.IoC
     /// <returns>
     /// An array of <see cref="ServiceRegistration"/> objects.
     /// </returns>
-    public static ServiceRegistration[] CreateAll(Type type)
-    {
-      return CreateAll(type, false);
-    }
+    public static ServiceRegistration[] CreateAll(Type type) =>
+      CreateAll(type, false);
 
     /// <summary>
     /// Creates an array of <see cref="ServiceRegistration"/> objects
@@ -67,32 +70,25 @@ namespace Xtensive.IoC
     /// by scanning it <see cref="ServiceAttribute"/>s.
     /// </summary>
     /// <param name="type">The type to provide <see cref="ServiceRegistration"/> objects for.</param>
-    /// <param name="defaultOnly">Return just registrations for which 
+    /// <param name="defaultOnly">Return just registrations for which
     /// <see cref="ServiceAttribute.Default"/>==<see langword="true" />.</param>
     /// <returns>
     /// An array of <see cref="ServiceRegistration"/> objects.
     /// </returns>
-    public static ServiceRegistration[] CreateAll(Type type, bool defaultOnly)
-    {
+    public static ServiceRegistration[] CreateAll(Type type, bool defaultOnly) =>
+      serviceRegistrationsByType.GetOrAdd(new ServiceRegistrationKey(type, defaultOnly), ServiceRegistrationsExtractor);
+
+    private static readonly Func<ServiceRegistrationKey, ServiceRegistration[]> ServiceRegistrationsExtractor = ((Type type, bool defaultOnly) t) => {
+      (var type, var defaultOnly) = t;
       ArgumentValidator.EnsureArgumentNotNull(type, "type");
       if (type.IsAbstract)
-        return ArrayUtils<ServiceRegistration>.EmptyArray;
+        return Array.Empty<ServiceRegistration>();
 
-      var attributes = type.GetAttributes<ServiceAttribute>(AttributeSearchOptions.InheritNone);
-      if (attributes==null)
-        return ArrayUtils<ServiceRegistration>.EmptyArray;
+      IEnumerable< ServiceAttribute> attributes = type.GetAttributes<ServiceAttribute>(AttributeSearchOptions.InheritNone);
       if (defaultOnly)
-        attributes = attributes.Where(a => a.Default).ToArray();
-      if (attributes.Length==0)
-        return ArrayUtils<ServiceRegistration>.EmptyArray;
-
-      var result = new ServiceRegistration[attributes.Length];
-      for (int i = 0; i < attributes.Length; i++) {
-        var sa = attributes[i];
-        result[i] = new ServiceRegistration(sa.Type, sa.Name.IsNullOrEmpty() ? null : sa.Name, type, sa.Singleton);
-      }
-      return result;
-    }
+        attributes = attributes.Where(a => a.Default);
+      return attributes.Select(sa => new ServiceRegistration(sa.Type, sa.Name.IsNullOrEmpty() ? null : sa.Name, type, sa.Singleton)).ToArray();
+    };
 
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/Configuration/DomainTypeRegistry.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/DomainTypeRegistry.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using Xtensive.Collections;
 using System.Linq;
+using Xtensive.IoC;
 using Xtensive.Orm.Internals;
 using Xtensive.Orm.Upgrade;
 
@@ -41,6 +42,9 @@ namespace Xtensive.Orm.Configuration
     /// Gets all the registered <see cref="Session"/>-level service types.
     /// </summary>
     public IEnumerable<Type> SessionServices => this.Where(IsSessionService);
+
+    public ServiceRegistration[] ServiceRegistrations =>
+      serviceRegistrations ??= SessionServices.SelectMany(ServiceRegistration.CreateAll).ToArray();
 
     /// <summary>
     /// Gets all the registered <see cref="IModule"/> implementations.

--- a/Orm/Xtensive.Orm/Orm/Session.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.cs
@@ -311,7 +311,7 @@ namespace Xtensive.Orm
     private IServiceContainer CreateServices()
     {
       var userContainerType = Configuration.ServiceContainerType ?? typeofServiceContainer;
-      var registrations = Domain.Configuration.Types.SessionServices.SelectMany(ServiceRegistration.CreateAll);
+      var registrations = Domain.Configuration.Types.ServiceRegistrations;
       var systemContainer = CreateSystemServices();
       var userContainer = ServiceContainer.Create(userContainerType, systemContainer);
       return new ServiceContainer(registrations, userContainer);

--- a/Orm/Xtensive.Orm/Orm/Session.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.cs
@@ -37,24 +37,24 @@ namespace Xtensive.Orm
   /// </summary>
   /// <remarks>
   /// <para>
-  /// Each session maintains its own connection to the database and 
+  /// Each session maintains its own connection to the database and
   /// caches a set of materialized persistent instates.
   /// </para>
   /// <para>
   /// <c>Session</c> implements <see cref="IContext"/> interface, that means each <c>Session</c>
   /// can be either active or not active in a particular thread (see <see cref="IsActive"/> property).
-  /// Each thread can contain only one active session in each point of time, such session 
-  /// can be a accessed via <see cref="Current">Session.Current</see> property 
+  /// Each thread can contain only one active session in each point of time, such session
+  /// can be a accessed via <see cref="Current">Session.Current</see> property
   /// or <see cref="Demand">Session.Demand()</see> method.
   /// </para>
   /// <para>
-  /// Sessions are opened (and, optionally, activated) by 
-  /// <see cref="Domain.OpenSession()">Domain.OpenSession()</see> method. 
+  /// Sessions are opened (and, optionally, activated) by
+  /// <see cref="Domain.OpenSession()">Domain.OpenSession()</see> method.
   /// Existing session can be activated by <see cref="Activate()"/> method.
   /// </para>
   /// </remarks>
   /// <example>
-  /// <code lang="cs" source="..\Xtensive.Orm\Xtensive.Orm.Manual\DomainAndSession\DomainAndSessionSample.cs" 
+  /// <code lang="cs" source="..\Xtensive.Orm\Xtensive.Orm.Manual\DomainAndSession\DomainAndSessionSample.cs"
   /// region="Session sample"></code>
   /// </example>
   /// <seealso cref="Domain"/>
@@ -62,13 +62,19 @@ namespace Xtensive.Orm
   [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
   public partial class Session : DomainBound,
     IVersionSetProvider,
-    IContext<SessionScope>, 
+    IContext<SessionScope>,
     IHasExtensions,
     IDisposable,
     IAsyncDisposable
   {
     private const string IdentifierFormat = "#{0}";
     private const string FullNameFormat   = "{0}, #{1}";
+
+    private static readonly Type
+      typeofSession = typeof(Session),
+      typeofSessionConfiguration = typeof(SessionConfiguration),
+      typeofSessionHandler = typeof(SessionHandler),
+      typeofServiceContainer = typeof(ServiceContainer);
 
     private static Func<Session> resolver;
     private static long lastUsedIdentifier;
@@ -110,7 +116,7 @@ namespace Xtensive.Orm
     /// Gets a value indicating whether session is disconnected:
     /// session supports non-transactional entity states and does not support autosaving of changes.
     /// </summary>
-    public bool IsDisconnected { 
+    public bool IsDisconnected {
       get
       {
         return Configuration.Supports(SessionOptions.NonTransactionalEntityStates) &&
@@ -122,7 +128,7 @@ namespace Xtensive.Orm
     /// Indicates whether lazy generation of keys is enabled.
     /// </summary>
     internal bool LazyKeyGenerationIsEnabled { get { return Configuration.Supports(SessionOptions.LazyKeyGeneration); } }
-    
+
     /// <summary>
     /// Gets the operations registry of this <see cref="Session"/>.
     /// </summary>
@@ -188,7 +194,7 @@ namespace Xtensive.Orm
     /// when there is no active <see cref="Session"/>.
     /// </summary>
     /// <remarks>
-    /// The setter of this property can be invoked just once per application lifetime; 
+    /// The setter of this property can be invoked just once per application lifetime;
     /// assigned resolver can not be changed.
     /// </remarks>
     /// <exception cref="NotSupportedException">Resolver is already assigned.</exception>
@@ -294,9 +300,9 @@ namespace Xtensive.Orm
     private IServiceContainer CreateSystemServices()
     {
       var registrations = new List<ServiceRegistration>{
-        new ServiceRegistration(typeof (Session), this),
-        new ServiceRegistration(typeof (SessionConfiguration), Configuration),
-        new ServiceRegistration(typeof (SessionHandler), Handler),
+        new ServiceRegistration(typeofSession, this),
+        new ServiceRegistration(typeofSessionConfiguration, Configuration),
+        new ServiceRegistration(typeofSessionHandler, Handler),
       };
       Handler.AddSystemServices(registrations);
       return new ServiceContainer(registrations, Domain.Services);
@@ -304,7 +310,7 @@ namespace Xtensive.Orm
 
     private IServiceContainer CreateServices()
     {
-      var userContainerType = Configuration.ServiceContainerType ?? typeof (ServiceContainer);
+      var userContainerType = Configuration.ServiceContainerType ?? typeofServiceContainer;
       var registrations = Domain.Configuration.Types.SessionServices.SelectMany(ServiceRegistration.CreateAll);
       var systemContainer = CreateSystemServices();
       var userContainer = ServiceContainer.Create(userContainerType, systemContainer);
@@ -351,8 +357,8 @@ namespace Xtensive.Orm
     }
 
     /// <summary>
-    /// Gets the current <see cref="Session"/>, 
-    /// or throws <see cref="InvalidOperationException"/>, 
+    /// Gets the current <see cref="Session"/>,
+    /// or throws <see cref="InvalidOperationException"/>,
     /// if active <see cref="Session"/> is not found.
     /// </summary>
     /// <returns>Current session.</returns>
@@ -382,7 +388,7 @@ namespace Xtensive.Orm
     /// See <see cref="SessionOptions.AllowSwitching"/> for more detailed explanation
     /// of purpose of this method.
     /// </summary>
-    /// <param name="checkSwitching">If set to <see langword="true"/>, 
+    /// <param name="checkSwitching">If set to <see langword="true"/>,
     /// <see cref="InvalidOperationException"/> is thrown if another session is active, and
     /// either this or active session does not have <see cref="SessionOptions.AllowSwitching"/> flag.</param>
     /// <returns>A disposable object reverting the action.</returns>

--- a/Orm/Xtensive.Orm/Reflection/AttributeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/AttributeHelper.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Reflection;
-//using Xtensive.Collections;
 
 namespace Xtensive.Reflection
 {

--- a/Orm/Xtensive.Orm/Reflection/AttributeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/AttributeHelper.cs
@@ -23,7 +23,7 @@ namespace Xtensive.Reflection
     private static readonly ConcurrentDictionary<AttributesKey, Attribute[]> attributesByMemberInfoAndSearchOptions
       = new ConcurrentDictionary<AttributesKey, Attribute[]>();
 
-    public static Attribute[] GetAttributes(this MemberInfo member, Type attributeType)
+    private static Attribute[] GetAttributes(this MemberInfo member, Type attributeType)
     {
       var attrObjects = member.GetCustomAttributes(attributeType, false);
       var attrs = new Attribute[attrObjects.Length];

--- a/Orm/Xtensive.Orm/Reflection/AttributeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/AttributeHelper.cs
@@ -7,8 +7,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
-using System.Reflection;
 using System.Linq;
+using System.Reflection;
 //using Xtensive.Collections;
 
 namespace Xtensive.Reflection
@@ -23,8 +23,15 @@ namespace Xtensive.Reflection
     private static readonly ConcurrentDictionary<AttributesKey, Attribute[]> attributesByMemberInfoAndSearchOptions
       = new ConcurrentDictionary<AttributesKey, Attribute[]>();
 
-    public static Attribute[] GetAttributes(this MemberInfo member, Type attributeType) =>
-      member.GetCustomAttributes(attributeType, false).Cast<Attribute>().ToArray();
+    public static Attribute[] GetAttributes(this MemberInfo member, Type attributeType)
+    {
+      var attrObjects = member.GetCustomAttributes(attributeType, false);
+      var attrs = new Attribute[attrObjects.Length];
+      for (int i = attrObjects.Length; i-- > 0;) {
+        attrs[i] = (Attribute)attrObjects[i];
+      }
+      return attrs;
+    }
 
     /// <summary>
     /// A shortcut to <see cref="MemberInfo.GetCustomAttributes(Type,bool)"/> method.

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -44,7 +44,7 @@ namespace Xtensive.Reflection
     private static readonly ConcurrentDictionary<Pair<Type, Type>, InterfaceMapping> interfaceMaps =
       new ConcurrentDictionary<Pair<Type, Type>, InterfaceMapping>();
 
-    class TypesCompares : IEqualityComparer<(Type, Type[])>
+    private class TypesCompares : IEqualityComparer<(Type, Type[])>
     {
       public bool Equals((Type, Type[]) x, (Type, Type[]) y) =>
         x.Item1 == y.Item1

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -47,8 +47,7 @@ namespace Xtensive.Reflection
     private class TypesCompares : IEqualityComparer<(Type, Type[])>
     {
       public bool Equals((Type, Type[]) x, (Type, Type[]) y) =>
-        x.Item1 == y.Item1
-        && x.Item2.Length == y.Item2.Length && x.Item2.Zip(y.Item2).All(t => t.First == t.Second);
+        x.Item1 == y.Item1 && x.Item2.SequenceEqual(y.Item2);
 
       public int GetHashCode((Type, Type[]) obj) =>
         HashCode.Combine(

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -46,18 +46,8 @@ namespace Xtensive.Reflection
 
     private class TypesEqualityComparer : IEqualityComparer<(Type, Type[])>
     {
-      public bool Equals((Type, Type[]) x, (Type, Type[]) y)
-      {
-        if (x.Item1 != y.Item1 || x.Item2.Length != y.Item2.Length) {
-          return false;
-        }
-        for (int i = x.Item2.Length; i-- > 0;) {
-          if (x.Item2[i] != y.Item2[i]) {
-            return false;
-          }
-        }
-        return true;
-      }
+      public bool Equals((Type, Type[]) x, (Type, Type[]) y) =>
+         x.Item1 == y.Item1 && x.Item2.SequenceEqual(y.Item2);
 
       public int GetHashCode((Type, Type[]) obj)
       {

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -49,6 +49,7 @@ namespace Xtensive.Reflection
       public bool Equals((Type, Type[]) x, (Type, Type[]) y) =>
         x.Item1 == y.Item1
         && x.Item2.Length == y.Item2.Length && x.Item2.Zip(y.Item2).All(t => t.First == t.Second);
+
       public int GetHashCode((Type, Type[]) obj) =>
         HashCode.Combine(
           obj.Item1,

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -19,7 +19,6 @@ using System.Linq;
 using Xtensive.Core;
 
 using Xtensive.Sorting;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Xtensive.Reflection
 {

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -44,7 +44,7 @@ namespace Xtensive.Reflection
     private static readonly ConcurrentDictionary<Pair<Type, Type>, InterfaceMapping> interfaceMaps =
       new ConcurrentDictionary<Pair<Type, Type>, InterfaceMapping>();
 
-    private class TypesCompares : IEqualityComparer<(Type, Type[])>
+    private class TypesEqualityComparer : IEqualityComparer<(Type, Type[])>
     {
       public bool Equals((Type, Type[]) x, (Type, Type[]) y) =>
         x.Item1 == y.Item1 && x.Item2.SequenceEqual(y.Item2);
@@ -54,7 +54,7 @@ namespace Xtensive.Reflection
     }
 
     private static readonly ConcurrentDictionary<(Type, Type[]), ConstructorInfo> constructorInfoByTypes =
-      new ConcurrentDictionary<(Type, Type[]), ConstructorInfo>(new TypesCompares());
+      new ConcurrentDictionary<(Type, Type[]), ConstructorInfo>(new TypesEqualityComparer());
 
     private static int createDummyTypeNumber = 0;
     private static AssemblyBuilder assemblyBuilder;

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -19,7 +19,7 @@ using System.Linq;
 using Xtensive.Core;
 
 using Xtensive.Sorting;
-
+using System.Diagnostics.CodeAnalysis;
 
 namespace Xtensive.Reflection
 {
@@ -44,6 +44,21 @@ namespace Xtensive.Reflection
 
     private static readonly ConcurrentDictionary<Pair<Type, Type>, InterfaceMapping> interfaceMaps =
       new ConcurrentDictionary<Pair<Type, Type>, InterfaceMapping>();
+
+    class TypesCompares : IEqualityComparer<(Type, Type[])>
+    {
+      public bool Equals((Type, Type[]) x, (Type, Type[]) y) =>
+        x.Item1 == y.Item1
+        && x.Item2.Length == y.Item2.Length && x.Item2.Zip(y.Item2).All(t => t.First == t.Second);
+      public int GetHashCode((Type, Type[]) obj) =>
+        HashCode.Combine(
+          obj.Item1,
+          obj.Item2.Aggregate(0, (total, o) => HashCode.Combine(total, o?.GetHashCode() ?? 0))
+        );
+    }
+
+    private static readonly ConcurrentDictionary<(Type, Type[]), ConstructorInfo> constructorInfoByTypes =
+      new ConcurrentDictionary<(Type, Type[]), ConstructorInfo>(new TypesCompares());
 
     private static int createDummyTypeNumber = 0;
     private static AssemblyBuilder assemblyBuilder;
@@ -482,7 +497,7 @@ namespace Xtensive.Reflection
     /// </summary>
     /// <param name="assembly">Assembly where the type is located.</param>
     /// <param name="typeName">Name of the type to instantiate.</param>
-    /// <param name="genericArguments">Generic arguments for the type to instantiate 
+    /// <param name="genericArguments">Generic arguments for the type to instantiate
     /// (<see langword="null"/> means type isn't a generic type definition).</param>
     /// <param name="arguments">Arguments to pass to the type constructor.</param>
     /// <returns>An instance of specified type; <see langword="null"/>, if either no such a type,
@@ -501,7 +516,7 @@ namespace Xtensive.Reflection
     /// or an error has occurred.
     /// </summary>
     /// <param name="type">Generic type definition to instantiate.</param>
-    /// <param name="genericArguments">Generic arguments for the type to instantiate 
+    /// <param name="genericArguments">Generic arguments for the type to instantiate
     /// (<see langword="null"/> means <paramref name="type"/> isn't a generic type definition).</param>
     /// <param name="arguments">Arguments to pass to the type constructor.</param>
     /// <returns>An instance of specified type; <see langword="null"/>, if either no such a type,
@@ -592,38 +607,40 @@ namespace Xtensive.Reflection
     }
 
     /// <summary>
-    /// Gets the public constructor of type <paramref name="type"/> 
-    /// accepting specified <paramref name="arguments"/>.
+    /// Gets the public constructor of type <paramref name="type"/>
+    /// accepting specified <paramref name="argumentTypes"/>.
     /// </summary>
     /// <param name="type">The type to get the constructor for.</param>
-    /// <param name="arguments">The arguments.</param>
+    /// <param name="argumentTypes">The argument types.</param>
     /// <returns>
     /// Appropriate constructor, if a single match is found;
     /// otherwise, <see langword="null"/>.
     /// </returns>
-    public static ConstructorInfo GetConstructor(this Type type, object[] arguments)
-    {
+    public static ConstructorInfo GetSingleConstructor(this Type type, Type[] argumentTypes) =>
+      constructorInfoByTypes.GetOrAdd((type, argumentTypes), ConstructorExtractor);
+
+    private static readonly Func<(Type, Type[]), ConstructorInfo> ConstructorExtractor = t => {
+      (var type, var argumentTypes) = t;
       var constructors =
         from ctor in type.GetConstructors()
         let parameters = ctor.GetParameters()
-        where parameters.Length == arguments.Length
-        let zipped = parameters.Zip(arguments, (parameter, argument) => (parameter, argument))
+        where parameters.Length == argumentTypes.Length
+        let zipped = parameters.Zip(argumentTypes, (parameter, argumentType) => (parameter, argumentType))
         where (
           from pair in zipped
           let parameter = pair.parameter
           let parameterType = parameter.ParameterType
-          let argument = pair.argument
-          let argumentType = argument == null ? WellKnownTypes.Object : argument.GetType()
+          let argumentType = pair.argumentType
           select
             !parameter.IsOut && (
-              parameterType.IsAssignableFrom(argumentType) ||
-              (!parameterType.IsValueType && argument == null) ||
-              (parameterType.IsNullable() && argument == null)
+              parameterType.IsAssignableFrom(argumentType ?? WellKnownTypes.Object) ||
+              (!parameterType.IsValueType && argumentType == null) ||
+              (parameterType.IsNullable() && argumentType == null)
             )
         ).All(passed => passed)
         select ctor;
       return constructors.SingleOrDefault();
-    }
+    };
 
     /// <summary>
     /// Orders the specified <paramref name="types"/> by their inheritance
@@ -880,7 +897,7 @@ namespace Xtensive.Reflection
     public static bool IsFinal<T>() => IsFinal(typeof(T));
 
     /// <summary>
-    /// Gets the delegate "Invoke" method (describing the delegate) for 
+    /// Gets the delegate "Invoke" method (describing the delegate) for
     /// the specified <paramref name="delegateType"/>.
     /// </summary>
     /// <param name="delegateType">Type of the delegate to get the "Invoke" method of.</param>
@@ -998,7 +1015,7 @@ namespace Xtensive.Reflection
     /// <returns>
     /// If <paramref name="type"/> is a reference type or a <see cref="Nullable{T}"/> instance
     /// returns <paramref name="type"/>.
-    /// Otherwise returns <see cref="Nullable{T}"/> of <paramref name="type"/>. 
+    /// Otherwise returns <see cref="Nullable{T}"/> of <paramref name="type"/>.
     /// </returns>
     public static Type ToNullable(this Type type)
     {

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -50,10 +50,7 @@ namespace Xtensive.Reflection
         x.Item1 == y.Item1 && x.Item2.SequenceEqual(y.Item2);
 
       public int GetHashCode((Type, Type[]) obj) =>
-        HashCode.Combine(
-          obj.Item1,
-          obj.Item2.Aggregate(0, (total, o) => HashCode.Combine(total, o?.GetHashCode() ?? 0))
-        );
+        HashCode.Combine(obj.Item1, obj.Item2.Aggregate(0, HashCode.Combine));
     }
 
     private static readonly ConcurrentDictionary<(Type, Type[]), ConstructorInfo> constructorInfoByTypes =


### PR DESCRIPTION
Also:
* Memoize Attributes search  in `AttributeHelper`
*  Memoize building `ServiceRegistrations` instances by types
*  Use ValueTuple as key type in `ServiceContainer` instead of boxed `ObjectPair`
*  Cache `ServiceRegistrations[]` in `DomainTypeRegistry` to avoid rebuilding them for every Session
*  Memoize `TypeHelper.GetSingleConstructor(typeArguments)`  (former `TypeHelper.GetConstructor()`)