### PR TITLE
Avoid unnecessary array copy before calling .Remap(); new() -> ValueTuple; Pair<>

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Rse/HeaderParseTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Rse/HeaderParseTest.cs
@@ -54,7 +54,7 @@ namespace Xtensive.Orm.Tests.Rse
           ResetState(state);
 
           // Select Id, TypeId, Title
-          CompilableProvider rsTitle = rsMain.Select(0, 1, 2);
+          CompilableProvider rsTitle = rsMain.Select(new[] { 0, 1, 2 });
           UpdateCache(session, rsTitle.GetRecordSetReader(session, parameterContext));
           state = Session.Current.EntityStateCache[key, true];
           Assert.IsNotNull(state);
@@ -63,7 +63,7 @@ namespace Xtensive.Orm.Tests.Rse
           ResetState(state);
 
           // Select Id, TypeId, Text
-          CompilableProvider rsText = rsMain.Select(0, 1, 3);
+          CompilableProvider rsText = rsMain.Select(new[] { 0, 1, 3 });
           UpdateCache(session, rsText.GetRecordSetReader(session, parameterContext));
           state = Session.Current.EntityStateCache[key, true];
           Assert.IsNotNull(state);

--- a/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/CharSupportTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/CharSupportTest.cs
@@ -66,7 +66,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
         var rs = GetRseQuery<MyEntity>();
         var parameterContext = new ParameterContext();
         var result = rs
-          .Select(rs.Header.IndexOf(charColumn))
+          .Select(new[] { rs.Header.IndexOf(charColumn) })
           .GetRecordSetReader(Session.Current, parameterContext)
           .ToEnumerable()
           .Select(i => i.GetValueOrDefault<char>(0))
@@ -88,7 +88,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
         var rs = GetRseQuery<MyEntity>();
         var parameterContext = new ParameterContext();
         var result = rs
-          .Select(rs.Header.IndexOf(charColumn))
+          .Select(new[] { rs.Header.IndexOf(charColumn) })
           .Filter(t => t.GetValueOrDefault<char>(0) == y)
           .GetRecordSetReader(Session.Current, parameterContext)
           .ToEnumerable()
@@ -108,7 +108,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
         var rs = GetRseQuery<MyEntity>();
         var parameterContext = new ParameterContext();
         var result = rs
-          .Select(rs.Header.IndexOf(charColumn))
+          .Select(new[] { rs.Header.IndexOf(charColumn) })
           .Filter(t => t.GetValueOrDefault<char>(0)=='Y')
           .GetRecordSetReader(Session.Current, parameterContext)
           .ToEnumerable()

--- a/Orm/Xtensive.Orm/Arithmetic/ArithmeticRules.cs
+++ b/Orm/Xtensive.Orm/Arithmetic/ArithmeticRules.cs
@@ -41,14 +41,8 @@ namespace Xtensive.Arithmetic
     }
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (obj==null)
-        return false;
-      if (obj is ArithmeticRules)
-        return Equals((ArithmeticRules)obj);
-      return false;
-    }
+    public override bool Equals(object obj) =>
+      obj is ArithmeticRules x && Equals(x);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Arithmetic/ArithmeticRules.cs
+++ b/Orm/Xtensive.Orm/Arithmetic/ArithmeticRules.cs
@@ -42,7 +42,7 @@ namespace Xtensive.Arithmetic
 
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
-      obj is ArithmeticRules x && Equals(x);
+      obj is ArithmeticRules other && Equals(other);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Caching/WeakestCache.cs
+++ b/Orm/Xtensive.Orm/Caching/WeakestCache.cs
@@ -131,33 +131,24 @@ namespace Xtensive.Caching
 
       public new bool Equals(object x, object y)
       {
-        TKey key;
-        var we = x as WeakEntry;
-        if (we!=null) {
+        if (x is WeakEntry we) {
           // x is WeakEntry
-          key = y as TKey;
-          if (key!=null)
+          if (y is TKey key)
             // x is WeakEntry, y is TKey
             return keyComparer.Equals(we.Key, key);
           else {
-            var we2 = y as WeakEntry;
-            if (we2==null)
-              return false;
-            // x is WeakEntry, y is WeakEntry
-            return keyComparer.Equals(we.Key, we2.Key);
+            return y is WeakEntry we2 && keyComparer.Equals(we.Key, we2.Key); // x is WeakEntry, y is WeakEntry
           }
         }
-        key = x as TKey;
-        if (key==null)
-          return false;
-        // x is TKey
-        we = y as WeakEntry;
-        if (we!=null)
-          // x is TKey, y is WeakEntry
-          return keyComparer.Equals(key, we.Key);
-        else
-          // x is TKey, y must be TKey
-          return keyComparer.Equals(key, y as TKey);
+        if (x is TKey keyX) {
+          if (y is WeakEntry weY)
+            // x is TKey, y is WeakEntry
+            return keyComparer.Equals(keyX, weY.Key);
+          else
+            // x is TKey, y must be TKey
+            return keyComparer.Equals(keyX, y as TKey);
+        }
+        return false;
       }
 
       public int GetHashCode(object obj)

--- a/Orm/Xtensive.Orm/Comparison/ComparisonRule.cs
+++ b/Orm/Xtensive.Orm/Comparison/ComparisonRule.cs
@@ -83,12 +83,8 @@ namespace Xtensive.Comparison
     }
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (obj is ComparisonRule)
-        return Equals((ComparisonRule)obj);
-      return false;
-    }
+    public override bool Equals(object obj) =>
+      obj is ComparisonRule rule && Equals(rule);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Comparison/ComparisonRule.cs
+++ b/Orm/Xtensive.Orm/Comparison/ComparisonRule.cs
@@ -84,7 +84,7 @@ namespace Xtensive.Comparison
 
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
-      obj is ComparisonRule rule && Equals(rule);
+      obj is ComparisonRule other && Equals(other);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Comparison/ComparisonRules.cs
+++ b/Orm/Xtensive.Orm/Comparison/ComparisonRules.cs
@@ -193,12 +193,8 @@ namespace Xtensive.Comparison
     #region Equals, GetHashCode
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (obj is ComparisonRules)
-        return Equals((ComparisonRules)obj);
-      return false;
-    }
+    public override bool Equals(object obj) =>
+      obj is ComparisonRules rules && Equals(rules);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Comparison/ComparisonRules.cs
+++ b/Orm/Xtensive.Orm/Comparison/ComparisonRules.cs
@@ -194,7 +194,7 @@ namespace Xtensive.Comparison
 
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
-      obj is ComparisonRules rules && Equals(rules);
+      obj is ComparisonRules other && Equals(other);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Conversion/Biconverter.cs
+++ b/Orm/Xtensive.Orm/Conversion/Biconverter.cs
@@ -54,7 +54,7 @@ namespace Xtensive.Conversion
 
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
-      obj is Biconverter<TFrom, TTo> x && Equals(x);
+      obj is Biconverter<TFrom, TTo> other && Equals(other);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Conversion/Biconverter.cs
+++ b/Orm/Xtensive.Orm/Conversion/Biconverter.cs
@@ -53,12 +53,8 @@ namespace Xtensive.Conversion
     }
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (obj.GetType()!=typeof (Biconverter<TFrom, TTo>))
-        return false;
-      return Equals((Biconverter<TFrom, TTo>) obj);
-    }
+    public override bool Equals(object obj) =>
+      obj is Biconverter<TFrom, TTo> x && Equals(x);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Core/HasVersion{TValue,TVersion}.cs
+++ b/Orm/Xtensive.Orm/Core/HasVersion{TValue,TVersion}.cs
@@ -58,7 +58,7 @@ namespace Xtensive.Core
 
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
-      obj is HasVersion<TValue, TVersion> x && Equals(x);
+      obj is HasVersion<TValue, TVersion> other && Equals(other);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Core/HasVersion{TValue,TVersion}.cs
+++ b/Orm/Xtensive.Orm/Core/HasVersion{TValue,TVersion}.cs
@@ -57,12 +57,8 @@ namespace Xtensive.Core
     #region Equals, GetHashCode, ==, !=
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (obj.GetType()!=typeof (HasVersion<TValue, TVersion>))
-        return false;
-      return Equals((HasVersion<TValue, TVersion>) obj);
-    }
+    public override bool Equals(object obj) =>
+      obj is HasVersion<TValue, TVersion> x && Equals(x);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Core/Pair{TFirst,TSecond}.cs
+++ b/Orm/Xtensive.Orm/Core/Pair{TFirst,TSecond}.cs
@@ -21,6 +21,9 @@ namespace Xtensive.Core
     IComparable<Pair<TFirst, TSecond>>,
     IEquatable<Pair<TFirst, TSecond>>
   {
+    private static readonly AdvancedComparerStruct<TFirst> firstComparer = AdvancedComparerStruct<TFirst>.System;
+    private static readonly AdvancedComparerStruct<TSecond> secondComparer = AdvancedComparerStruct<TSecond>.System;
+
     /// <summary>
     /// A first value.
     /// </summary>
@@ -33,20 +36,16 @@ namespace Xtensive.Core
     #region IComparable<...>, IEquatable<...> methods
 
     /// <inheritdoc/>
-    public bool Equals(Pair<TFirst, TSecond> other)
-    {
-      if (!AdvancedComparerStruct<TFirst>.System.Equals(First, other.First))
-        return false;
-      return AdvancedComparerStruct<TSecond>.System.Equals(Second, other.Second);
-    }
+    public bool Equals(Pair<TFirst, TSecond> other) =>
+      firstComparer.Equals(First, other.First) && secondComparer.Equals(Second, other.Second);
 
     /// <inheritdoc/>
     public int CompareTo(Pair<TFirst, TSecond> other)
     {
-      int result = AdvancedComparerStruct<TFirst>.System.Compare(First, other.First);
-      if (result != 0)
-        return result;
-      return AdvancedComparerStruct<TSecond>.System.Compare(Second, other.Second);
+      int result = firstComparer.Compare(First, other.First);
+      return result != 0
+        ? result
+        : secondComparer.Compare(Second, other.Second);
     }
 
     #endregion
@@ -54,12 +53,8 @@ namespace Xtensive.Core
     #region Equals, GetHashCode, ==, !=
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (obj.GetType() != typeof(Pair<TFirst, TSecond>))
-        return false;
-      return Equals((Pair<TFirst, TSecond>) obj);
-    }
+    public override bool Equals(object obj) =>
+      obj is Pair<TFirst, TSecond> x && Equals(x);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Core/Pair{TFirst,TSecond}.cs
+++ b/Orm/Xtensive.Orm/Core/Pair{TFirst,TSecond}.cs
@@ -54,7 +54,7 @@ namespace Xtensive.Core
 
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
-      obj is Pair<TFirst, TSecond> x && Equals(x);
+      obj is Pair<TFirst, TSecond> other && Equals(other);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Core/Pair{T}.cs
+++ b/Orm/Xtensive.Orm/Core/Pair{T}.cs
@@ -22,6 +22,8 @@ namespace Xtensive.Core
     IEquatable<Pair<T>>,
     IComparable<Pair<T>>
   {
+    private static readonly AdvancedComparerStruct<T> comparer = AdvancedComparerStruct<T>.System;
+
     /// <summary>
     /// The first value.
     /// </summary>
@@ -35,20 +37,16 @@ namespace Xtensive.Core
     #region IComparable<...>, IEquatable<...> methods
 
     /// <inheritdoc/>
-    public bool Equals(Pair<T> other)
-    {
-      if (!AdvancedComparerStruct<T>.System.Equals(First, other.First))
-        return false;
-      return AdvancedComparerStruct<T>.System.Equals(Second, other.Second);
-    }
+    public bool Equals(Pair<T> other) =>
+      comparer.Equals(First, other.First) && comparer.Equals(Second, other.Second);
 
     /// <inheritdoc/>
     public int CompareTo(Pair<T> other)
     {
-      int result = AdvancedComparerStruct<T>.System.Compare(First, other.First);
-      if (result!=0)
-        return result;
-      return AdvancedComparerStruct<T>.System.Compare(Second, other.Second);
+      int result = comparer.Compare(First, other.First);
+      return result != 0
+        ? result
+        : comparer.Compare(Second, other.Second);
     }
 
     #endregion
@@ -56,12 +54,8 @@ namespace Xtensive.Core
     #region Equals, GetHashCode, ==, !=
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (obj.GetType()!=typeof (Pair<T>))
-        return false;
-      return Equals((Pair<T>) obj);
-    }
+    public override bool Equals(object obj) =>
+      obj is Pair<T> x && Equals(x);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Core/Pair{T}.cs
+++ b/Orm/Xtensive.Orm/Core/Pair{T}.cs
@@ -55,7 +55,7 @@ namespace Xtensive.Core
 
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
-      obj is Pair<T> x && Equals(x);
+      obj is Pair<T> other && Equals(other);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Core/Segment.cs
+++ b/Orm/Xtensive.Orm/Core/Segment.cs
@@ -62,14 +62,8 @@ namespace Xtensive.Core
     #region Equals, GetHashCode
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (obj is Pair<T>) {
-        Pair<T> other = (Pair<T>)obj;
-        return Equals(other);
-      }
-      return false;
-    }
+    public override bool Equals(object obj) =>
+      obj is Pair<T> other && Equals(other);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/Internals/SerializableExpressionToExpressionConverter.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/Internals/SerializableExpressionToExpressionConverter.cs
@@ -148,16 +148,12 @@ namespace Xtensive.Linq.SerializableExpressions.Internals
     private Expression VisitMemberAccess(SerializableMemberExpression m)
     {
       var target = Visit(m.Expression);
-      var field = m.Member as FieldInfo;
-      if (field != null)
-        return Expression.Field(target, field);
-      var property = m.Member as PropertyInfo;
-      if (property != null)
-        return Expression.Property(target, property);
-      var method = m.Member as MethodInfo;
-      if (method != null)
-        return Expression.Property(target, method);
-      throw new ArgumentException();
+      return m.Member switch {
+        FieldInfo field => Expression.Field(target, field),
+        PropertyInfo property => Expression.Property(target, property),
+        MethodInfo method => Expression.Property(target, method),
+        _ => throw new ArgumentException()
+      };
     }
 
     private Expression VisitMethodCall(SerializableMethodCallExpression mc)

