### PR TITLE
Optimize TypeInfoCollection

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfoCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfoCollection.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2007-2020 Xtensive LLC.
+// Copyright (C) 2007-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
@@ -34,14 +34,9 @@ namespace Xtensive.Orm.Model
     /// An indexer that provides access to collection items.
     /// </summary>
     /// <exception cref="ArgumentException">Item was not found.</exception>
-    public TypeInfo this[Type key] {
-      get {
-        TypeInfo result;
-        if (!TryGetValue(key, out result))
-          throw new KeyNotFoundException(string.Format(Strings.TypeXIsNotRegistered, key.GetShortName()));
-        return result;
-      }
-    }
+    public TypeInfo this[Type key] => TryGetValue(key, out var result)
+      ? result
+      : throw new KeyNotFoundException(string.Format(Strings.TypeXIsNotRegistered, key.GetShortName()));
 
     /// <summary>
     /// An indexer that provides access to collection items by their <see cref="TypeInfo.TypeId"/>.
@@ -217,15 +212,13 @@ namespace Xtensive.Orm.Model
     {
       ArgumentValidator.EnsureArgumentNotNull(item, "item");
 
-      HashSet<TypeInfo> result;
-      if (!descendantTable.TryGetValue(item, out result))
-        result = new HashSet<TypeInfo>();
-
-      foreach (var item1 in result) {
-        yield return item1;
-        if (recursive)
-          foreach (var item2 in FindDescendants(item1, true))
-            yield return item2;
+      if (descendantTable.TryGetValue(item, out var result)) {
+        foreach (var item1 in result) {
+          yield return item1;
+          if (recursive)
+            foreach (var item2 in FindDescendants(item1, true))
+              yield return item2;
+        }
       }
     }
 
@@ -251,12 +244,10 @@ namespace Xtensive.Orm.Model
     {
       ArgumentValidator.EnsureArgumentNotNull(item, "item");
 
-      HashSet<TypeInfo> result;
-      if (!interfaceTable.TryGetValue(item, out result))
-        result = new HashSet<TypeInfo>();
-
-      foreach (var item1 in result)
-        yield return item1;
+      if (interfaceTable.TryGetValue(item, out var result)) {
+        foreach (var item1 in result)
+          yield return item1;
+      }
 
       if (!recursive || item.IsInterface)
         yield break;
@@ -294,14 +285,13 @@ namespace Xtensive.Orm.Model
       ArgumentValidator.EnsureArgumentNotNull(item, "item");
 
       HashSet<TypeInfo> result;
-      if (!implementorTable.TryGetValue(item, out result))
-        result = new HashSet<TypeInfo>();
-
-      foreach (var item1 in result) {
-        yield return item1;
-        if (recursive && !item1.IsInterface)
-          foreach (var item2 in FindDescendants(item1, true))
-            yield return item2;
+      if (implementorTable.TryGetValue(item, out result)) {
+        foreach (var item1 in result) {
+          yield return item1;
+          if (recursive && !item1.IsInterface)
+            foreach (var item2 in FindDescendants(item1, true))
+              yield return item2;
+        }
       }
     }
 
@@ -334,12 +324,13 @@ namespace Xtensive.Orm.Model
     /// <returns><see name="TypeDef"/> instance that is ancestor of specified <paramref name="type"/> or 
     /// <see langword="null"/> if the ancestor is not found in this collection.</returns>
     /// <exception cref="ArgumentNullException">When <paramref name="type"/> is <see langword="null"/>.</exception>
-    private TypeInfo FindAncestor(Type type)
-    {
-      if (type == WellKnownTypes.Object || type.BaseType == null)
-        return null;
-      return Contains(type.BaseType) ? this[type.BaseType] : FindAncestor(type.BaseType);
-    }
+    private TypeInfo FindAncestor(Type type) =>
+      type == WellKnownTypes.Object
+        ? null
+        : type.BaseType switch {
+          null => null,
+          var baseType => TryGetValue(baseType, out var typeInfo) ? typeInfo : FindAncestor(baseType)
+        };
 
     #endregion
 


### PR DESCRIPTION
* Avoid allocation empty `HashSet<>` just to enumerate them
* Using `TryGetValue()` instead of  double-lookup by `Contains/this[]`. 