### PR TITLE
Optimization: allocate immutable Expression objects statically; ValueFieldAccessorResolver

### DIFF
--- a/Orm/Xtensive.Orm/Linq/ConstantExtractor.cs
+++ b/Orm/Xtensive.Orm/Linq/ConstantExtractor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -21,9 +21,10 @@ namespace Xtensive.Linq
   /// </summary>
   public sealed class ConstantExtractor : ExpressionVisitor
   {
+    private static readonly ParameterExpression constantParameter = Expression.Parameter(WellKnownTypes.ObjectArray, "constants");
+
     private readonly Func<ConstantExpression, bool> constantFilter;
     private readonly LambdaExpression lambda;
-    private readonly ParameterExpression constantParameter;
     private List<object> constantValues;
 
     /// <summary>
@@ -106,7 +107,6 @@ namespace Xtensive.Linq
       ArgumentValidator.EnsureArgumentNotNull(lambda, "lambda");
       this.lambda = lambda;
       this.constantFilter = constantFilter ?? DefaultConstantFilter;
-      constantParameter = Expression.Parameter(WellKnownTypes.ObjectArray, "constants");
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/PartialIndexFilterBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/PartialIndexFilterBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2011-2020 Xtensive LLC.
+// Copyright (C) 2011-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -26,18 +26,18 @@ namespace Xtensive.Orm.Building.Builders
 {
   internal class PartialIndexFilterBuilder : ExpressionVisitor
   {
+    private static readonly ParameterExpression parameter = Expression.Parameter(WellKnownOrmTypes.Tuple, "tuple");
+
     private readonly TypeInfo declaringType;
     private readonly TypeInfo reflectedType;
     private readonly IndexInfo index;
-    private readonly ParameterExpression parameter;
     private readonly List<FieldInfo> usedFields = new List<FieldInfo>();
     private readonly Dictionary<Expression, FieldInfo> entityAccessMap = new Dictionary<Expression, FieldInfo>();
 
     public static void BuildFilter(IndexInfo index)
     {
       ArgumentValidator.EnsureArgumentNotNull(index, "index");
-      var parameter = Expression.Parameter(WellKnownOrmTypes.Tuple, "tuple");
-      var builder = new PartialIndexFilterBuilder(index, parameter);
+      var builder = new PartialIndexFilterBuilder(index);
       var body = builder.Visit(index.FilterExpression.Body);
       var filter = new PartialIndexFilterInfo {
         Expression = FastExpression.Lambda(body, parameter),
@@ -185,10 +185,9 @@ namespace Xtensive.Orm.Building.Builders
       return UnableToTranslate(expression, string.Format(Strings.ExpressionsOfTypeXAreNotSupported, expression.NodeType));
     }
 
-    private PartialIndexFilterBuilder(IndexInfo index, ParameterExpression parameter)
+    private PartialIndexFilterBuilder(IndexInfo index)
     {
       this.index = index;
-      this.parameter = parameter;
 
       declaringType = index.DeclaringType;
       reflectedType = index.ReflectedType;

--- a/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
+++ b/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2008-2020 Xtensive LLC.
+// Copyright (C) 2008-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Aleksey Gamzov

--- a/Orm/Xtensive.Orm/Orm/EntitySet{T}.cs
+++ b/Orm/Xtensive.Orm/Orm/EntitySet{T}.cs
@@ -62,6 +62,9 @@ namespace Xtensive.Orm
     IQueryable<TItem>
     where TItem : IEntity
   {
+    private static readonly MemberExpression ownerPropertyExpression = Expression.Property(Expression.Constant(ownerParameter), ownerParameter.GetType()
+      .GetProperty("Value", WellKnownOrmTypes.Entity));
+
     private Expression expression;
 
     /// <summary>
@@ -230,9 +233,7 @@ namespace Xtensive.Orm
 
     private static IQueryable<TItem> GetItemsQuery(QueryEndpoint qe, FieldInfo field)
     {
-      var owner = Expression.Property(Expression.Constant(ownerParameter), ownerParameter.GetType()
-        .GetProperty("Value", WellKnownOrmTypes.Entity));
-      var queryExpression = QueryHelper.CreateEntitySetQuery(owner, field);
+      var queryExpression = QueryHelper.CreateEntitySetQuery(ownerPropertyExpression, field);
       return qe.Provider.CreateQuery<TItem>(queryExpression);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/IncludeFilterMappingGatherer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/IncludeFilterMappingGatherer.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Gamzov
@@ -34,7 +34,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       }
     }
 
-    private readonly ParameterExpression calculatedColumnParameter;
+    private static readonly ParameterExpression calculatedColumnParameter = Expression.Parameter(WellKnownOrmTypes.Tuple, "filteredRow");
 
     private readonly Expression filterDataTuple;
     private readonly ApplyParameter filteredTuple;
@@ -102,8 +102,6 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
 
     private IncludeFilterMappingGatherer(Expression filterDataTuple, ApplyParameter filteredTuple, MappingEntry[] resultMapping)
     {
-      calculatedColumnParameter = Expression.Parameter(WellKnownOrmTypes.Tuple, "filteredRow");
-
       this.filterDataTuple = filterDataTuple;
       this.filteredTuple = filteredTuple;
       this.resultMapping = resultMapping;

--- a/Orm/Xtensive.Orm/Orm/Linq/ItemToTupleConverter{TItem}.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ItemToTupleConverter{TItem}.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Gamzov
@@ -52,6 +52,9 @@ namespace Xtensive.Orm.Linq
       }
     }
 
+    private static readonly ParameterExpression paramContext = Expression.Parameter(WellKnownOrmTypes.ParameterContext, "context");
+    private static readonly MethodInfo selectMethod = WellKnownMembers.Enumerable.Select.MakeGenericMethod(typeof(TItem), WellKnownOrmTypes.Tuple);
+
     private readonly Func<ParameterContext, IEnumerable<TItem>> enumerableFunc;
     private readonly DomainModel model;
     private Func<TItem, Tuple> converter;
@@ -61,9 +64,7 @@ namespace Xtensive.Orm.Linq
 
     public override Expression<Func<ParameterContext, IEnumerable<Tuple>>> GetEnumerable()
     {
-      var paramContext = Expression.Parameter(WellKnownOrmTypes.ParameterContext, "context");
       var call = Expression.Call(Expression.Constant(enumerableFunc.Target), enumerableFunc.Method, paramContext);
-      var selectMethod = WellKnownMembers.Enumerable.Select.MakeGenericMethod(typeof (TItem), WellKnownOrmTypes.Tuple);
       var select = Expression.Call(selectMethod, call, Expression.Constant(converter));
       return FastExpression.Lambda<Func<ParameterContext, IEnumerable<Tuple>>>(select, paramContext);
     }

--- a/Orm/Xtensive.Orm/Orm/Linq/ParameterAccessorFactory.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ParameterAccessorFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Xtensive LLC.
+// Copyright (C) 2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
@@ -17,6 +17,8 @@ namespace Xtensive.Orm.Linq
   {
     private static readonly MethodInfo GetParameterValueMethod =
       WellKnownOrmTypes.ParameterContext.GetMethod(nameof(ParameterContext.GetValue));
+
+    private static readonly ParameterExpression parameterContextArgument = Expression.Parameter(WellKnownOrmTypes.ParameterContext, "context");
 
     private class ParameterAccessorFactoryImpl<T>: ExpressionVisitor
     {
@@ -55,7 +57,6 @@ namespace Xtensive.Orm.Linq
 
     public static Expression<Func<ParameterContext, T>> CreateAccessorExpression<T>(Expression parameterExpression)
     {
-      var parameterContextArgument = Expression.Parameter(WellKnownOrmTypes.ParameterContext, "context");
       return new ParameterAccessorFactoryImpl<T>(parameterContextArgument).BindToParameterContext(parameterExpression);
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Linq/QueryHelper.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/QueryHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -33,10 +33,11 @@ namespace Xtensive.Orm.Linq
       }
     }
 
+    private static readonly ParameterExpression tupleParameter = Expression.Parameter(WellKnownOrmTypes.Tuple, "tuple");
+
     public static Expression<Func<Tuple, bool>> BuildFilterLambda(int startIndex, IReadOnlyList<Type> keyColumnTypes, Parameter<Tuple> keyParameter)
     {
       Expression filterExpression = null;
-      var tupleParameter = Expression.Parameter(WellKnownOrmTypes.Tuple, "tuple");
       var valueProperty = WellKnownOrmTypes.ParameterOfTuple
         .GetProperty(nameof(Parameter<Tuple>.Value), WellKnownOrmTypes.Tuple);
       var keyValue = Expression.Property(Expression.Constant(keyParameter), valueProperty);

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
@@ -23,6 +23,10 @@ namespace Xtensive.Orm.Linq
 {
   internal sealed partial class Translator
   {
+    private static readonly ParameterExpression parameterContext = Expression.Parameter(WellKnownOrmTypes.ParameterContext, "parameterContext");
+    private static readonly ParameterExpression tupleReader = Expression.Parameter(typeof(RecordSetReader), "tupleReader");
+    private static readonly ParameterExpression session = Expression.Parameter(typeof(Session), "session");
+
     private readonly CompiledQueryProcessingScope compiledQueryScope;
     public static readonly MethodInfo TranslateMethod;
     private static readonly MethodInfo VisitLocalCollectionSequenceMethod;
@@ -107,10 +111,6 @@ namespace Xtensive.Orm.Linq
     private Materializer
       BuildMaterializer(ProjectionExpression projection, IEnumerable<Parameter<Tuple>> tupleParameters)
     {
-      var tupleReader = Expression.Parameter(typeof (RecordSetReader), "tupleReader");
-      var session = Expression.Parameter(typeof (Session), "session");
-      var parameterContext = Expression.Parameter(WellKnownOrmTypes.ParameterContext, "parameterContext");
-
       var itemProjector = projection.ItemProjector;
       var materializationInfo = itemProjector.Materialize(context, tupleParameters);
       var elementType = itemProjector.Item.Type;
@@ -148,8 +148,8 @@ namespace Xtensive.Orm.Linq
         using (CreateScope(new TranslatorState(state) { CalculateExpressions = false })) {
           body = Visit(argument);
         }
-        body = body.IsProjection() 
-          ? BuildSubqueryResult((ProjectionExpression) body, argument.Type) 
+        body = body.IsProjection()
+          ? BuildSubqueryResult((ProjectionExpression) body, argument.Type)
           : ProcessProjectionElement(body);
         arguments.Add(body);
       }
@@ -172,9 +172,9 @@ namespace Xtensive.Orm.Linq
         var indexProjectionExpression = new ProjectionExpression(WellKnownTypes.Int64, indexItemProjector, sequence.TupleParameterBindings);
         var sequenceItemProjector = sequence.ItemProjector.Remap(indexDataSource, 0);
         sequence = new ProjectionExpression(
-          sequence.Type, 
-          sequenceItemProjector, 
-          sequence.TupleParameterBindings, 
+          sequence.Type,
+          sequenceItemProjector,
+          sequence.TupleParameterBindings,
           sequence.ResultAccessMethod);
         return indexProjectionExpression;
       }

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -27,6 +27,8 @@ namespace Xtensive.Orm.Linq
   internal sealed partial class Translator : QueryableVisitor
   {
     private static readonly Type IEnumerableOfKeyType = typeof(IEnumerable<Key>);
+    private static readonly ParameterExpression tupleParameter = Expression.Parameter(WellKnownOrmTypes.Tuple, "tuple");
+    private static readonly ParameterExpression parameterContextContextParameter = Expression.Parameter(WellKnownOrmTypes.ParameterContext, "context");
 
     internal TranslatorState state { get; private set; } = TranslatorState.InitState;
     private readonly TranslatorContext context;
@@ -548,7 +550,7 @@ namespace Xtensive.Orm.Linq
         ParameterExpression contextParameter;
         if (compiledQueryScope == null) {
           var indexLambda = (Expression<Func<int>>) index;
-          contextParameter = Expression.Parameter(WellKnownOrmTypes.ParameterContext, "context");
+          contextParameter = parameterContextContextParameter;
           elementAtIndex = FastExpression.Lambda<Func<ParameterContext, int>>(indexLambda.Body, contextParameter);
         }
         else {
@@ -625,9 +627,8 @@ namespace Xtensive.Orm.Linq
 
       if (take.Type == typeof(Func<int>)) {
         if (compiledQueryScope == null) {
-          var contextParameter = Expression.Parameter(WellKnownOrmTypes.ParameterContext, "context");
           var takeLambda = (Expression<Func<int>>) take;
-          var newTakeLambda = FastExpression.Lambda<Func<ParameterContext, int>>(takeLambda.Body, contextParameter);
+          var newTakeLambda = FastExpression.Lambda<Func<ParameterContext, int>>(takeLambda.Body, parameterContextContextParameter);
           compiledParameter = newTakeLambda.CachingCompile();
         }
         else {
@@ -990,7 +991,6 @@ namespace Xtensive.Orm.Linq
         })
         .ToList();
       var applyParameter = context.GetApplyParameter(groupingProjection);
-      var tupleParameter = Expression.Parameter(WellKnownOrmTypes.Tuple, "tuple");
 
       var filterBody = (nullableKeyColumns.Count == 0)
         ? comparisonInfos.Aggregate(

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyFilterRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyFilterRewriter.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexander Nikolaev
@@ -17,15 +17,14 @@ namespace Xtensive.Orm.Rse.Transformation
 {
   internal sealed class ApplyFilterRewriter : ExpressionVisitor
   {
+    private static readonly ParameterExpression leftTupleParameter = Expression.Parameter(WellKnownOrmTypes.Tuple, "leftTuple");
     private ColumnCollection sourceColumns;
     private ColumnCollection targetColumns;
-    private ParameterExpression leftTupleParameter;
 
     public Expression<Func<Tuple, Tuple, bool>> Rewrite(Expression<Func<Tuple, bool>> predicate,
       ColumnCollection predicateColumns, ColumnCollection currentColumns)
     {
       Initialize(predicate, predicateColumns, currentColumns);
-      leftTupleParameter = Expression.Parameter(WellKnownOrmTypes.Tuple, "leftTuple");
       var visited = Visit(predicate.Body);
       return (Expression<Func<Tuple, Tuple, bool>>) FastExpression
         .Lambda(visited, leftTupleParameter, predicate.Parameters[0]);

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/RedundantColumnRemover.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/RedundantColumnRemover.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using Xtensive.Core;
 using Xtensive.Linq;
 using Xtensive.Orm.Internals;
@@ -20,6 +21,12 @@ namespace Xtensive.Orm.Rse.Transformation
 {
   internal sealed class RedundantColumnRemover : ColumnMappingInspector
   {
+    private static readonly MethodInfo selectMethodInfo = WellKnownTypes.Enumerable
+      .GetMethods()
+      .Single(methodInfo => methodInfo.Name == nameof(Enumerable.Select)
+        && methodInfo.GetParameters()[1].ParameterType.GetGenericTypeDefinition() == typeof(Func<,>))
+      .MakeGenericMethod(WellKnownOrmTypes.Tuple, WellKnownOrmTypes.Tuple);
+
     protected override Pair<CompilableProvider, List<int>> OverrideRightApplySource(ApplyProvider applyProvider, CompilableProvider provider, List<int> requestedMapping)
     {
       var currentMapping = mappings[applyProvider.Right];
@@ -42,12 +49,6 @@ namespace Xtensive.Orm.Rse.Transformation
     private static Expression<Func<ParameterContext, IEnumerable<Tuple>>> RemapRawProviderSource(
       Expression<Func<ParameterContext, IEnumerable<Tuple>>> source, MapTransform mappingTransform)
     {
-      var selectMethodInfo = WellKnownTypes.Enumerable
-        .GetMethods()
-        .Single(methodInfo => methodInfo.Name == nameof(Enumerable.Select)
-          && methodInfo.GetParameters()[1].ParameterType.GetGenericTypeDefinition() == typeof(Func<,>))
-        .MakeGenericMethod(WellKnownOrmTypes.Tuple, WellKnownOrmTypes.Tuple);
-
       Func<Tuple, Tuple> selector = tuple => mappingTransform.Apply(TupleTransformType.Auto, tuple);
       var newExpression = Expression.Call(selectMethodInfo, source.Body, Expression.Constant(selector));
       return (Expression<Func<ParameterContext, IEnumerable<Tuple>>>)FastExpression.Lambda(newExpression, source.Parameters[0]);

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/RedundantColumnRemover.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/RedundantColumnRemover.cs
@@ -24,7 +24,7 @@ namespace Xtensive.Orm.Rse.Transformation
     private static readonly MethodInfo selectMethodInfo = WellKnownTypes.Enumerable
       .GetMethods()
       .Single(methodInfo => methodInfo.Name == nameof(Enumerable.Select)
-        && methodInfo.GetParameters()[1].ParameterType.GetGenericTypeDefinition() == typeof(Func<,>))
+        && methodInfo.GetParameters()[1].ParameterType.GetGenericTypeDefinition() == WellKnownTypes.FuncOfTArgTResultType)
       .MakeGenericMethod(WellKnownOrmTypes.Tuple, WellKnownOrmTypes.Tuple);
 
     protected override Pair<CompilableProvider, List<int>> OverrideRightApplySource(ApplyProvider applyProvider, CompilableProvider provider, List<int> requestedMapping)

--- a/Orm/Xtensive.Orm/Reflection/WellKnownTypes.cs
+++ b/Orm/Xtensive.Orm/Reflection/WellKnownTypes.cs
@@ -69,6 +69,8 @@ namespace Xtensive.Reflection
     public static readonly Type Expression = typeof(Expression);
     public static readonly Type ExpressionOfT = typeof(Expression<>);
 
+    public static readonly Type FuncOfTArgTResultType = typeof(Func<,>);
+
     public static readonly Type ByteArray = typeof(byte[]);
     public static readonly Type ObjectArray = typeof(object[]);
 

--- a/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (C) 2012-2020 Xtensive LLC.
+// Copyright (C) 2012-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2012.12.29
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Xtensive.Reflection;
 
@@ -52,46 +53,47 @@ namespace Xtensive.Tuples.Packed
 
       private static readonly int NullableTypeMetadataToken = WellKnownTypes.NullableOfT.MetadataToken;
 
-      public static ValueFieldAccessor GetValue(Type probeType)
-      {
-        static ValueFieldAccessor ResolveByType(Type type) =>
-          ReferenceEquals(type, WellKnownTypes.Bool) ? BoolAccessor :
-          ReferenceEquals(type, WellKnownTypes.Byte) ? ByteAccessor :
-          ReferenceEquals(type, WellKnownTypes.SByte) ? SByteAccessor :
-          ReferenceEquals(type, WellKnownTypes.Int16) ? Int16Accessor :
-          ReferenceEquals(type, WellKnownTypes.UInt16) ? UInt16Accessor :
-          ReferenceEquals(type, WellKnownTypes.Int32) ? Int32Accessor :
-          ReferenceEquals(type, WellKnownTypes.UInt32) ? UInt32Accessor :
-          ReferenceEquals(type, WellKnownTypes.Int64) ? Int64Accessor :
-          ReferenceEquals(type, WellKnownTypes.UInt64) ? UInt64Accessor :
-          ReferenceEquals(type, WellKnownTypes.Single) ? SingleAccessor :
-          ReferenceEquals(type, WellKnownTypes.Double) ? DoubleAccessor :
-          ReferenceEquals(type, WellKnownTypes.DateTime) ? DateTimeAccessor :
-          ReferenceEquals(type, WellKnownTypes.TimeSpan) ? TimeSpanAccessor :
-          ReferenceEquals(type, WellKnownTypes.Decimal) ? DecimalAccessor :
-          ReferenceEquals(type, WellKnownTypes.Guid) ? GuidAccessor : null;
+      private static readonly IReadOnlyDictionary<Type, ValueFieldAccessor> accessorByType =
+        new Dictionary<Type, ValueFieldAccessor>(ReferenceEqualityComparer.Instance) {
+          [WellKnownTypes.Bool] = BoolAccessor,
+          [WellKnownTypes.Byte] = ByteAccessor,
+          [WellKnownTypes.SByte] = SByteAccessor,
+          [WellKnownTypes.Int16] = Int16Accessor,
+          [WellKnownTypes.UInt16] = UInt16Accessor,
+          [WellKnownTypes.Int32] = Int32Accessor,
+          [WellKnownTypes.UInt32] = UInt32Accessor,
+          [WellKnownTypes.Int64] = Int64Accessor,
+          [WellKnownTypes.UInt64] = UInt64Accessor,
+          [WellKnownTypes.Single] = SingleAccessor,
+          [WellKnownTypes.Double] = DoubleAccessor,
+          [WellKnownTypes.DateTime] = DateTimeAccessor,
+          [WellKnownTypes.TimeSpan] = TimeSpanAccessor,
+          [WellKnownTypes.Decimal] = DecimalAccessor,
+          [WellKnownTypes.Guid] = GuidAccessor,
+        };
 
-        static ValueFieldAccessor ResolveByNullableType(Type type) =>
-          ReferenceEquals(type, WellKnownTypes.NullableBool) ? BoolAccessor :
-          ReferenceEquals(type, WellKnownTypes.NullableByte) ? ByteAccessor :
-          ReferenceEquals(type, WellKnownTypes.NullableSByte) ? SByteAccessor :
-          ReferenceEquals(type, WellKnownTypes.NullableInt16) ? Int16Accessor :
-          ReferenceEquals(type, WellKnownTypes.NullableUInt16) ? UInt16Accessor :
-          ReferenceEquals(type, WellKnownTypes.NullableInt32) ? Int32Accessor :
-          ReferenceEquals(type, WellKnownTypes.NullableUInt32) ? UInt32Accessor :
-          ReferenceEquals(type, WellKnownTypes.NullableInt64) ? Int64Accessor :
-          ReferenceEquals(type, WellKnownTypes.NullableUInt64) ? UInt64Accessor :
-          ReferenceEquals(type, WellKnownTypes.NullableSingle) ? SingleAccessor :
-          ReferenceEquals(type, WellKnownTypes.NullableDouble) ? DoubleAccessor :
-          ReferenceEquals(type, WellKnownTypes.NullableDateTime) ? DateTimeAccessor :
-          ReferenceEquals(type, WellKnownTypes.NullableTimeSpan) ? TimeSpanAccessor :
-          ReferenceEquals(type, WellKnownTypes.NullableDecimal) ? DecimalAccessor :
-          ReferenceEquals(type, WellKnownTypes.NullableGuid) ? GuidAccessor : null;
+      private static readonly IReadOnlyDictionary<Type, ValueFieldAccessor> accessorByNullableType =
+        new Dictionary<Type, ValueFieldAccessor>(ReferenceEqualityComparer.Instance) {
+          [WellKnownTypes.NullableBool] = BoolAccessor,
+          [WellKnownTypes.NullableByte] = ByteAccessor,
+          [WellKnownTypes.NullableSByte] = SByteAccessor,
+          [WellKnownTypes.NullableInt16] = Int16Accessor,
+          [WellKnownTypes.NullableUInt16] = UInt16Accessor,
+          [WellKnownTypes.NullableInt32] = Int32Accessor,
+          [WellKnownTypes.NullableUInt32] = UInt32Accessor,
+          [WellKnownTypes.NullableInt64] = Int64Accessor,
+          [WellKnownTypes.NullableUInt64] = UInt64Accessor,
+          [WellKnownTypes.NullableSingle] = SingleAccessor,
+          [WellKnownTypes.NullableDouble] = DoubleAccessor,
+          [WellKnownTypes.NullableDateTime] = DateTimeAccessor,
+          [WellKnownTypes.NullableTimeSpan] = TimeSpanAccessor,
+          [WellKnownTypes.NullableDecimal] = DecimalAccessor,
+          [WellKnownTypes.NullableGuid] = GuidAccessor,
+        };
 
-        return (probeType.MetadataToken ^ NullableTypeMetadataToken) == 0
-          ? ResolveByNullableType(probeType)
-          : ResolveByType(probeType);
-      }
+      public static ValueFieldAccessor GetValue(Type probeType) =>
+        ((probeType.MetadataToken ^ NullableTypeMetadataToken) == 0 ? accessorByNullableType : accessorByType)
+          .GetValueOrDefault(probeType);
     }
 
     private delegate void CounterIncrementer(ref Counters counters);

--- a/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
@@ -51,8 +51,6 @@ namespace Xtensive.Tuples.Packed
       private static readonly ValueFieldAccessor DecimalAccessor = new DecimalFieldAccessor();
       private static readonly ValueFieldAccessor GuidAccessor = new GuidFieldAccessor();
 
-      private static readonly int NullableTypeMetadataToken = WellKnownTypes.NullableOfT.MetadataToken;
-
       private static readonly IReadOnlyDictionary<Type, ValueFieldAccessor> accessorByType =
         new Dictionary<Type, ValueFieldAccessor>(ReferenceEqualityComparer.Instance) {
           [WellKnownTypes.Bool] = BoolAccessor,
@@ -70,10 +68,7 @@ namespace Xtensive.Tuples.Packed
           [WellKnownTypes.TimeSpan] = TimeSpanAccessor,
           [WellKnownTypes.Decimal] = DecimalAccessor,
           [WellKnownTypes.Guid] = GuidAccessor,
-        };
 
-      private static readonly IReadOnlyDictionary<Type, ValueFieldAccessor> accessorByNullableType =
-        new Dictionary<Type, ValueFieldAccessor>(ReferenceEqualityComparer.Instance) {
           [WellKnownTypes.NullableBool] = BoolAccessor,
           [WellKnownTypes.NullableByte] = ByteAccessor,
           [WellKnownTypes.NullableSByte] = SByteAccessor,
@@ -92,8 +87,7 @@ namespace Xtensive.Tuples.Packed
         };
 
       public static ValueFieldAccessor GetValue(Type probeType) =>
-        ((probeType.MetadataToken ^ NullableTypeMetadataToken) == 0 ? accessorByNullableType : accessorByType)
-          .GetValueOrDefault(probeType);
+          accessorByType.GetValueOrDefault(probeType);
     }
 
     private delegate void CounterIncrementer(ref Counters counters);

--- a/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
@@ -1,11 +1,10 @@
-// Copyright (C) 2012-2021 Xtensive LLC.
+﻿// Copyright (C) 2012-2020 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2012.12.29
 
 using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Xtensive.Reflection;
 
@@ -51,43 +50,48 @@ namespace Xtensive.Tuples.Packed
       private static readonly ValueFieldAccessor DecimalAccessor = new DecimalFieldAccessor();
       private static readonly ValueFieldAccessor GuidAccessor = new GuidFieldAccessor();
 
-      private static readonly IReadOnlyDictionary<Type, ValueFieldAccessor> accessorByType =
-        new Dictionary<Type, ValueFieldAccessor>(ReferenceEqualityComparer.Instance) {
-          [WellKnownTypes.Bool] = BoolAccessor,
-          [WellKnownTypes.Byte] = ByteAccessor,
-          [WellKnownTypes.SByte] = SByteAccessor,
-          [WellKnownTypes.Int16] = Int16Accessor,
-          [WellKnownTypes.UInt16] = UInt16Accessor,
-          [WellKnownTypes.Int32] = Int32Accessor,
-          [WellKnownTypes.UInt32] = UInt32Accessor,
-          [WellKnownTypes.Int64] = Int64Accessor,
-          [WellKnownTypes.UInt64] = UInt64Accessor,
-          [WellKnownTypes.Single] = SingleAccessor,
-          [WellKnownTypes.Double] = DoubleAccessor,
-          [WellKnownTypes.DateTime] = DateTimeAccessor,
-          [WellKnownTypes.TimeSpan] = TimeSpanAccessor,
-          [WellKnownTypes.Decimal] = DecimalAccessor,
-          [WellKnownTypes.Guid] = GuidAccessor,
+      private static readonly int NullableTypeMetadataToken = WellKnownTypes.NullableOfT.MetadataToken;
 
-          [WellKnownTypes.NullableBool] = BoolAccessor,
-          [WellKnownTypes.NullableByte] = ByteAccessor,
-          [WellKnownTypes.NullableSByte] = SByteAccessor,
-          [WellKnownTypes.NullableInt16] = Int16Accessor,
-          [WellKnownTypes.NullableUInt16] = UInt16Accessor,
-          [WellKnownTypes.NullableInt32] = Int32Accessor,
-          [WellKnownTypes.NullableUInt32] = UInt32Accessor,
-          [WellKnownTypes.NullableInt64] = Int64Accessor,
-          [WellKnownTypes.NullableUInt64] = UInt64Accessor,
-          [WellKnownTypes.NullableSingle] = SingleAccessor,
-          [WellKnownTypes.NullableDouble] = DoubleAccessor,
-          [WellKnownTypes.NullableDateTime] = DateTimeAccessor,
-          [WellKnownTypes.NullableTimeSpan] = TimeSpanAccessor,
-          [WellKnownTypes.NullableDecimal] = DecimalAccessor,
-          [WellKnownTypes.NullableGuid] = GuidAccessor,
-        };
+      public static ValueFieldAccessor GetValue(Type probeType)
+      {
+        static ValueFieldAccessor ResolveByType(Type type) =>
+          ReferenceEquals(type, WellKnownTypes.Bool) ? BoolAccessor :
+          ReferenceEquals(type, WellKnownTypes.Byte) ? ByteAccessor :
+          ReferenceEquals(type, WellKnownTypes.SByte) ? SByteAccessor :
+          ReferenceEquals(type, WellKnownTypes.Int16) ? Int16Accessor :
+          ReferenceEquals(type, WellKnownTypes.UInt16) ? UInt16Accessor :
+          ReferenceEquals(type, WellKnownTypes.Int32) ? Int32Accessor :
+          ReferenceEquals(type, WellKnownTypes.UInt32) ? UInt32Accessor :
+          ReferenceEquals(type, WellKnownTypes.Int64) ? Int64Accessor :
+          ReferenceEquals(type, WellKnownTypes.UInt64) ? UInt64Accessor :
+          ReferenceEquals(type, WellKnownTypes.Single) ? SingleAccessor :
+          ReferenceEquals(type, WellKnownTypes.Double) ? DoubleAccessor :
+          ReferenceEquals(type, WellKnownTypes.DateTime) ? DateTimeAccessor :
+          ReferenceEquals(type, WellKnownTypes.TimeSpan) ? TimeSpanAccessor :
+          ReferenceEquals(type, WellKnownTypes.Decimal) ? DecimalAccessor :
+          ReferenceEquals(type, WellKnownTypes.Guid) ? GuidAccessor : null;
 
-      public static ValueFieldAccessor GetValue(Type probeType) =>
-          accessorByType.GetValueOrDefault(probeType);
+        static ValueFieldAccessor ResolveByNullableType(Type type) =>
+          ReferenceEquals(type, WellKnownTypes.NullableBool) ? BoolAccessor :
+          ReferenceEquals(type, WellKnownTypes.NullableByte) ? ByteAccessor :
+          ReferenceEquals(type, WellKnownTypes.NullableSByte) ? SByteAccessor :
+          ReferenceEquals(type, WellKnownTypes.NullableInt16) ? Int16Accessor :
+          ReferenceEquals(type, WellKnownTypes.NullableUInt16) ? UInt16Accessor :
+          ReferenceEquals(type, WellKnownTypes.NullableInt32) ? Int32Accessor :
+          ReferenceEquals(type, WellKnownTypes.NullableUInt32) ? UInt32Accessor :
+          ReferenceEquals(type, WellKnownTypes.NullableInt64) ? Int64Accessor :
+          ReferenceEquals(type, WellKnownTypes.NullableUInt64) ? UInt64Accessor :
+          ReferenceEquals(type, WellKnownTypes.NullableSingle) ? SingleAccessor :
+          ReferenceEquals(type, WellKnownTypes.NullableDouble) ? DoubleAccessor :
+          ReferenceEquals(type, WellKnownTypes.NullableDateTime) ? DateTimeAccessor :
+          ReferenceEquals(type, WellKnownTypes.NullableTimeSpan) ? TimeSpanAccessor :
+          ReferenceEquals(type, WellKnownTypes.NullableDecimal) ? DecimalAccessor :
+          ReferenceEquals(type, WellKnownTypes.NullableGuid) ? GuidAccessor : null;
+
+        return (probeType.MetadataToken ^ NullableTypeMetadataToken) == 0
+          ? ResolveByNullableType(probeType)
+          : ResolveByType(probeType);
+      }
     }
 
     private delegate void CounterIncrementer(ref Counters counters);


### PR DESCRIPTION
* Reuse Expression objects, they are immutable.
* Use dictionary in `ValueFieldAccessorResolver` instead of linear search.