--- a/Orm/Xtensive.Orm/Modelling/Comparison/Comparer.cs
+++ b/Orm/Xtensive.Orm/Modelling/Comparison/Comparer.cs
@@ -194,7 +194,7 @@ namespace Xtensive.Modelling.Comparison
           if ((difference.MovementInfo & recreated) != recreated) {
             var propertyAccessors = difference.PropertyChanges
               .Where(p => p.Value.Source != null && p.Value.Target != null)
-              .Select(p => new {Pair = p, NodeDifference = p.Value as NodeDifference})
+              .Select(p => (Pair: p, NodeDifference: p.Value as NodeDifference))
               .Where(a => a.NodeDifference != null && !a.NodeDifference.IsNameChanged)
               .Select(a => source.PropertyAccessors[a.Pair.Key])
               .ToList();

--- a/Orm/Xtensive.Orm/Modelling/Comparison/Upgrader.cs
+++ b/Orm/Xtensive.Orm/Modelling/Comparison/Upgrader.cs
@@ -658,12 +658,12 @@ namespace Xtensive.Modelling.Comparison
     /// <returns>A disposable deactivating the group.</returns>
     protected IDisposable OpenActionGroup(string comment)
     {
-      var oldActions = new {
+      var oldActions = (
         Context.PreConditions,
         Context.Actions,
         Context.Renames,
         Context.PostConditions
-      };
+      );
       Context.PreConditions = new GroupingNodeAction {
         Comment = PreConditionsGroupComment
       };

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/DatabaseDependencyBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/DatabaseDependencyBuilder.cs
@@ -29,7 +29,7 @@ namespace Xtensive.Orm.Building.Builders
       }
 
       public override bool Equals(object obj) =>
-        obj is DatabaseReference x && Equals(x);
+        obj is DatabaseReference other && Equals(other);
 
       public override int GetHashCode()
       {

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/DatabaseDependencyBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/DatabaseDependencyBuilder.cs
@@ -28,12 +28,8 @@ namespace Xtensive.Orm.Building.Builders
         return string.Equals(TargetDatabase, other.TargetDatabase) && string.Equals(OwnerDatabase, other.OwnerDatabase);
       }
 
-      public override bool Equals(object obj)
-      {
-        if (ReferenceEquals(null, obj))
-          return false;
-        return obj is DatabaseReference && Equals((DatabaseReference) obj);
-      }
+      public override bool Equals(object obj) =>
+        obj is DatabaseReference x && Equals(x);
 
       public override int GetHashCode()
       {

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
@@ -192,7 +192,7 @@ namespace Xtensive.Orm.Building.Builders
                   .Where(t => t.Hierarchy == grouping.Key && !t.IsAbstract)
                   .ToList();
                 var primaryIndexes = allImplementors
-                  .Select(t => new {Index = t.Indexes.Single(i => i.IsPrimary && !i.IsVirtual), Type = t})
+                  .Select(t => (Index: t.Indexes.Single(i => i.IsPrimary && !i.IsVirtual), Type: t))
                   .Select(p => untypedIndexes.Contains(p.Index) 
                     ? p.Type.Indexes.Single(i => i.IsPrimary && i.IsTyped) 
                     : p.Index)
@@ -260,7 +260,7 @@ namespace Xtensive.Orm.Building.Builders
               case InheritanceSchema.ConcreteTable: {
                 var indexes = @interface.GetImplementors(true)
                   .Where(t => t.Hierarchy == grouping.Key)
-                  .Select(t => new { Index = t.Indexes.Single(i => i.DeclaringIndex == localIndex.DeclaringIndex && !i.IsVirtual), Type = t })
+                  .Select(t => (Index: t.Indexes.Single(i => i.DeclaringIndex == localIndex.DeclaringIndex && !i.IsVirtual), Type: t))
                   .Select(p => untypedIndexes.Contains(p.Index)
                     ? p.Type.Indexes.Single(i => i.DeclaringIndex == localIndex.DeclaringIndex && i.IsTyped)
                     : p.Index);
@@ -377,7 +377,7 @@ namespace Xtensive.Orm.Building.Builders
         // There might be difference in columns order of type and columns list
         // so we have to reorder them in correct sequence.
         if (typeInfo.IsInterface) {
-          var indexedColumns = columns.Select((column, i) => new { i, j = typeInfo.Columns.IndexOf(column), column }).ToList();
+          var indexedColumns = columns.Select((column, i) => (i, j: typeInfo.Columns.IndexOf(column), column)).ToList();
           var orderedColumns = indexedColumns.OrderBy(el => el.j).Select(el => el.column).Distinct();
           result.ValueColumns.AddRange(GatherValueColumns(orderedColumns));
         }
@@ -592,7 +592,7 @@ namespace Xtensive.Orm.Building.Builders
       // Adding value columns
       var typeOrder = reflectedType.GetAncestors()
         .Append(reflectedType)
-        .Select((t, i) => new {Type = t, Index = i})
+        .Select((t, i) => (Type: t, Index: i))
         .ToDictionary(a => a.Type, a => a.Index);
       var types = reflectedType.GetAncestors().ToHashSet();
       types.Add(reflectedType);
@@ -627,7 +627,7 @@ namespace Xtensive.Orm.Building.Builders
         valueColumnMap.Add(columnMap);
       }
       var orderedIndexes = indexesToJoin
-        .Select((index, i) => new {index, columns = valueColumnMap[i], i})
+        .Select((index, i) => (index, columns: valueColumnMap[i], i))
         .OrderBy(a => typeOrder[a.index.ValueColumns.First().Field.ReflectedType])
         .ToList();
 
@@ -758,7 +758,7 @@ namespace Xtensive.Orm.Building.Builders
         columnMap.Add(keyLength + i);
       }
       var actualColumnMapping = valueColumns
-        .Zip(columnMap, (column, sourceIndex) => new {column, sourceIndex})
+        .Zip(columnMap, (column, sourceIndex) => (column, sourceIndex))
         .OrderBy(p => reflectedType.Columns.IndexOf(p.column))
         .ToList();
       valueColumns.Clear();
@@ -814,7 +814,7 @@ namespace Xtensive.Orm.Building.Builders
         : index.KeyColumns
             .Select(pair => pair.Key)
             .Concat(index.ValueColumns)
-            .Select((c, i) => new {c, i})
+            .Select((c, i) => (c, i))
             .Where(arg => arg.c.IsPrimaryKey)
             .Select(arg => arg.i)
             .ToList();

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/MemberCompilerProviderBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/MemberCompilerProviderBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2011-2020 Xtensive LLC.
+// Copyright (C) 2011-2020 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -56,10 +56,10 @@ namespace Xtensive.Orm.Building.Builders
     private void RegisterContainers(IEnumerable<Type> containers)
     {
       var groupings = containers
-        .Select(container => new {
-          Container = container,
-          Attribute = GetCompilerContainerAttribute(container)
-        })
+        .Select(container => (
+          Container: container,
+          Attribute: GetCompilerContainerAttribute(container)
+        ))
         .GroupBy(item => item.Attribute.TargetType);
 
       foreach (var grouping in groupings) {

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/ProviderDescriptor.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/ProviderDescriptor.cs
@@ -41,10 +41,10 @@ namespace Xtensive.Orm.Building.Builders
       var entry = providerAssembly.GetTypes()
         .Where(type => type.IsPublicNonAbstractInheritorOf(typeof (HandlerFactory)))
         .Where(type => type.IsDefined(typeof (ProviderAttribute), false))
-        .Select(type => new {HandlerFactory = type, Attribute = type.GetAttribute<ProviderAttribute>()})
-        .SingleOrDefault(e => e.Attribute.Name==providerName);
+        .Select(type => (HandlerFactory: type, Attribute: type.GetAttribute<ProviderAttribute>()))
+        .SingleOrDefault(e => e.Attribute.Name == providerName);
 
-      if (entry==null)
+      if (entry == default)
         throw new DomainBuilderException(string.Format(
           Strings.ExStorageProviderXIsNotFound, providerName));
 

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingBuilder.cs
@@ -28,12 +28,8 @@ namespace Xtensive.Orm.Building.Builders
         return Equals(Assembly, other.Assembly) && string.Equals(Namespace, other.Namespace, StringComparison.Ordinal);
       }
 
-      public override bool Equals(object obj)
-      {
-        if (ReferenceEquals(null, obj))
-          return false;
-        return obj is MappingRequest && Equals((MappingRequest) obj);
-      }
+      public override bool Equals(object obj) =>
+        obj is MappingRequest x && Equals(x);
 
       public override int GetHashCode()
       {

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingBuilder.cs
@@ -29,7 +29,7 @@ namespace Xtensive.Orm.Building.Builders
       }
 
       public override bool Equals(object obj) =>
-        obj is MappingRequest x && Equals(x);
+        obj is MappingRequest other && Equals(other);
 
       public override int GetHashCode()
       {

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/TypeBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/TypeBuilder.cs
@@ -296,13 +296,13 @@ namespace Xtensive.Orm.Building.Builders
           }
 
           currentIndex.Fields.AddRange(structureFullTextIndex.Fields
-            .Select(f => new {
+            .Select(f => (
               fieldInfo.DeclaringType
                 .StructureFieldMapping[new Pair<FieldInfo>(fieldInfo, structureTypeInfo.Fields[f.Name])].Name,
               f.IsAnalyzed,
               f.Configuration,
               f.TypeFieldName
-            })
+            ))
             .Select(g => new FullTextFieldDef(g.Name, g.IsAnalyzed) {
               Configuration = g.Configuration, TypeFieldName = g.TypeFieldName
             }));

--- a/Orm/Xtensive.Orm/Orm/Building/DependencyGraph/Edge.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/DependencyGraph/Edge.cs
@@ -9,7 +9,7 @@ using System;
 namespace Xtensive.Orm.Building.DependencyGraph
 {
   [Serializable]
-  internal class Edge<TValue>
+  internal sealed class Edge<TValue>
   {
     public Node<TValue> Tail { get; private set; }
 
@@ -38,16 +38,9 @@ namespace Xtensive.Orm.Building.DependencyGraph
     }
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (ReferenceEquals(null, obj))
-        return false;
-      if (ReferenceEquals(this, obj))
-        return true;
-      if (obj.GetType()!=typeof (Edge<TValue>))
-        return false;
-      return Equals((Edge<TValue>) obj);
-    }
+    public override bool Equals(object obj) =>
+      ReferenceEquals(this, obj)
+      || obj is Edge<TValue> x && Equals(x);
 
     /// <inheritdoc/>
     public static bool operator ==(Edge<TValue> left, Edge<TValue> right)

--- a/Orm/Xtensive.Orm/Orm/Building/DependencyGraph/Edge.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/DependencyGraph/Edge.cs
@@ -40,7 +40,7 @@ namespace Xtensive.Orm.Building.DependencyGraph
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
       ReferenceEquals(this, obj)
-      || obj is Edge<TValue> x && Equals(x);
+      || obj is Edge<TValue> other && Equals(other);
 
     /// <inheritdoc/>
     public static bool operator ==(Edge<TValue> left, Edge<TValue> right)

--- a/Orm/Xtensive.Orm/Orm/Configuration/SessionConfigurationCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/SessionConfigurationCollection.cs
@@ -102,7 +102,7 @@ namespace Xtensive.Orm.Configuration
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
       ReferenceEquals(this, obj)
-        || obj is SessionConfigurationCollection scc && Equals(scc);
+        || obj is SessionConfigurationCollection other && Equals(other);
 
     /// <inheritdoc/>
     public bool Equals(SessionConfigurationCollection obj)

--- a/Orm/Xtensive.Orm/Orm/Configuration/SessionConfigurationCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/SessionConfigurationCollection.cs
@@ -100,17 +100,9 @@ namespace Xtensive.Orm.Configuration
     #region Equality members
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (ReferenceEquals(null, obj))
-        return false;
-      if (ReferenceEquals(this, obj))
-        return true;
-      var scc = obj as SessionConfigurationCollection;
-      if (scc == null)
-        return false;
-      return Equals(scc);
-    }
+    public override bool Equals(object obj) =>
+      ReferenceEquals(this, obj)
+        || obj is SessionConfigurationCollection scc && Equals(scc);
 
     /// <inheritdoc/>
     public bool Equals(SessionConfigurationCollection obj)

--- a/Orm/Xtensive.Orm/Orm/Entity.cs
+++ b/Orm/Xtensive.Orm/Orm/Entity.cs
@@ -272,7 +272,7 @@ namespace Xtensive.Orm
         var query = index.GetQuery()
           .Seek(context => context.GetValue(keyParameter))
           .Lock(() => triplet.Item2, () => triplet.Item3)
-          .Select();
+          .Select(Array.Empty<int>());
         return Session.Compile(query);
       };
       var source = (ExecutableProvider) Session.StorageNode.InternalQueryCache.GetOrAdd(key, generator);

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityGroupTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityGroupTask.cs
@@ -124,7 +124,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     public override bool Equals(object obj) =>
       ReferenceEquals(this, obj)
