### PR TITLE
Split type-unsafe InternalQueryCache into 4 statically typed caches

### DIFF
--- a/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
+++ b/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
@@ -42,6 +42,43 @@ namespace Xtensive.Orm
     private static readonly Parameter<Tuple> keyParameter = new Parameter<Tuple>(WellKnown.KeyFieldName);
     internal static readonly Parameter<Entity> ownerParameter = new Parameter<Entity>("Owner");
 
+    private static readonly Func<object, EntitySetBase, EntitySetTypeState> BuildEntitySetTypeState = (object key, EntitySetBase entitySet) => {
+      var field = ((Pair<object, FieldInfo>) key).Second;
+      var association = field.Associations.Last();
+      var query = association.UnderlyingIndex.GetQuery().Seek(context => context.GetValue(keyParameter));
+      var seek = entitySet.Session.Compile(query);
+      var ownerDescriptor = association.OwnerType.Key.TupleDescriptor;
+      var targetDescriptor = association.TargetType.Key.TupleDescriptor;
+
+      var itemColumnOffsets = association.AuxiliaryType == null
+        ? association.UnderlyingIndex.ValueColumns
+            .Where(ci => ci.IsPrimaryKey)
+            .Select(ci => ci.Field.MappingInfo.Offset)
+            .ToList()
+        : Enumerable.Range(0, targetDescriptor.Count).ToList();
+
+      var keyFieldCount = ownerDescriptor.Count + itemColumnOffsets.Count;
+      var keyFieldTypes = ownerDescriptor
+        .Concat(itemColumnOffsets.Select(i => targetDescriptor[i]))
+        .ToArray(keyFieldCount);
+      var keyDescriptor = TupleDescriptor.Create(keyFieldTypes);
+
+      var map = Enumerable.Range(0, ownerDescriptor.Count)
+        .Select(i => new Pair<int, int>(0, i))
+        .Concat(itemColumnOffsets.Select(i => new Pair<int, int>(1, i)))
+        .ToArray(keyFieldCount);
+      var seekTransform = new MapTransform(true, keyDescriptor, map);
+
+      Func<Tuple, Entity> itemCtor = null;
+      if (association.AuxiliaryType != null) {
+        itemCtor = DelegateHelper.CreateDelegate<Func<Tuple, Entity>>(null,
+          association.AuxiliaryType.UnderlyingType, DelegateHelper.AspectedFactoryMethodName,
+          Array.Empty<Type>());
+      }
+
+      return new EntitySetTypeState(seek, seekTransform, itemCtor, entitySet.GetItemCountQueryDelegate(field));
+    };
+
     private readonly Entity owner;
     private readonly CombineTransform auxilaryTypeKeyTransform;
     private readonly bool skipOwnerVersionChange;
