### PR TITLE
Optimizing refactoring: make TranslatorState struct

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
@@ -145,8 +145,7 @@ namespace Xtensive.Orm.Linq
       var arguments = new List<Expression>();
       foreach (var argument in n.Arguments) {
         Expression body;
-        using (state.CreateScope()) {
-          state.CalculateExpressions = false;
+        using (CreateScope(new TranslatorState(state) { CalculateExpressions = false })) {
           body = Visit(argument);
         }
         body = body.IsProjection() 
@@ -203,7 +202,6 @@ namespace Xtensive.Orm.Linq
     {
       this.compiledQueryScope = compiledQueryScope;
       this.context = context;
-      state = new TranslatorState(this);
     }
 
     static Translator()

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -31,12 +31,12 @@ namespace Xtensive.Orm.Linq
     internal TranslatorState state { get; private set; } = TranslatorState.InitState;
     private readonly TranslatorContext context;
 
-    internal void RestoreState(TranslatorState previousState) =>
+    internal void RestoreState(in TranslatorState previousState) =>
       state = previousState;
 
-    public TranslatorState.TranslatorScope CreateScope(TranslatorState newState)
+    public TranslatorState.TranslatorScope CreateScope(in TranslatorState newState)
     {
-      var scope = new TranslatorState.TranslatorScope(this, state);
+      var scope = new TranslatorState.TranslatorScope(this);
       state = newState;
       return scope;
     }

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexis Kochetov
@@ -28,8 +28,34 @@ namespace Xtensive.Orm.Linq
   {
     private static readonly Type IEnumerableOfKeyType = typeof(IEnumerable<Key>);
 
-    public TranslatorState state;
+    internal TranslatorState state { get; private set; } = TranslatorState.InitState;
     private readonly TranslatorContext context;
+
+    internal void RestoreState(TranslatorState previousState) =>
+      state = previousState;
+
+    public TranslatorState.TranslatorScope CreateScope(TranslatorState newState)
+    {
+      var scope = new TranslatorState.TranslatorScope(this, state);
+      state = newState;
+      return scope;
+    }
+
+    public TranslatorState.TranslatorScope CreateLambdaScope(LambdaExpression le, bool allowCalculableColumnCombine)
+    {
+      var newOuterParameters = new ParameterExpression[state.OuterParameters.Length + state.Parameters.Length];
+      state.OuterParameters.CopyTo(newOuterParameters, 0);
+      state.Parameters.CopyTo(newOuterParameters, state.OuterParameters.Length);
+      return CreateScope(new TranslatorState(state) {
+        OuterParameters = newOuterParameters,
+        Parameters = le.Parameters.ToArray(le.Parameters.Count),
+        CurrentLambda = le,
+        AllowCalculableColumnCombine = allowCalculableColumnCombine
+      });
+    }
+
+    private void ModifyStateAllowCalculableColumnCombine(bool b) =>
+      state = new TranslatorState(state) { AllowCalculableColumnCombine = b };
 
     protected override Expression VisitConstant(ConstantExpression c)
     {
@@ -46,7 +72,7 @@ namespace Xtensive.Orm.Linq
 
     protected override Expression VisitQueryableMethod(MethodCallExpression mc, QueryableMethodKind methodKind)
     {
-      using (state.CreateScope()) {
+      using (CreateScope(new TranslatorState(state))) {
         switch (methodKind) {
           case QueryableMethodKind.Cast:
             return VisitCast(mc.Arguments[0], mc.Method.GetGenericArguments()[0],
@@ -73,8 +99,9 @@ namespace Xtensive.Orm.Linq
           case QueryableMethodKind.Intersect:
           case QueryableMethodKind.Concat:
           case QueryableMethodKind.Union:
-            state.BuildingProjection = false;
-            return VisitSetOperations(mc.Arguments[0], mc.Arguments[1], methodKind, mc.Method.GetGenericArguments()[0]);
+            using (CreateScope(new TranslatorState(state) { BuildingProjection = false })) {
+              return VisitSetOperations(mc.Arguments[0], mc.Arguments[1], methodKind, mc.Method.GetGenericArguments()[0]);
+            }
           case QueryableMethodKind.Reverse:
             break;
           case QueryableMethodKind.SequenceEqual:
@@ -142,34 +169,39 @@ namespace Xtensive.Orm.Linq
 
             break;
           case QueryableMethodKind.GroupBy:
-            state.BuildingProjection = false;
-            var groupBy = QueryParser.ParseGroupBy(mc);
-            return VisitGroupBy(mc.Method.ReturnType,
-              groupBy.Source,
-              groupBy.KeySelector,
-              groupBy.ElementSelector,
-              groupBy.ResultSelector);
+            using (CreateScope(new TranslatorState(state) { BuildingProjection = false })) {
+              var groupBy = QueryParser.ParseGroupBy(mc);
+              return VisitGroupBy(mc.Method.ReturnType,
+                groupBy.Source,
+                groupBy.KeySelector,
+                groupBy.ElementSelector,
+                groupBy.ResultSelector);
+            }
           case QueryableMethodKind.GroupJoin:
-            state.BuildingProjection = false;
-            return VisitGroupJoin(mc.Arguments[0],
-              mc.Arguments[1],
-              mc.Arguments[2].StripQuotes(),
-              mc.Arguments[3].StripQuotes(),
-              mc.Arguments[4].StripQuotes(),
-              mc.Arguments.Count > 5 ? mc.Arguments[5] : null,
-              mc);
+            using (CreateScope(new TranslatorState(state) { BuildingProjection = false })) {
+              return VisitGroupJoin(mc.Arguments[0],
+                mc.Arguments[1],
+                mc.Arguments[2].StripQuotes(),
+                mc.Arguments[3].StripQuotes(),
+                mc.Arguments[4].StripQuotes(),
+                mc.Arguments.Count > 5 ? mc.Arguments[5] : null,
+                mc);
+            }
           case QueryableMethodKind.Join:
-            state.BuildingProjection = false;
-            return VisitJoin(mc.Arguments[0],
-              mc.Arguments[1],
-              mc.Arguments[2].StripQuotes(),
-              mc.Arguments[3].StripQuotes(),
-              mc.Arguments[4].StripQuotes(),
-              false,
-              mc);
+            using (CreateScope(new TranslatorState(state) { BuildingProjection = false })) {
+              return VisitJoin(mc.Arguments[0],
+                mc.Arguments[1],
+                mc.Arguments[2].StripQuotes(),
+                mc.Arguments[3].StripQuotes(),
+                mc.Arguments[4].StripQuotes(),
+                false,
+                mc);
+            }
           case QueryableMethodKind.OrderBy:
           case QueryableMethodKind.OrderByDescending:
-            return VisitSort(mc);
+            using (CreateScope(new TranslatorState(state) { BuildingProjection = false })) {
+              return VisitSort(mc);
+            }
           case QueryableMethodKind.Select:
             return VisitSelect(mc.Arguments[0], mc.Arguments[1].StripQuotes());
           case QueryableMethodKind.SelectMany:
@@ -217,10 +249,13 @@ namespace Xtensive.Orm.Linq
             break;
           case QueryableMethodKind.ThenBy:
           case QueryableMethodKind.ThenByDescending:
-            return VisitSort(mc);
+            using (CreateScope(new TranslatorState(state) { BuildingProjection = false })) {
+              return VisitSort(mc);
+            }
           case QueryableMethodKind.Where:
-            state.BuildingProjection = false;
-            return VisitWhere(mc.Arguments[0], mc.Arguments[1].StripQuotes());
+            using (CreateScope(new TranslatorState(state) { BuildingProjection = false })) {
+              return VisitWhere(mc.Arguments[0], mc.Arguments[1].StripQuotes());
+            }
           default:
             throw new ArgumentOutOfRangeException(nameof(methodKind));
         }
@@ -432,10 +467,9 @@ namespace Xtensive.Orm.Linq
       var applySequenceType = ApplySequenceType.All;
 
       ProjectionExpression projection;
-      using (state.CreateScope()) {
-        var isPrimitiveType = context.ProviderInfo.SupportedTypes.Contains(method.ReturnType);
-        state.RequestCalculateExpressions = state.RequestCalculateExpressions
-          || !isRoot && isPrimitiveType;
+      using (CreateScope(new TranslatorState(state) {
+            RequestCalculateExpressions = state.RequestCalculateExpressions || !isRoot && context.ProviderInfo.SupportedTypes.Contains(method.ReturnType)
+          })) {
         projection = predicate != null ? VisitWhere(source, predicate) : VisitSequence(source);
       }
 
@@ -655,8 +689,7 @@ namespace Xtensive.Orm.Linq
     private ProjectionExpression VisitDistinct(Expression expression)
     {
       ProjectionExpression result;
-      using (state.CreateScope()) {
-        state.RequestCalculateExpressionsOnce = true;
+      using (CreateScope(new TranslatorState(state) { RequestCalculateExpressionsOnce = true })) {
         result = VisitSequence(expression);
       }
 
@@ -842,8 +875,7 @@ namespace Xtensive.Orm.Linq
 
       if (aggregateParameter != null) {
         using (context.Bindings.Add(aggregateParameter.Parameters[0], sourceProjection))
-        using (state.CreateScope()) {
-          state.CalculateExpressions = true;
+        using (CreateScope(new TranslatorState(state) { CalculateExpressions = true })) {
           var result = (ItemProjectorExpression) VisitLambda(aggregateParameter);
           if (!result.IsPrimitive) {
             throw new NotSupportedException(
@@ -921,9 +953,7 @@ namespace Xtensive.Orm.Linq
 
       ProjectionExpression groupingSourceProjection;
       context.Bindings.PermanentAdd(keySelector.Parameters[0], sequence);
-      using (state.CreateScope()) {
-        state.CalculateExpressions = true;
-        state.GroupingKey = true;
+      using (CreateScope(new TranslatorState(state) { CalculateExpressions = true, GroupingKey = true })) {
         var itemProjector = (ItemProjectorExpression) VisitLambda(keySelector);
         groupingSourceProjection = new ProjectionExpression(
           WellKnownInterfaces.QueryableOfT.MakeGenericType(keySelector.Body.Type),
@@ -1027,8 +1057,7 @@ namespace Xtensive.Orm.Linq
       //      var groupingParameter = Expression.Parameter(groupingProjection.ItemProjector.Item.Type, "groupingParameter");
       //      var applyParameter = context.GetApplyParameter(groupingProjection);
       //      using (context.Bindings.Add(groupingParameter, groupingProjection))
-      //      using (state.CreateScope()) {
-      //        state.Parameters = state.Parameters.AddOne(groupingParameter).ToArray();
+      //      using (CreateScope(new TranslatorState(state) { Parameters = state.Parameters.AddOne(groupingParameter).ToArray() })) {
       //        var lambda = FastExpression.Lambda(Expression.Equal(groupingParameter, keySelector.Body), keySelector.Parameters);
       //        subqueryProjection = VisitWhere(VisitSequence(source), lambda);
       //      }
@@ -1080,10 +1109,8 @@ namespace Xtensive.Orm.Linq
         throw new InvalidOperationException(string.Format(Strings.ExInvalidSortExpressionX, expression));
       }
 
-      state.BuildingProjection = false;
       ProjectionExpression projection;
-      using (state.CreateScope()) {
-        state.CalculateExpressions = false;
+      using (CreateScope(new TranslatorState(state) { CalculateExpressions = false })) {
         projection = VisitSequence(extractor.BaseExpression);
       }
 
@@ -1094,9 +1121,7 @@ namespace Xtensive.Orm.Linq
         var direction = item.Value;
         var sortParameter = sortExpression.Parameters[0];
         using (context.Bindings.Add(sortParameter, projection))
-        using (state.CreateScope()) {
-          state.ShouldOmitConvertToObject = true;
-          state.CalculateExpressions = true;
+        using (CreateScope(new TranslatorState(state) { ShouldOmitConvertToObject = true, CalculateExpressions = true })) {
           var orderByProjector = (ItemProjectorExpression) VisitLambda(sortExpression);
           var columns = orderByProjector
             .GetColumns(ColumnExtractionModes.TreatEntityAsKey | ColumnExtractionModes.Distinct);
@@ -1126,8 +1151,7 @@ namespace Xtensive.Orm.Linq
       using (context.Bindings.Add(innerParameter, innerSequence)) {
         ItemProjectorExpression outerKeyProjector;
         ItemProjectorExpression innerKeyProjector;
-        using (state.CreateScope()) {
-          state.CalculateExpressions = true;
+        using (CreateScope(new TranslatorState(state) { CalculateExpressions = true })) {
           outerKeyProjector = (ItemProjectorExpression) VisitLambda(outerKey);
           innerKeyProjector = (ItemProjectorExpression) VisitLambda(innerKey);
         }
@@ -1194,8 +1218,7 @@ namespace Xtensive.Orm.Linq
       var groupingResultType = WellKnownInterfaces.QueryableOfT.MakeGenericType(enumerableType);
 
       ProjectionExpression innerGrouping;
-      using (state.CreateScope()) {
-        state.SkipNullableColumnsDetectionInGroupBy = true;
+      using (CreateScope(new TranslatorState(state) { SkipNullableColumnsDetectionInGroupBy = true })) {
         innerGrouping = VisitGroupBy(groupingResultType, visitedInnerSource, innerKey, null, null);
       }
 
@@ -1260,13 +1283,14 @@ namespace Xtensive.Orm.Linq
         }
 
         ProjectionExpression innerProjection;
-        using (state.CreateScope()) {
-          state.OuterParameters = state.OuterParameters
-            .Concat(state.Parameters)
-            .Concat(collectionSelector.Parameters)
-            .Append(outerParameter).ToArray();
-          state.Parameters = Array.Empty<ParameterExpression>();
-          state.RequestCalculateExpressionsOnce = true;
+        using (CreateScope(new TranslatorState(state) {
+              OuterParameters = state.OuterParameters
+                .Concat(state.Parameters)
+                .Concat(collectionSelector.Parameters)
+                .Append(outerParameter).ToArray(),
+              Parameters = Array.Empty<ParameterExpression>(),
+              RequestCalculateExpressionsOnce = true
+            })) {
           var visitedCollectionSelector = Visit(collectionSelector.Body);
 
           if (visitedCollectionSelector.IsGroupingExpression()) {
@@ -1346,18 +1370,17 @@ namespace Xtensive.Orm.Linq
       }
 
       context.Bindings.PermanentAdd(le.Parameters[0], sequence);
-      using (state.CreateScope()) {
-        state.CalculateExpressions = state.RequestCalculateExpressions || state.RequestCalculateExpressionsOnce;
-        state.RequestCalculateExpressionsOnce = false;
-
+      using (CreateScope(new TranslatorState(state) {
+            CalculateExpressions = state.RequestCalculateExpressions || state.RequestCalculateExpressionsOnce,
+            RequestCalculateExpressionsOnce = false
+          })) {
         return BuildProjection(le);
       }
     }
 
     private ProjectionExpression BuildProjection(LambdaExpression le)
     {
-      using (state.CreateScope()) {
-        state.BuildingProjection = true;
+      using (CreateScope(new TranslatorState(state) { BuildingProjection = true })) {
         var itemProjector = (ItemProjectorExpression) VisitLambda(le);
         return new ProjectionExpression(
           WellKnownInterfaces.QueryableOfT.MakeGenericType(le.Body.Type),
@@ -1378,9 +1401,7 @@ namespace Xtensive.Orm.Linq
 
       using (indexBinding)
       using (context.Bindings.Add(parameter, visitedSource))
-      using (state.CreateScope()) {
-        state.CalculateExpressions = false;
-        state.CurrentLambda = le;
+      using (CreateScope(new TranslatorState(state) { CalculateExpressions = false, CurrentLambda = le })) {
         var predicateExpression = (ItemProjectorExpression) VisitLambda(le);
         var predicate = predicateExpression.ToLambda(context);
         var source = context.Bindings[parameter];
@@ -1419,8 +1440,7 @@ namespace Xtensive.Orm.Linq
       }
 
       ProjectionExpression subquery;
-      using (state.CreateScope()) {
-        state.CalculateExpressions = false;
+      using (CreateScope(new TranslatorState(state) { CalculateExpressions = false })) {
         subquery = predicate == null
           ? VisitSequence(source)
           : VisitWhere(source, predicate);
@@ -1445,25 +1465,20 @@ namespace Xtensive.Orm.Linq
 
       var parameter = predicate.Parameters[0];
       ProjectionExpression visitedSource;
-      using (state.CreateScope()) {
-        if (source.IsLocalCollection(context) && IsKeyCollection(source.Type)) {
-          var localCollectionKeyType = LocalCollectionKeyTypeExtractor.Extract((BinaryExpression) predicate.Body);
-          state.TypeOfEntityStoredInKey = localCollectionKeyType;
-        }
-
-        state.IncludeAlgorithm = IncludeAlgorithm.Auto;
+      using (CreateScope(new TranslatorState(state) {
+            TypeOfEntityStoredInKey = source.IsLocalCollection(context) && IsKeyCollection(source.Type)
+              ? LocalCollectionKeyTypeExtractor.Extract((BinaryExpression) predicate.Body)
+              : state.TypeOfEntityStoredInKey,
+            IncludeAlgorithm = IncludeAlgorithm.Auto
+          })) {
         visitedSource = VisitSequence(source);
       }
 
       var outerParameter = state.Parameters[0];
       using (context.Bindings.Add(parameter, visitedSource))
-      using (state.CreateScope()) {
-        state.CalculateExpressions = false;
-        state.CurrentLambda = predicate;
-
+      using (CreateScope(new TranslatorState(state) { CalculateExpressions = false, CurrentLambda = predicate })) {
         ItemProjectorExpression predicateExpression;
-        using (state.CreateScope()) {
-          state.IncludeAlgorithm = IncludeAlgorithm.Auto;
+        using (CreateScope(new TranslatorState(state) { IncludeAlgorithm = IncludeAlgorithm.Auto })) {
           predicateExpression = (ItemProjectorExpression) VisitLambda(predicate);
         }
 
@@ -1540,8 +1555,7 @@ namespace Xtensive.Orm.Linq
           break;
       }
 
-      using (state.CreateScope()) {
-        state.IncludeAlgorithm = algorithm;
+      using (CreateScope(new TranslatorState(state) { IncludeAlgorithm = algorithm })) {
         return VisitContains(source, match, false);
       }
     }
@@ -1555,10 +1569,7 @@ namespace Xtensive.Orm.Linq
       QueryHelper.TryAddConvarianceCast(ref outerSource, elementType);
       QueryHelper.TryAddConvarianceCast(ref innerSource, elementType);
 
-      using (state.CreateScope()) {
-        state.JoinLocalCollectionEntity = true;
-        state.CalculateExpressions = true;
-        state.RequestCalculateExpressions = true;
+      using (CreateScope(new TranslatorState(state) { JoinLocalCollectionEntity = true, CalculateExpressions = true, RequestCalculateExpressions = true })) {
         outer = VisitSequence(outerSource);
         inner = VisitSequence(innerSource);
       }

--- a/Orm/Xtensive.Orm/Orm/Linq/TranslatorState.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/TranslatorState.cs
@@ -130,7 +130,7 @@ namespace Xtensive.Orm.Linq
       init => ModifyFlag(ref flags, TranslatorStateFlags.SkipNullableColumnsDetectionInGroupBy, value);
     }
 
-    public TranslatorState(TranslatorState currentState) =>
+    public TranslatorState(in TranslatorState currentState) =>
       this = currentState;
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/TranslatorState.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/TranslatorState.cs
@@ -34,10 +34,10 @@ namespace Xtensive.Orm.Linq
 
       public void Dispose() => translator.RestoreState(previousState);
 
-      public TranslatorScope(Translator translator, TranslatorState previousState)
+      public TranslatorScope(Translator translator)
       {
         this.translator = translator;
-        this.previousState = previousState;
+        previousState = translator.state;
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/TranslatorState.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/TranslatorState.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2020 Xtensive LLC.
+// Copyright (C) 2010-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Gamzov
@@ -6,11 +6,11 @@
 
 using System;
 using System.Linq.Expressions;
-using Xtensive.Core;
+using System.Runtime.CompilerServices;
 
 namespace Xtensive.Orm.Linq
 {
-  internal sealed class TranslatorState
+  internal readonly struct TranslatorState
   {
     [Flags]
     private enum TranslatorStateFlags
@@ -27,12 +27,12 @@ namespace Xtensive.Orm.Linq
       SkipNullableColumnsDetectionInGroupBy = 1 << 9
     }
 
-    internal readonly ref struct TranslatorScope
+    internal readonly struct TranslatorScope : IDisposable
     {
       private readonly TranslatorState previousState;
       private readonly Translator translator;
 
-      public void Dispose() => translator.state = previousState;
+      public void Dispose() => translator.RestoreState(previousState);
 
       public TranslatorScope(Translator translator, TranslatorState previousState)
       {
@@ -41,141 +41,104 @@ namespace Xtensive.Orm.Linq
       }
     }
 
-    private readonly Translator translator;
+    public static readonly TranslatorState InitState = new TranslatorState {
+      BuildingProjection = true,
+      IsTailMethod = true,
+      OuterParameters = Array.Empty<ParameterExpression>(),
+      Parameters = Array.Empty<ParameterExpression>(),
+      CurrentLambda = null,
+      IncludeAlgorithm = IncludeAlgorithm.Auto,
+      TypeOfEntityStoredInKey = null,
+    };
 
-    private TranslatorStateFlags flags;
+    private readonly TranslatorStateFlags flags;
 
-    public ParameterExpression[] Parameters { get; set; }
+    public ParameterExpression[] Parameters { get; init; }
 
-    public ParameterExpression[] OuterParameters { get; set; }
+    public ParameterExpression[] OuterParameters { get; init; }
 
-    public LambdaExpression CurrentLambda { get; set; }
+    public LambdaExpression CurrentLambda { get; init; }
 
-    public IncludeAlgorithm IncludeAlgorithm { get; set; }
+    public IncludeAlgorithm IncludeAlgorithm { get; init; }
 
-    public Type TypeOfEntityStoredInKey { get; set; }
+    public Type TypeOfEntityStoredInKey { get; init; }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool GetFlag(TranslatorStateFlags f) => (flags & f) != 0;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ModifyFlag(ref TranslatorStateFlags flags, TranslatorStateFlags f, bool value) =>
+      flags = value ? flags | f : flags & ~f;
 
     public bool JoinLocalCollectionEntity
     {
-      get => (flags & TranslatorStateFlags.JoinLocalCollectionEntity) != 0;
-      set => flags = value
-        ? flags | TranslatorStateFlags.JoinLocalCollectionEntity
-        : flags & ~TranslatorStateFlags.JoinLocalCollectionEntity;
+      get => GetFlag(TranslatorStateFlags.JoinLocalCollectionEntity);
+      init => ModifyFlag(ref flags, TranslatorStateFlags.JoinLocalCollectionEntity, value);
     }
 
-    public bool AllowCalculableColumnCombine    {
-      get => (flags & TranslatorStateFlags.AllowCalculableColumnCombine) != 0;
-      set => flags = value
-        ? flags | TranslatorStateFlags.AllowCalculableColumnCombine
-        : flags & ~TranslatorStateFlags.AllowCalculableColumnCombine;
+    public bool AllowCalculableColumnCombine
+    {
+      get => GetFlag(TranslatorStateFlags.AllowCalculableColumnCombine);
+      init => ModifyFlag(ref flags, TranslatorStateFlags.AllowCalculableColumnCombine, value);
     }
 
     public bool BuildingProjection
     {
-      get => (flags & TranslatorStateFlags.IsBuildingProjection) != 0;
-      set => flags = value
-        ? flags | TranslatorStateFlags.IsBuildingProjection
-        : flags & ~TranslatorStateFlags.IsBuildingProjection;
+      get => GetFlag(TranslatorStateFlags.IsBuildingProjection);
+      init => ModifyFlag(ref flags, TranslatorStateFlags.IsBuildingProjection, value);
     }
 
     public bool CalculateExpressions
     {
-      get => (flags & TranslatorStateFlags.CalculateExpressions) != 0;
-      set => flags = value
-        ? flags | TranslatorStateFlags.CalculateExpressions
-        : flags & ~TranslatorStateFlags.CalculateExpressions;
+      get => GetFlag(TranslatorStateFlags.CalculateExpressions);
+      init => ModifyFlag(ref flags, TranslatorStateFlags.CalculateExpressions, value);
     }
 
     public bool GroupingKey
     {
-      get => (flags & TranslatorStateFlags.IsGroupingKey) != 0;
-      set => flags = value
-        ? flags | TranslatorStateFlags.IsGroupingKey
-        : flags & ~TranslatorStateFlags.IsGroupingKey;
+      get => GetFlag(TranslatorStateFlags.IsGroupingKey);
+      init => ModifyFlag(ref flags, TranslatorStateFlags.IsGroupingKey, value);
     }
 
     public bool IsTailMethod
     {
-      get => (flags & TranslatorStateFlags.IsTailMethod) != 0;
-      set => flags = value
-        ? flags | TranslatorStateFlags.IsTailMethod
-        : flags & ~TranslatorStateFlags.IsTailMethod;
+      get => GetFlag(TranslatorStateFlags.IsTailMethod);
+      init => ModifyFlag(ref flags, TranslatorStateFlags.IsTailMethod, value);
     }
 
     public bool ShouldOmitConvertToObject
     {
-      get => (flags & TranslatorStateFlags.ShouldOmitConvertToObject) != 0;
-      set => flags = value
-        ? flags | TranslatorStateFlags.ShouldOmitConvertToObject
-        : flags & ~TranslatorStateFlags.ShouldOmitConvertToObject;
+      get => GetFlag(TranslatorStateFlags.ShouldOmitConvertToObject);
+      init => ModifyFlag(ref flags, TranslatorStateFlags.ShouldOmitConvertToObject, value);
     }
 
     public bool RequestCalculateExpressions
     {
-      get => (flags & TranslatorStateFlags.RequestCalculateExpressions) != 0;
-      set => flags = value
-        ? flags | TranslatorStateFlags.RequestCalculateExpressions
-        : flags & ~TranslatorStateFlags.RequestCalculateExpressions;
+      get => GetFlag(TranslatorStateFlags.RequestCalculateExpressions);
+      init => ModifyFlag(ref flags, TranslatorStateFlags.RequestCalculateExpressions, value);
     }
 
     public bool RequestCalculateExpressionsOnce
     {
-      get => (flags & TranslatorStateFlags.RequestCalculateExpressionsOnce) != 0;
-      set => flags = value
-        ? flags | TranslatorStateFlags.RequestCalculateExpressionsOnce
-        : flags & ~TranslatorStateFlags.RequestCalculateExpressionsOnce;
+      get => GetFlag(TranslatorStateFlags.RequestCalculateExpressionsOnce);
+      init => ModifyFlag(ref flags, TranslatorStateFlags.RequestCalculateExpressionsOnce, value);
     }
 
-    public bool SkipNullableColumnsDetectionInGroupBy 
+    public bool SkipNullableColumnsDetectionInGroupBy
     {
-      get => (flags & TranslatorStateFlags.SkipNullableColumnsDetectionInGroupBy) != 0;
-      set => flags = value
-        ? flags | TranslatorStateFlags.SkipNullableColumnsDetectionInGroupBy
-        : flags & ~TranslatorStateFlags.SkipNullableColumnsDetectionInGroupBy;
+      get => GetFlag(TranslatorStateFlags.SkipNullableColumnsDetectionInGroupBy);
+      init => ModifyFlag(ref flags, TranslatorStateFlags.SkipNullableColumnsDetectionInGroupBy, value);
     }
 
-    public TranslatorScope CreateScope()
-    {
-      var currentState = translator.state;
-      translator.state = new TranslatorState(currentState);
-      return new TranslatorScope(translator, currentState);
-    }
-
-    public TranslatorScope CreateLambdaScope(LambdaExpression le)
-    {
-      var currentState = translator.state;
-      var newState = new TranslatorState(currentState);
-      var newOuterParameters = new ParameterExpression[newState.OuterParameters.Length + newState.Parameters.Length];
-      newState.OuterParameters.CopyTo(newOuterParameters, 0);
-      newState.Parameters.CopyTo(newOuterParameters, newState.OuterParameters.Length);
-      newState.OuterParameters = newOuterParameters;
-      newState.Parameters = le.Parameters.ToArray(le.Parameters.Count);
-      newState.CurrentLambda = le;
-      translator.state = newState;
-      return new TranslatorScope(translator, currentState);
-    }
-
-
-    // Constructors
-
-    public TranslatorState(Translator translator)
-    {
-      this.translator = translator;
-      flags = TranslatorStateFlags.IsBuildingProjection | TranslatorStateFlags.IsTailMethod;
-      OuterParameters = Parameters = Array.Empty<ParameterExpression>();
-      IncludeAlgorithm = IncludeAlgorithm.Auto;
-      TypeOfEntityStoredInKey = null;
-    }
-
-    private TranslatorState(TranslatorState currentState)
-    {
-      translator = currentState.translator;
-      flags = currentState.flags;
-      Parameters = currentState.Parameters;
-      OuterParameters = currentState.OuterParameters;
-      CurrentLambda = currentState.CurrentLambda;
-      IncludeAlgorithm = currentState.IncludeAlgorithm;
-      TypeOfEntityStoredInKey = currentState.TypeOfEntityStoredInKey;
-    }
+    public TranslatorState(TranslatorState currentState) =>
+      this = currentState;
   }
 }
+
+#if !NET5_0_OR_GREATER
+// Workaround of error CS0518: Predefined type 'System.Runtime.CompilerServices.IsExternalInit' is not defined or imported
+namespace System.Runtime.CompilerServices
+{
+  internal static class IsExternalInit { }
+}
+#endif


### PR DESCRIPTION
Make `TranslatorState` readonly struct to avoid allocations

I'm suggesting to change `TranslatorState.flags` bit-field to  10 `bool` fields.
The struct will be 8 byte-longer, but simpler and faster
@AlexUstinov  what do you think?