-        || obj is EntityGroupTask entityGroupTask && Equals(entityGroupTask);
+        || obj is EntityGroupTask other && Equals(other);
 
     public override int GetHashCode() => cacheKey.GetHashCode();
 

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityGroupTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityGroupTask.cs
@@ -46,7 +46,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       }
 
       public override bool Equals(object obj) =>
-        obj is CacheKey x && Equals(x);
+        obj is CacheKey other && Equals(other);
 
       public override int GetHashCode() => cachedHashCode;
 

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityGroupTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityGroupTask.cs
@@ -45,18 +45,8 @@ namespace Xtensive.Orm.Internals.Prefetch
         return true;
       }
 
-      public override bool Equals(object obj)
-      {
-        if (ReferenceEquals(null, obj)) {
-          return false;
-        }
-
-        if (obj.GetType() != typeof(CacheKey)) {
-          return false;
-        }
-
-        return Equals((CacheKey) obj);
-      }
+      public override bool Equals(object obj) =>
+        obj is CacheKey x && Equals(x);
 
       public override int GetHashCode() => cachedHashCode;
 
@@ -132,18 +122,9 @@ namespace Xtensive.Orm.Internals.Prefetch
       return ReferenceEquals(this, other) || other.cacheKey.Equals(cacheKey);
     }
 
