### PR TITLE
ARCH-1220: Get rid of lock in Xtensive.Orm.Internals.EntityDataReader

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Internals/EntityDataReader.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/EntityDataReader.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2008-2020 Xtensive LLC.
+// Copyright (C) 2008-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
@@ -19,13 +19,13 @@ namespace Xtensive.Orm.Internals
 {
   internal class EntityDataReader : DomainBound
   {
-    private class RecordPartMapping
+    private readonly struct RecordPartMapping
     {
-      public int TypeIdColumnIndex { get; private set; }
-      public Pair<int>[] Columns { get; private set; }
-      public TypeInfo ApproximateType { get; private set; }
+      public int TypeIdColumnIndex { get; }
+      public IReadOnlyList<Pair<int>> Columns { get; }
+      public TypeInfo ApproximateType { get; }
 
-      public RecordPartMapping(int typeIdColumnIndex, Pair<int>[] columns, TypeInfo approximateType)
+      public RecordPartMapping(int typeIdColumnIndex, IReadOnlyList<Pair<int>> columns, TypeInfo approximateType)
       {
         TypeIdColumnIndex = typeIdColumnIndex;
         Columns = columns;
@@ -33,10 +33,10 @@ namespace Xtensive.Orm.Internals
       }
     }
 
-    private class CacheItem
+    private readonly struct CacheItem
     {
-      public RecordSetHeader Header { get; private set; }
-      public RecordPartMapping[] Mappings { get; private set; }
+      public RecordSetHeader Header { get; }
+      public RecordPartMapping[] Mappings { get; }
 
       public CacheItem(RecordSetHeader header, RecordPartMapping[] mappings)
       {
@@ -46,65 +46,57 @@ namespace Xtensive.Orm.Internals
     }
 
     private readonly ICache<RecordSetHeader, CacheItem> cache;
-    private readonly object _lock = new object();
-    
+
     public IEnumerable<Record> Read(IEnumerable<Tuple> source, RecordSetHeader header, Session session)
     {
-      CacheItem cacheItem;
-      var recordPartCount = header.ColumnGroups.Count;
+      var columns = header.Columns;
+      var columnGroups = header.ColumnGroups;
+      var recordPartCount = columnGroups.Count;
       var context = new MaterializationContext(session, recordPartCount);
-      lock (_lock) {
-        if (!cache.TryGetItem(header, false, out cacheItem)) {
-          var typeIdColumnName = Domain.Handlers.NameBuilder.TypeIdColumnName;
-          var model = context.Model;
-          var mappings = new RecordPartMapping[recordPartCount];
-          for (int i = 0; i < recordPartCount; i++) {
-            var columnGroup = header.ColumnGroups[i];
-            var approximateType = columnGroup.TypeInfoRef.Resolve(model);
-            var columnMapping = new List<Pair<int>>();
-            var typeIdColumnIndex = -1;
-            foreach (var columnIndex in columnGroup.Columns) {
-              var column = (MappedColumn) header.Columns[columnIndex];
-              var columnInfo = column.ColumnInfoRef.Resolve(model);
-              FieldInfo fieldInfo;
-              if (!approximateType.Fields.TryGetValue(columnInfo.Field.Name, out fieldInfo))
-                continue;
+      if (!cache.TryGetItem(header, false, out var cacheItem)) {
+        var typeIdColumnName = Domain.Handlers.NameBuilder.TypeIdColumnName;
+        var model = context.Model;
+        var mappings = new RecordPartMapping[recordPartCount];
+        for (int i = 0; i < recordPartCount; i++) {
+          var columnGroup = columnGroups[i];
+          var approximateType = columnGroup.TypeInfoRef.Resolve(model);
+          var columnMapping = new List<Pair<int>>(columnGroup.Columns.Count);
+          var typeIdColumnIndex = -1;
+          foreach (var columnIndex in columnGroup.Columns) {
+            var column = (MappedColumn) columns[columnIndex];
+            var columnInfo = column.ColumnInfoRef.Resolve(model);
+            if (approximateType.Fields.TryGetValue(columnInfo.Field.Name, out var fieldInfo)) {
               var targetColumnIndex = fieldInfo.MappingInfo.Offset;
-              if (columnInfo.Name==typeIdColumnName)
+              if (columnInfo.Name == typeIdColumnName) {
                 typeIdColumnIndex = column.Index;
+              }
               columnMapping.Add(new Pair<int>(targetColumnIndex, columnIndex));
             }
-            mappings[i] = new RecordPartMapping(typeIdColumnIndex, columnMapping.ToArray(), approximateType);
           }
-          cacheItem = new CacheItem(header, mappings);
-          cache.Add(cacheItem);
+          mappings[i] = new RecordPartMapping(typeIdColumnIndex, columnMapping, approximateType);
         }
+        cacheItem = new CacheItem(header, mappings);
+        cache.Add(cacheItem);
       }
       return source.Select(tuple => ParseRow(tuple, context, cacheItem.Mappings));
     }
 
-    private Record ParseRow(Tuple tuple, MaterializationContext context, RecordPartMapping[] recordPartMappings)
-    {
-      var count = recordPartMappings.Length;
-
-      if (count==1)
-        return new Record(tuple, ParseColumnGroup(tuple, context, 0, recordPartMappings[0]));
-
-      var pairs = new List<Pair<Key, Tuple>>(
-        recordPartMappings
-          .Select((recordPartMapping, i) => ParseColumnGroup(tuple, context, i, recordPartMapping)));
-      return new Record(tuple, pairs);
-    }
+    private Record ParseRow(Tuple tuple, MaterializationContext context, RecordPartMapping[] recordPartMappings) =>
+      recordPartMappings.Length == 1
+        ? new Record(tuple, ParseColumnGroup(tuple, context, 0, recordPartMappings[0]))
+        : new Record(tuple, recordPartMappings.Select(
+            (recordPartMapping, i) => ParseColumnGroup(tuple, context, i, recordPartMapping))
+          );
 
     private Pair<Key, Tuple> ParseColumnGroup(Tuple tuple, MaterializationContext context, int groupIndex, RecordPartMapping mapping)
     {
       TypeReferenceAccuracy accuracy;
       int typeId = ExtractTypeId(mapping.ApproximateType, context.TypeIdRegistry, tuple, mapping.TypeIdColumnIndex, out accuracy);
-      var typeMapping = typeId==TypeInfo.NoTypeId ? null : context.GetTypeMapping(groupIndex, mapping.ApproximateType, typeId, mapping.Columns);
-      if (typeMapping==null)
+      var typeMapping = typeId == TypeInfo.NoTypeId ? null : context.GetTypeMapping(groupIndex, mapping.ApproximateType, typeId, mapping.Columns);
+      if (typeMapping == null)
         return new Pair<Key, Tuple>(null, null);
 
-      bool canCache = accuracy==TypeReferenceAccuracy.ExactType;
+      bool canCache = accuracy == TypeReferenceAccuracy.ExactType;
       Key key;
       if (typeMapping.KeyTransform.Descriptor.Count <= WellKnown.MaxGenericKeyLength)
         key = KeyFactory.Materialize(Domain, context.Session.StorageNodeId, typeMapping.Type, tuple, accuracy, canCache, typeMapping.KeyIndexes);
@@ -146,8 +138,10 @@ namespace Xtensive.Orm.Internals
     internal EntityDataReader(Domain domain)
       : base(domain)
     {
-      cache = new LruCache<RecordSetHeader, CacheItem>(domain.Configuration.RecordSetMappingCacheSize,
-          m => m.Header, new WeakestCache<RecordSetHeader, CacheItem>(false, false, m => m.Header));
+      cache = new FastConcurrentLruCache<RecordSetHeader, CacheItem>(
+        domain.Configuration.RecordSetMappingCacheSize,
+        m => m.Header
+      );
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Internals/EntityDataReader.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/EntityDataReader.cs
@@ -88,7 +88,7 @@ namespace Xtensive.Orm.Internals
             (recordPartMapping, i) => ParseColumnGroup(tuple, context, i, recordPartMapping))
           );
 
-    private Pair<Key, Tuple> ParseColumnGroup(Tuple tuple, MaterializationContext context, int groupIndex, RecordPartMapping mapping)
+    private Pair<Key, Tuple> ParseColumnGroup(Tuple tuple, MaterializationContext context, int groupIndex, in RecordPartMapping mapping)
     {
       TypeReferenceAccuracy accuracy;
       int typeId = ExtractTypeId(mapping.ApproximateType, context.TypeIdRegistry, tuple, mapping.TypeIdColumnIndex, out accuracy);

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityGroupTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityGroupTask.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexander Nikolaev
@@ -161,13 +161,11 @@ namespace Xtensive.Orm.Internals.Prefetch
     {
       var entityRecords = reader.Read(queryResult, Provider.Header, manager.Owner.Session);
       foreach (var entityRecord in entityRecords) {
-        if (entityRecord != null) {
-          var fetchedKey = entityRecord.GetKey();
-          var tuple = entityRecord.GetTuple();
-          if (tuple != null) {
-            manager.SaveStrongReference(manager.Owner.UpdateState(fetchedKey, tuple));
-            foundedKeys.Add(fetchedKey);
-          }
+        var fetchedKey = entityRecord.GetKey();
+        var tuple = entityRecord.GetTuple();
+        if (tuple != null) {
+          manager.SaveStrongReference(manager.Owner.UpdateState(fetchedKey, tuple));
+          foundedKeys.Add(fetchedKey);
         }
       }
     }

--- a/Orm/Xtensive.Orm/Orm/Internals/TypeMapping.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/TypeMapping.cs
@@ -10,7 +10,7 @@ using Xtensive.Orm.Model;
 
 namespace Xtensive.Orm.Internals
 {
-  internal class TypeMapping
+  internal readonly struct TypeMapping
   {
     public readonly TypeInfo Type;
     public readonly MapTransform KeyTransform;

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
@@ -20,7 +20,7 @@ namespace Xtensive.Orm.Linq.Materialization
 
     private struct EntityMappingCache
     {
-      public TypeMapping SingleItem;
+      public TypeMapping? SingleItem;
       public Dictionary<int, TypeMapping> Items;
     }
 
@@ -62,16 +62,17 @@ namespace Xtensive.Orm.Linq.Materialization
     {
       TypeMapping result;
       var cache = entityMappings[entityIndex];
-      if (cache.SingleItem!=null) {
-        if (typeId!=ResolveTypeToNodeSpecificTypeIdentifier(cache.SingleItem.Type))
+      if (cache.SingleItem != null) {
+        if (typeId != ResolveTypeToNodeSpecificTypeIdentifier(cache.SingleItem?.Type)) {
           throw new ArgumentOutOfRangeException("typeId");
-        return cache.SingleItem;
+        }
+        return cache.SingleItem.Value;
       }
       if (cache.Items.TryGetValue(typeId, out result))
         return result;
 
-      var type       = TypeIdRegistry[typeId];
-      var keyInfo    = type.Key;
+      var type = TypeIdRegistry[typeId];
+      var keyInfo = type.Key;
       var descriptor = type.TupleDescriptor;
 
       var typeColumnMap = columns;

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
@@ -61,7 +61,7 @@ namespace Xtensive.Orm.Linq.Materialization
     public TypeMapping GetTypeMapping(int entityIndex, TypeInfo approximateType, int typeId, IReadOnlyList<Pair<int>> columns)
     {
       TypeMapping result;
-      var cache = entityMappings[entityIndex];
+      ref var cache = ref entityMappings[entityIndex];
       if (cache.SingleItem != null) {
         if (typeId != ResolveTypeToNodeSpecificTypeIdentifier(cache.SingleItem?.Type)) {
           throw new ArgumentOutOfRangeException("typeId");
@@ -102,7 +102,6 @@ namespace Xtensive.Orm.Linq.Materialization
         cache.SingleItem = result;
       else
         cache.Items.Add(typeId, result);
-      entityMappings[entityIndex] = cache;
       
       return result;
     }

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
@@ -58,7 +58,7 @@ namespace Xtensive.Orm.Linq.Materialization
     /// </summary>
     public Queue<Action> MaterializationQueue { get; set; }
 
-    public TypeMapping GetTypeMapping(int entityIndex, TypeInfo approximateType, int typeId, Pair<int>[] columns)
+    public TypeMapping GetTypeMapping(int entityIndex, TypeInfo approximateType, int typeId, IReadOnlyList<Pair<int>> columns)
     {
       TypeMapping result;
       var cache = entityMappings[entityIndex];
@@ -77,15 +77,16 @@ namespace Xtensive.Orm.Linq.Materialization
       var typeColumnMap = columns;
       if (approximateType.IsInterface) {
         // fixup target index
-        typeColumnMap = new Pair<int>[columns.Length];
-        for (int i = columns.Length; i-- > 0;) {
+        var newColumns = new Pair<int>[columns.Count];
+        for (int i = columns.Count; i-- > 0;) {
           var pair = columns[i];
           var approxTargetIndex = pair.First;
           var interfaceField = approximateType.Columns[approxTargetIndex].Field;
           var field = type.FieldMap[interfaceField];
           var targetIndex = field.MappingInfo.Offset;
-          typeColumnMap[i] = new Pair<int>(targetIndex, pair.Second);
+          newColumns[i] = new Pair<int>(targetIndex, pair.Second);
         }
+        typeColumnMap = newColumns;
       }
 
       ArraySegment<int> allIndexes = MaterializationHelper.CreateSingleSourceMap(descriptor.Count, typeColumnMap);

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationHelper.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationHelper.cs
@@ -30,12 +30,12 @@ namespace Xtensive.Orm.Linq.Materialization
     public static readonly MethodInfo ThrowEmptySequenceExceptionMethodInfo;
     public static readonly MethodInfo PrefetchEntitySetMethodInfo;
 
-    public static int[] CreateSingleSourceMap(int targetLength, Pair<int>[] remappedColumns)
+    public static int[] CreateSingleSourceMap(int targetLength, IReadOnlyList<Pair<int>> remappedColumns)
     {
       var map = new int[targetLength];
       Array.Fill(map, MapTransform.NoMapping);
 
-      for (var i = 0; i < remappedColumns.Length; i++) {
+      for (var i = 0; i < remappedColumns.Count; i++) {
         var remappedColumn = remappedColumns[i];
         var targetIndex = remappedColumn.First;
         var sourceIndex = remappedColumn.Second;

--- a/Orm/Xtensive.Orm/Orm/Record.cs
+++ b/Orm/Xtensive.Orm/Orm/Record.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2008-2020 Xtensive LLC.
+// Copyright (C) 2008-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Kochetov
@@ -17,63 +17,49 @@ namespace Xtensive.Orm
   /// A single item in <see cref="EntityDataReader.Read"/> result
   /// containing both raw <see cref="Source"/> and parsed primary keys.
   /// </summary>
-  public sealed class Record
+  public readonly struct Record
   {
     private readonly Pair<Key, Tuple> keyTuplePair;
     private readonly Pair<Key, Tuple>[] keyTuplePairs;
 
     /// <summary>
+    /// Gets raw tuple this record is build from.
+    /// </summary>
+    public readonly Tuple Source { get; }
+
+    /// <summary>
     /// Gets the first primary key in the <see cref="Record"/>.
     /// </summary>
-    public Key GetKey()
-    {
-      return keyTuplePair.First;
-    }
+    public Key GetKey() => keyTuplePair.First;
 
     /// <summary>
     /// Gets the <see cref="Key"/> by specified index.
     /// </summary>
-    public Key GetKey(int index)
-    {
-      if (index == 0)
-        return keyTuplePair.First;
-      if (keyTuplePairs == null || index < 0 || index >= keyTuplePairs.Length)
-        return null;
-      return keyTuplePairs[index].First;
-    }
+    public Key GetKey(int index) => GetPair(index)?.First;
 
     /// <summary>
     /// Gets the first tuple in the <see cref="Record"/>.
     /// </summary>
-    public Tuple GetTuple()
-    {
-      return keyTuplePair.Second;
-    }
+    public Tuple GetTuple() => keyTuplePair.Second;
 
     /// <summary>
     /// Gets the <see cref="Tuple"/> by specified index.
     /// </summary>
-    public Tuple GetTuple(int index)
+    public Tuple GetTuple(int index) => GetPair(index)?.Second;
+
+    private Pair<Key, Tuple>? GetPair(int index)
     {
       if (index == 0)
-        return keyTuplePair.Second;
+        return keyTuplePair;
       if (keyTuplePairs == null || index < 0 || index >= keyTuplePairs.Length)
         return null;
-      return keyTuplePairs[index].Second;
+      return keyTuplePairs[index];
     }
 
     /// <summary>
     /// Gets the key count.
     /// </summary>
-    public int Count
-    {
-      get { return keyTuplePairs == null ? 1 : keyTuplePairs.Length; }
-    }
-
-    /// <summary>
-    /// Gets raw tuple this record is build from.
-    /// </summary>
-    public Tuple Source { get; private set; }
+    public int Count => keyTuplePairs?.Length ?? 1;
 
 
     // Constructors
@@ -88,8 +74,8 @@ namespace Xtensive.Orm
     internal Record(Tuple tuple, Pair<Key, Tuple> keyTuplePair)
     {
       Source = tuple;
+      keyTuplePairs = null;
       this.keyTuplePair = keyTuplePair;
     }
-
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Record.cs
+++ b/Orm/Xtensive.Orm/Orm/Record.cs
@@ -47,14 +47,10 @@ namespace Xtensive.Orm
     /// </summary>
     public Tuple GetTuple(int index) => GetPair(index)?.Second;
 
-    private Pair<Key, Tuple>? GetPair(int index)
-    {
-      if (index == 0)
-        return keyTuplePair;
-      if (keyTuplePairs == null || index < 0 || index >= keyTuplePairs.Length)
-        return null;
-      return keyTuplePairs[index];
-    }
+    private Pair<Key, Tuple>? GetPair(int index) =>
+      index == 0 ? keyTuplePair
+      : keyTuplePairs == null || index < 0 || index >= keyTuplePairs.Length ? null
+      : keyTuplePairs[index];
 
     /// <summary>
     /// Gets the key count.

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -37,22 +37,22 @@ namespace Xtensive.Orm.Rse
     /// Gets the <see cref="Provider"/> keys.
     /// </summary>
     /// <value>The keys.</value>
-    public ColumnGroupCollection ColumnGroups { get; private set; }
+    public ColumnGroupCollection ColumnGroups { get; }
 
     /// <summary>
     /// Gets the <see cref="Provider"/> columns.
     /// </summary>
-    public ColumnCollection Columns { get; private set; }
+    public ColumnCollection Columns { get; }
 
     /// <summary>
     /// Gets the <see cref="Provider"/> tuple descriptor.
     /// </summary>
-    public TupleDescriptor TupleDescriptor { get; private set; }
+    public TupleDescriptor TupleDescriptor { get; }
 
     /// <summary>
     /// Gets the indexes of columns <see cref="Provider"/> is ordered by.
     /// </summary>
-    public DirectionCollection<int> Order { get; private set; }
+    public DirectionCollection<int> Order { get; }
 
     /// <summary>
     /// Gets the tuple descriptor describing


### PR DESCRIPTION
* The cache changed to `FastConcurrentLruCache`
* `RecordPartMapping`, `Record`, `CacheItem`, `TypeMapping` are converted into `readonly struct`
* Avoided unnecessary List -> Array conversions