### PR TITLE
Optimize GetMemberType() extension; TypeHelper

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/ExpressionExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ExpressionExtensions.cs
@@ -1,10 +1,11 @@
-// Copyright (C) 2008-2020 Xtensive LLC.
+// Copyright (C) 2008-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Kochetov
 // Created:    2008.12.02
 
 using System;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -17,6 +18,16 @@ namespace Xtensive.Orm.Linq
 {
   internal static class ExpressionExtensions
   {
+    private static readonly ConcurrentDictionary<Type, MemberType> memberTypeByType = new ConcurrentDictionary<Type, MemberType>();
+
+    private static readonly Func<Type, MemberType> memberTypeFactory = type =>
+      WellKnownOrmTypes.Key.IsAssignableFrom(type) ? MemberType.Key
+      : WellKnownOrmInterfaces.Entity.IsAssignableFrom(type) ? MemberType.Entity
+      : WellKnownOrmTypes.Structure.IsAssignableFrom(type) ? MemberType.Structure
+      : WellKnownOrmTypes.EntitySetBase.IsAssignableFrom(type) ? MemberType.EntitySet
+      : type.IsAnonymous() ? MemberType.Anonymous
+      : MemberType.Unknown;
+
     public static void EnsureKeyExpressionCompatible(this KeyExpression left, KeyExpression right, Expression expressionPart)
     {
       if (left==null || right==null) {
@@ -52,15 +63,21 @@ namespace Xtensive.Orm.Linq
     public static bool IsQuery(this Expression expression) =>
       expression.Type.IsOfGenericInterface(WellKnownInterfaces.QueryableOfT);
 
-    public static bool IsLocalCollection(this Expression expression, TranslatorContext context) =>
-      expression != null
-      && !expression.IsProjection()
+    public static bool IsLocalCollection(this Expression expression, TranslatorContext context)
+    {
+      if (expression == null) {
+        return false;
+      }
+      expression = expression.StripMarkers();
+
+      return !expression.IsProjection()
       && !expression.IsGroupingExpression()
       && !expression.IsEntitySet()
       && !expression.IsSubqueryExpression()
       && expression.Type != WellKnownTypes.String
       && expression.Type.IsOfGenericInterface(WellKnownInterfaces.EnumerableOfT)
       && (IsEvaluableCollection(context, expression) || IsForeignQuery(expression));
+    }
 
     private static bool IsEvaluableCollection(TranslatorContext context, Expression expression) =>
       !expression.Type.IsOfGenericInterface(WellKnownInterfaces.QueryableOfT)
@@ -88,11 +105,8 @@ namespace Xtensive.Orm.Linq
       return (ExtendedExpressionType) expression.NodeType == ExtendedExpressionType.ItemProjector;
     }
 
-    public static bool IsProjection(this Expression expression)
-    {
-      expression = expression.StripMarkers();
-      return (ExtendedExpressionType) expression.NodeType == ExtendedExpressionType.Projection;
-    }
+    public static bool IsProjection(this Expression strippedMarkerExpression) =>
+      (ExtendedExpressionType) strippedMarkerExpression.NodeType == ExtendedExpressionType.Projection;
 
     public static bool IsEntitySetProjection(this Expression expression)
     {
@@ -100,17 +114,11 @@ namespace Xtensive.Orm.Linq
       return (ExtendedExpressionType) expression.NodeType == ExtendedExpressionType.EntitySet;
     }
 
-    public static bool IsGroupingExpression(this Expression expression)
-    {
-      expression = expression.StripMarkers();
-      return (ExtendedExpressionType) expression.NodeType == ExtendedExpressionType.Grouping;
-    }
+    public static bool IsGroupingExpression(this Expression strippedMarkerExpression) =>
+      (ExtendedExpressionType) strippedMarkerExpression.NodeType == ExtendedExpressionType.Grouping;
 
-    public static bool IsSubqueryExpression(this Expression expression)
-    {
-      expression = expression.StripMarkers();
-      return (ExtendedExpressionType) expression.NodeType == ExtendedExpressionType.SubQuery;
-    }
+    public static bool IsSubqueryExpression(this Expression strippedMarkerExpression) =>
+      (ExtendedExpressionType) strippedMarkerExpression.NodeType == ExtendedExpressionType.SubQuery;
 
     public static bool IsFullTextMatchExpression(this Expression expression)
     {
@@ -124,25 +132,16 @@ namespace Xtensive.Orm.Linq
       return (ExtendedExpressionType) expression.NodeType == ExtendedExpressionType.Entity;
     }
 
-    public static bool IsEntitySetExpression(this Expression expression)
-    {
-      expression = expression.StripMarkers();
-      return (ExtendedExpressionType) expression.NodeType == ExtendedExpressionType.EntitySet;
-    }
+    public static bool IsEntitySetExpression(this Expression strippedMarkerExpression) =>
+      (ExtendedExpressionType) strippedMarkerExpression.NodeType == ExtendedExpressionType.EntitySet;
 
     public static bool IsEntitySet(this Expression expression) =>
-      expression.Type.IsGenericType
-      && expression.Type.GetGenericTypeDefinition() == WellKnownOrmTypes.EntitySetOfT;
+      expression.Type switch {
+        var type => type.IsGenericType && type.GetGenericTypeDefinition() == WellKnownOrmTypes.EntitySetOfT
+      };
 
-    public static Expression StripMarkers(this Expression e)
-    {
-      if (e is ExtendedExpression ee && ee.ExtendedType == ExtendedExpressionType.Marker) {
-        var marker = (MarkerExpression) ee;
-        return marker.Target;
-      }
-
-      return e;
-    }
+    public static Expression StripMarkers(this Expression e) =>
+      e is MarkerExpression marker ? marker.Target : e;
 
     public static bool IsMarker(this Expression e)
     {
@@ -152,63 +151,31 @@ namespace Xtensive.Orm.Linq
 
     public static bool TryGetMarker(this Expression e, out MarkerType markerType)
     {
-      e = e.StripCasts();
-      markerType = MarkerType.None;
-      var result = (ExtendedExpressionType) e.NodeType == ExtendedExpressionType.Marker;
-      if (result) {
-        var marker = (MarkerExpression) e;
+      if (e.StripCasts() is MarkerExpression marker) {
         markerType = marker.MarkerType;
+        return true;
       }
-
-      return result;
+      markerType = MarkerType.None;
+      return false;
     }
 
     public static MemberType GetMemberType(this Expression e)
     {
       e = e.StripMarkers();
       var type = e.Type;
-      if (WellKnownOrmTypes.Key.IsAssignableFrom(type)) {
-        return MemberType.Key;
+
+      if (memberTypeByType.GetOrAdd(type, memberTypeFactory) is var memberType && memberType != MemberType.Unknown) {
+        return memberType;
       }
 
-      if (WellKnownOrmInterfaces.Entity.IsAssignableFrom(type)) {
-        return MemberType.Entity;
-      }
-
-      if (WellKnownOrmTypes.Structure.IsAssignableFrom(type)) {
-        return MemberType.Structure;
-      }
-
-      if (WellKnownOrmTypes.EntitySetBase.IsAssignableFrom(type)) {
-        return MemberType.EntitySet;
-      }
-
-      if (type.IsAnonymous()) {
-        return MemberType.Anonymous;
-      }
-
-      if (e.IsGroupingExpression()) {
-        return MemberType.Grouping;
-      }
-
-      if (e.IsSubqueryExpression()) {
-        return MemberType.Subquery;
-      }
-
-      if (e.IsFullTextMatchExpression()) {
-        return MemberType.FullTextMatch;
-      }
-
-      if (type.IsArray) {
-        return MemberType.Array;
-      }
-
-      if ((ExtendedExpressionType) e.NodeType == ExtendedExpressionType.Field
-        || (ExtendedExpressionType) e.NodeType == ExtendedExpressionType.Column) {
-        return MemberType.Primitive;
-      }
-
-      return MemberType.Unknown;
+      return (ExtendedExpressionType) e.NodeType switch {
+        ExtendedExpressionType.Grouping => MemberType.Grouping,
+        ExtendedExpressionType.SubQuery => MemberType.Subquery,
+        ExtendedExpressionType.FullText => MemberType.FullTextMatch,
+        _ when type.IsArray => MemberType.Array,
+        ExtendedExpressionType.Field or ExtendedExpressionType.Column => MemberType.Primitive,
+        _ => MemberType.Unknown
+      };
     }
 
     public static ParameterInfo[] GetConstructorParameters(this NewExpression expression)

--- a/Orm/Xtensive.Orm/Orm/Linq/ExpressionExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ExpressionExtensions.cs
@@ -16,13 +16,11 @@ using Xtensive.Reflection;
 
 namespace Xtensive.Orm.Linq
 {
-  using MemberTypeDictinaryKey = ValueTuple<int, Module>;
-
   internal static class ExpressionExtensions
   {
-    private static readonly ConcurrentDictionary<MemberTypeDictinaryKey, MemberType> memberTypeByType = new ConcurrentDictionary<MemberTypeDictinaryKey, MemberType>();
+    private static readonly ConcurrentDictionary<Type, MemberType> memberTypeByType = new ConcurrentDictionary<Type, MemberType>();
 
-    private static readonly Func<MemberTypeDictinaryKey, Type, MemberType> memberTypeFactory = (_, type) =>
+    private static readonly Func<Type, MemberType> memberTypeFactory = type =>
       WellKnownOrmTypes.Key.IsAssignableFrom(type) ? MemberType.Key
       : WellKnownOrmInterfaces.Entity.IsAssignableFrom(type) ? MemberType.Entity
       : WellKnownOrmTypes.Structure.IsAssignableFrom(type) ? MemberType.Structure
@@ -166,8 +164,7 @@ namespace Xtensive.Orm.Linq
       e = e.StripMarkers();
       var type = e.Type;
 
-      if (memberTypeByType.GetOrAdd((type.MetadataToken, type.Module), memberTypeFactory, type) is var memberType
-          && memberType != MemberType.Unknown) {
+      if (memberTypeByType.GetOrAdd(type, memberTypeFactory) is var memberType && memberType != MemberType.Unknown) {
         return memberType;
       }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/ExpressionExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ExpressionExtensions.cs
@@ -16,11 +16,13 @@ using Xtensive.Reflection;
 
 namespace Xtensive.Orm.Linq
 {
+  using MemberTypeDictinaryKey = ValueTuple<int, Module>;
+
   internal static class ExpressionExtensions
   {
-    private static readonly ConcurrentDictionary<Type, MemberType> memberTypeByType = new ConcurrentDictionary<Type, MemberType>();
+    private static readonly ConcurrentDictionary<MemberTypeDictinaryKey, MemberType> memberTypeByType = new ConcurrentDictionary<MemberTypeDictinaryKey, MemberType>();
 
-    private static readonly Func<Type, MemberType> memberTypeFactory = type =>
+    private static readonly Func<MemberTypeDictinaryKey, Type, MemberType> memberTypeFactory = (_, type) =>
       WellKnownOrmTypes.Key.IsAssignableFrom(type) ? MemberType.Key
       : WellKnownOrmInterfaces.Entity.IsAssignableFrom(type) ? MemberType.Entity
       : WellKnownOrmTypes.Structure.IsAssignableFrom(type) ? MemberType.Structure
@@ -164,7 +166,8 @@ namespace Xtensive.Orm.Linq
       e = e.StripMarkers();
       var type = e.Type;
 
-      if (memberTypeByType.GetOrAdd(type, memberTypeFactory) is var memberType && memberType != MemberType.Unknown) {
+      if (memberTypeByType.GetOrAdd((type.MetadataToken, type.Module), memberTypeFactory, type) is var memberType
+          && memberType != MemberType.Unknown) {
         return memberType;
       }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -75,7 +75,7 @@ namespace Xtensive.Orm.Linq
     {
       if (e==null)
         return null;
-      if (e.IsProjection())
+      if (e.StripMarkers().IsProjection())
         return e;
       if (context.Evaluator.CanBeEvaluated(e)) {
         if (WellKnownInterfaces.Queryable.IsAssignableFrom(e.Type))
@@ -135,7 +135,7 @@ namespace Xtensive.Orm.Linq
           && body.NodeType!=ExpressionType.MemberInit
           && !(body.NodeType==ExpressionType.Constant && state.BuildingProjection);
         if (shouldTranslate)
-          body = body.IsProjection()
+          body = body.StripMarkers().IsProjection()
             ? BuildSubqueryResult((ProjectionExpression) body, le.Body.Type)
             : ProcessProjectionElement(body);
         ProjectionExpression projection = context.Bindings[parameter];
@@ -150,7 +150,7 @@ namespace Xtensive.Orm.Linq
         expression = Visit(ma.Expression);
       }
 
-      expression = expression.IsProjection() 
+      expression = expression.StripMarkers().IsProjection()
         ? BuildSubqueryResult((ProjectionExpression) expression, ma.Expression.Type) 
         : ProcessProjectionElement(expression);
 
@@ -440,7 +440,7 @@ namespace Xtensive.Orm.Linq
         var result = base.VisitMethodCall(mc);
         if (result!=mc && result.NodeType==ExpressionType.Call) {
           var visitedMethodCall = (MethodCallExpression) result;
-          if (visitedMethodCall.Arguments.Any(arg => arg.IsProjection()))
+          if (visitedMethodCall.Arguments.Any(arg => arg.StripMarkers().IsProjection()))
             throw new InvalidOperationException(String.Format(Strings.ExMethodCallExpressionXIsNotSupported, mc.ToString(true)));
         }
         return result;
@@ -578,9 +578,10 @@ namespace Xtensive.Orm.Linq
       // ReSharper disable HeuristicUnreachableCode
       // ReSharper disable ConditionIsAlwaysTrueOrFalse
 
-      if (newExpression.Members==null) {
-        if (newExpression.IsGroupingExpression()
-          || newExpression.IsSubqueryExpression()
+      var strippedMarkersExpression = newExpression.StripMarkers();
+      if (newExpression.Members == null) {
+        if (strippedMarkersExpression.IsGroupingExpression()
+          || strippedMarkersExpression.IsSubqueryExpression()
           || newExpression.IsNewExpressionSupportedByStorage())
           return base.VisitNew(newExpression);
       }
@@ -589,7 +590,7 @@ namespace Xtensive.Orm.Linq
       // ReSharper restore HeuristicUnreachableCode
 
       var arguments = VisitNewExpressionArguments(newExpression);
-      if (newExpression.IsAnonymousConstructor()) {
+      if (strippedMarkersExpression.IsAnonymousConstructor()) {
         return newExpression.Members==null
           ? Expression.New(newExpression.Constructor, arguments)
           : Expression.New(newExpression.Constructor, arguments, newExpression.Members);

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
@@ -148,7 +148,7 @@ namespace Xtensive.Orm.Linq
         using (CreateScope(new TranslatorState(state) { CalculateExpressions = false })) {
           body = Visit(argument);
         }
-        body = body.IsProjection() 
+        body = body.StripMarkers().IsProjection()
           ? BuildSubqueryResult((ProjectionExpression) body, argument.Type) 
           : ProcessProjectionElement(body);
         arguments.Add(body);

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2007-2021 Xtensive LLC.
+// Copyright (C) 2007-2020 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Nick Svetlov
@@ -61,9 +61,6 @@ namespace Xtensive.Reflection
 
     private static readonly ConcurrentDictionary<Pair<Type, Type>, InterfaceMapping> interfaceMaps =
       new ConcurrentDictionary<Pair<Type, Type>, InterfaceMapping>();
-
-    private static readonly ConcurrentDictionary<(Type, Type), Type> genericInterfaceMap =
-      new ConcurrentDictionary<(Type, Type), Type>();
 
     private static int createDummyTypeNumber = 0;
     private static AssemblyBuilder assemblyBuilder;
@@ -995,11 +992,8 @@ namespace Xtensive.Reflection
     /// where type parameters are bound in case it is implemented by the <paramref name="type"/>;
     /// otherwise, <see langword="null"/>.
     /// </returns>
-    public static Type GetGenericInterface(this Type type, Type openGenericInterface) =>
-      genericInterfaceMap.GetOrAdd((type, openGenericInterface), GenericInterfaceMapFactory);
-
-    private static readonly Func<(Type, Type), Type> GenericInterfaceMapFactory = key => {
-      (Type type, Type openGenericInterface) = key;
+    public static Type GetGenericInterface(this Type type, Type openGenericInterface)
+    {
       var metadataToken = openGenericInterface.MetadataToken;
       var module = openGenericInterface.Module;
       if (type == null || ((type.MetadataToken ^ metadataToken) == 0 && ReferenceEquals(type.Module, module))) {
@@ -1015,7 +1009,7 @@ namespace Xtensive.Reflection
       }
 
       return null;
-    };
+    }
 
     /// <summary>
     /// Converts <paramref name="type"/> to type that can assign both

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2007-2020 Xtensive LLC.
+// Copyright (C) 2007-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Nick Svetlov
@@ -61,6 +61,9 @@ namespace Xtensive.Reflection
 
     private static readonly ConcurrentDictionary<Pair<Type, Type>, InterfaceMapping> interfaceMaps =
       new ConcurrentDictionary<Pair<Type, Type>, InterfaceMapping>();
+
+    private static readonly ConcurrentDictionary<(Type, Type), Type> genericInterfaceMap =
+      new ConcurrentDictionary<(Type, Type), Type>();
 
     private static int createDummyTypeNumber = 0;
     private static AssemblyBuilder assemblyBuilder;
@@ -992,8 +995,11 @@ namespace Xtensive.Reflection
     /// where type parameters are bound in case it is implemented by the <paramref name="type"/>;
     /// otherwise, <see langword="null"/>.
     /// </returns>
-    public static Type GetGenericInterface(this Type type, Type openGenericInterface)
-    {
+    public static Type GetGenericInterface(this Type type, Type openGenericInterface) =>
+      genericInterfaceMap.GetOrAdd((type, openGenericInterface), GenericInterfaceMapFactory);
+
+    private static readonly Func<(Type, Type), Type> GenericInterfaceMapFactory = key => {
+      (Type type, Type openGenericInterface) = key;
       var metadataToken = openGenericInterface.MetadataToken;
       var module = openGenericInterface.Module;
       if (type == null || ((type.MetadataToken ^ metadataToken) == 0 && ReferenceEquals(type.Module, module))) {
@@ -1009,7 +1015,7 @@ namespace Xtensive.Reflection
       }
 
       return null;
-    }
+    };
 
     /// <summary>
     /// Converts <paramref name="type"/> to type that can assign both


### PR DESCRIPTION
* Memoize results of `Type` -> `MemberType` mapping in  `GetMemberType()`
* Avoid multiple calling `StripMarkers()` for the same expression