-    public override bool Equals(object obj)
-    {
-      if (ReferenceEquals(null, obj)) {
-        return false;
-      }
-
-      if (ReferenceEquals(this, obj)) {
-        return true;
-      }
-
-      return obj is EntityGroupTask entityGroupTask && Equals(entityGroupTask);
-    }
+    public override bool Equals(object obj) =>
+      ReferenceEquals(this, obj)
+        || obj is EntityGroupTask entityGroupTask && Equals(entityGroupTask);
 
     public override int GetHashCode() => cacheKey.GetHashCode();
 

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntitySetTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntitySetTask.cs
@@ -36,16 +36,8 @@ namespace Xtensive.Orm.Internals.Prefetch
           && Equals(other.ReferencingField, ReferencingField);
       }
 
-      public override bool Equals(object obj)
-      {
-        if (ReferenceEquals(null, obj)) {
-          return false;
-        }
-        if (obj.GetType() != typeof (CacheKey)) {
-          return false;
-        }
-        return Equals((CacheKey) obj);
-      }
+      public override bool Equals(object obj) =>
+        obj is CacheKey x && Equals(x);
 
       public override int GetHashCode() => cachedHashCode;
 
@@ -158,19 +150,9 @@ namespace Xtensive.Orm.Internals.Prefetch
       return other.cacheKey.Equals(cacheKey);
     }
 
-    public override bool Equals(object obj)
-    {
-      if (ReferenceEquals(null, obj)) {
-        return false;
-      }
-      if (ReferenceEquals(this, obj)) {
-        return true;
-      }
-      if (obj.GetType() != typeof (EntitySetTask)) {
-        return false;
-      }
-      return Equals((EntitySetTask) obj);
-    }
+    public override bool Equals(object obj) =>
+      ReferenceEquals(this, obj)
+        || obj is EntitySetTask x && Equals(x);
 
     public override int GetHashCode() => cacheKey.GetHashCode();
 
@@ -205,7 +187,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       var result = association.AuxiliaryType == null
         ? CreateQueryForDirectAssociation(pair, primaryTargetIndex, resultColumns)
         : CreateQueryForAssociationViaAuxType(pair, primaryTargetIndex, resultColumns);
-      result = result.Select(resultColumns.ToArray());
+      result = result.Select(resultColumns);
       if (pair.Second.ItemCountLimit != null)
         result = result.Take(context => context.GetValue(itemCountLimitParameter));
       return result;

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntitySetTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntitySetTask.cs
@@ -37,7 +37,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       }
 
       public override bool Equals(object obj) =>
-        obj is CacheKey x && Equals(x);
+        obj is CacheKey other && Equals(other);
 
       public override int GetHashCode() => cachedHashCode;
 
@@ -152,7 +152,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     public override bool Equals(object obj) =>
       ReferenceEquals(this, obj)
-        || obj is EntitySetTask x && Equals(x);
+        || obj is EntitySetTask other && Equals(other);
 
     public override int GetHashCode() => cacheKey.GetHashCode();
 

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/GraphContainer.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/GraphContainer.cs
@@ -110,17 +110,9 @@ namespace Xtensive.Orm.Internals.Prefetch
       return Key.Equals(other.Key);
     }
 
-    public override bool Equals(object obj)
-    {
-      if (ReferenceEquals(null, obj))
-        return false;
-      if (ReferenceEquals(this, obj))
-        return true;
-      var otherType = obj.GetType();
-      if (otherType != (typeof(GraphContainer)))
-        return false;
-      return Equals((GraphContainer) obj);
-    }
+    public override bool Equals(object obj) =>
+      ReferenceEquals(this, obj)
+        || obj is GraphContainer x && Equals(x);
 
     public override int GetHashCode()
     {

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/GraphContainer.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/GraphContainer.cs
@@ -112,7 +112,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     public override bool Equals(object obj) =>
       ReferenceEquals(this, obj)
-        || obj is GraphContainer x && Equals(x);
+        || obj is GraphContainer other && Equals(other);
 
     public override int GetHashCode()
     {

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchFieldDescriptor.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchFieldDescriptor.cs
@@ -15,7 +15,7 @@ namespace Xtensive.Orm.Internals.Prefetch
   /// Descriptor of a field's fetching request.
   /// </summary>
   [Serializable]
-  public class PrefetchFieldDescriptor
+  public sealed class PrefetchFieldDescriptor
   {
     private readonly Action<Key, FieldInfo, Key> keyExtractionSubscriber;
 
@@ -52,15 +52,8 @@ namespace Xtensive.Orm.Internals.Prefetch
     }
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (ReferenceEquals(null, obj)) {
-        return false;
-      }
-      return obj.GetType() != typeof(PrefetchFieldDescriptor)
-        ? false :
-        Equals((PrefetchFieldDescriptor) obj);
-    }
+    public override bool Equals(object obj) =>
+      obj is PrefetchFieldDescriptor x && Equals(x);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchFieldDescriptor.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchFieldDescriptor.cs
@@ -53,7 +53,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
-      obj is PrefetchFieldDescriptor x && Equals(x);
+      obj is PrefetchFieldDescriptor other && Equals(other);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnExpression.cs
@@ -24,7 +24,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return new ColumnExpression(Type, newMapping, OuterParameter, DefaultIfEmpty);
     }
 
-    public Expression Remap(int[] map, Dictionary<Expression, Expression> processedExpressions)
+    public Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
@@ -74,7 +74,7 @@ namespace Xtensive.Orm.Linq
       return result;
     }
 
-    public Expression Remap(int[] map, Dictionary<Expression, Expression> processedExpressions)
+    public Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
     {
       Func<IMappedExpression, Expression> remapper = delegate(IMappedExpression mapped) {
         var parametrizedExpression = mapped as ParameterizedExpression;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityExpression.cs
@@ -58,7 +58,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public Expression Remap(int[] map, Dictionary<Expression, Expression> processedExpressions)
+    public Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap) {
         return this;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityFieldExpression.cs
@@ -59,7 +59,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression Remap(int[] map, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap) {
         return this;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntitySetExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntitySetExpression.cs
@@ -60,7 +60,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression Remap(int[] map, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
@@ -51,7 +51,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression Remap(int[] map, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap) {
         return this;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/FullTextExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/FullTextExpression.cs
@@ -59,7 +59,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return new FullTextExpression(FullTextIndex, remappedEntityExpression, remappedRankExpression, OuterParameter);
     }
 
-    public Expression Remap(int[] map, Dictionary<Expression, Expression> processedExpressions)
+    public Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/GroupingExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/GroupingExpression.cs
@@ -70,7 +70,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression Remap(int[] map, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
     {
       var remappedSubquery = (SubQueryExpression) base.Remap(map, processedExpressions);
       var remappedKeyExpression = GenericExpressionVisitor<IMappedExpression>.Process(KeyExpression, mapped => mapped.Remap(map, processedExpressions));

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Interfaces/IMappedExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Interfaces/IMappedExpression.cs
@@ -15,6 +15,6 @@ namespace Xtensive.Orm.Linq.Expressions
     Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions);
     Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions);
     Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions);
-    Expression Remap(int[] map, Dictionary<Expression, Expression> processedExpressions);
+    Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions);
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
@@ -44,7 +44,7 @@ namespace Xtensive.Orm.Linq.Expressions
       }
     }
 
