### PR TITLE
Optimization: Replace .In() by C#9 is/or operator for constants and == operator for fixed number of arguments

### DIFF
--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/SetOperation.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/SetOperation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2019-2020 Xtensive LLC.
+// Copyright (C) 2019-2020 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
@@ -55,7 +55,7 @@ namespace Xtensive.Orm.BulkOperations
               Expression ex = setDescriptor.Expression;
               var call = ex as MethodCallExpression;
               if (call != null && call.Method.DeclaringType == typeof(Queryable) &&
-                call.Method.Name.In("First", "FirstOrDefault", "Single", "SingleOrDefault"))
+                call.Method.Name.IsOneOf("First", "FirstOrDefault", "Single", "SingleOrDefault"))
                 throw new NotSupportedException("Subqueries with structures are not supported");
               /*ex = call.Arguments[0];
         ParameterExpression parameter = Expression.Parameter(setDescriptor.Expression.Type, "parameter");
@@ -165,7 +165,7 @@ namespace Xtensive.Orm.BulkOperations
       int i;
       if (methodCall!=null) {
         if (methodCall.Method.DeclaringType==typeof (QueryEndpoint) &&
-          methodCall.Method.Name.In("Single", "SingleOrDefault")) {
+          methodCall.Method.Name.IsOneOf("Single", "SingleOrDefault")) {
           object[] keys;
           if (methodCall.Arguments[0].Type==typeof (Key) || methodCall.Arguments[0].Type.IsSubclassOf(typeof (Key))) {
             var key = (Key) methodCall.Arguments[0].Invoke();
@@ -193,7 +193,7 @@ namespace Xtensive.Orm.BulkOperations
           return;
         }
         if (methodCall.Method.DeclaringType==typeof (Queryable) &&
-          methodCall.Method.Name.In("Single", "SingleOrDefault", "First", "FirstOrDefault")) {
+          methodCall.Method.Name.IsOneOf("Single", "SingleOrDefault", "First", "FirstOrDefault")) {
           Expression exp = methodCall.Arguments[0];
           TypeInfo info = parent.GetTypeInfo(addContext.Field.ValueType);
           if (methodCall.Arguments.Count==2)

--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/SetOperation.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/SetOperation.cs
@@ -55,7 +55,7 @@ namespace Xtensive.Orm.BulkOperations
               Expression ex = setDescriptor.Expression;
               var call = ex as MethodCallExpression;
               if (call != null && call.Method.DeclaringType == typeof(Queryable) &&
-                call.Method.Name.IsOneOf("First", "FirstOrDefault", "Single", "SingleOrDefault"))
+                call.Method.Name is "First" or "FirstOrDefault" or "Single" or "SingleOrDefault")
                 throw new NotSupportedException("Subqueries with structures are not supported");
               /*ex = call.Arguments[0];
         ParameterExpression parameter = Expression.Parameter(setDescriptor.Expression.Type, "parameter");
@@ -165,7 +165,7 @@ namespace Xtensive.Orm.BulkOperations
       int i;
       if (methodCall!=null) {
         if (methodCall.Method.DeclaringType==typeof (QueryEndpoint) &&
-          methodCall.Method.Name.IsOneOf("Single", "SingleOrDefault")) {
+          methodCall.Method.Name is "Single" or "SingleOrDefault") {
           object[] keys;
           if (methodCall.Arguments[0].Type==typeof (Key) || methodCall.Arguments[0].Type.IsSubclassOf(typeof (Key))) {
             var key = (Key) methodCall.Arguments[0].Invoke();
@@ -193,7 +193,7 @@ namespace Xtensive.Orm.BulkOperations
           return;
         }
         if (methodCall.Method.DeclaringType==typeof (Queryable) &&
-          methodCall.Method.Name.IsOneOf("Single", "SingleOrDefault", "First", "FirstOrDefault")) {
+          methodCall.Method.Name is "Single" or "SingleOrDefault" or "First" or "FirstOrDefault") {
           Expression exp = methodCall.Arguments[0];
           TypeInfo info = parent.GetTypeInfo(addContext.Field.ValueType);
           if (methodCall.Arguments.Count==2)

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/ModelBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/ModelBuilder.cs
@@ -165,7 +165,7 @@ namespace Xtensive.Orm.Building.Builders
       var domain = context.Domain;
       foreach (var type in context.Model.Types.Entities) {
         var associations = type.GetOwnerAssociations()
-          .Where(a => a.OnOwnerRemove.In(OnRemoveAction.Cascade, OnRemoveAction.Clear))
+          .Where(a => a.OnOwnerRemove.IsOneOf(OnRemoveAction.Cascade, OnRemoveAction.Clear))
           .ToList();
         if (associations.Count <= 0)
           continue;
@@ -324,7 +324,7 @@ namespace Xtensive.Orm.Building.Builders
 
     private void TryAddForeignKeyIndex(AssociationInfo association)
     {
-      if (!association.Multiplicity.In(Multiplicity.OneToOne, Multiplicity.ZeroToOne))
+      if (!association.Multiplicity.IsOneOf(Multiplicity.OneToOne, Multiplicity.ZeroToOne))
         return;
       var typeDef = context.ModelDef.Types[association.OwnerType.UnderlyingType];
       var field = association.OwnerField;

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/ModelBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/ModelBuilder.cs
@@ -165,7 +165,7 @@ namespace Xtensive.Orm.Building.Builders
       var domain = context.Domain;
       foreach (var type in context.Model.Types.Entities) {
         var associations = type.GetOwnerAssociations()
-          .Where(a => a.OnOwnerRemove.IsOneOf(OnRemoveAction.Cascade, OnRemoveAction.Clear))
+          .Where(a => a.OnOwnerRemove is OnRemoveAction.Cascade or OnRemoveAction.Clear)
           .ToList();
         if (associations.Count <= 0)
           continue;
@@ -324,7 +324,7 @@ namespace Xtensive.Orm.Building.Builders
 
     private void TryAddForeignKeyIndex(AssociationInfo association)
     {
-      if (!association.Multiplicity.IsOneOf(Multiplicity.OneToOne, Multiplicity.ZeroToOne))
+      if (!(association.Multiplicity is Multiplicity.OneToOne or Multiplicity.ZeroToOne))
         return;
       var typeDef = context.ModelDef.Types[association.OwnerType.UnderlyingType];
       var field = association.OwnerField;

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/PartialIndexFilterBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/PartialIndexFilterBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2011-2020 Xtensive LLC.
+// Copyright (C) 2011-2020 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -50,7 +50,7 @@ namespace Xtensive.Orm.Building.Builders
     {
       // Detect f!=null and f==null for entity fields
 
-      if (!b.NodeType.In(ExpressionType.Equal, ExpressionType.NotEqual))
+      if (!b.NodeType.IsOneOf(ExpressionType.Equal, ExpressionType.NotEqual))
         return base.VisitBinary(b);
 
       var left = Visit(b.Left);

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/PartialIndexFilterBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/PartialIndexFilterBuilder.cs
@@ -50,7 +50,7 @@ namespace Xtensive.Orm.Building.Builders
     {
       // Detect f!=null and f==null for entity fields
 
-      if (!b.NodeType.IsOneOf(ExpressionType.Equal, ExpressionType.NotEqual))
+      if (!(b.NodeType is ExpressionType.Equal or ExpressionType.NotEqual))
         return base.VisitBinary(b);
 
       var left = Visit(b.Left);

--- a/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
+++ b/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
@@ -874,14 +874,14 @@ namespace Xtensive.Orm
       var itemState = item == null
         ? PersistenceState.Synchronized
         : item.PersistenceState;
-      if (PersistenceState.New.In(ownerState, itemState) || State.IsFullyLoaded) {
+      if (PersistenceState.New.IsOneOf(ownerState, itemState) || State.IsFullyLoaded) {
         return false;
       }
 
       // association check
       if (item != null) {
         var association = Field.GetAssociation(item.TypeInfo);
-        if (association.IsPaired && association.Multiplicity.In(Multiplicity.ManyToOne, Multiplicity.OneToMany)) {
+        if (association.IsPaired && association.Multiplicity.IsOneOf(Multiplicity.ManyToOne, Multiplicity.OneToMany)) {
           var candidate = (IEntity)item.GetFieldValue(association.Reversed.OwnerField);
           return candidate == Owner;
         }

--- a/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
+++ b/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
@@ -874,7 +874,7 @@ namespace Xtensive.Orm
       var itemState = item == null
         ? PersistenceState.Synchronized
         : item.PersistenceState;
-      if (PersistenceState.New.IsOneOf(ownerState, itemState) || State.IsFullyLoaded) {
+      if (PersistenceState.New == ownerState || PersistenceState.New == itemState || State.IsFullyLoaded) {
         return false;
       }
 

--- a/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
+++ b/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
@@ -881,7 +881,7 @@ namespace Xtensive.Orm
       // association check
       if (item != null) {
         var association = Field.GetAssociation(item.TypeInfo);
-        if (association.IsPaired && association.Multiplicity.IsOneOf(Multiplicity.ManyToOne, Multiplicity.OneToMany)) {
+        if (association.IsPaired && association.Multiplicity is Multiplicity.ManyToOne or Multiplicity.OneToMany) {
           var candidate = (IEntity)item.GetFieldValue(association.Reversed.OwnerField);
           return candidate == Owner;
         }

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/ExpressionMapBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/ExpressionMapBuilder.cs
@@ -95,7 +95,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 
       e = e.StripCasts();
 
-      var isSupported = e.NodeType.In(
+      var isSupported = e.NodeType.IsOneOf(
         ExpressionType.MemberAccess, ExpressionType.Call, ExpressionType.New,
         ExpressionType.Lambda, ExpressionType.Parameter);
 

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/ExpressionMapBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/ExpressionMapBuilder.cs
@@ -95,9 +95,8 @@ namespace Xtensive.Orm.Internals.Prefetch
 
       e = e.StripCasts();
 
-      var isSupported = e.NodeType.IsOneOf(
-        ExpressionType.MemberAccess, ExpressionType.Call, ExpressionType.New,
-        ExpressionType.Lambda, ExpressionType.Parameter);
+      var isSupported = e.NodeType is ExpressionType.MemberAccess or ExpressionType.Call or ExpressionType.New
+        or ExpressionType.Lambda or ExpressionType.Parameter;
 
       if (!isSupported)
         throw new NotSupportedException(string.Format(

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/NullComparsionRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/NullComparsionRewriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2012-2020 Xtensive LLC.
+// Copyright (C) 2012-2020 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
@@ -23,7 +23,7 @@ namespace Xtensive.Orm.Linq.Rewriters
       var ifTrue = Visit(c.IfTrue);
       var ifFalse = Visit(c.IfFalse);
 
-      if (test.NodeType.In(ExpressionType.Equal, ExpressionType.NotEqual)) {
+      if (test.NodeType.IsOneOf(ExpressionType.Equal, ExpressionType.NotEqual)) {
         var binaryExpression = (BinaryExpression) test;
         var left = binaryExpression.Left.StripCasts();
         var right = binaryExpression.Right.StripCasts();

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/NullComparsionRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/NullComparsionRewriter.cs
@@ -23,7 +23,7 @@ namespace Xtensive.Orm.Linq.Rewriters
       var ifTrue = Visit(c.IfTrue);
       var ifFalse = Visit(c.IfFalse);
 
-      if (test.NodeType.IsOneOf(ExpressionType.Equal, ExpressionType.NotEqual)) {
+      if (test.NodeType is ExpressionType.Equal or ExpressionType.NotEqual) {
         var binaryExpression = (BinaryExpression) test;
         var left = binaryExpression.Left.StripCasts();
         var right = binaryExpression.Right.StripCasts();

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/PersistentIndexerRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/PersistentIndexerRewriter.cs
@@ -21,7 +21,7 @@ namespace Xtensive.Orm.Linq.Rewriters
     /// <exception cref="InvalidOperationException"><c>InvalidOperationException</c>.</exception>
     protected override Expression VisitBinary(BinaryExpression binaryExpression)
     {
-      if (binaryExpression.NodeType.IsOneOf(ExpressionType.NotEqual, ExpressionType.Equal)) {
+      if (binaryExpression.NodeType is ExpressionType.NotEqual or ExpressionType.Equal) {
         Expression leftExpression = null;
         Expression rightExpression = null;
         if (IsIndexerAccessor(binaryExpression.Left))

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/PersistentIndexerRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/PersistentIndexerRewriter.cs
@@ -21,7 +21,7 @@ namespace Xtensive.Orm.Linq.Rewriters
     /// <exception cref="InvalidOperationException"><c>InvalidOperationException</c>.</exception>
     protected override Expression VisitBinary(BinaryExpression binaryExpression)
     {
-      if (binaryExpression.NodeType.In(ExpressionType.NotEqual, ExpressionType.Equal)) {
+      if (binaryExpression.NodeType.IsOneOf(ExpressionType.NotEqual, ExpressionType.Equal)) {
         Expression leftExpression = null;
         Expression rightExpression = null;
         if (IsIndexerAccessor(binaryExpression.Left))
@@ -93,7 +93,7 @@ namespace Xtensive.Orm.Linq.Rewriters
       var methodCallExpression = (MethodCallExpression) expression;
       return methodCallExpression.Object!=null && 
         methodCallExpression.Method.Name=="get_Item" && 
-        methodCallExpression.Method.DeclaringType.In(WellKnownOrmTypes.Persistent, WellKnownOrmInterfaces.Entity) &&
+        methodCallExpression.Method.DeclaringType.IsOneOf(WellKnownOrmTypes.Persistent, WellKnownOrmInterfaces.Entity) &&
         context.Evaluator.CanBeEvaluated(methodCallExpression.Arguments[0]);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/PersistentIndexerRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/PersistentIndexerRewriter.cs
@@ -88,13 +88,17 @@ namespace Xtensive.Orm.Linq.Rewriters
 
     private bool IsIndexerAccessor(Expression expression)
     {
-      if (expression.NodeType!=ExpressionType.Call)
+      if (expression.NodeType != ExpressionType.Call) {
         return false;
+      }
       var methodCallExpression = (MethodCallExpression) expression;
-      return methodCallExpression.Object != null &&
-        methodCallExpression.Method.Name == "get_Item" &&
-        (methodCallExpression.Method.DeclaringType == WellKnownOrmTypes.Persistent || methodCallExpression.Method.DeclaringType == WellKnownOrmInterfaces.Entity) &&
-        context.Evaluator.CanBeEvaluated(methodCallExpression.Arguments[0]);
+      if (methodCallExpression.Object == null) {
+        return false;
+      }
+      var method = methodCallExpression.Method;
+      return method.Name == "get_Item"
+        && method.DeclaringType switch { var declaringType => declaringType == WellKnownOrmTypes.Persistent || declaringType == WellKnownOrmInterfaces.Entity }
+        && context.Evaluator.CanBeEvaluated(methodCallExpression.Arguments[0]);
     }
 
     public static Expression Rewrite(Expression query, TranslatorContext context)

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/PersistentIndexerRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/PersistentIndexerRewriter.cs
@@ -91,9 +91,9 @@ namespace Xtensive.Orm.Linq.Rewriters
       if (expression.NodeType!=ExpressionType.Call)
         return false;
       var methodCallExpression = (MethodCallExpression) expression;
-      return methodCallExpression.Object!=null && 
-        methodCallExpression.Method.Name=="get_Item" && 
-        methodCallExpression.Method.DeclaringType.IsOneOf(WellKnownOrmTypes.Persistent, WellKnownOrmInterfaces.Entity) &&
+      return methodCallExpression.Object != null &&
+        methodCallExpression.Method.Name == "get_Item" &&
+        (methodCallExpression.Method.DeclaringType == WellKnownOrmTypes.Persistent || methodCallExpression.Method.DeclaringType == WellKnownOrmInterfaces.Entity) &&
         context.Evaluator.CanBeEvaluated(methodCallExpression.Arguments[0]);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.Helpers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.Helpers.cs
@@ -227,7 +227,7 @@ namespace Xtensive.Orm.Providers
 
     private static bool IsComparisonExpression(Expression expression)
     {
-      return expression.NodeType.In(
+      return expression.NodeType.IsOneOf(
         ExpressionType.Equal,
         ExpressionType.NotEqual,
         ExpressionType.GreaterThan,

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.Helpers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.Helpers.cs
@@ -225,16 +225,14 @@ namespace Xtensive.Orm.Providers
       return StripObjectCasts(expression).Type.StripNullable() == type;
     }
 
-    private static bool IsComparisonExpression(Expression expression)
-    {
-      return expression.NodeType.IsOneOf(
-        ExpressionType.Equal,
-        ExpressionType.NotEqual,
-        ExpressionType.GreaterThan,
-        ExpressionType.LessThan,
-        ExpressionType.GreaterThanOrEqual,
-        ExpressionType.LessThanOrEqual);
-    }
+    private static bool IsComparisonExpression(Expression expression) =>
+      expression.NodeType is 
+        ExpressionType.Equal or
+        ExpressionType.NotEqual or
+        ExpressionType.GreaterThan or
+        ExpressionType.LessThan or
+        ExpressionType.GreaterThanOrEqual or
+        ExpressionType.LessThanOrEqual;
 
     private static Expression StripObjectCasts(Expression expression)
     {

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Apply.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Apply.cs
@@ -67,7 +67,7 @@ namespace Xtensive.Orm.Providers
         providerVisitor.VisitCompilable(provider.Right);
         shouldUseQueryReference = usedOuterColumns.Any(calculatedColumnIndexes.Contains)
           || groupByIsUsed
-          || provider.Left.Type.In(ProviderType.Store, ProviderType.Include)
+          || provider.Left.Type.IsOneOf(ProviderType.Store, ProviderType.Include)
           || left.Header.Columns.Count!=left.Request.Statement.Columns.Count;
       }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Apply.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Apply.cs
@@ -67,7 +67,7 @@ namespace Xtensive.Orm.Providers
         providerVisitor.VisitCompilable(provider.Right);
         shouldUseQueryReference = usedOuterColumns.Any(calculatedColumnIndexes.Contains)
           || groupByIsUsed
-          || provider.Left.Type.IsOneOf(ProviderType.Store, ProviderType.Include)
+          || provider.Left.Type is ProviderType.Store or ProviderType.Include
           || left.Header.Columns.Count!=left.Request.Statement.Columns.Count;
       }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -336,7 +336,7 @@ namespace Xtensive.Orm.Providers
       var rootSelectProvider = RootProvider as SelectProvider;
       var currentIsRoot = RootProvider==provider;
       var currentIsOwnedRootSelect = (rootSelectProvider!=null && rootSelectProvider.Source==provider);
-      var currentIsOwnedByPaging = !currentIsRoot && Owner.Type.IsOneOf(ProviderType.Take, ProviderType.Skip, ProviderType.Paging);
+      var currentIsOwnedByPaging = !currentIsRoot && Owner.Type is ProviderType.Take or ProviderType.Skip or ProviderType.Paging;
 
       if (currentIsRoot || currentIsOwnedRootSelect || currentIsOwnedByPaging) {
         query.OrderBy.Clear();

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -336,7 +336,7 @@ namespace Xtensive.Orm.Providers
       var rootSelectProvider = RootProvider as SelectProvider;
       var currentIsRoot = RootProvider==provider;
       var currentIsOwnedRootSelect = (rootSelectProvider!=null && rootSelectProvider.Source==provider);
-      var currentIsOwnedByPaging = !currentIsRoot && Owner.Type.In(ProviderType.Take, ProviderType.Skip, ProviderType.Paging);
+      var currentIsOwnedByPaging = !currentIsRoot && Owner.Type.IsOneOf(ProviderType.Take, ProviderType.Skip, ProviderType.Paging);
 
       if (currentIsRoot || currentIsOwnedRootSelect || currentIsOwnedByPaging) {
         query.OrderBy.Clear();

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
@@ -181,53 +181,6 @@ namespace Xtensive.Orm
     }
 
     /// <summary>
-    /// Checks if <paramref name="source"/> value is on of three specified values.
-    /// </summary>
-    /// <typeparam name="T">Type of value to check.</typeparam>
-    /// <param name="source">Source value.</param>
-    /// <param name="value1">First value</param>
-    /// <param name="value2">Second value</param>
-    /// <param name="value3">Third value</param>
-    /// <returns><see langword="True"/> if <paramref name="source"/> contains is value1 or value2 or value3 <see langword="false"/>.</returns>
-    public static bool IsOneOf<T>(this T source, T value1, T value2, T value3)
-    {
-      var comparer = EqualityComparer<T>.Default;
-      return comparer.Equals(source, value1)
-        || comparer.Equals(source, value2)
-        || comparer.Equals(source, value3);
-    }
-
-    public static bool IsOneOf<T>(this T source, T value1, T value2, T value3, T value4)
-    {
-      var comparer = EqualityComparer<T>.Default;
-      return comparer.Equals(source, value1)
-        || comparer.Equals(source, value2)
-        || comparer.Equals(source, value3)
-        || comparer.Equals(source, value4);
-    }
-
-    public static bool IsOneOf<T>(this T source, T value1, T value2, T value3, T value4, T value5)
-    {
-      var comparer = EqualityComparer<T>.Default;
-      return comparer.Equals(source, value1)
-        || comparer.Equals(source, value2)
-        || comparer.Equals(source, value3)
-        || comparer.Equals(source, value4)
-        || comparer.Equals(source, value5);
-    }
-
-    public static bool IsOneOf<T>(this T source, T value1, T value2, T value3, T value4, T value5, T value6)
-    {
-      var comparer = EqualityComparer<T>.Default;
-      return comparer.Equals(source, value1)
-        || comparer.Equals(source, value2)
-        || comparer.Equals(source, value3)
-        || comparer.Equals(source, value4)
-        || comparer.Equals(source, value5)
-        || comparer.Equals(source, value6);
-    }
-
-    /// <summary>
     /// Checks if <paramref name="source"/> value is contained in the specified list of values.
     /// </summary>
     /// <typeparam name="T">Type of value to check.</typeparam>

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
@@ -166,6 +166,68 @@ namespace Xtensive.Orm
     }
 
     /// <summary>
+    /// Checks if <paramref name="source"/> value is on of two specified values.
+    /// </summary>
+    /// <typeparam name="T">Type of value to check.</typeparam>
+    /// <param name="source">Source value.</param>
+    /// <param name="value1">First value</param>
+    /// <param name="value2">Second value</param>
+    /// <returns><see langword="True"/> if <paramref name="source"/> contains is value1 or value2 <see langword="false"/>.</returns>
+    public static bool IsOneOf<T>(this T source, T value1, T value2)
+    {
+      var comparer = EqualityComparer<T>.Default;
+      return comparer.Equals(source, value1)
+        || comparer.Equals(source, value2);
+    }
+
+    /// <summary>
+    /// Checks if <paramref name="source"/> value is on of three specified values.
+    /// </summary>
+    /// <typeparam name="T">Type of value to check.</typeparam>
+    /// <param name="source">Source value.</param>
+    /// <param name="value1">First value</param>
+    /// <param name="value2">Second value</param>
+    /// <param name="value3">Third value</param>
+    /// <returns><see langword="True"/> if <paramref name="source"/> contains is value1 or value2 or value3 <see langword="false"/>.</returns>
+    public static bool IsOneOf<T>(this T source, T value1, T value2, T value3)
+    {
+      var comparer = EqualityComparer<T>.Default;
+      return comparer.Equals(source, value1)
+        || comparer.Equals(source, value2)
+        || comparer.Equals(source, value3);
+    }
+
+    public static bool IsOneOf<T>(this T source, T value1, T value2, T value3, T value4)
+    {
+      var comparer = EqualityComparer<T>.Default;
+      return comparer.Equals(source, value1)
+        || comparer.Equals(source, value2)
+        || comparer.Equals(source, value3)
+        || comparer.Equals(source, value4);
+    }
+
+    public static bool IsOneOf<T>(this T source, T value1, T value2, T value3, T value4, T value5)
+    {
+      var comparer = EqualityComparer<T>.Default;
+      return comparer.Equals(source, value1)
+        || comparer.Equals(source, value2)
+        || comparer.Equals(source, value3)
+        || comparer.Equals(source, value4)
+        || comparer.Equals(source, value5);
+    }
+
+    public static bool IsOneOf<T>(this T source, T value1, T value2, T value3, T value4, T value5, T value6)
+    {
+      var comparer = EqualityComparer<T>.Default;
+      return comparer.Equals(source, value1)
+        || comparer.Equals(source, value2)
+        || comparer.Equals(source, value3)
+        || comparer.Equals(source, value4)
+        || comparer.Equals(source, value5)
+        || comparer.Equals(source, value6);
+    }
+
+    /// <summary>
     /// Checks if <paramref name="source"/> value is contained in the specified list of values.
     /// </summary>
     /// <typeparam name="T">Type of value to check.</typeparam>

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
@@ -166,21 +166,6 @@ namespace Xtensive.Orm
     }
 
     /// <summary>
-    /// Checks if <paramref name="source"/> value is on of two specified values.
-    /// </summary>
-    /// <typeparam name="T">Type of value to check.</typeparam>
-    /// <param name="source">Source value.</param>
-    /// <param name="value1">First value</param>
-    /// <param name="value2">Second value</param>
-    /// <returns><see langword="True"/> if <paramref name="source"/> contains is value1 or value2 <see langword="false"/>.</returns>
-    public static bool IsOneOf<T>(this T source, T value1, T value2)
-    {
-      var comparer = EqualityComparer<T>.Default;
-      return comparer.Equals(source, value1)
-        || comparer.Equals(source, value2);
-    }
-
-    /// <summary>
     /// Checks if <paramref name="source"/> value is contained in the specified list of values.
     /// </summary>
     /// <typeparam name="T">Type of value to check.</typeparam>

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/SkipTakeRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/SkipTakeRewriter.cs
@@ -29,7 +29,7 @@ namespace Xtensive.Orm.Rse.Transformation
 
     protected override Provider Visit(CompilableProvider cp)
     {
-      var isPagingProvider = cp.Type.In(ProviderType.Take, ProviderType.Skip, ProviderType.Paging);
+      var isPagingProvider = cp.Type.IsOneOf(ProviderType.Take, ProviderType.Skip, ProviderType.Paging);
       if (isPagingProvider && !State.IsSkipTakeChain) {
         var visitedProvider = (CompilableProvider) base.Visit(cp);
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/SkipTakeRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/SkipTakeRewriter.cs
@@ -29,7 +29,7 @@ namespace Xtensive.Orm.Rse.Transformation
 
     protected override Provider Visit(CompilableProvider cp)
     {
-      var isPagingProvider = cp.Type.IsOneOf(ProviderType.Take, ProviderType.Skip, ProviderType.Paging);
+      var isPagingProvider = cp.Type is ProviderType.Take or ProviderType.Skip or ProviderType.Paging;
       if (isPagingProvider && !State.IsSkipTakeChain) {
         var visitedProvider = (CompilableProvider) base.Visit(cp);
 

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SchemaComparer.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SchemaComparer.cs
@@ -295,7 +295,7 @@ namespace Xtensive.Orm.Upgrade
     {
       var filter = schemaUpgradeMode!=SchemaUpgradeMode.ValidateCompatible
         ? (Func<Type, bool>) (targetType => true)
-        : targetType => targetType.IsOneOf(WellKnownUpgradeTypes.TableInfo, WellKnownUpgradeTypes.StorageColumnInfo);
+        : targetType => targetType == WellKnownUpgradeTypes.TableInfo || targetType == WellKnownUpgradeTypes.StorageColumnInfo;
       var hasCreateActions = actions
         .OfType<CreateNodeAction>()
         .Select(action => action.Difference.Target.GetType())
@@ -303,7 +303,7 @@ namespace Xtensive.Orm.Upgrade
       var hasRemoveActions = actions
         .OfType<RemoveNodeAction>()
         .Select(action => action.Difference.Source.GetType())
-        .Any(sourceType => sourceType.IsOneOf(WellKnownUpgradeTypes.TableInfo, WellKnownUpgradeTypes.StorageColumnInfo));
+        .Any(sourceType => sourceType == WellKnownUpgradeTypes.TableInfo || sourceType == WellKnownUpgradeTypes.StorageColumnInfo);
 
       if (hasCreateActions && hasRemoveActions)
         return SchemaComparisonStatus.NotEqual;

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SchemaComparer.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SchemaComparer.cs
@@ -295,7 +295,7 @@ namespace Xtensive.Orm.Upgrade
     {
       var filter = schemaUpgradeMode!=SchemaUpgradeMode.ValidateCompatible
         ? (Func<Type, bool>) (targetType => true)
-        : targetType => targetType.In(WellKnownUpgradeTypes.TableInfo, WellKnownUpgradeTypes.StorageColumnInfo);
+        : targetType => targetType.IsOneOf(WellKnownUpgradeTypes.TableInfo, WellKnownUpgradeTypes.StorageColumnInfo);
       var hasCreateActions = actions
         .OfType<CreateNodeAction>()
         .Select(action => action.Difference.Target.GetType())
@@ -303,7 +303,7 @@ namespace Xtensive.Orm.Upgrade
       var hasRemoveActions = actions
         .OfType<RemoveNodeAction>()
         .Select(action => action.Difference.Source.GetType())
-        .Any(sourceType => sourceType.In(WellKnownUpgradeTypes.TableInfo, WellKnownUpgradeTypes.StorageColumnInfo));
+        .Any(sourceType => sourceType.IsOneOf(WellKnownUpgradeTypes.TableInfo, WellKnownUpgradeTypes.StorageColumnInfo));
 
       if (hasCreateActions && hasRemoveActions)
         return SchemaComparisonStatus.NotEqual;

--- a/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
@@ -596,7 +596,7 @@ namespace Xtensive.Orm.Upgrade
         var breifExceptionFormat = domain.Configuration.SchemaSyncExceptionFormat==SchemaSyncExceptionFormat.Brief;
         var result = SchemaComparer.Compare(extractedSchema, targetSchema,
           hints, context.Hints, schemaUpgradeMode, domain.Model, breifExceptionFormat, context.Stage);
-        var shouldDumpSchema = !schemaUpgradeMode.In(
+        var shouldDumpSchema = !schemaUpgradeMode.IsOneOf(
           SchemaUpgradeMode.Skip, SchemaUpgradeMode.ValidateCompatible, SchemaUpgradeMode.Recreate);
         if (shouldDumpSchema && UpgradeLog.IsLogged(LogLevel.Info))
           UpgradeLog.Info(result.ToString());
@@ -682,7 +682,7 @@ namespace Xtensive.Orm.Upgrade
         var briefExceptionFormat = domain.Configuration.SchemaSyncExceptionFormat==SchemaSyncExceptionFormat.Brief;
         var result = SchemaComparer.Compare(extractedSchema, targetSchema,
           hints, context.Hints, schemaUpgradeMode, domain.Model, briefExceptionFormat, context.Stage);
-        var shouldDumpSchema = !schemaUpgradeMode.In(
+        var shouldDumpSchema = !schemaUpgradeMode.IsOneOf(
           SchemaUpgradeMode.Skip, SchemaUpgradeMode.ValidateCompatible, SchemaUpgradeMode.Recreate);
         if (shouldDumpSchema && UpgradeLog.IsLogged(LogLevel.Info))
           UpgradeLog.Info(result.ToString());

--- a/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
@@ -596,8 +596,7 @@ namespace Xtensive.Orm.Upgrade
         var breifExceptionFormat = domain.Configuration.SchemaSyncExceptionFormat==SchemaSyncExceptionFormat.Brief;
         var result = SchemaComparer.Compare(extractedSchema, targetSchema,
           hints, context.Hints, schemaUpgradeMode, domain.Model, breifExceptionFormat, context.Stage);
-        var shouldDumpSchema = !schemaUpgradeMode.IsOneOf(
-          SchemaUpgradeMode.Skip, SchemaUpgradeMode.ValidateCompatible, SchemaUpgradeMode.Recreate);
+        var shouldDumpSchema = !(schemaUpgradeMode is SchemaUpgradeMode.Skip or SchemaUpgradeMode.ValidateCompatible or SchemaUpgradeMode.Recreate);
         if (shouldDumpSchema && UpgradeLog.IsLogged(LogLevel.Info))
           UpgradeLog.Info(result.ToString());
 
@@ -682,8 +681,7 @@ namespace Xtensive.Orm.Upgrade
         var briefExceptionFormat = domain.Configuration.SchemaSyncExceptionFormat==SchemaSyncExceptionFormat.Brief;
         var result = SchemaComparer.Compare(extractedSchema, targetSchema,
           hints, context.Hints, schemaUpgradeMode, domain.Model, briefExceptionFormat, context.Stage);
-        var shouldDumpSchema = !schemaUpgradeMode.IsOneOf(
-          SchemaUpgradeMode.Skip, SchemaUpgradeMode.ValidateCompatible, SchemaUpgradeMode.Recreate);
+        var shouldDumpSchema = !(schemaUpgradeMode is SchemaUpgradeMode.Skip or SchemaUpgradeMode.ValidateCompatible or SchemaUpgradeMode.Recreate);
         if (shouldDumpSchema && UpgradeLog.IsLogged(LogLevel.Info))
           UpgradeLog.Info(result.ToString());
 


### PR DESCRIPTION
We cannot make it overload of `.In()` because `.In()` is interpreted special way by LINQ translator which expects array argument.