### PR TITLE
Optimizations: allocations in RecordSetHeader.Join(); use IReadOnlyList instead of ReadOnlyList to save allocations

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Model/ColumnGroup.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnGroup.cs
@@ -28,12 +28,12 @@ namespace Xtensive.Orm.Model
     /// <summary>
     /// Gets the indexes of key columns.
     /// </summary>
-    public ReadOnlyList<int> Keys { get; private set; }
+    public IReadOnlyList<int> Keys { get; private set; }
 
     /// <summary>
     /// Gets the indexes of all columns.
     /// </summary>
-    public ReadOnlyList<int> Columns { get; private set; }
+    public IReadOnlyList<int> Columns { get; private set; }
 
 
     // Constructors
@@ -55,11 +55,11 @@ namespace Xtensive.Orm.Model
     /// <param name="type">The type.</param>
     /// <param name="keys">The keys.</param>
     /// <param name="columns">The columns.</param>
-    public ColumnGroup(TypeInfoRef type, IList<int> keys, IList<int> columns)
+    public ColumnGroup(TypeInfoRef type, IReadOnlyList<int> keys, IReadOnlyList<int> columns)
     {
       TypeInfoRef = type;
-      Keys = new ReadOnlyList<int>(keys);
-      Columns = new ReadOnlyList<int>(columns);
+      Keys = keys;
+      Columns = columns;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Index.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Index.cs
@@ -69,6 +69,7 @@ namespace Xtensive.Orm.Providers
       if (!atRootPolicy) {
         var tableRef = SqlDml.TableRef(table);
         query = SqlDml.Select(tableRef);
+        query.Columns.Capacity = query.Columns.Count + index.Columns.Count;
         query.Columns.AddRange(index.Columns.Select(c => tableRef[c.Name]));
       }
       else {
@@ -76,6 +77,7 @@ namespace Xtensive.Orm.Providers
         var lookup = root.Columns.ToDictionary(c => c.Field, c => c.Name);
         var tableRef = SqlDml.TableRef(table);
         query = SqlDml.Select(tableRef);
+        query.Columns.Capacity = query.Columns.Count + index.Columns.Count;
         query.Columns.AddRange(index.Columns.Select(c => tableRef[lookup[c.Field]]));
       }
       return query;

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Index.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Index.cs
@@ -65,20 +65,22 @@ namespace Xtensive.Orm.Providers
         atRootPolicy = true;
       }
 
-      SqlSelect query;
+      var indexColumns = index.Columns;
+      var tableRef = SqlDml.TableRef(table);
+      var query = SqlDml.Select(tableRef);
+      var queryColumns = query.Columns;
+      queryColumns.Capacity = queryColumns.Count + indexColumns.Count;
       if (!atRootPolicy) {
-        var tableRef = SqlDml.TableRef(table);
-        query = SqlDml.Select(tableRef);
-        query.Columns.Capacity = query.Columns.Count + index.Columns.Count;
-        query.Columns.AddRange(index.Columns.Select(c => tableRef[c.Name]));
+        foreach (var c in indexColumns) {
+          queryColumns.Add(tableRef[c.Name]);
+        }
       }
       else {
         var root = index.ReflectedType.GetRoot().AffectedIndexes.First(i => i.IsPrimary);
         var lookup = root.Columns.ToDictionary(c => c.Field, c => c.Name);
-        var tableRef = SqlDml.TableRef(table);
-        query = SqlDml.Select(tableRef);
-        query.Columns.Capacity = query.Columns.Count + index.Columns.Count;
-        query.Columns.AddRange(index.Columns.Select(c => tableRef[lookup[c.Field]]));
+        foreach (var c in indexColumns) {
+          queryColumns.Add(tableRef[lookup[c.Field]]);
+        }
       }
       return query;
     }

--- a/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
@@ -37,12 +37,6 @@ namespace Xtensive.Orm.Rse
       }
     }
 
-    private void BuildNameIndex()
-    {
-      for (var index = 0; index < Count; index++) 
-        nameIndex.Add(this[index].Name, index);
-    }
-
     /// <summary>
     /// Joins this collection with specified the column collection.
     /// </summary>
@@ -71,10 +65,8 @@ namespace Xtensive.Orm.Rse
     /// </summary>
     /// <param name="collection">Collection of items to add.</param>
     public ColumnCollection(IEnumerable<Column> collection)
-      : base(collection.ToList())
+      : this(collection.ToList())
     {
-      nameIndex = new Dictionary<string, int>(Count);
-      BuildNameIndex();
     }
 
     /// <summary>