-    public List<int> GetColumns(ColumnExtractionModes columnExtractionModes) =>
+    public IEnumerable<int> GetColumns(ColumnExtractionModes columnExtractionModes) =>
       ColumnGatherer.GetColumns(Item, columnExtractionModes);
 
     public List<Pair<int, Expression>> GetColumnsAndExpressions(ColumnExtractionModes columnExtractionModes) =>
@@ -61,7 +61,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return new ItemProjectorExpression(item, dataSource, Context, AggregateType);
     }
 
-    public ItemProjectorExpression Remap(CompilableProvider dataSource, int[] columnMap)
+    public ItemProjectorExpression Remap(CompilableProvider dataSource, IReadOnlyList<int> columnMap)
     {
       var item = GenericExpressionVisitor<IMappedExpression>
         .Process(Item, mapped => mapped.Remap(columnMap, new Dictionary<Expression, Expression>()));

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/KeyExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/KeyExpression.cs
@@ -46,7 +46,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression Remap(int[] map, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap) {
         return this;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/LocalCollectionExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/LocalCollectionExpression.cs
@@ -49,7 +49,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public Expression Remap(int[] map, Dictionary<Expression, Expression> processedExpressions)
+    public Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/PersistentFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/PersistentFieldExpression.cs
@@ -22,7 +22,7 @@ namespace Xtensive.Orm.Linq.Expressions
     public abstract Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions);
     public abstract Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions);
     public abstract Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions);
-    public abstract Expression Remap(int[] map, Dictionary<Expression, Expression> processedExpressions);
+    public abstract Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions);
 
     public override string ToString()
     {

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureExpression.cs
@@ -60,7 +60,7 @@ namespace Xtensive.Orm.Linq.Expressions
     }
 
     
-    public Expression Remap(int[] map, Dictionary<Expression, Expression> processedExpressions)
+    public Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap) {
         return this;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureFieldExpression.cs
@@ -61,7 +61,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression Remap(int[] map, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap) {
         return this;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/SubQueryExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/SubQueryExpression.cs
@@ -67,7 +67,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public virtual Expression Remap(int[] map, Dictionary<Expression, Expression> processedExpressions)
+    public virtual Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
     {
       // Don't check CanRemap - Remap always.
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ColumnGatherer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ColumnGatherer.cs
@@ -57,7 +57,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       return ordered.ToList();
     }
     
-    public static List<int> GetColumns(Expression expression, ColumnExtractionModes columnExtractionModes)
+    public static IEnumerable<int> GetColumns(Expression expression, ColumnExtractionModes columnExtractionModes)
     {
       var gatherer = new ColumnGatherer(columnExtractionModes);
       gatherer.Visit(expression);
@@ -67,7 +67,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       var ordered = gatherer.OrderedValues
         ? distinct.OrderBy(i => i)
         : distinct;
-      return ordered.ToList();
+      return ordered;
     }
 
     protected override Expression VisitMarker(MarkerExpression expression)

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -1198,7 +1198,7 @@ namespace Xtensive.Orm.Linq
         var newExpression = ((NewExpression) expression);
         IEnumerable<Expression> arguments = newExpression
           .Members
-          .Select((methodInfo, index) => new {methodInfo.Name, Argument = newExpression.Arguments[index]})
+          .Select((methodInfo, index) => (methodInfo.Name, Argument: newExpression.Arguments[index]))
           .OrderBy(a => a.Name)
           .Select(a => a.Argument);
         return arguments.ToList();

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
@@ -87,7 +87,7 @@ namespace Xtensive.Orm.Linq
         usedColumns.Add(0);
       if (usedColumns.Count < origin.ItemProjector.DataSource.Header.Length) {
         var resultProvider = new SelectProvider(originProvider, usedColumns.ToArray());
-        var itemProjector = origin.ItemProjector.Remap(resultProvider, usedColumns.ToArray());
+        var itemProjector = origin.ItemProjector.Remap(resultProvider, usedColumns);
         var result = new ProjectionExpression(
           origin.Type,
           itemProjector,

--- a/Orm/Xtensive.Orm/Orm/Linq/WellKnownMembers.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/WellKnownMembers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2020 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -55,7 +55,7 @@ namespace Xtensive.Orm.Linq
           .Single(ft => ft.GetParameters().Length==2 && ft.GetParameterTypes()[0]==typeof(Expression<Func<string>>) && ft.GetParameterTypes()[1]==WellKnownTypes.Int32);
         var containsTableMethods = typeof (Orm.Query).GetMethods()
           .Where(m => m.Name==nameof(Orm.Query.ContainsTable))
-          .Select(m => new {Method = m, ParameterTypes = m.GetParameterTypes()}).ToArray();
+          .Select(m => (Method: m, ParameterTypes: m.GetParameterTypes())).ToArray();
         ContainsTableExpr = containsTableMethods
           .Single(g => g.ParameterTypes.Length==1 && g.ParameterTypes[0]==typeof (Expression<Func<ConditionEndpoint, IOperand>>)).Method;
         ContainsTableExprWithColumns = containsTableMethods
@@ -113,7 +113,7 @@ namespace Xtensive.Orm.Linq
           .Single(ft => ft.GetParameters().Length==2 && ft.GetParameterTypes()[0]==typeof(Expression<Func<string>>) && ft.GetParameterTypes()[1]==WellKnownTypes.Int32);
         var containsTableMethods = typeof (Orm.QueryEndpoint).GetMethods()
           .Where(m => m.Name==nameof(Orm.QueryEndpoint.ContainsTable))
-          .Select(m=> new {Method = m, ParameterTypes = m.GetParameterTypes()}).ToArray();
+          .Select(m=> (Method: m, ParameterTypes: m.GetParameterTypes())).ToArray();
         ContainsTableExpr = containsTableMethods
           .Single(g => g.ParameterTypes.Length==1 && g.ParameterTypes[0]==typeof (Expression<Func<ConditionEndpoint, IOperand>>)).Method;
         ContainsTableExprWithColumns = containsTableMethods

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnInfo.cs
@@ -233,7 +233,7 @@ namespace Xtensive.Orm.Model
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
       ReferenceEquals(this, obj)
-      || obj is ColumnInfo x && Equals(x);
+      || obj is ColumnInfo other && Equals(other);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnInfo.cs
@@ -231,14 +231,9 @@ namespace Xtensive.Orm.Model
     }
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (ReferenceEquals(this, obj))
-        return true;
-      if (obj.GetType()!=typeof (ColumnInfo))
-        return false;
-      return Equals((ColumnInfo) obj);
-    }
+    public override bool Equals(object obj) =>
+      ReferenceEquals(this, obj)
+      || obj is ColumnInfo x && Equals(x);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
@@ -726,14 +726,9 @@ namespace Xtensive.Orm.Model
     }
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (ReferenceEquals(this, obj))
-        return true;
-      if (obj.GetType() != typeof(FieldInfo))
-        return false;
-      return Equals((FieldInfo) obj);
-    }
+    public override bool Equals(object obj) =>
+      ReferenceEquals(this, obj)
+        || obj is FieldInfo other && Equals(other);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Orm/Model/KeyField.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/KeyField.cs
@@ -28,15 +28,9 @@ namespace Xtensive.Orm.Model
     }
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      var kf = obj as KeyField;
-      if (kf == null)
-        return false;
-      if (ReferenceEquals(this, kf))
-        return true;
-      return (Name==kf.Name && Direction==kf.Direction);
-    }
+    public override bool Equals(object obj) =>
+      ReferenceEquals(this, obj)
+      || obj is KeyField kf && Name == kf.Name && Direction == kf.Direction;
 
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/Model/ModelVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ModelVisitor.cs
@@ -22,44 +22,21 @@ namespace Xtensive.Orm.Model
     /// <param name="node">The node.</param>
     /// <returns>Visit result.</returns>
     /// <exception cref="ArgumentException">Node type is unknown.</exception>
