### PR TITLE
Session.Tag() method()

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityGroupTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityGroupTask.cs
@@ -136,9 +136,8 @@ namespace Xtensive.Orm.Internals.Prefetch
       Func<object, object> generator = CreateRecordSet;
       var session = manager.Owner.Session;
       Provider = (CompilableProvider) session.StorageNode.InternalQueryCache.GetOrAdd(key, generator);
-      if (!string.IsNullOrEmpty(session.Tag)) {
-        Provider = new TagProvider(Provider, session.Tag);
-        session.Tag = null;
+      if (Scope<TagContext>.CurrentContext is TagContext tagContext) {
+        Provider = new TagProvider(Provider, tagContext.Tag);
       }
       var executableProvider = session.Compile(Provider);
       return new QueryTask(executableProvider, session.GetLifetimeToken(), parameterContext);

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityGroupTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityGroupTask.cs
@@ -136,6 +136,10 @@ namespace Xtensive.Orm.Internals.Prefetch
       Func<object, object> generator = CreateRecordSet;
       var session = manager.Owner.Session;
       Provider = (CompilableProvider) session.StorageNode.InternalQueryCache.GetOrAdd(key, generator);
+      if (!string.IsNullOrEmpty(session.Tag)) {
+        Provider = new TagProvider(Provider, session.Tag);
+        session.Tag = null;
+      }
       var executableProvider = session.Compile(Provider);
       return new QueryTask(executableProvider, session.GetLifetimeToken(), parameterContext);
     }

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityGroupTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityGroupTask.cs
@@ -143,8 +143,10 @@ namespace Xtensive.Orm.Internals.Prefetch
       parameterContext.SetValue(includeParameter, currentKeySet);
       var session = manager.Owner.Session;
       Provider = session.StorageNode.InternalRecordSetCache.GetOrAdd(cacheKey, CreateRecordSet);