@@ -85,7 +77,8 @@ namespace Xtensive.Orm.Rse
       : base(collection)
     {
       nameIndex = new Dictionary<string, int>(Count);
-      BuildNameIndex();
+      for (var index = 0; index < Count; index++)
+        nameIndex.Add(this[index].Name, index);
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -141,11 +141,15 @@ namespace Xtensive.Orm.Rse
       var groups = new List<ColumnGroup>(columnGroupCount + joined.ColumnGroups.Count);
       groups.AddRange(ColumnGroups);
       foreach (var g in joined.ColumnGroups) {
-        groups.Add(new ColumnGroup(
-            g.TypeInfoRef,
-            g.Keys.Select(i => columnCount + i),
-            g.Columns.Select(i => columnCount + i))
-        );
+        var keys = new List<int>(g.Keys.Count);
+        foreach (var i in g.Keys) {
+          keys.Add(columnCount + i);
+        }
+        var columns = new List<int>(g.Columns.Count);
+        foreach (var i in g.Columns) {
+          columns.Add(columnCount + i);
+        }
+        groups.Add(new ColumnGroup(g.TypeInfoRef, keys, columns));
       }
 
       return new RecordSetHeader(

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -126,17 +126,17 @@ namespace Xtensive.Orm.Rse
     public RecordSetHeader Join(RecordSetHeader joined)
     {
       var columnCount = Columns.Count;
-      var newColumns = new List<Column>(Columns);
-      newColumns.AddRange(
-        from c in joined.Columns 
-        select c.Clone(columnCount + c.Index));
+      var newColumns = new List<Column>(Columns.Count + joined.Columns.Count);
+      newColumns.AddRange(Columns);
+      newColumns.AddRange(joined.Columns.Select(c => c.Clone(columnCount + c.Index)));
 
       var newFieldTypes = new Type[newColumns.Count];
       for (var i = 0; i < newColumns.Count; i++)
         newFieldTypes[i] = newColumns[i].Type;
       var newTupleDescriptor = TupleDescriptor.Create(newFieldTypes);
 
-      var groups = new List<ColumnGroup>(ColumnGroups);
+      var groups = new List<ColumnGroup>(ColumnGroups.Count + joined.ColumnGroups.Count);
+      groups.AddRange(ColumnGroups);
       groups.AddRange(
         joined.ColumnGroups
           .Select(g => new ColumnGroup(

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -126,24 +126,28 @@ namespace Xtensive.Orm.Rse
     public RecordSetHeader Join(RecordSetHeader joined)
     {
       var columnCount = Columns.Count;
-      var newColumns = new List<Column>(Columns.Count + joined.Columns.Count);
+      var newColumns = new List<Column>(columnCount + joined.Columns.Count);
       newColumns.AddRange(Columns);
-      newColumns.AddRange(joined.Columns.Select(c => c.Clone(columnCount + c.Index)));
+      foreach (var c in joined.Columns) {
+        newColumns.Add(c.Clone(columnCount + c.Index));
+      }
 
       var newFieldTypes = new Type[newColumns.Count];
       for (var i = 0; i < newColumns.Count; i++)
         newFieldTypes[i] = newColumns[i].Type;
       var newTupleDescriptor = TupleDescriptor.Create(newFieldTypes);
 
-      var groups = new List<ColumnGroup>(ColumnGroups.Count + joined.ColumnGroups.Count);
+      var columnGroupCount = ColumnGroups.Count;
+      var groups = new List<ColumnGroup>(columnGroupCount + joined.ColumnGroups.Count);
       groups.AddRange(ColumnGroups);
-      groups.AddRange(
-        joined.ColumnGroups
-          .Select(g => new ColumnGroup(
+      foreach (var g in joined.ColumnGroups) {
+        groups.Add(new ColumnGroup(
             g.TypeInfoRef,
             g.Keys.Select(i => columnCount + i),
-            g.Columns.Select(i => columnCount + i))));
-      
+            g.Columns.Select(i => columnCount + i))
+        );
+      }
+
       return new RecordSetHeader(
         newTupleDescriptor, 
         newColumns, 

--- a/Orm/Xtensive.Orm/Sql/Dml/Collections/SqlColumnCollection.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Collections/SqlColumnCollection.cs
@@ -24,6 +24,11 @@ namespace Xtensive.Sql.Dml
     /// </summary>
     public int Count => columnList.Count;
 
+    public int Capacity {
+      get => columnList.Capacity;
+      set => columnList.Capacity = value;
+    }
+
     /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>>
     bool ICollection<SqlColumn>.IsReadOnly => false;
 

--- a/Version.props
+++ b/Version.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.0.0.14</DoVersion>
+    <DoVersion>7.0.0.15</DoVersion>
     <DoVersionSuffix>servicetitan</DoVersionSuffix>
 </PropertyGroup>
 


### PR DESCRIPTION
Trace files show many List allocations in these parts of DataObjects

* Sometime we know final List size to preallocate that capacity.
* `ReadOnlyList` wrapper is obsolete. Can be replaced by `IReadOnlyList` interface` to `List<>`