-    protected virtual TResult Visit(Node node)
-    {
-      var domainModel = node as DomainModel;
-      if (domainModel != null)
-        return VisitDomainModel(domainModel);
-      var keyProviderInfo = node as KeyInfo;
-      if (keyProviderInfo != null)
-        return VisitKeyInfo(keyProviderInfo);
-      var sequenceInfo = node as SequenceInfo;
-      if (sequenceInfo != null)
-        return VisitSequenceInfo(sequenceInfo);
-      var keyField = node as KeyField;
-      if (keyField != null)
-        return VisitKeyField(keyField);
-      var association = node as AssociationInfo;
-      if (association != null)
-        return VisitAssociationInfo(association);
-      var field = node as FieldInfo;
-      if (field != null)
-        return VisitFieldInfo(field);
-      var type = node as TypeInfo;
-      if (type != null)
-        return VisitTypeInfo(type);
-      var column = node as ColumnInfo;
-      if (column != null)
-        return VisitColumnInfo(column);
-      var hierarchy = node as HierarchyInfo;
-      if (hierarchy != null)
-        return VisitHierarchyInfo(hierarchy);
-      var index = node as IndexInfo;
-      if (index != null)
-        return VisitIndexInfo(index);
-      var fullTextIndex = node as FullTextIndexInfo;
-      if (fullTextIndex != null)
-        return VisitFullTextIndexInfo(fullTextIndex);
-
-      throw new ArgumentException(Strings.ExNodeTypeIsUnknown, "node");
-    }
+    protected virtual TResult Visit(Node node) =>
+      node switch {
+        DomainModel domainModel => VisitDomainModel(domainModel),
+        KeyInfo keyProviderInfo => VisitKeyInfo(keyProviderInfo),
+        SequenceInfo sequenceInfo => VisitSequenceInfo(sequenceInfo),
+        KeyField keyField => VisitKeyField(keyField),
+        AssociationInfo association => VisitAssociationInfo(association),
+        FieldInfo field => VisitFieldInfo(field),
+        TypeInfo type => VisitTypeInfo(type),
+        ColumnInfo column => VisitColumnInfo(column),
+        HierarchyInfo hierarchy => VisitHierarchyInfo(hierarchy),
+        IndexInfo index => VisitIndexInfo(index),
+        FullTextIndexInfo fullTextIndex => VisitFullTextIndexInfo(fullTextIndex),
+        _ => throw new ArgumentException(Strings.ExNodeTypeIsUnknown, "node")
+      };
 
     /// <summary>
     /// Visits key field.

--- a/Orm/Xtensive.Orm/Orm/Model/TypeIndexInfoCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeIndexInfoCollection.cs
@@ -109,7 +109,7 @@ namespace Xtensive.Orm.Model
       var candidates = this
         .Where(i => i.KeyColumns
           .TakeWhile((_, index) => index < columns.Count)
-          .Select((pair, index) => new {column = pair.Key, columnIndex = index})
+          .Select((pair, index) => (column: pair.Key, columnIndex: index))
           .All(p => p.column==columns[p.columnIndex]))
         .OrderByDescending(i => i.Attributes).ToList();
 

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/QueryParameterIdentity.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/QueryParameterIdentity.cs
@@ -53,14 +53,9 @@ namespace Xtensive.Orm.Providers
       return !Equals(left, right);
     }
 
-    public override bool Equals(object obj)
-    {
-      if (ReferenceEquals(null, obj))
-        return false;
-      if (ReferenceEquals(this, obj))
-        return true;
-      return obj is QueryParameterIdentity && Equals((QueryParameterIdentity) obj);
-    }
+    public override bool Equals(object obj) =>
+      ReferenceEquals(this, obj)
+        || obj is QueryParameterIdentity other && Equals(other);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilderTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilderTask.cs
@@ -45,21 +45,19 @@ namespace Xtensive.Orm.Providers
     /// <inheritdoc/>
     public override bool Equals(object obj)
     {
-      if (obj==null)
-        return false;
       if (ReferenceEquals(this, obj))
         return true;
-      var other = obj as PersistRequestBuilderTask;
-      if (other==null)
-        return false;
-      if (Type!=other.Type)
-        return false;
-      if (Kind!=other.Kind)
-        return false;
-      if (ValidateVersion!=other.ValidateVersion)
-        return false;
-      return CompareBits(AvailableFields, other.AvailableFields)
-        && CompareBits(ChangedFields, other.ChangedFields);
+      if (obj is PersistRequestBuilderTask other) {
+        if (Type != other.Type)
+          return false;
+        if (Kind != other.Kind)
+          return false;
+        if (ValidateVersion != other.ValidateVersion)
+          return false;
+        return CompareBits(AvailableFields, other.AvailableFields)
+          && CompareBits(ChangedFields, other.ChangedFields);
+      }
+      return false;
     }
 
     /// <inheritdoc/>

--- a/Orm/Xtensive.Orm/Orm/Providers/SessionHandler.References.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SessionHandler.References.cs
@@ -104,7 +104,7 @@ namespace Xtensive.Orm.Providers
           var index = association.OwnerType.Indexes.PrimaryIndex;
           var nonLazyColumnsSelector = index
             .Columns
-            .Select((column, i)=>new {Column = column, Index = i})
+            .Select((column, i) => (Column: column, Index: i))
             .Where(a=>!a.Column.IsLazyLoad)
             .Select(a=>a.Index)
             .ToArray();
@@ -122,7 +122,7 @@ namespace Xtensive.Orm.Providers
           var targetIndex = association.TargetType.Indexes.PrimaryIndex;
           var nonLazyColumnsSelector = index
             .Columns
-            .Select((column, i)=>new {Column = column, Index = i})
+            .Select((column, i) => (Column: column, Index: i))
             .Where(a=>!a.Column.IsLazyLoad)
             .Select(a=>targetIndex.Columns.Count + a.Index)
             .ToArray();
@@ -152,7 +152,7 @@ namespace Xtensive.Orm.Providers
           var targetIndex = association.AuxiliaryType.Indexes.PrimaryIndex;
           var nonLazyColumnsSelector = index
             .Columns
-            .Select((column, i)=>new {Column = column, Index = i})
+            .Select((column, i) => (Column: column, Index: i))
             .Where(a=>!a.Column.IsLazyLoad)
             .Select(a=>targetIndex.Columns.Count + a.Index)
             .ToArray();

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Index.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Index.cs
@@ -168,7 +168,7 @@ namespace Xtensive.Orm.Providers
         var columnType = discriminatorMap.Column.ValueType;
         var discriminatorColumnIndex = underlyingIndex.Columns
           .Where(c => !c.Field.IsTypeId)
-          .Select((c,i) => new {c,i})
+          .Select((c, i) => (c, i))
           .Where(p => p.c == discriminatorMap.Column)
           .Single().i;
         var discriminatorColumn = baseQuery.From.Columns[discriminatorColumnIndex];
@@ -220,7 +220,7 @@ namespace Xtensive.Orm.Providers
 
       var baseColumns = baseQuery.Columns.ToList();
       var typeIdColumnIndex = index.Columns
-        .Select((c, i) => new {c.Field, i})
+        .Select((c, i) => (c.Field, i))
         .Single(p => p.Field.IsTypeId && p.Field.IsSystem).i;
       var type = index.ReflectedType;
       var typeIdColumn = SqlDml.ColumnRef(

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -74,20 +74,23 @@ namespace Xtensive.Orm.Providers
 
       SqlSelect sourceSelect = source.Request.Statement;
       var sqlSelect = sourceSelect.ShallowClone();
-      var columns = sqlSelect.Columns.ToList();
-      sqlSelect.Columns.Clear();
+      var sqlSelectColumns = sqlSelect.Columns;
+      var columns = sqlSelectColumns.ToList();
+      sqlSelectColumns.Clear();
       for (int i = 0; i < columns.Count; i++) {
         var columnName = provider.Header.Columns[i].Name;
         columnName = ProcessAliasedName(columnName);
-        var column = columns[i];
-        var columnRef = column as SqlColumnRef;
-        var columnStub = column as SqlColumnStub;
-        if (!ReferenceEquals(null, columnRef))
-          sqlSelect.Columns.Add(SqlDml.ColumnRef(columnRef.SqlColumn, columnName));
-        else if (!ReferenceEquals(null, columnStub))
-          sqlSelect.Columns.Add(columnStub);
-        else
-          sqlSelect.Columns.Add(column, columnName);
+        switch (columns[i]) {
+          case SqlColumnRef columnRef:
+            sqlSelectColumns.Add(SqlDml.ColumnRef(columnRef.SqlColumn, columnName));
+            break;
+          case SqlColumnStub columnStub:
+            sqlSelectColumns.Add(columnStub);
+            break;
+          case var column:
+            sqlSelectColumns.Add(column, columnName);
+            break;
+        }
       }
       return CreateProvider(sqlSelect, provider, source);
     }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlIncludeProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlIncludeProvider.cs
@@ -28,7 +28,7 @@ namespace Xtensive.Orm.Providers
 
       public override bool Equals(object obj) =>
         ReferenceEquals(this, obj)
-          || obj is RowFilterParameter rowFilterParameter && Equals(rowFilterParameter);
+          || obj is RowFilterParameter other && Equals(other);
 
       public override int GetHashCode() => temporaryTableDescriptor != null ? temporaryTableDescriptor.GetHashCode() : 0;
 

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlIncludeProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlIncludeProvider.cs
@@ -27,8 +27,8 @@ namespace Xtensive.Orm.Providers
         && (ReferenceEquals(this, other) || ReferenceEquals(temporaryTableDescriptor, other.temporaryTableDescriptor));
 
       public override bool Equals(object obj) =>