-      if (Scope<TagContext>.CurrentContext is TagContext tagContext) {
-        Provider = new TagProvider(Provider, tagContext.Tag);
+      if (session.Tags != null) {
+        foreach (var tag in session.Tags) {
+          Provider = new TagProvider(Provider, tag);
+        }
       }
       var executableProvider = session.Compile(Provider);
       return new QueryTask(executableProvider, session.GetLifetimeToken(), parameterContext);

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/TagContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/TagContext.cs
@@ -3,11 +3,26 @@
 // See the License.txt file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using Xtensive.Core;
 
 namespace Xtensive.Orm.Rse.Providers
 {
-  public class TagContext
+  public readonly struct TagContext : IDisposable
   {
-    public string Tag { get; init; }
+    private readonly List<string> tags;
+
+    public void Dispose()
+    {
+      if (tags != null) {
+        tags.RemoveAt(tags.Count - 1);
+      }
+    }
+
+    public TagContext(List<string> tags, string tag)
+    {
+      ArgumentValidator.EnsureArgumentNotNull(tag, nameof(tag));
+      (this.tags = tags)?.Add(tag);
+    }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/TagContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/TagContext.cs
@@ -15,7 +15,7 @@ namespace Xtensive.Orm.Rse.Providers
     public void Dispose() =>
       tags.RemoveAt(tags.Count - 1);
 
-    public TagContext(List<string> tags, string tag)
+    internal TagContext(List<string> tags, string tag)
     {
       ArgumentValidator.EnsureArgumentNotNull(tags, nameof(tags));
       ArgumentValidator.EnsureArgumentNotNull(tag, nameof(tag));

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/TagContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/TagContext.cs
@@ -12,12 +12,8 @@ namespace Xtensive.Orm.Rse.Providers
   {
     private readonly List<string> tags;
 
-    public void Dispose()
-    {
-      if (tags != null) {
-        tags.RemoveAt(tags.Count - 1);
-      }
-    }
+    public void Dispose() =>
+      tags.RemoveAt(tags.Count - 1);
 
     public TagContext(List<string> tags, string tag)
     {

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/TagContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/TagContext.cs
@@ -1,0 +1,13 @@
+// Copyright (C) 2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+
+namespace Xtensive.Orm.Rse.Providers
+{
+  public class TagContext
+  {
+    public string Tag { get; init; }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/TagContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/TagContext.cs
@@ -17,8 +17,9 @@ namespace Xtensive.Orm.Rse.Providers
 
     public TagContext(List<string> tags, string tag)
     {
+      ArgumentValidator.EnsureArgumentNotNull(tags, nameof(tags));
       ArgumentValidator.EnsureArgumentNotNull(tag, nameof(tag));
-      (this.tags = tags)?.Add(tag);
+      (this.tags = tags).Add(tag);
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Session.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.cs
@@ -240,6 +240,8 @@ namespace Xtensive.Orm
 
     internal CompilationService CompilationService { get { return Handlers.DomainHandler.CompilationService; } }
 
+    internal string Tag { get; set; }
+
     internal void EnsureNotDisposed()
     {
       if (isDisposed)
@@ -604,6 +606,12 @@ namespace Xtensive.Orm
 
       // Query endpoint
       SystemQuery = Query = new QueryEndpoint(new QueryProvider(this));
+    }
+
+    public Session WithTag(string tag)
+    {
+      Tag = tag;
+      return this;
     }
 
     // IDisposable implementation

--- a/Orm/Xtensive.Orm/Orm/Session.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.cs
@@ -240,8 +240,6 @@ namespace Xtensive.Orm
 
     internal CompilationService CompilationService { get { return Handlers.DomainHandler.CompilationService; } }
 
-    internal string Tag { get; set; }
-
     internal void EnsureNotDisposed()
     {
       if (isDisposed)
@@ -608,10 +606,10 @@ namespace Xtensive.Orm
       SystemQuery = Query = new QueryEndpoint(new QueryProvider(this));
     }
 
-    public Session WithTag(string tag)
+    public Scope<TagContext> Tag(string tag)
     {
-      Tag = tag;
-      return this;
+      ArgumentValidator.EnsureArgumentNotNull(tag, nameof(tag));
+      return new Scope<TagContext>(new TagContext { Tag = tag });
     }
 
     // IDisposable implementation

--- a/Orm/Xtensive.Orm/Orm/Session.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.cs
@@ -240,6 +240,9 @@ namespace Xtensive.Orm
 
     internal CompilationService CompilationService { get { return Handlers.DomainHandler.CompilationService; } }
 
+    private List<string> tags;
+    internal IReadOnlyList<string> Tags => tags;
+
     internal void EnsureNotDisposed()
     {
       if (isDisposed)
@@ -606,11 +609,7 @@ namespace Xtensive.Orm
       SystemQuery = Query = new QueryEndpoint(new QueryProvider(this));
     }
 
-    public Scope<TagContext> Tag(string tag)
-    {
-      ArgumentValidator.EnsureArgumentNotNull(tag, nameof(tag));
-      return new Scope<TagContext>(new TagContext { Tag = tag });
-    }
+    public TagContext Tag(string tag) => new TagContext(tags ??= new List<string>(), tag);
 
     // IDisposable implementation
 


### PR DESCRIPTION
It allows to tag `Single` queries like following:

All nested  tag scopes are effective.

```
using var _ = session.Tag("First tag");
var single = session.Query.SingleOrDefault<Customer>(1L);
var single2 = session.Query.SingleOrDefault<Customer>(2L);
using var __ = session.Tag("Second tag");
var single3 = session.Query.SingleOrDefault<Customer>(3L);
```
Tags first two queries with `First tag`, and the third query with both: `First tag` & `Second tag`

This method also works for `.Prefetch()`:
```
using var _ = session.Tag("Session tag");
var invoices = session.Query.All<Invoice>().Tag("Query tag").Prefetch(o => o.BusinessUnit).ToList();
```
The query for Invoice will be tagged by `Query tag`.
The query for BusinessUnit will be tagged by `Session tag`