@@ -922,45 +959,7 @@ namespace Xtensive.Orm
     private EntitySetTypeState GetEntitySetTypeState()
     {
       EnsureOwnerIsNotRemoved();
-      return Session.StorageNode.InternalEntitySetCache.GetOrAdd(Field, BuildEntitySetTypeState);
-    }
-
-    private EntitySetTypeState BuildEntitySetTypeState(object key)
-    {
-      var field = ((Pair<object, FieldInfo>) key).Second;
-      var association = field.Associations.Last();
-      var query = association.UnderlyingIndex.GetQuery().Seek(context => context.GetValue(keyParameter));
-      var seek = Session.Compile(query);
-      var ownerDescriptor = association.OwnerType.Key.TupleDescriptor;
-      var targetDescriptor = association.TargetType.Key.TupleDescriptor;
-
-      var itemColumnOffsets = association.AuxiliaryType == null
-        ? association.UnderlyingIndex.ValueColumns
-            .Where(ci => ci.IsPrimaryKey)
-            .Select(ci => ci.Field.MappingInfo.Offset)
-            .ToList()
-        : Enumerable.Range(0, targetDescriptor.Count).ToList();
-
-      var keyFieldCount = ownerDescriptor.Count + itemColumnOffsets.Count;
-      var keyFieldTypes = ownerDescriptor
-        .Concat(itemColumnOffsets.Select(i => targetDescriptor[i]))
-        .ToArray(keyFieldCount);
-      var keyDescriptor = TupleDescriptor.Create(keyFieldTypes);
-
-      var map = Enumerable.Range(0, ownerDescriptor.Count)
-        .Select(i => new Pair<int, int>(0, i))
-        .Concat(itemColumnOffsets.Select(i => new Pair<int, int>(1, i)))
-        .ToArray(keyFieldCount);
-      var seekTransform = new MapTransform(true, keyDescriptor, map);
-
-      Func<Tuple, Entity> itemCtor = null;
-      if (association.AuxiliaryType != null) {
-        itemCtor = DelegateHelper.CreateDelegate<Func<Tuple, Entity>>(null,
-          association.AuxiliaryType.UnderlyingType, DelegateHelper.AspectedFactoryMethodName,
-          Array.Empty<Type>());
-      }
-
-      return new EntitySetTypeState(seek, seekTransform, itemCtor, GetItemCountQueryDelegate(field));
+      return Session.StorageNode.InternalEntitySetCache.GetOrAdd(Field, BuildEntitySetTypeState, this);
     }
 
     private int? GetItemIndex(EntitySetState state, Key key)

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityContainer.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityContainer.cs
@@ -16,7 +16,6 @@ namespace Xtensive.Orm.Internals.Prefetch
   [Serializable]
   internal abstract class EntityContainer
   {
-    private static readonly object indexSeekCachingRegion = new object();
     private static readonly Parameter<Tuple> seekParameter = new Parameter<Tuple>(WellKnown.KeyFieldName);
 
     private SortedDictionary<int, ColumnInfo> columns;

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityGroupTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityGroupTask.cs
@@ -15,7 +15,7 @@ using Tuple = Xtensive.Tuples.Tuple;
 
 namespace Xtensive.Orm.Internals.Prefetch
 {
-  internal struct RecordSetCacheKey : IEquatable<RecordSetCacheKey>
+  internal readonly struct RecordSetCacheKey : IEquatable<RecordSetCacheKey>
   {
     public readonly int[] ColumnIndexes;
     public readonly TypeInfo Type;

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntitySetTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntitySetTask.cs
@@ -19,7 +19,7 @@ using Tuple = Xtensive.Tuples.Tuple;
 
 namespace Xtensive.Orm.Internals.Prefetch
 {
-  internal struct ItemsQueryCacheKey : IEquatable<ItemsQueryCacheKey>
+  internal readonly struct ItemsQueryCacheKey : IEquatable<ItemsQueryCacheKey>
   {
     public readonly FieldInfo ReferencingField;
     public readonly int? ItemCountLimit;
@@ -184,7 +184,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       return new QueryTask(executableProvider, session.GetLifetimeToken(), parameterContext);
     }
 
-    private static CompilableProvider CreateQueryForAssociationViaAuxType(ItemsQueryCacheKey cachingKey, IndexInfo primaryTargetIndex, List<int> resultColumns)
+    private static CompilableProvider CreateQueryForAssociationViaAuxType(in ItemsQueryCacheKey cachingKey, IndexInfo primaryTargetIndex, List<int> resultColumns)
     {
       var association = cachingKey.ReferencingField.Associations.Last();
       var associationIndex = association.UnderlyingIndex;
@@ -205,7 +205,7 @@ namespace Xtensive.Orm.Internals.Prefetch
         .Join(primaryTargetIndex.GetQuery(), joiningColumns);
     }
 
-    private static CompilableProvider CreateQueryForDirectAssociation(ItemsQueryCacheKey cachingKey, IndexInfo primaryTargetIndex, List<int> resultColumns)
+    private static CompilableProvider CreateQueryForDirectAssociation(in ItemsQueryCacheKey cachingKey, IndexInfo primaryTargetIndex, List<int> resultColumns)
     {
       AddResultColumnIndexes(resultColumns, primaryTargetIndex, 0);
       var association = cachingKey.ReferencingField.Associations.Last();

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchManager.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchManager.cs
@@ -22,7 +22,7 @@ namespace Xtensive.Orm.Internals.Prefetch
   {
     #region Nested classes
 
-    private struct RootContainerCacheKey : IEquatable<RootContainerCacheKey>
+    private readonly struct RootContainerCacheKey : IEquatable<RootContainerCacheKey>
     {
       private readonly int hashCode;
 
@@ -69,7 +69,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 
       // Constructors
 
-      public RootContainerCacheEntry(RootContainerCacheKey key, SortedDictionary<int, ColumnInfo> columns,
+      public RootContainerCacheEntry(in RootContainerCacheKey key, SortedDictionary<int, ColumnInfo> columns,
         List<int> columnsToBeLoaded)
       {
         Key = key;

--- a/Orm/Xtensive.Orm/Orm/Providers/SessionHandler.References.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SessionHandler.References.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -29,11 +29,7 @@ namespace Xtensive.Orm.Providers
     {
       if (association.IsPaired)
         return FindReferences(target, association, true);
-      object key = new Pair<object, AssociationInfo>(CachingRegion, association);
-      Func<object, object> generator = p => BuildReferencingQuery(((Pair<object, AssociationInfo>) p).Second);
-      var pair = (Pair<CompilableProvider, Parameter<Tuple>>) Session.StorageNode.InternalQueryCache.GetOrAdd(key, generator);
-      var recordSet = pair.First;
-      var parameter = pair.Second;
+      var (recordSet, parameter) = Session.StorageNode.InternalAssociationCache.GetOrAdd(association, BuildReferencingQuery);
       var parameterContext = new ParameterContext();
       parameterContext.SetValue(parameter, target.Key.Value);
       ExecutableProvider executableProvider = Session.Compile(recordSet);
@@ -94,7 +90,7 @@ namespace Xtensive.Orm.Providers
       }
     }
 
-    private static Pair<CompilableProvider, Parameter<Tuple>> BuildReferencingQuery(AssociationInfo association)
+    private static (CompilableProvider, Parameter<Tuple>) BuildReferencingQuery(AssociationInfo association)
     {
       var provider = (CompilableProvider)null;
       var parameter = new Parameter<Tuple>("pTuple");
@@ -178,7 +174,7 @@ namespace Xtensive.Orm.Providers
           break;
         }
       }
-      return new Pair<CompilableProvider, Parameter<Tuple>>(provider, parameter);
+      return (provider, parameter);
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/SessionHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SessionHandler.cs
@@ -19,8 +19,6 @@ namespace Xtensive.Orm.Providers
   /// </summary>
   public abstract partial class SessionHandler : IDisposable, IAsyncDisposable
   {
-    private static readonly object CachingRegion = new object();
-
     /// <summary>
     /// Gets <see cref="HandlerAccessor"/>.
     /// </summary>

--- a/Orm/Xtensive.Orm/Orm/StorageNode.cs
+++ b/Orm/Xtensive.Orm/Orm/StorageNode.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2020 Xtensive LLC.
+// Copyright (C) 2014-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -14,6 +14,9 @@ using Xtensive.Orm.Configuration;
 using Xtensive.Orm.Interfaces;
 using Xtensive.Orm.Model;
 using Xtensive.Orm.Providers;
+using Xtensive.Orm.Rse.Providers;
+using Xtensive.Orm.Internals;
+using Xtensive.Orm.Internals.Prefetch;
 
 namespace Xtensive.Orm
 {
@@ -44,11 +47,25 @@ namespace Xtensive.Orm
     /// </summary>
     public TypeIdRegistry TypeIdRegistry { get; private set; }
 
-    internal ConcurrentDictionary<object, object> InternalQueryCache { get; private set; }
+    internal ConcurrentDictionary<(TypeInfo, LockMode, LockBehavior), ExecutableProvider> InternalExecutableProviderCache { get; } =
+      new ConcurrentDictionary<(TypeInfo, LockMode, LockBehavior), ExecutableProvider>();
 
-    internal ConcurrentDictionary<SequenceInfo, object> KeySequencesCache { get; private set; }
+    internal ConcurrentDictionary<EntityGroupTask.CacheKey, CompilableProvider> InternalRecordSetCache { get; } =
+      new ConcurrentDictionary<EntityGroupTask.CacheKey, CompilableProvider>();
 
-    internal ConcurrentDictionary<PersistRequestBuilderTask, ICollection<PersistRequest>> PersistRequestCache { get; private set; }
+    internal ConcurrentDictionary<EntitySetTask.CacheKey, CompilableProvider> InternalItemsQueryCache { get; } =
+      new ConcurrentDictionary<EntitySetTask.CacheKey, CompilableProvider>();
+
+    internal ConcurrentDictionary<Xtensive.Orm.Model.FieldInfo, EntitySetTypeState> InternalEntitySetCache { get; } =
+      new ConcurrentDictionary<Xtensive.Orm.Model.FieldInfo, EntitySetTypeState>();
+
+    internal ConcurrentDictionary<AssociationInfo, (CompilableProvider, Parameter<Xtensive.Tuples.Tuple>)> InternalAssociationCache { get; } =
+      new ConcurrentDictionary<AssociationInfo, (CompilableProvider, Parameter<Xtensive.Tuples.Tuple>)>();
+
+    internal ConcurrentDictionary<SequenceInfo, object> KeySequencesCache { get; } = new ConcurrentDictionary<SequenceInfo, object>();
+
+    internal ConcurrentDictionary<PersistRequestBuilderTask, ICollection<PersistRequest>> PersistRequestCache { get; }
+      = new ConcurrentDictionary<PersistRequestBuilderTask, ICollection<PersistRequest>>();
 
     /// <inheritdoc/>
     public Session OpenSession()
@@ -121,10 +138,6 @@ namespace Xtensive.Orm
       Configuration = configuration;
       Mapping = mapping;
       TypeIdRegistry = typeIdRegistry;
-
-      KeySequencesCache = new ConcurrentDictionary<SequenceInfo, object>();
-      PersistRequestCache = new ConcurrentDictionary<PersistRequestBuilderTask, ICollection<PersistRequest>>();
-      InternalQueryCache = new ConcurrentDictionary<object, object>();
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/StorageNode.cs
+++ b/Orm/Xtensive.Orm/Orm/StorageNode.cs
@@ -50,8 +50,8 @@ namespace Xtensive.Orm
     internal ConcurrentDictionary<(TypeInfo, LockMode, LockBehavior), ExecutableProvider> InternalExecutableProviderCache { get; } =
       new ConcurrentDictionary<(TypeInfo, LockMode, LockBehavior), ExecutableProvider>();
 
-    internal ConcurrentDictionary<EntityGroupTask.CacheKey, CompilableProvider> InternalRecordSetCache { get; } =
-      new ConcurrentDictionary<EntityGroupTask.CacheKey, CompilableProvider>();
+    internal ConcurrentDictionary<RecordSetCacheKey, CompilableProvider> InternalRecordSetCache { get; } =
+      new ConcurrentDictionary<RecordSetCacheKey, CompilableProvider>();
 
     internal ConcurrentDictionary<EntitySetTask.CacheKey, CompilableProvider> InternalItemsQueryCache { get; } =
       new ConcurrentDictionary<EntitySetTask.CacheKey, CompilableProvider>();

--- a/Orm/Xtensive.Orm/Orm/StorageNode.cs
+++ b/Orm/Xtensive.Orm/Orm/StorageNode.cs
@@ -53,8 +53,8 @@ namespace Xtensive.Orm
     internal ConcurrentDictionary<RecordSetCacheKey, CompilableProvider> InternalRecordSetCache { get; } =
       new ConcurrentDictionary<RecordSetCacheKey, CompilableProvider>();
 
-    internal ConcurrentDictionary<EntitySetTask.CacheKey, CompilableProvider> InternalItemsQueryCache { get; } =
-      new ConcurrentDictionary<EntitySetTask.CacheKey, CompilableProvider>();
+    internal ConcurrentDictionary<ItemsQueryCacheKey, CompilableProvider> InternalItemsQueryCache { get; } =
+      new ConcurrentDictionary<ItemsQueryCacheKey, CompilableProvider>();
 
     internal ConcurrentDictionary<Xtensive.Orm.Model.FieldInfo, EntitySetTypeState> InternalEntitySetCache { get; } =
       new ConcurrentDictionary<Xtensive.Orm.Model.FieldInfo, EntitySetTypeState>();


### PR DESCRIPTION
Also eliminated boxing for keys and values