-        !ReferenceEquals(null, obj)
-        && (ReferenceEquals(this, obj) || (obj is RowFilterParameter rowFilterParameter && Equals(rowFilterParameter)));
+        ReferenceEquals(this, obj)
+          || obj is RowFilterParameter rowFilterParameter && Equals(rowFilterParameter);
 
       public override int GetHashCode() => temporaryTableDescriptor != null ? temporaryTableDescriptor.GetHashCode() : 0;
 

--- a/Orm/Xtensive.Orm/Orm/Rse/CompilableProviderExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/CompilableProviderExtensions.cs
@@ -80,7 +80,7 @@ namespace Xtensive.Orm.Rse
       return new FilterProvider(source, predicate);
     }
 
-    public static CompilableProvider Select(this CompilableProvider source, params int[] columnIndexes)
+    public static CompilableProvider Select(this CompilableProvider source, IReadOnlyList<int> columnIndexes)
     {
       ArgumentValidator.EnsureArgumentNotNull(columnIndexes, "columnIndexes");
       return new SelectProvider(source, columnIndexes);

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
@@ -395,7 +395,7 @@ namespace Xtensive.Orm.Rse.Transformation
       }
 
       var columns = expectedColumns
-        .Select(originalIndex => new { OriginalIndex = originalIndex, NewIndex = returningColumns.IndexOf(originalIndex) })
+        .Select(originalIndex => (OriginalIndex: originalIndex, NewIndex: returningColumns.IndexOf(originalIndex)))
         .Select(x => x.NewIndex < 0 ? x.OriginalIndex : x.NewIndex).ToArray(expectedColumns.Count);
       return new SelectProvider(provider, columns);
     }

--- a/Orm/Xtensive.Orm/Orm/Structure.cs
+++ b/Orm/Xtensive.Orm/Orm/Structure.cs
@@ -312,13 +312,8 @@ namespace Xtensive.Orm
     }
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (obj==null || !(obj is Structure)) {
-        return false;
-      }
-      return Equals((Structure) obj);
-    }
+    public override bool Equals(object obj) =>
+      obj is Structure x && Equals(x);
 
     /// <inheritdoc/>
     public bool Equals(Structure other)

--- a/Orm/Xtensive.Orm/Orm/Structure.cs
+++ b/Orm/Xtensive.Orm/Orm/Structure.cs
@@ -313,7 +313,7 @@ namespace Xtensive.Orm
 
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
-      obj is Structure x && Equals(x);
+      obj is Structure other && Equals(other);
 
     /// <inheritdoc/>
     public bool Equals(Structure other)

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Hints/UpgradeHint.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Hints/UpgradeHint.cs
@@ -22,14 +22,9 @@ namespace Xtensive.Orm.Upgrade
     }
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (ReferenceEquals(null, obj))
-        return false;
-      if (ReferenceEquals(this, obj))
-        return true;
-      return obj is UpgradeHint otherHint && Equals(otherHint);
-    }
+    public override bool Equals(object obj) =>
+      ReferenceEquals(this, obj)
+        || obj is UpgradeHint otherHint && Equals(otherHint);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Hints/UpgradeHint.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Hints/UpgradeHint.cs
@@ -24,7 +24,7 @@ namespace Xtensive.Orm.Upgrade
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
       ReferenceEquals(this, obj)
-        || obj is UpgradeHint otherHint && Equals(otherHint);
+        || obj is UpgradeHint other && Equals(other);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/CatalogCloner.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/CatalogCloner.cs
@@ -330,9 +330,9 @@ namespace Xtensive.Orm.Upgrade.Internals
       }
 
       //foreign keys are handled by special method
-      var foreignKey = sourceConstraint as ForeignKey;
-      if (foreignKey!=null)
+      if (sourceConstraint is ForeignKey) {
         return;
+      }
 
       var uniqueConstraint = sourceConstraint as UniqueConstraint;
       if (uniqueConstraint!=null) {

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/DomainModelConverter.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/DomainModelConverter.cs
@@ -118,7 +118,7 @@ namespace Xtensive.Orm.Upgrade
         if (type.Indexes.PrimaryIndex.IsVirtual) {
           Dictionary<TypeInfo, int> typeOrder = type.GetAncestors()
             .Append(type)
-            .Select((t, i) => new {Type = t, Index = i})
+            .Select((t, i) => (Type: t, Index: i))
             .ToDictionary(a => a.Type, a => a.Index);
           List<IndexInfo> realPrimaryIndexes = type.Indexes.RealPrimaryIndexes
             .OrderBy(index => typeOrder[index.ReflectedType])

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/HintGenerator.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/HintGenerator.cs
@@ -298,7 +298,7 @@ namespace Xtensive.Orm.Upgrade
           // X.EntitySet<Y>, where X is in removedTypeAndAncestors,
           // connectorType.X must be cleaned up as well
           requiresInverseCleanup
-        select new {association, requiresInverseCleanup}
+        select (association, requiresInverseCleanup)
         ).ToList();
       foreach (var pair in affectedAssociations) {
         var association = pair.association;

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/TypeMetadata.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/TypeMetadata.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (C) 2012 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2012-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2012.02.16
 
@@ -9,16 +9,14 @@ using Xtensive.Reflection;
 
 namespace Xtensive.Orm.Upgrade
 {
-  internal sealed class TypeMetadata
+  internal readonly struct TypeMetadata
   {
-    public int Id { get; private set; }
+    public int Id { get; }
 
-    public string Name { get; set; }
+    public string Name { get; }
 
-    public override string ToString()
-    {
-      return string.Format(Strings.MetadataTypeFormat, Name, Id);
-    }
+    public override string ToString() =>
+      string.Format(Strings.MetadataTypeFormat, Name, Id);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SchemaComparer.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SchemaComparer.cs
@@ -242,11 +242,11 @@ namespace Xtensive.Orm.Upgrade
     private static void GetTableRecreateDataLossActions(IEnumerable<NodeAction> actions, ICollection<NodeAction> output)
     {
       actions.OfType<DataAction>()
-        .Select(da => new {
-          DataAction = da,
-          Difference = da.Difference as NodeDifference,
-          DeleteDataHint = da.DataHint as DeleteDataHint
-        })
+        .Select(da => (
+          DataAction: da,
+          Difference: da.Difference as NodeDifference,
+          DeleteDataHint: da.DataHint as DeleteDataHint
+        ))
         .Where(a => a.DeleteDataHint != null && a.Difference != null && a.Difference.MovementInfo.HasFlag(MovementInfo.Removed | MovementInfo.Created))
         .Select(a => a.DataAction)
         .ForEach(output.Add);

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/UpgradeHintsProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/UpgradeHintsProcessor.cs
@@ -181,20 +181,18 @@ namespace Xtensive.Orm.Upgrade.Internals
         from triplet in genericTypeMapping
         group triplet by triplet.Item2.GetGenericTypeDefinition()
           into g
-          select new { Definition = g.Key, Instances = g.ToArray() }
+        select (Definition: g.Key, Instances: g.ToArray())
         ).ToDictionary(g => g.Definition);
 
       // Build rename generic type field hints
       foreach (var hint in renameFieldHints) {
         var newGenericDefType = hint.TargetType;
-        var instanceGroup = genericTypeDefLookup.GetValueOrDefault(newGenericDefType);
-        if (instanceGroup == null) {
-          continue;
-        }
-        foreach (var triplet in instanceGroup.Instances) {
-          var newGenericArguments = triplet.Item3.SelectToArray(pair => pair.Second);
-          rewrittenHints.Add(new RenameFieldHint(newGenericDefType.MakeGenericType(newGenericArguments),
-            hint.OldFieldName, hint.NewFieldName));
+        if (genericTypeDefLookup.TryGetValue(newGenericDefType, out var instanceGroup)) {
+          foreach (var triplet in instanceGroup.Instances) {
+            var newGenericArguments = triplet.Item3.SelectToArray(pair => pair.Second);
+            rewrittenHints.Add(new RenameFieldHint(newGenericDefType.MakeGenericType(newGenericArguments),
+              hint.OldFieldName, hint.NewFieldName));
+          }
         }
       }
     }

--- a/Orm/Xtensive.Orm/Orm/Upgrade/SystemUpgradeHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/SystemUpgradeHandler.cs
@@ -237,7 +237,7 @@ namespace Xtensive.Orm.Upgrade
       var indexes = types
         .SelectMany(type => type.Indexes
           .Where(i => i.IsPartial && !i.IsVirtual && !i.IsAbstract)
-          .Select(i => new {Type = type, Index = i}))
+          .Select(i => (Type: type, Index: i)))
         .Select(item => new StoredPartialIndexFilterInfo {
           Database = item.Type.MappingDatabase,
           Schema = item.Type.MappingSchema,

--- a/Orm/Xtensive.Orm/Orm/Upgrade/UpgradeHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/UpgradeHandler.cs
@@ -346,7 +346,7 @@ namespace Xtensive.Orm.Upgrade
         from t in registeredTypes
         let a = t.GetAttribute<RecycledAttribute>()
         where a!=null
-        select new {Type = t, Attribute = a};
+        select (Type: t, Attribute: a);
 
       foreach (var r in recycledTypes) {
         var oldName = r.Attribute.OriginalName;
@@ -378,7 +378,7 @@ namespace Xtensive.Orm.Upgrade
         let pa = p.GetAttribute<FieldAttribute>()
         let ra = p.GetAttribute<RecycledAttribute>()
         where pa!=null && ra!=null
-        select new {Property = p, Attribute = ra};
+        select (Property: p, Attribute: ra);
 
       foreach (var r in recycledProperties) {
         var oldName = r.Attribute.OriginalName;

--- a/Orm/Xtensive.Orm/Sql/Model/SqlModelVisitor.cs
+++ b/Orm/Xtensive.Orm/Sql/Model/SqlModelVisitor.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Ivan Galkin
 // Created:    2009.03.31
 
@@ -21,104 +21,41 @@ namespace Xtensive.Sql.Model
     /// <param name="node">The node.</param>
     /// <returns>Visit result.</returns>
     /// <exception cref="ArgumentException">Node type is unknown.</exception>
-    protected virtual TResult Visit(Node node)
-    {
-      var characterSet = node as CharacterSet;
-      if (characterSet!=null)
-        return VisitCharacterSet(characterSet);
-      var collation = node as Collation;
-      if (collation!=null)
-        return VisitCollation(collation);
-      var temporaryTable = node as TemporaryTable;
-      if (temporaryTable!=null)
-        return VisitTemporaryTable(temporaryTable);
-      var table = node as Table;
-      if (table!=null)
-        return VisitTable(table);
-      var view = node as View;
-      if (view!=null)
-        return VisitView(view);
-      var dataTable = node as DataTable;
-      if (dataTable!=null)
-        return VisitDataTable(dataTable);
-      var tableColumn = node as TableColumn;
-      if (tableColumn!=null)
-        return VisitTableColumn(tableColumn);
-      var viewColumn = node as ViewColumn;
-      if (viewColumn!=null)
-        return VisitViewColumn(viewColumn);
-      var dataTableColumn = node as DataTableColumn;
-      if (dataTableColumn!=null)
-        return VisitDataTableColumn(dataTableColumn);
-      var domain = node as Domain;
-      if (domain!=null)
-        return VisitDomain(domain);
-      var ftIndex = node as FullTextIndex;
-      if (ftIndex != null)
-        return VisitFullTextIndex(ftIndex);
-      var index = node as Index;
-      if (index!=null)
-        return VisitIndex(index);
-      var indexColumn = node as IndexColumn;
-      if (indexColumn!=null)
-        return VisitIndexColumn(indexColumn);
-      var foreignKey = node as ForeignKey;
-      if (foreignKey!=null)
-        return VisitForeignKey(foreignKey);
-      var primaryKey = node as PrimaryKey;
-      if (primaryKey!=null)
-        return VisitPrimaryKey(primaryKey);
-      var uniqueConstraint = node as UniqueConstraint;
-      if (uniqueConstraint!=null)
-        return VisitUniqueConstraint(uniqueConstraint);
-      var checkConstraint = node as CheckConstraint;
-      if (checkConstraint!=null)
-        return VisitCheckConstraint(checkConstraint);
-      var domainConstraint = node as DomainConstraint;
-      if (domainConstraint!=null)
-        return VisitDomainConstraint(domainConstraint);
-      var constraint = node as Constraint;
-      if (constraint!=null)
-        return VisitConstraint(constraint);
-      var schema = node as Schema;
-      if (schema!=null)
-        return VisitSchema(schema);
-      var sequence = node as Sequence;
-      if (sequence!=null)
-        return VisitSequence(sequence);
-      var sequenceDescriptor = node as SequenceDescriptor;
-      if (sequenceDescriptor!=null)
-        return VisitSequenceDescriptor(sequenceDescriptor);
-      var catalog = node as Catalog;
-      if (catalog!=null)
-        return VisitCatalog(catalog);
-      var translation = node as Translation;
-      if (translation!=null)
-        return VisitTranslation(translation);
-      var hashPartition = node as HashPartition;
-      if (hashPartition!=null)
-        return VisitHashPartition(hashPartition);
-      var listPartition = node as ListPartition;
-      if (listPartition!=null)
-        return VisitListPartition(listPartition);
-      var rangePartition = node as RangePartition;
-      if (rangePartition!=null)
-        return VisitRangePartition(rangePartition);
-      var partition = node as Partition;
-      if (partition!=null)
-        return VisitPartition(partition);
-      var partitionDescriptor = node as PartitionDescriptor;
-      if (partitionDescriptor!=null)
-        return VisitPartitionDescriptor(partitionDescriptor);
-      var partitionFunction = node as PartitionFunction;
-      if (partitionFunction!=null)
-        return VisitPartitionFunction(partitionFunction);
-      var partitionSchema = node as PartitionSchema;
-      if (partitionSchema!=null)
-        return VisitPartitionSchema(partitionSchema);
-
-      throw new ArgumentException(Strings.ExNodeTypeIsUnknown, "node");
-    }
+    protected virtual TResult Visit(Node node) =>
+      node switch {
+        CharacterSet characterSet => VisitCharacterSet(characterSet),
+        Collation collation => VisitCollation(collation),
+        TemporaryTable temporaryTable => VisitTemporaryTable(temporaryTable),
+        Table table => VisitTable(table),
+        View view => VisitView(view),
+        DataTable dataTable => VisitDataTable(dataTable),
+        TableColumn tableColumn => VisitTableColumn(tableColumn),
+        ViewColumn viewColumn => VisitViewColumn(viewColumn),
+        DataTableColumn dataTableColumn => VisitDataTableColumn(dataTableColumn),
+        Domain domain => VisitDomain(domain),
+        FullTextIndex ftIndex => VisitFullTextIndex(ftIndex),
+        Index index => VisitIndex(index),
+        IndexColumn indexColumn => VisitIndexColumn(indexColumn),
+        ForeignKey foreignKey => VisitForeignKey(foreignKey),
+        PrimaryKey primaryKey => VisitPrimaryKey(primaryKey),
+        UniqueConstraint uniqueConstraint => VisitUniqueConstraint(uniqueConstraint),
+        CheckConstraint checkConstraint => VisitCheckConstraint(checkConstraint),
+        DomainConstraint domainConstraint => VisitDomainConstraint(domainConstraint),
+        Constraint constraint => VisitConstraint(constraint),
+        Schema schema => VisitSchema(schema),
+        Sequence sequence => VisitSequence(sequence),
+        SequenceDescriptor sequenceDescriptor => VisitSequenceDescriptor(sequenceDescriptor),
+        Catalog catalog => VisitCatalog(catalog),
+        Translation translation => VisitTranslation(translation),
+        HashPartition hashPartition => VisitHashPartition(hashPartition),
+        ListPartition listPartition => VisitListPartition(listPartition),
+        RangePartition rangePartition => VisitRangePartition(rangePartition),
+        Partition partition => VisitPartition(partition),
+        PartitionDescriptor partitionDescriptor => VisitPartitionDescriptor(partitionDescriptor),
+        PartitionFunction partitionFunction => VisitPartitionFunction(partitionFunction),
+        PartitionSchema partitionSchema => VisitPartitionSchema(partitionSchema),
+        _ => throw new ArgumentException(Strings.ExNodeTypeIsUnknown, "node")
+      };
 
     /// <summary>
     /// Visits unique constraint.

--- a/Orm/Xtensive.Orm/Sql/SqlType.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlType.cs
@@ -190,7 +190,7 @@ namespace Xtensive.Sql
     }
 
     public override bool Equals(object obj) =>
-      obj is SqlType x && Equals(x);
+      obj is SqlType other && Equals(other);
 
     public override int GetHashCode()
     {

--- a/Orm/Xtensive.Orm/Sql/SqlType.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlType.cs
@@ -189,12 +189,8 @@ namespace Xtensive.Sql
       return string.Equals(Name, other.Name, StringComparison.Ordinal);
     }
 
-    public override bool Equals(object obj)
-    {
-      if (ReferenceEquals(null, obj))
-        return false;
-      return obj is SqlType && Equals((SqlType) obj);
-    }
+    public override bool Equals(object obj) =>
+      obj is SqlType x && Equals(x);
 
     public override int GetHashCode()
     {


### PR DESCRIPTION
*  `new { x, y }` -> `(x, y)` in `.Select()` to avoid allocations
* Avoid double-checking for null in `.Equal(object obj)` -  `is` operator checks for null
* Convert `if` chains into modern C# `switch`
* Make Remap() to accept `IReadOnlyList<>` to avoid unnecessary `.ToArray()`
* `TypeMetadata` converted to readonly struct