### PR TITLE
Minor optimizations

### DIFF
--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/BulkDeleteOperation.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/BulkDeleteOperation.cs
@@ -51,10 +51,10 @@ namespace Xtensive.Orm.BulkOperations
       }
     }
 
-    private QueryCommand CreateCommand(QueryTranslationResult request)
+    private QueryCommand CreateCommand(in QueryTranslationResult request)
     {
       var delete = SqlDml.Delete(SqlDml.TableRef(PrimaryIndexes[0].Table));
-      Join(delete, (SqlSelect) request.Query);
+      Join(delete, request.Query);
       return ToCommand(delete);
     }
 

--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/BulkUpdateOperation.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/BulkUpdateOperation.cs
@@ -54,11 +54,11 @@ namespace Xtensive.Orm.BulkOperations
       }
     }
 
-    private QueryCommand CreateCommand(QueryTranslationResult request)
+    private QueryCommand CreateCommand(in QueryTranslationResult request)
     {
       var update = SqlDml.Update(SqlDml.TableRef(PrimaryIndexes[0].Table));
       setOperation.Statement = SetStatement.Create(update);
-      Join(update, (SqlSelect) request.Query);
+      Join(update, request.Query);
       setOperation.AddValues();
       return ToCommand(update);
     }

--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/SetOperation.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/SetOperation.cs
@@ -103,7 +103,7 @@ namespace Xtensive.Orm.BulkOperations
         all,
         addContext.Lambda);
       QueryTranslationResult request = parent.GetRequest(parent.QueryProvider.CreateQuery<T>(selectExpression));
-      var sqlSelect = ((SqlSelect)request.Query);
+      var sqlSelect = request.Query;
       SqlExpression ex = sqlSelect.OrderBy[0].Expression;
       var placeholder = ex as SqlPlaceholder;
       if (placeholder == null)
@@ -133,7 +133,7 @@ namespace Xtensive.Orm.BulkOperations
         all,
         addContext.Lambda);
       QueryTranslationResult request = parent.GetRequest(parent.QueryProvider.CreateQuery<T>(selectExpression));
-      var sqlSelect = ((SqlSelect) request.Query);
+      var sqlSelect = request.Query;
       SqlExpression ex = sqlSelect.OrderBy[0].Expression;
       parent.Bindings.AddRange(request.ParameterBindings);
       
@@ -217,7 +217,7 @@ namespace Xtensive.Orm.BulkOperations
             QueryTranslationResult request = parent.GetRequest(field.ValueType, q);
             parent.Bindings.AddRange(request.ParameterBindings);
             SqlTableColumn c = SqlDml.TableColumn(addContext.Statement.Table, addContext.Field.Columns[i].Name);
-            addContext.Statement.AddValue(c, SqlDml.SubQuery((ISqlQueryExpression) request.Query));
+            addContext.Statement.AddValue(c, SqlDml.SubQuery(request.Query));
           }
           return;
         }

--- a/Orm/Xtensive.Orm.Tests/Storage/QueryBuilderTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/QueryBuilderTest.cs
@@ -56,7 +56,7 @@ namespace Xtensive.Orm.Tests.Storage
         Assert.That(translated.Query, Is.Not.Null);
         Assert.That(translated.ParameterBindings, Is.Not.Null);
 
-        var select = (SqlSelect) translated.Query;
+        var select = translated.Query;
         select.Columns.Clear();
         select.Columns.Add(SqlDml.Count());
         var compiled = builder.CompileQuery(translated.Query);

--- a/Orm/Xtensive.Orm/Caching/WeakestCache.cs
+++ b/Orm/Xtensive.Orm/Caching/WeakestCache.cs
@@ -236,9 +236,7 @@ namespace Xtensive.Caching
     public override void RemoveKey(TKey key)
     {
       ArgumentValidator.EnsureArgumentNotNull(key, "key");
-      WeakEntry entry;
-      if (items.TryGetValue(key, out entry)) {
-        items.Remove(key);
+      if (items.Remove(key, out var entry)) {
         entry.Dispose();
       }
     }

--- a/Orm/Xtensive.Orm/Collections/ExtensionCollection.cs
+++ b/Orm/Xtensive.Orm/Collections/ExtensionCollection.cs
@@ -153,12 +153,13 @@ namespace Xtensive.Collections
       ArgumentValidator.EnsureArgumentNotNull(source, "source");
       if (source.Count==0)
         return;
-      var sourceLikeMe = source as ExtensionCollection;
-      if (sourceLikeMe!=null)
+      if (source is ExtensionCollection sourceLikeMe) {
         extensions = new Dictionary<Type, object>(sourceLikeMe.extensions);
-      else
+      }
+      else {
         foreach (Type extensionType in source)
           Set(extensionType, source.Get(extensionType));
+      }
     }
   }
 }

--- a/Orm/Xtensive.Orm/Collections/Graphs/TopologicalSorter.cs
+++ b/Orm/Xtensive.Orm/Collections/Graphs/TopologicalSorter.cs
@@ -41,10 +41,8 @@ namespace Xtensive.Collections.Graphs
 
       public void Remove(T item)
       {
-        LinkedListNode<T> node;
-        if (map.TryGetValue(item, out node)) {
+        if (map.Remove(item, out var node)) {
           list.Remove(node);
-          map.Remove(item);
         }
       }
 

--- a/Orm/Xtensive.Orm/Collections/Graphs/TopologicalSorter.cs
+++ b/Orm/Xtensive.Orm/Collections/Graphs/TopologicalSorter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2003-2012 Xtensive LLC.
+// Copyright (C) 2003-2012 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Alex Yakunin
@@ -104,8 +104,7 @@ namespace Xtensive.Collections.Graphs
 
     restart:
       // Sorting
-      while (nodesWithoutIncomingEdges.Count!=0) {
-        var node = nodesWithoutIncomingEdges.Dequeue();
+      while (nodesWithoutIncomingEdges.TryDequeue(out var node)) {
         if (unsortedNodes!=null) // Break edges
           unsortedNodes.Remove(node);
         else
@@ -126,8 +125,7 @@ namespace Xtensive.Collections.Graphs
       if (unsortedNodes!=null) { // Break edges
         if (unsortedNodes.Count != 0) {
           // Trying to break edges (collection is always empty when breakEdges==false)
-          while (breakableEdges.Count != 0) {
-            var edge = breakableEdges.Dequeue();
+          while (breakableEdges.TryDequeue(out var edge)) {
             if (!edge.IsAttached || !edgeBreaker(edge))
               continue;
             result.BrokenEdges.Add(edge);

--- a/Orm/Xtensive.Orm/Collections/TopDeque.cs
+++ b/Orm/Xtensive.Orm/Collections/TopDeque.cs
@@ -253,10 +253,8 @@ namespace Xtensive.Collections
     /// <inheritdoc/>
     public void Remove(K key)
     {
-      LinkedListNode<Pair<K, V>> valueContainer;
-      if (map.TryGetValue(key, out valueContainer)) {
+      if (map.Remove(key, out var valueContainer)) {
         list.Remove(valueContainer);
-        map.Remove(key);
       }
     }
 

--- a/Orm/Xtensive.Orm/Collections/TypeRegistry.cs
+++ b/Orm/Xtensive.Orm/Collections/TypeRegistry.cs
@@ -61,12 +61,9 @@ namespace Xtensive.Collections
       ArgumentValidator.EnsureArgumentNotNull(type, "type");
       if (!isProcessingPendingActions)
         Register(new TypeRegistration(type));
-      else {
-        if (typeSet.Contains(type))
-          return;
+      else if (typeSet.Add(type)) {
         serviceRegistrations = null;
         types.Add(type);
-        typeSet.Add(type);
         assemblies.Add(type.Assembly);
       }
     }

--- a/Orm/Xtensive.Orm/Modelling/Comparison/Comparer.cs
+++ b/Orm/Xtensive.Orm/Modelling/Comparison/Comparer.cs
@@ -296,11 +296,13 @@ namespace Xtensive.Modelling.Comparison
             continue;
 
           if (any.Nesting.PropertyInfo != null && accessor.DependencyRootType==any.Nesting.PropertyInfo.PropertyType) {
-            if (propertyDifference is NodeDifference)
-              ((NodeDifference) propertyDifference).IsDependentOnParent = true;
-            else if (propertyDifference is NodeCollectionDifference)
-              ((NodeCollectionDifference) propertyDifference).ItemChanges
+            if (propertyDifference is NodeDifference nodeDifference) {
+              nodeDifference.IsDependentOnParent = true;
+            }
+            else if (propertyDifference is NodeCollectionDifference nodeCollectionDifference) {
+              nodeCollectionDifference.ItemChanges
                 .ForEach(item=>item.IsDependentOnParent = true);
+            }
           }
           difference.PropertyChanges.Add(property.Name, propertyDifference);
         }
@@ -590,10 +592,10 @@ namespace Xtensive.Modelling.Comparison
     /// <returns>Comparison key for the specified node.</returns>
     protected virtual string GetNodeComparisonKey(Node node)
     {
-      if (!(node is INodeReference))
+      if (!(node is INodeReference nodeReference))
         return GetTargetName(node);
 
-      var targetNode = ((INodeReference) node).Value;
+      var targetNode = nodeReference.Value;
       return targetNode==null ? null : GetTargetPath(targetNode);
     }
 

--- a/Orm/Xtensive.Orm/Modelling/NodeCollection.cs
+++ b/Orm/Xtensive.Orm/Modelling/NodeCollection.cs
@@ -252,8 +252,7 @@ namespace Xtensive.Modelling
       string name = node.Name;
       try {
         list.RemoveAt(index);
-        if (nameIndex.ContainsKey(name))
-          nameIndex.Remove(name);
+        nameIndex.Remove(name);
         OnCollectionChanged(new NotifyCollectionChangedEventArgs(
           NotifyCollectionChangedAction.Remove, index));
       }
@@ -309,21 +308,18 @@ namespace Xtensive.Modelling
     internal void AddName(Node node)
     {
       this.EnsureNotLocked();
-      string name = node.Name;
-      if (nameIndex.ContainsKey(name))
+      if (!nameIndex.TryAdd(node.Name, node)) {
         throw Exceptions.InternalError("Wrong NodeCollection.AddName arguments: nameIndex[node.Name]!=null!", CoreLog.Instance);
-      nameIndex.Add(name, node);
+      }
     }
 
     /// <exception cref="InvalidOperationException">Internal error.</exception>
     internal void CheckIntegrity()
     {
       foreach (var node in list) {
-        var name = node.Name;
-        if (!nameIndex.ContainsKey(name))
+        if (!nameIndex.TryGetValue(node.Name, out var value) || value != node) {
           throw Exceptions.InternalError("Integrity check failed.", CoreLog.Instance);
-        if (node!=nameIndex[name])
-          throw Exceptions.InternalError("Integrity check failed.", CoreLog.Instance);
+        }
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.ClusteredIndexes.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.ClusteredIndexes.cs
@@ -22,8 +22,7 @@ namespace Xtensive.Orm.Building.Builders
         var queue = new Queue<TypeInfo>();
         var clusteredIndexesMap = new Dictionary<TypeInfo, IndexInfo>();
         queue.Enqueue(hierarchy.Root);
-        while (queue.Count > 0) {
-          var type = queue.Dequeue();
+        while (queue.TryDequeue(out var type)) {
           foreach (var decendant in type.GetDescendants())
             queue.Enqueue(decendant);
           var clusteredIndexes = type.Indexes

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.FullText.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.FullText.cs
@@ -127,8 +127,7 @@ namespace Xtensive.Orm.Building.Builders
         ftid => model.Types[ftid.Type.UnderlyingType],
         ftid => new List<FullTextIndexDef>() {ftid});
 
-      while (processQueue.Count > 0) {
-        var type = processQueue.Dequeue();
+      while (processQueue.TryDequeue(out var type)) {
         List<FullTextIndexDef> indexes;
         List<FullTextIndexDef> parentIndexes;
         var typeHasIndexDef = indexDefs.TryGetValue(type, out indexes);

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/ModelDefBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/ModelDefBuilder.cs
@@ -28,8 +28,7 @@ namespace Xtensive.Orm.Building.Builders
       var closedGenericTypes = new List<Type>();
       var openGenericTypes = new List<Type>();
 
-      while (types.Count != 0) {
-        var type = types.Dequeue();
+      while (types.TryDequeue(out var type)) {
         if (!IsTypeAvailable(type)) {
           continue;
         }

--- a/Orm/Xtensive.Orm/Orm/Building/Definitions/TypeDefCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Definitions/TypeDefCollection.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2007-2020 Xtensive LLC.
+// Copyright (C) 2007-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
@@ -30,7 +30,7 @@ namespace Xtensive.Orm.Building.Definitions
   /// </summary>
   public sealed class TypeDefCollection : NodeCollection<TypeDef>
   {
-    private readonly Dictionary<Type, TypeDef> typeIndex;
+    private readonly Dictionary<Type, TypeDef> typeIndex = new Dictionary<Type, TypeDef>();
 
     public event EventHandler<TypeDefCollectionChangedEventArgs> Added;
 
@@ -62,12 +62,10 @@ namespace Xtensive.Orm.Building.Definitions
     /// <returns><see name="TypeDef"/> instance that is ancestor of specified <paramref name="type"/> or 
     /// <see langword="null"/> if the ancestor is not found in this collection.</returns>
     /// <exception cref="ArgumentNullException">When <paramref name="type"/> is <see langword="null"/>.</exception>
-    private TypeDef FindAncestor(Type type)
-    {
-      if (type == WellKnownTypes.Object || type.BaseType == null)
-        return null;
-      return Contains(type.BaseType) ? this[type.BaseType] : FindAncestor(type.BaseType);
-    }
+    private TypeDef FindAncestor(Type type) =>
+      type == WellKnownTypes.Object || type.BaseType == null
+        ? null
+        : TryGetValue(type.BaseType) ?? FindAncestor(type.BaseType);
 
     /// <summary>
     /// Find the <see cref="IEnumerable{T}"/> of interfaces that specified <paramref name="type"/> implements.
@@ -90,15 +88,8 @@ namespace Xtensive.Orm.Building.Definitions
     /// <returns>
     ///   <see langword="True"/> if the object is found; otherwise, <see langword="false"/>.
     /// </returns>
-    public override bool Contains(TypeDef item)
-    {
-      if (item==null)
-        return false;
-      TypeDef result = TryGetValue(item.UnderlyingType);
-      if (result == null)
-        return false;
-      return result==item;
-    }
+    public override bool Contains(TypeDef item) =>
+      item != null && TryGetValue(item.UnderlyingType) == item;
 
     /// <summary>
     /// Determines whether this instance contains an item with the specified key.
@@ -107,10 +98,7 @@ namespace Xtensive.Orm.Building.Definitions
     /// <returns>
     /// <see langword="true"/> if this instance contains the specified key; otherwise, <see langword="false"/>.
     /// </returns>
-    public bool Contains(Type key)
-    {
-      return typeIndex.ContainsKey(key);
-    }
+    public bool Contains(Type key) => typeIndex.ContainsKey(key);
 
     /// <summary>
     /// Gets the value associated with the specified key.
@@ -120,8 +108,7 @@ namespace Xtensive.Orm.Building.Definitions
     /// if item was not found.</returns>
     public TypeDef TryGetValue(Type key)
     {
-      TypeDef result;
-      typeIndex.TryGetValue(key, out result);
+      typeIndex.TryGetValue(key, out var result);
       return result;
     }
 
@@ -129,17 +116,8 @@ namespace Xtensive.Orm.Building.Definitions
     /// An indexer that provides access to collection items.
     /// </summary>
     /// <exception cref="ArgumentException"> when item was not found.</exception>
-    public TypeDef this[Type key]
-    {
-      get
-      {
-        TypeDef result = TryGetValue(key);
-        if (result == null)
-          throw new ArgumentException(String.Format(Strings.ExItemByKeyXWasNotFound, key), "key");
-        return result;
-
-      }
-    }
+    public TypeDef this[Type key] =>
+      TryGetValue(key) ?? throw new ArgumentException(String.Format(Strings.ExItemByKeyXWasNotFound, key), "key");
 
     /// <inheritdoc/>
     public override void Add(TypeDef item) {
@@ -180,7 +158,6 @@ namespace Xtensive.Orm.Building.Definitions
     internal TypeDefCollection(Node owner, string name)
       : base(owner, name)
     {
-      typeIndex = new Dictionary<Type, TypeDef>();
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Building/Definitions/TypeDefCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Definitions/TypeDefCollection.cs
@@ -78,7 +78,7 @@ namespace Xtensive.Orm.Building.Definitions
       ArgumentValidator.EnsureArgumentNotNull(type, "type");
 
       var interfaces = type.GetInterfaces();
-      return interfaces.Select(t => TryGetValue(t)).Where(result => result != null);
+      return interfaces.Select(TryGetValue).Where(result => result != null);
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Building/FixupActionProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/FixupActionProcessor.cs
@@ -28,8 +28,7 @@ namespace Xtensive.Orm.Building
     private void ProcessAll()
     {
       using (BuildLog.InfoRegion(Strings.LogProcessingFixupActions))
-        while (context.ModelInspectionResult.Actions.Count > 0) {
-          var action = context.ModelInspectionResult.Actions.Dequeue();
+        while (context.ModelInspectionResult.Actions.TryDequeue(out var action)) {
           BuildLog.Info(string.Format(Strings.LogExecutingActionX, action));
           action.Run(this);
         }
@@ -103,8 +102,7 @@ namespace Xtensive.Orm.Building
           where !root.IsSystem && !root.IsAutoGenericInstance
           select root.UnderlyingType);
         var types = new List<Type>();
-        while (queue.Count > 0) {
-          var candidate = queue.Dequeue();
+        while (queue.TryDequeue(out var candidate)) {
           if (constraints.All(ct => ct.IsAssignableFrom(candidate)))
             // First suitable descendant is found
             types.Add(candidate);
@@ -146,8 +144,7 @@ namespace Xtensive.Orm.Building
       var queue = new Queue<TypeDef>();
       var interfaces = new HashSet<TypeDef>();
       queue.Enqueue(type);
-      while (queue.Count > 0) {
-        var item = queue.Dequeue();
+      while (queue.TryDequeue(out var item)) {
         foreach (var @interface in context.ModelDef.Types.FindInterfaces(item.UnderlyingType)) {
           queue.Enqueue(@interface);
           interfaces.Add(@interface);

--- a/Orm/Xtensive.Orm/Orm/Domain.cs
+++ b/Orm/Xtensive.Orm/Orm/Domain.cs
@@ -119,8 +119,9 @@ namespace Xtensive.Orm
 
     internal KeyGeneratorRegistry KeyGenerators { get; private set; }
 
-    internal ConcurrentDictionary<TypeInfo, IReadOnlyList<PrefetchFieldDescriptor>> PrefetchFieldDescriptorCache { get; private set; }
-    
+    internal ConcurrentDictionary<TypeInfo, IReadOnlyList<PrefetchFieldDescriptor>> PrefetchFieldDescriptorCache { get; } =
+       new ConcurrentDictionary<TypeInfo, IReadOnlyList<PrefetchFieldDescriptor>>();
+
     internal ICache<object, Pair<object, ParameterizedQuery>> QueryCache { get; private set; }
 
     internal ICache<Key, Key> KeyCache { get; private set; }
@@ -420,7 +421,6 @@ namespace Xtensive.Orm
       GenericKeyFactories = new ConcurrentDictionary<TypeInfo, GenericKeyFactory>();
       EntityDataReader = new EntityDataReader(this);
       KeyGenerators = new KeyGeneratorRegistry();
-      PrefetchFieldDescriptorCache = new ConcurrentDictionary<TypeInfo, IReadOnlyList<PrefetchFieldDescriptor>>();
       KeyCache = new LruCache<Key, Key>(Configuration.KeyCacheSize, k => k);
       QueryCache = new FastConcurrentLruCache<object, Pair<object, ParameterizedQuery>>(Configuration.QueryCacheSize, k => k.First);
       PrefetchActionMap = new Dictionary<TypeInfo, Action<SessionHandler, IEnumerable<Key>>>();

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Fetcher.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Fetcher.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexander Nikolaev
@@ -13,11 +13,10 @@ using Xtensive.Core;
 
 namespace Xtensive.Orm.Internals.Prefetch
 {
-  internal sealed class Fetcher
+  internal readonly struct Fetcher
   {
-    private readonly HashSet<EntityGroupTask> tasks = new HashSet<EntityGroupTask>();
-    private readonly HashSet<Key> foundKeys = new HashSet<Key>();
-
+    private readonly HashSet<EntityGroupTask> tasks;
+    private readonly HashSet<Key> foundKeys;
     private readonly PrefetchManager manager;
 
     public async ValueTask<int> ExecuteTasks(IReadOnlyCollection<GraphContainer> containers, bool skipPersist,
@@ -126,6 +125,8 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     public Fetcher(PrefetchManager manager)
     {
+      tasks = new HashSet<EntityGroupTask>();
+      foundKeys = new HashSet<Key>();
       ArgumentValidator.EnsureArgumentNotNull(manager, nameof(manager));
       this.manager = manager;
     }

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchHelper.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchHelper.cs
@@ -13,18 +13,16 @@ namespace Xtensive.Orm.Internals.Prefetch
 {
   internal static class PrefetchHelper
   {
-    public static bool IsFieldToBeLoadedByDefault(FieldInfo field)
-    {
-      return field.IsPrimaryKey || field.IsSystem || (!field.IsLazyLoad && !field.IsEntitySet);
-    }
-
-    public static IReadOnlyList<PrefetchFieldDescriptor> CreateDescriptorsForFieldsLoadedByDefault(TypeInfo type)
-    {
-      return type.Fields
+    private static readonly Func<TypeInfo, IReadOnlyList<PrefetchFieldDescriptor>> CreateDescriptorsForFieldsLoadedByDefault = type =>
+      type.Fields
         .Where(field => field.Parent == null && IsFieldToBeLoadedByDefault(field))
         .Select(field => new PrefetchFieldDescriptor(field, false, false))
         .ToList()
         .AsReadOnly();
+
+    public static bool IsFieldToBeLoadedByDefault(FieldInfo field)
+    {
+      return field.IsPrimaryKey || field.IsSystem || (!field.IsLazyLoad && !field.IsEntitySet);
     }
 
     public static IReadOnlyList<PrefetchFieldDescriptor> GetCachedDescriptorsForFieldsLoadedByDefault(Domain domain, TypeInfo type)

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchKeyIterator.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchKeyIterator.cs
@@ -51,8 +51,7 @@ namespace Xtensive.Orm.Internals.Prefetch
         }
 
         if (unknownTypeQueue.Count > 0) {
-          while (unknownTypeQueue.Count > 0) {
-            var unknownKey = unknownTypeQueue.Dequeue();
+          while (unknownTypeQueue.TryDequeue(out var unknownKey)) {
             var unknownType = session.EntityStateCache[unknownKey, false].Type;
             var unknownDescriptors =
               PrefetchHelper.GetCachedDescriptorsForFieldsLoadedByDefault(session.Domain, unknownType);
@@ -62,8 +61,8 @@ namespace Xtensive.Orm.Internals.Prefetch
           session.Handler.ExecutePrefetchTasks();
         }
 
-        while (resultQueue.Count > 0) {
-          yield return (T) (IEntity) session.EntityStateCache[resultQueue.Dequeue(), true].Entity;
+        while (resultQueue.TryDequeue(out var item)) {
+          yield return (T) (IEntity) session.EntityStateCache[item, true].Entity;
         }
 
         taskCount = session.Handler.PrefetchTaskExecutionCount;
@@ -106,8 +105,7 @@ namespace Xtensive.Orm.Internals.Prefetch
         }
 
         if (unknownTypeQueue.Count > 0) {
-          while (unknownTypeQueue.Count > 0) {
-            var unknownKey = unknownTypeQueue.Dequeue();
+          while (unknownTypeQueue.TryDequeue(out var unknownKey)) {
             var unknownType = session.EntityStateCache[unknownKey, false].Type;
             var unknownDescriptors =
               PrefetchHelper.GetCachedDescriptorsForFieldsLoadedByDefault(session.Domain, unknownType);
@@ -118,8 +116,8 @@ namespace Xtensive.Orm.Internals.Prefetch
           await session.Handler.ExecutePrefetchTasksAsync(token).ConfigureAwait(false);
         }
 
-        while (resultQueue.Count > 0) {
-          yield return (T) (IEntity) session.EntityStateCache[resultQueue.Dequeue(), true].Entity;
+        while (resultQueue.TryDequeue(out var item)) {
+          yield return (T) (IEntity) session.EntityStateCache[item, true].Entity;
         }
 
         taskCount = session.Handler.PrefetchTaskExecutionCount;

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchQueryEnumerable.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchQueryEnumerable.cs
@@ -46,16 +46,16 @@ namespace Xtensive.Orm.Internals.Prefetch
         while (container.JoinIfPossible(sessionHandler.ExecutePrefetchTasks())) {
           _ = container.JoinIfPossible(ProcessFetchedElements(enumerationIdentifier));
         }
-        while (resultQueue.Count > 0) {
-          yield return resultQueue.Dequeue();
+        while (resultQueue.TryDequeue(out var queueElement)) {
+          yield return queueElement;
         }
         currentTaskCount = sessionHandler.PrefetchTaskExecutionCount;
       }
       while (container.JoinIfPossible(sessionHandler.ExecutePrefetchTasks())) {
         _ = container.JoinIfPossible(ProcessFetchedElements(enumerationIdentifier));
       }
-      while (resultQueue.Count > 0) {
-        yield return resultQueue.Dequeue();
+      while (resultQueue.TryDequeue(out var queueElement)) {
+        yield return queueElement;
       }
     }
 
@@ -96,8 +96,7 @@ namespace Xtensive.Orm.Internals.Prefetch
     private StrongReferenceContainer ProcessFetchedElements(Guid enumerationId)
     {
       var container = new StrongReferenceContainer(null);
-      while (unknownTypeQueue.Count > 0) {
-        var unknownKey = unknownTypeQueue.Dequeue();
+      while (unknownTypeQueue.TryDequeue(out var unknownKey)) {
         var unknownType = session.EntityStateCache[unknownKey, false].Type;
         var unknownDescriptors = PrefetchHelper.GetCachedDescriptorsForFieldsLoadedByDefault(session.Domain, unknownType);
         _ = sessionHandler.Prefetch(unknownKey, unknownType, unknownDescriptors);

--- a/Orm/Xtensive.Orm/Orm/Internals/ReferentialIntegrity/RemovalContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/ReferentialIntegrity/RemovalContext.cs
@@ -40,8 +40,7 @@ namespace Xtensive.Orm.ReferentialIntegrity
 
     public List<Entity> GatherEntitiesForProcessing()
     {
-      while (types.Count > 0) {
-        var type = types.Dequeue();
+      while (types.TryDequeue(out var type)) {
         var list = queue[type];
         if (list.Count == 0) {
           continue;

--- a/Orm/Xtensive.Orm/Orm/Linq/ItemToTupleConverter{TItem}.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ItemToTupleConverter{TItem}.cs
@@ -112,44 +112,43 @@ namespace Xtensive.Orm.Linq
       if (item==null)
         return;
       // LocalCollectionExpression
-      if (expression is LocalCollectionExpression) {
-        var itemExpression = (LocalCollectionExpression) expression;
-        foreach (var field in itemExpression.Fields) {
-          var propertyInfo = field.Key as PropertyInfo;
-          object value = propertyInfo==null
-            ? ((FieldInfo) field.Key).GetValue(item)
-            : propertyInfo.GetValue(item, BindingFlags.InvokeMethod, null, null, null);
-          if (value!=null)
-            FillLocalCollectionField(value, tuple, (Expression) field.Value);
+      switch (expression) {
+        case LocalCollectionExpression itemExpression:
+          foreach (var field in itemExpression.Fields) {
+            var propertyInfo = field.Key as PropertyInfo;
+            object value = propertyInfo==null
+              ? ((FieldInfo) field.Key).GetValue(item)
+              : propertyInfo.GetValue(item, BindingFlags.InvokeMethod, null, null, null);
+            if (value!=null)
+              FillLocalCollectionField(value, tuple, (Expression) field.Value);
+          }
+          break;
+        case ColumnExpression columnExpression:
+          tuple.SetValue(columnExpression.Mapping.Offset, item);
+          break;
+        case StructureExpression structureExpression:
+          var structure = (Structure) item;
+          var typeInfo = structureExpression.PersistentType;
+          var tupleDescriptor = typeInfo.TupleDescriptor;
+          var tupleSegment = new Segment<int>(0, tupleDescriptor.Count);
+          var structureTuple = structure.Tuple.GetSegment(tupleSegment);
+          structureTuple.CopyTo(tuple, 0, structureExpression.Mapping.Offset, structureTuple.Count);
+          break;
+        case EntityExpression entityExpression: {
+          var entity = (Entity) item;
+          var keyTuple = entity.Key.Value;
+          keyTuple.CopyTo(tuple, 0, entityExpression.Key.Mapping.Offset, keyTuple.Count);
         }
+        break;
+        case KeyExpression keyExpression: {
+          var key = (Key) item;
+          var keyTuple = key.Value;
+          keyTuple.CopyTo(tuple, 0, keyExpression.Mapping.Offset, keyTuple.Count);
+        }
+        break;
+        default:
+          throw new NotSupportedException();
       }
-      else if (expression is ColumnExpression) {
-        var columnExpression = (ColumnExpression) expression;
-        tuple.SetValue(columnExpression.Mapping.Offset, item);
-      }
-      else if (expression is StructureExpression) {
-        var structureExpression = (StructureExpression) expression;
-        var structure = (Structure) item;
-        var typeInfo = structureExpression.PersistentType;
-        var tupleDescriptor = typeInfo.TupleDescriptor;
-        var tupleSegment = new Segment<int>(0, tupleDescriptor.Count);
-        var structureTuple = structure.Tuple.GetSegment(tupleSegment);
-        structureTuple.CopyTo(tuple, 0, structureExpression.Mapping.Offset, structureTuple.Count);
-      }
-      else if (expression is EntityExpression) {
-        var entityExpression = (EntityExpression) expression;
-        var entity = (Entity) item;
-        var keyTuple = entity.Key.Value;
-        keyTuple.CopyTo(tuple, 0, entityExpression.Key.Mapping.Offset, keyTuple.Count);
-      }
-      else if (expression is KeyExpression) {
-        var keyExpression = (KeyExpression) expression;
-        var key = (Key) item;
-        var keyTuple = key.Value;
-        keyTuple.CopyTo(tuple, 0, keyExpression.Mapping.Offset, keyTuple.Count);
-      }
-      else
-        throw new NotSupportedException();
     }
 
     private LocalCollectionExpression BuildLocalCollectionExpression(Type type, HashSet<Type> processedTypes, ref int columnIndex, MemberInfo parentMember, TupleTypeCollection types)

--- a/Orm/Xtensive.Orm/Orm/Linq/MemberCompilation/MemberCompilerProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/MemberCompilation/MemberCompilerProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2020 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -321,8 +321,8 @@ namespace Xtensive.Orm.Linq.MemberCompilation
         else if (canonicalMember is MethodInfo methodInfo) {
           canonicalMember = GetCanonicalMethod(methodInfo, targetType.GetMethods());
         }
-        else if (canonicalMember is ConstructorInfo)
-          canonicalMember = GetCanonicalMethod((ConstructorInfo) canonicalMember, targetType.GetConstructors());
+        else if (canonicalMember is ConstructorInfo constructorInfo)
+          canonicalMember = GetCanonicalMethod(constructorInfo, targetType.GetConstructors());
         else
           canonicalMember = null;
       }

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -701,12 +701,12 @@ namespace Xtensive.Orm.Linq
       var leftIsConstant = context.Evaluator.CanBeEvaluated(left);
       bool leftOrRightIsIndex = false;
 
-      if (left is IndexExpression) {
-        left = VisitIndex((IndexExpression) left);
+      if (left is IndexExpression leftIndexExpression) {
+        left = VisitIndex(leftIndexExpression);
         leftOrRightIsIndex = true;
       }
-      if (right is IndexExpression) {
-        right = VisitIndex((IndexExpression) right);
+      if (right is IndexExpression rightIndexExpression) {
+        right = VisitIndex(rightIndexExpression);
         leftOrRightIsIndex = true;
       }
 
@@ -974,12 +974,13 @@ namespace Xtensive.Orm.Linq
       Type structureType)
     {
       expression = expression.StripCasts();
-      if (expression is IPersistentExpression)
-        return ((IPersistentExpression) expression)
+      if (expression is IPersistentExpression persistentExpression) {
+        return persistentExpression
           .Fields
           .Where(field => field.GetMemberType()==MemberType.Primitive)
           .Select(e => (Expression) e)
           .ToList();
+      }
 
       ConstantExpression nullExpression = Expression.Constant(null, structureType);
       BinaryExpression isNullExpression = Expression.Equal(expression, nullExpression);
@@ -1035,8 +1036,9 @@ namespace Xtensive.Orm.Linq
     private static IList<Expression> GetEntityFields(Expression expression, IEnumerable<Type> keyFieldTypes)
     {
       expression = expression.StripCasts();
-      if (expression is IEntityExpression)
-        return GetKeyFields(((IEntityExpression) expression).Key, null);
+      if (expression is IEntityExpression entityExpression) {
+        return GetKeyFields(entityExpression.Key, null);
+      }
 
 
       Expression keyExpression;

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnGroup.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnGroup.cs
@@ -17,23 +17,23 @@ namespace Xtensive.Orm.Model
   /// </summary>
   [Serializable]
   [DebuggerDisplay("Type = {TypeInfoRef}, Keys = {Keys}, Columns = {Columns}")]
-  public sealed class ColumnGroup
+  public readonly struct ColumnGroup
   {
     /// <summary>
     /// Gets the <see cref="Model.TypeInfoRef"/> pointing to <see cref="TypeInfo"/>
     /// this column group belongs to.
     /// </summary>
-    public TypeInfoRef TypeInfoRef { get; private set; }
+    public TypeInfoRef TypeInfoRef { get; }
 
     /// <summary>
     /// Gets the indexes of key columns.
     /// </summary>
-    public IReadOnlyList<int> Keys { get; private set; }
+    public IReadOnlyList<int> Keys { get; }
 
     /// <summary>
     /// Gets the indexes of all columns.
     /// </summary>
-    public IReadOnlyList<int> Columns { get; private set; }
+    public IReadOnlyList<int> Columns { get; }
 
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnInfoRef.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnInfoRef.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Kochetov
 // Created:    2007.09.21
 
@@ -18,52 +18,44 @@ namespace Xtensive.Orm.Model
   /// </summary>
   [Serializable]
   [DebuggerDisplay("TypeName = {TypeName}, FieldName = {FieldName}, ColumnName = {ColumnName}, CultureInfo = {CultureInfo}")]
-  public sealed class ColumnInfoRef: IEquatable<ColumnInfoRef>
+  public readonly struct ColumnInfoRef: IEquatable<ColumnInfoRef>
   {
     /// <summary>
     /// Gets type name of reflecting <see cref="TypeInfo"/>.
     /// </summary>
-    public string TypeName { get; private set; }
+    public string TypeName { get; }
 
     /// <summary>
     /// Gets name of the <see cref="FieldInfo"/>.
     /// </summary>
-    public string FieldName { get; private set; }
+    public string FieldName { get; }
 
     /// <summary>
     /// Gets name of the <see cref="ColumnInfo"/>.
     /// </summary>
-    public string ColumnName { get; private set; }
+    public string ColumnName { get; }
 
     /// <summary>
     /// Gets <see cref="CultureInfo"/> info of the <see cref="ColumnInfo"/>.
     /// </summary>
-    public CultureInfo CultureInfo { get; private set; }
+    public CultureInfo CultureInfo { get; }
 
     /// <summary>
     /// Resolves this instance to <see cref="ColumnInfo"/> object within specified <paramref name="model"/>.
     /// </summary>
     /// <param name="model">Domain model.</param>
-    public ColumnInfo Resolve(DomainModel model)
-    {
-      TypeInfo type;
-      if (!model.Types.TryGetValue(TypeName, out type))
-        throw new InvalidOperationException(string.Format(Strings.ExCouldNotResolveXYWithinDomain, "type", TypeName));
-      FieldInfo field;
-      if (!type.Fields.TryGetValue(FieldName, out field))
-        throw new InvalidOperationException(string.Format(Strings.ExCouldNotResolveXYWithinDomain, "field", FieldName));
-      if (field.Column == null)
-        throw new InvalidOperationException(string.Format(Strings.ExCouldNotResolveXYWithinDomain, "column", ColumnName));
-      return field.Column;
-    }
+    public ColumnInfo Resolve(DomainModel model) =>
+      !model.Types.TryGetValue(TypeName, out var type)
+        ? throw new InvalidOperationException(string.Format(Strings.ExCouldNotResolveXYWithinDomain, "type", TypeName))
+        : !type.Fields.TryGetValue(FieldName, out var field)
+          ? throw new InvalidOperationException(string.Format(Strings.ExCouldNotResolveXYWithinDomain, "field", FieldName))
+          : field.Column ?? throw new InvalidOperationException(string.Format(Strings.ExCouldNotResolveXYWithinDomain, "column", ColumnName));
 
     /// <summary>
     /// Creates reference for <see cref="ColumnInfo"/>.
     /// </summary>
-    public static implicit operator ColumnInfoRef (ColumnInfo columnInfo)
-    {
-      return new ColumnInfoRef(columnInfo);
-    }
+    public static implicit operator ColumnInfoRef(ColumnInfo columnInfo) => 
+      new ColumnInfoRef(columnInfo);
 
     #region Equality members, ==, !=
 
@@ -75,10 +67,7 @@ namespace Xtensive.Orm.Model
     /// <returns>
     /// The result of the operator.
     /// </returns>
-    public static bool operator !=(ColumnInfoRef x, ColumnInfoRef y)
-    {
-      return !Equals(x, y);
-    }
+    public static bool operator !=(in ColumnInfoRef x, in ColumnInfoRef y) => !x.Equals(y);
 
     /// <summary>
     /// Implements the operator ==.
@@ -88,47 +77,31 @@ namespace Xtensive.Orm.Model
     /// <returns>
     /// The result of the operator.
     /// </returns>
-    public static bool operator ==(ColumnInfoRef x, ColumnInfoRef y)
-    {
-      return Equals(x, y);
-    }
+    public static bool operator ==(in ColumnInfoRef x, in ColumnInfoRef y) => x.Equals(y);
 
     /// <inheritdoc/>
-    public bool Equals(ColumnInfoRef other)
-    {
-      if (ReferenceEquals(other, null))
-        return false;
-      return 
-        FieldName==other.FieldName && TypeName==other.TypeName;
-    }
+    public bool Equals(ColumnInfoRef other) =>
+        FieldName == other.FieldName && TypeName == other.TypeName;
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (ReferenceEquals(this, obj))
-        return true;
-      return Equals(obj as ColumnInfoRef);
-    }
+    public override bool Equals(object obj) =>
+      obj is ColumnInfoRef other && Equals(other);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      return unchecked( FieldName.GetHashCode() + 29*TypeName.GetHashCode() );
-    }
+    public override int GetHashCode() =>
+      HashCode.Combine(FieldName, TypeName);
 
     #endregion
 
     /// <inheritdoc/>
-    public override string ToString()
-    {
-      return $"{TypeName}.{FieldName} ({ColumnName})";
-    }
+    public override string ToString() =>
+      $"{TypeName}.{FieldName} ({ColumnName})";
 
 
     // Constructors
 
     /// <summary>
-    ///   Initializes a new instance of this class.
+    ///   Initializes a new instance of this struct.
     /// </summary>
     /// <param name="columnInfo">The <see cref="ColumnInfo"/> instance.</param>
     public ColumnInfoRef(ColumnInfo columnInfo)
@@ -142,7 +115,7 @@ namespace Xtensive.Orm.Model
 
 
     /// <summary>
-    ///   Initializes a new instance of this class.
+    ///   Initializes a new instance of this struct.
     /// </summary>
     /// <param name="typeName">Column type name.</param>
     /// <param name="columnName">Column name.</param>

--- a/Orm/Xtensive.Orm/Orm/Model/Stored/StoredFieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/Stored/StoredFieldInfo.cs
@@ -70,8 +70,7 @@ namespace Xtensive.Orm.Model.Stored
         else {
           var queue = new Queue<StoredFieldInfo>();
           queue.Enqueue(this);
-          while (queue.Count > 0) {
-            var field = queue.Dequeue();
+          while (queue.TryDequeue(out var field)) {
             if (field.IsPrimitive)
               result.Add(field);
             else

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
@@ -45,12 +45,12 @@ namespace Xtensive.Orm.Model
     private readonly NodeCollection<IndexInfo> affectedIndexes;
     private readonly DomainModel               model;
     private TypeAttributes                     attributes;
-    private ReadOnlyCollection<TypeInfo>             ancestors;
-    private ReadOnlyCollection<AssociationInfo>      targetAssociations;
-    private ReadOnlyCollection<AssociationInfo>      ownerAssociations;
+    private IReadOnlyList<TypeInfo>             ancestors;
+    private IReadOnlyList<AssociationInfo>      targetAssociations;
+    private IReadOnlyList<AssociationInfo>      ownerAssociations;
     private IReadOnlyList<AssociationInfo>      removalSequence;
-    private ReadOnlyCollection<FieldInfo>            versionFields;
-    private ReadOnlyCollection<ColumnInfo> versionColumns;
+    private IReadOnlyList<FieldInfo>            versionFields;
+    private IReadOnlyList<ColumnInfo> versionColumns;
     private IList<IObjectValidator> validators;
     private Type                               underlyingType;
     private HierarchyInfo                      hierarchy;
@@ -610,8 +610,8 @@ namespace Xtensive.Orm.Model
 
       if (IsEntity) {
         if (HasVersionRoots) {
-          versionFields = Array.AsReadOnly(Array.Empty<FieldInfo>());
-          versionColumns = Array.AsReadOnly(Array.Empty<ColumnInfo>());
+          versionFields = Array.Empty<FieldInfo>();
+          versionColumns = Array.Empty<ColumnInfo>();
         }
         else {
           versionFields = InnerGetVersionFields().AsReadOnly();

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfoRef.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfoRef.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Kochetov
 // Created:    2008.07.22
 
@@ -16,34 +16,26 @@ namespace Xtensive.Orm.Model
   /// </summary>
   [Serializable]
   [DebuggerDisplay("TypeName = {TypeName}")]
-  public sealed class TypeInfoRef : IEquatable<TypeInfoRef>
+  public readonly struct TypeInfoRef : IEquatable<TypeInfoRef>
   {
-    private const string ToStringFormat = "Type '{0}'";
-
     /// <summary>
     /// Name of the type.
     /// </summary>
-    public string TypeName { get; private set; }
+    public string TypeName { get; }
 
     /// <summary>
     /// Resolves this instance to <see cref="TypeInfo"/> object within specified <paramref name="model"/>.
     /// </summary>
     /// <param name="model">Domain model.</param>
-    public TypeInfo Resolve(DomainModel model)
-    {
-      TypeInfo type;
-      if (!model.Types.TryGetValue(TypeName, out type))
-        throw new InvalidOperationException(string.Format(Strings.ExCouldNotResolveXYWithinDomain, "type", TypeName));
-      return type;
-    }
+    public TypeInfo Resolve(DomainModel model) =>
+      model.Types.TryGetValue(TypeName, out var type)
+        ? type
+        : throw new InvalidOperationException(string.Format(Strings.ExCouldNotResolveXYWithinDomain, "type", TypeName));
 
     /// <summary>
     /// Creates reference for <see cref="TypeInfo"/>.
     /// </summary>
-    public static implicit operator TypeInfoRef (TypeInfo typeInfo)
-    {
-      return new TypeInfoRef(typeInfo);
-    }
+    public static implicit operator TypeInfoRef (TypeInfo typeInfo) => new TypeInfoRef(typeInfo);
 
     #region Equality members, ==, !=
 
@@ -55,10 +47,7 @@ namespace Xtensive.Orm.Model
     /// <returns>
     /// The result of the operator.
     /// </returns>
-    public static bool operator !=(TypeInfoRef x, TypeInfoRef y)
-    {
-      return !Equals(x, y);
-    }
+    public static bool operator !=(TypeInfoRef x, TypeInfoRef y) => !Equals(x, y);
 
     /// <summary>
     /// Implements the operator ==.
@@ -68,41 +57,23 @@ namespace Xtensive.Orm.Model
     /// <returns>
     /// The result of the operator.
     /// </returns>
-    public static bool operator ==(TypeInfoRef x, TypeInfoRef y)
-    {
-      return Equals(x, y);
-    }
+    public static bool operator ==(TypeInfoRef x, TypeInfoRef y) => Equals(x, y);
 
     /// <inheritdoc/>
-    public bool Equals(TypeInfoRef other)
-    {
-      if (ReferenceEquals(other, null))
-        return false;
-      return 
-        TypeName==other.TypeName;
-    }
+    public bool Equals(TypeInfoRef other) =>
+        TypeName == other.TypeName;
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (ReferenceEquals(this, obj))
-        return true;
-      return Equals(obj as TypeInfoRef);
-    }
+    public override bool Equals(object obj) =>
+      obj is TypeInfoRef other && Equals(other);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      return unchecked( TypeName.GetHashCode() );
-    }
+    public override int GetHashCode() => TypeName.GetHashCode();
 
     #endregion
 
     /// <inheritdoc/>
-    public override string ToString()
-    {
-      return string.Format(ToStringFormat, TypeName);
-    }
+    public override string ToString() => $"Type '{TypeName}'";
 
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/Command.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/Command.cs
@@ -136,7 +136,7 @@ namespace Xtensive.Orm.Providers
       }
 
       prepared = true;
-      underlyingCommand.CommandText = origin.Driver.BuildBatch(statements.ToArray());
+      underlyingCommand.CommandText = origin.Driver.BuildBatch(statements);
       return underlyingCommand;
     }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/DbCommandExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/DbCommandExtensions.cs
@@ -29,10 +29,14 @@ namespace Xtensive.Orm.Providers
       result.Append(" [");
       foreach (DbParameter parameter in command.Parameters) {
         var value = parameter.Value;
-        if (value is DateTime)
-          value = ((DateTime) value).ToString("yyyy-MM-dd HH:mm:ss.fffffff");
-        else if (value is DateTimeOffset)
-          value = ((DateTimeOffset) value).ToString("yyyy-MM-dd HH:mm:ss.fffffffK");
+        switch (value) {
+          case DateTime dateTime:
+            value = dateTime.ToString("yyyy-MM-dd HH:mm:ss.fffffff");
+            break;
+          case DateTimeOffset dateTimeOffset:
+            value = dateTimeOffset.ToString("yyyy-MM-dd HH:mm:ss.fffffffK");
+            break;
+        }
         result.AppendFormat("{0}='{1}';", parameter.ParameterName, value);
       }
       result.Remove(result.Length - 1, 1);

--- a/Orm/Xtensive.Orm/Orm/Providers/EnumerationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/EnumerationContext.cs
@@ -36,8 +36,7 @@ namespace Xtensive.Orm.Providers
 
       public void Dispose()
       {
-        while (finalizationQueue.Count > 0) {
-          var materializeSelf = finalizationQueue.Dequeue();
+        while (finalizationQueue.TryDequeue(out var materializeSelf)) {
           materializeSelf.Invoke();
         }
         transactionScope.DisposeSafely();

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
@@ -253,13 +253,11 @@ namespace Xtensive.Orm.Providers
       }
 
       //handle wrapped enums
-      var container = left as SqlContainer;
-      if (container != null) {
-        left = TryUnwrapEnum(container);
+      if (left is SqlContainer leftContainer) {
+        left = TryUnwrapEnum(leftContainer);
       }
-      container = right as SqlContainer;
-      if (container != null) {
-        right = TryUnwrapEnum(container);
+      if (right is SqlContainer rightContainer) {
+        right = TryUnwrapEnum(rightContainer);
       }
 
       switch (expression.NodeType) {

--- a/Orm/Xtensive.Orm/Orm/Providers/SessionHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SessionHandler.cs
@@ -38,8 +38,9 @@ namespace Xtensive.Orm.Providers
     public SessionHandler GetRealHandler()
     {
       var handler = this;
-      while (handler is ChainingSessionHandler)
-        handler = (handler as ChainingSessionHandler).ChainedHandler;
+      while (handler is ChainingSessionHandler chainingSessionHandler) {
+        handler = chainingSessionHandler.ChainedHandler;
+      }
       return handler;
     }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlExecutor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlExecutor.cs
@@ -194,7 +194,7 @@ namespace Xtensive.Orm.Providers
     {
       var groups = SplitOnEmptyEntries(statements);
       foreach (var group in groups) {
-        var batch = driver.BuildBatch(group.ToArray());
+        var batch = driver.BuildBatch(group);
         if (string.IsNullOrEmpty(batch)) {
           return;
         }
@@ -208,7 +208,7 @@ namespace Xtensive.Orm.Providers
     {
       var groups = SplitOnEmptyEntries(statements);
       foreach (var group in groups) {
-        var batch = driver.BuildBatch(group.ToArray());
+        var batch = driver.BuildBatch(group);
         if (string.IsNullOrEmpty(batch)) {
           return;
         }
@@ -220,7 +220,7 @@ namespace Xtensive.Orm.Providers
       }
     }
 
-    private static IEnumerable<IEnumerable<string>> SplitOnEmptyEntries(IEnumerable<string> items)
+    private static IEnumerable<IReadOnlyList<string>> SplitOnEmptyEntries(IEnumerable<string> items)
     {
       var group = new List<string>();
       foreach (var item in items) {

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
@@ -48,7 +48,7 @@ namespace Xtensive.Orm.Providers
 
     public ServerInfo ServerInfo { get; private set; }
 
-    public string BuildBatch(string[] statements)
+    public string BuildBatch(IReadOnlyList<string> statements)
     {
       return translator.BuildBatch(statements);
     }

--- a/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
@@ -925,11 +925,12 @@ namespace Xtensive.Orm
       if (keyValues.Length == 0)
         throw new ArgumentException(Strings.ExKeyValuesArrayIsEmpty, "keyValues");
       if (keyValues.Length == 1) {
-        var keyValue = keyValues[0];
-        if (keyValue is Key)
-          return keyValue as Key;
-        if (keyValue is Entity)
-          return (keyValue as Entity).Key;
+        switch (keyValues[0]) {
+          case Key key:
+            return key;
+          case Entity entity:
+            return entity.Key;
+        }
       }
       return Key.Create(session.Domain, session.StorageNodeId, typeof(T), TypeReferenceAccuracy.BaseType, keyValues);
     }

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
@@ -40,10 +40,11 @@ namespace Xtensive.Orm
       ArgumentValidator.EnsureArgumentNotNull(source, "source");
       ArgumentValidator.EnsureArgumentNotNull(tag, "tag");
 
-      var errorMessage = Strings.ExTakeDoesNotSupportQueryProviderOfTypeX;
       var providerType = source.Provider.GetType();
-      if (providerType != WellKnownOrmTypes.QueryProvider)
+      if (providerType != WellKnownOrmTypes.QueryProvider) {
+        var errorMessage = Strings.ExTakeDoesNotSupportQueryProviderOfTypeX;
         throw new NotSupportedException(string.Format(errorMessage, providerType));
+      }
 
       var genericMethod = WellKnownMembers.Queryable.ExtensionTag.MakeGenericMethod(new[] { typeof(TSource) });
       var expression = Expression.Call(null, genericMethod, new[] { source.Expression, Expression.Constant(tag)});
@@ -63,10 +64,11 @@ namespace Xtensive.Orm
       ArgumentValidator.EnsureArgumentNotNull(source, "source");
       ArgumentValidator.EnsureArgumentNotNull(tag, "tag");
 
-      var errorMessage = Strings.ExTakeDoesNotSupportQueryProviderOfTypeX;
       var providerType = source.Provider.GetType();
-      if (providerType != WellKnownOrmTypes.QueryProvider)
+      if (providerType != WellKnownOrmTypes.QueryProvider) {
+        var errorMessage = Strings.ExTakeDoesNotSupportQueryProviderOfTypeX;
         throw new NotSupportedException(string.Format(errorMessage, providerType));
+      }
 
       var genericMethod = WellKnownMembers.Queryable.ExtensionTag.MakeGenericMethod(new[] { source.ElementType });
       var expression = Expression.Call(null, genericMethod, new[] { source.Expression, Expression.Constant(tag) });

--- a/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
@@ -20,7 +20,7 @@ namespace Xtensive.Orm.Rse
   public sealed class ColumnCollection : IReadOnlyList<Column>
   {
     private readonly Dictionary<string, int> nameIndex;
-    private readonly List<Column> columns;
+    private readonly IReadOnlyList<Column> columns;
 
     /// <summary>
     /// Gets the number of <see href="Column"/>s in the collection.
@@ -39,14 +39,8 @@ namespace Xtensive.Orm.Rse
     /// Returns <see cref="Column"/> if it was found; otherwise <see langword="null"/>.
     /// </remarks>
     /// <param name="fullName">Full name of the <see cref="Column"/> to find.</param>
-    public Column this[string fullName] {
-      get {
-        int index;
-        if (nameIndex.TryGetValue(fullName, out index))
-          return this[index];
-        return null;
-      }
-    }
+    public Column this[string fullName] =>
+      nameIndex.TryGetValue(fullName, out var index) ? columns[index] : null;
 
     /// <summary>
     /// Joins this collection with specified the column collection.
@@ -72,10 +66,7 @@ namespace Xtensive.Orm.Rse
     /// <summary>
     /// Returns an enumerator that iterates through the <see href="ColumnCollection"/>.
     /// </summary>
-    public List<Column>.Enumerator GetEnumerator() => columns.GetEnumerator();
-
-    /// <inheritdoc/>
-    IEnumerator<Column> IEnumerable<Column>.GetEnumerator() => GetEnumerator();
+    public IEnumerator<Column> GetEnumerator() => columns.GetEnumerator();
     
     /// <inheritdoc/>
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
@@ -85,23 +76,14 @@ namespace Xtensive.Orm.Rse
     /// <summary>
     /// Initializes a new instance of this class.
     /// </summary>
-    /// <param name="collection">Collection of items to add.</param>
-    public ColumnCollection(IEnumerable<Column> collection)
-      : this(collection.ToList())
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of this class.
-    /// </summary>
     /// <param name="columns">Collection of items to add.</param>
-    public ColumnCollection(List<Column> columns)
+    public ColumnCollection(IEnumerable<Column> columns)
     {
-      this.columns = columns;
-      var count = columns.Count;
+      this.columns = columns as IReadOnlyList<Column> ?? columns.ToList();
+      var count = this.columns.Count;
       nameIndex = new Dictionary<string, int>(count);
       for (var index = count; index-- > 0;) {
-        nameIndex.Add(columns[index].Name, index);
+        nameIndex.Add(this.columns[index].Name, index);
       }
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Rse/ColumnGroupCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/ColumnGroupCollection.cs
@@ -53,9 +53,9 @@ namespace Xtensive.Orm.Rse
     /// Initializes a new instance of this class.
     /// </summary>
     /// <param name="items">The collection items.</param>
-    public ColumnGroupCollection(IEnumerable<ColumnGroup> items)
+    public ColumnGroupCollection(IReadOnlyList<ColumnGroup> items)
     {
-      this.items = items as IReadOnlyList<ColumnGroup> ?? items.ToList();
+      this.items = items;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Rse/ColumnGroupCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/ColumnGroupCollection.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alex Kofman
 // Created:    2008.08.07
 
@@ -44,9 +44,7 @@ namespace Xtensive.Orm.Rse
     /// </summary>    
     public static ColumnGroupCollection Empty {
       [DebuggerStepThrough]
-      get {
-        return cachedEmpty.Value;
-      }
+      get => cachedEmpty.Value;
     }
 
     // Constructors
@@ -57,16 +55,7 @@ namespace Xtensive.Orm.Rse
     /// <param name="items">The collection items.</param>
     public ColumnGroupCollection(IEnumerable<ColumnGroup> items)
     {
-      this.items = items.ToList();
-    }
-
-    /// <summary>
-    /// Initializes a new instance of this class.
-    /// </summary>
-    /// <param name="items">The collection items.</param>
-    public ColumnGroupCollection(IReadOnlyList<ColumnGroup> items)
-    {
-      this.items = items;
+      this.items = items as IReadOnlyList<ColumnGroup> ?? items.ToList();
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Alexey Kochetov
 // Created:    2007.09.21
 
@@ -20,7 +20,7 @@ namespace Xtensive.Orm.Rse
     /// <summary>
     /// Gets the reference that describes a column.
     /// </summary>    
-    public ColumnInfoRef ColumnInfoRef { get; private set; }
+    public ColumnInfoRef ColumnInfoRef { get; }
 
     /// <inheritdoc/>
     public override string ToString()
@@ -61,7 +61,7 @@ namespace Xtensive.Orm.Rse
     /// <param name="columnInfoRef"><see cref="ColumnInfoRef"/> property value.</param>
     /// <param name="index"><see cref="Column.Index"/> property value.</param>
     /// <param name="type"><see cref="Column.Type"/> property value.</param>
-    public MappedColumn(ColumnInfoRef columnInfoRef, int index, Type type)
+    public MappedColumn(in ColumnInfoRef columnInfoRef, int index, Type type)
       : this(columnInfoRef, columnInfoRef.ColumnName, index, type)
     {
     }
@@ -73,7 +73,7 @@ namespace Xtensive.Orm.Rse
     /// <param name="name"><see cref="Column.Name"/> property value.</param>
     /// <param name="index"><see cref="Column.Index"/> property value.</param>
     /// <param name="type"><see cref="Column.Type"/> property value.</param>
-    public MappedColumn(ColumnInfoRef columnInfoRef, string name, int index, Type type)
+    public MappedColumn(in ColumnInfoRef columnInfoRef, string name, int index, Type type)
       : base(name, index, type, null)
     {
       ColumnInfoRef = columnInfoRef;

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ConcatProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ConcatProvider.cs
@@ -28,9 +28,7 @@ namespace Xtensive.Orm.Rse.Providers
       for (int i = 0; i < Left.Header.Columns.Count; i++) {
         var leftColumn = Left.Header.Columns[i];
         var rightColumn = Right.Header.Columns[i];
-        if (leftColumn is MappedColumn && rightColumn is MappedColumn) {
-          var leftMappedColumn = (MappedColumn) leftColumn;
-          var rightMappedColumn = (MappedColumn) rightColumn;
+        if (leftColumn is MappedColumn leftMappedColumn && rightColumn is MappedColumn rightMappedColumn) {
           if (leftMappedColumn.ColumnInfoRef.Equals(rightMappedColumn.ColumnInfoRef)) {
             columns.Add(leftMappedColumn);
             mappedColumnIndexes.Add(i);

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -195,7 +195,7 @@ namespace Xtensive.Orm.Rse
       return new RecordSetHeader(
         resultTupleDescriptor,
         resultColumns,
-        resultGroups,
+        resultGroups.ToList(),
         null,
         resultOrder);
     }
@@ -292,7 +292,7 @@ namespace Xtensive.Orm.Rse
     public RecordSetHeader(
       TupleDescriptor tupleDescriptor,
       IEnumerable<Column> columns,
-      IEnumerable<ColumnGroup> columnGroups)
+      IReadOnlyList<ColumnGroup> columnGroups)
       : this(tupleDescriptor, columns, columnGroups, null, null)
     {
     }
@@ -325,7 +325,7 @@ namespace Xtensive.Orm.Rse
     public RecordSetHeader(
       TupleDescriptor tupleDescriptor,
       IEnumerable<Column> columns,
-      IEnumerable<ColumnGroup> columnGroups,
+      IReadOnlyList<ColumnGroup> columnGroups,
       TupleDescriptor orderKeyDescriptor,
       DirectionCollection<int> order)
     {

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -334,18 +334,14 @@ namespace Xtensive.Orm.Rse
 
       TupleDescriptor = tupleDescriptor;
       // Unsafe perf. optimization: if you pass a list, it should be immutable!
-      Columns = columns is List<Column> columnList
-        ? new ColumnCollection(columnList)
-        : new ColumnCollection(columns);
-      if (tupleDescriptor.Count!=Columns.Count)
+      Columns = new ColumnCollection(columns);
+      if (tupleDescriptor.Count != Columns.Count)
         throw new ArgumentOutOfRangeException("columns.Count");
 
       ColumnGroups = columnGroups == null
         ? ColumnGroupCollection.Empty
         // Unsafe perf. optimization: if you pass a list, it should be immutable!
-        : (columnGroups is List<ColumnGroup> columnGroupList
-          ? new ColumnGroupCollection(columnGroupList)
-          : new ColumnGroupCollection(columnGroups));
+        : new ColumnGroupCollection(columnGroups);
 
       orderTupleDescriptor = orderKeyDescriptor ?? TupleDescriptor.Empty;
       Order = order ?? new DirectionCollection<int>();

--- a/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryParameterBinding.cs
+++ b/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryParameterBinding.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2020 Xtensive LLC.
+// Copyright (C) 2012-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -13,7 +13,7 @@ namespace Xtensive.Orm.Services
   /// <summary>
   /// Binding of a query parameter.
   /// </summary>
-  public sealed class QueryParameterBinding
+  public readonly struct QueryParameterBinding
   {
     /// <summary>
     /// Gets type of the parameter.
@@ -22,14 +22,7 @@ namespace Xtensive.Orm.Services
     /// Any user-created <see cref="QueryParameterBinding"/>
     /// always has this property set to non <see langword="null"/> value.
     /// </summary>
-    public Type ValueType
-    {
-      get
-      {
-        var mapping = RealBinding.TypeMapping;
-        return mapping!=null ? mapping.Type : null;
-      }
-    }
+    public Type ValueType => RealBinding.TypeMapping?.Type;
 
     /// <summary>
     /// Gets accessor of the parameter.
@@ -37,21 +30,15 @@ namespace Xtensive.Orm.Services
     /// to <see cref="ValueType"/>
     /// unless <see cref="ValueType"/> is null.
     /// </summary>
-    public Func<ParameterContext, object> ValueAccessor
-    {
-      get { return RealBinding.ValueAccessor; }
-    }
+    public Func<ParameterContext, object> ValueAccessor => RealBinding.ValueAccessor;
 
     /// <summary>
     /// Gets <see cref="SqlExpression"/> that allows
     /// to access parameter in SQL DOM query.
     /// </summary>
-    public SqlExpression ParameterReference
-    {
-      get { return RealBinding.ParameterReference; }
-    }
+    public SqlExpression ParameterReference => RealBinding.ParameterReference;
 
-    internal Providers.QueryParameterBinding RealBinding { get; private set; }
+    internal Providers.QueryParameterBinding RealBinding { get; }
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryRequest.cs
+++ b/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryRequest.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2012 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2012-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2012.02.26
 
@@ -17,25 +17,20 @@ namespace Xtensive.Orm.Services
   /// might contain reference to a session thus turning corresponding request
   /// to a session-dependent object.
   /// </summary>
-  public sealed class QueryRequest
+  public readonly struct QueryRequest
   {
     /// <summary>
     /// Gets compiled statement.
     /// </summary>
-    public SqlCompilationResult CompiledQuery
-    {
-      get { return RealRequest.GetCompiledStatement(); }
-    }
+    public SqlCompilationResult CompiledQuery => RealRequest.GetCompiledStatement();
 
     /// <summary>
     /// Gets all <see cref="QueryParameterBinding"/> associated with this request.
     /// </summary>
-    public IEnumerable<QueryParameterBinding> ParameterBindings
-    {
-      get { return RealRequest.ParameterBindings.Select(b => new QueryParameterBinding(b)); }
-    }
+    public IEnumerable<QueryParameterBinding> ParameterBindings =>
+      RealRequest.ParameterBindings.Select(b => new QueryParameterBinding(b));
 
-    internal UserQueryRequest RealRequest { get; private set; }
+    internal UserQueryRequest RealRequest { get; }
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryTranslationResult.cs
+++ b/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryTranslationResult.cs
@@ -1,33 +1,34 @@
-﻿// Copyright (C) 2012 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2012-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2012.02.27
 
 using System.Collections.Generic;
 using System.Linq;
 using Xtensive.Sql;
+using Xtensive.Sql.Dml;
 
 namespace Xtensive.Orm.Services
 {
   /// <summary>
   /// Result of LINQ query translation.
   /// </summary>
-  public sealed class QueryTranslationResult
+  public readonly struct QueryTranslationResult
   {
     /// <summary>
     /// Gets or sets SQL DOM query.
     /// </summary>
-    public ISqlCompileUnit Query { get; set; }
+    public SqlSelect Query { get; }
 
     /// <summary>
     /// Gets or sets parameter bindings for translated query.
     /// </summary>
-    public IList<QueryParameterBinding> ParameterBindings { get; set; }
+    public IReadOnlyList<QueryParameterBinding> ParameterBindings { get; }
 
     // Constructors
 
-    internal QueryTranslationResult(ISqlCompileUnit query, IEnumerable<QueryParameterBinding> bindings)
+    internal QueryTranslationResult(SqlSelect query, IEnumerable<QueryParameterBinding> bindings)
     {
       Query = query;
       ParameterBindings = bindings.ToList();

--- a/Orm/Xtensive.Orm/Orm/Services/TransactionMonitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Services/TransactionMonitor.cs
@@ -30,8 +30,7 @@ namespace Xtensive.Orm.Services
 
     private void EndTransaction(object sender, TransactionEventArgs e)
     {
-      if (registry.TryGetValue(Session.Transaction, out var set)) {
-        registry.Remove(Session.Transaction);
+      if (registry.Remove(Session.Transaction, out var set)) {
         foreach (var disposable in set) {
           disposable.DisposeSafely();
         }

--- a/Orm/Xtensive.Orm/Orm/TypeReference.cs
+++ b/Orm/Xtensive.Orm/Orm/TypeReference.cs
@@ -1,6 +1,6 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2021 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 // Created by: Dmitri Maximov
 // Created:    2009.10.09
 
@@ -14,17 +14,17 @@ namespace Xtensive.Orm
   /// Reference to <see cref="TypeInfo"/> with the specified degree of accuracy.
   /// </summary>
   [Serializable]
-  public struct TypeReference
+  public readonly struct TypeReference
   {
     /// <summary>
     /// Gets or sets the referenced type.
     /// </summary>
-    public TypeInfo Type { get; private set; }
+    public TypeInfo Type { get; }
 
     /// <summary>
     /// Gets or sets the type reference accuracy.
     /// </summary>
-    public TypeReferenceAccuracy Accuracy { get; private set; }
+    public TypeReferenceAccuracy Accuracy { get; }
 
 
     // Constructor
@@ -35,7 +35,6 @@ namespace Xtensive.Orm
     /// <param name="type">The referenced type.</param>
     /// <param name="accuracy">The type reference accuracy.</param>
     public TypeReference(TypeInfo type, TypeReferenceAccuracy accuracy)
-      : this()
     {
       Type = type;
       Accuracy = accuracy;

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/HintGenerator.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/HintGenerator.cs
@@ -955,8 +955,7 @@ namespace Xtensive.Orm.Upgrade
         tasks.Enqueue(task);
       }
 
-      while (tasks.Count > 0) {
-        var task = tasks.Dequeue();
+      while (tasks.TryDequeue(out var task)) {
         var source = task.First;
         var target = task.Second;
         // both fields are primitive -> put to result is types match

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SqlActionTranslator.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SqlActionTranslator.cs
@@ -116,9 +116,10 @@ namespace Xtensive.Orm.Upgrade
 
     private void VisitAction(NodeAction action)
     {
-      if (action is GroupingNodeAction)
-        foreach (var nodeAction in ((GroupingNodeAction) action).Actions)
+      if (action is GroupingNodeAction groupingNodeAction) {
+        foreach (var nodeAction in groupingNodeAction.Actions)
           VisitAction(nodeAction);
+      }
       else if (action is CreateNodeAction createNodeAction)
         VisitCreateAction(createNodeAction);
       else if (action is RemoveNodeAction removeNodeAction)

--- a/Orm/Xtensive.Orm/Orm/VersionSet.cs
+++ b/Orm/Xtensive.Orm/Orm/VersionSet.cs
@@ -240,11 +240,7 @@ namespace Xtensive.Orm
     public bool Remove(Key key)
     {
       ArgumentValidator.EnsureArgumentNotNull(key, "key");
-      if (Contains(key)) {
-        versions.Remove(key);
-        return true;
-      }
-      return false;
+      return versions.Remove(key);
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlCompiler.cs
@@ -59,26 +59,26 @@ namespace Xtensive.Sql.Compiler
     {
       using (context.EnterScope(node)) {
         AppendTranslated(node, AlterDomainSection.Entry);
-        if (node.Action is SqlAddConstraint) {
-          var constraint = (DomainConstraint) ((SqlAddConstraint) node.Action).Constraint;
-          AppendTranslated(node, AlterDomainSection.AddConstraint);
-          AppendTranslated(constraint, ConstraintSection.Entry);
-          AppendTranslated(constraint, ConstraintSection.Check);
-          constraint.Condition.AcceptVisitor(this);
-          AppendTranslated(constraint, ConstraintSection.Exit);
-        }
-        else if (node.Action is SqlDropConstraint) {
-          var action = node.Action as SqlDropConstraint;
-          AppendTranslated(node, AlterDomainSection.DropConstraint);
-          AppendTranslated(action.Constraint, ConstraintSection.Entry);
-        }
-        else if (node.Action is SqlSetDefault) {
-          var action = node.Action as SqlSetDefault;
-          AppendTranslated(node, AlterDomainSection.SetDefault);
-          action.DefaultValue.AcceptVisitor(this);
-        }
-        else if (node.Action is SqlDropDefault) {
-          AppendTranslated(node, AlterDomainSection.DropDefault);
+        switch (node.Action) {
+          case SqlAddConstraint action:
+            var constraint = (DomainConstraint) action.Constraint;
+            AppendTranslated(node, AlterDomainSection.AddConstraint);
+            AppendTranslated(constraint, ConstraintSection.Entry);
+            AppendTranslated(constraint, ConstraintSection.Check);
+            constraint.Condition.AcceptVisitor(this);
+            AppendTranslated(constraint, ConstraintSection.Exit);
+            break;
+          case SqlDropConstraint action:
+            AppendTranslated(node, AlterDomainSection.DropConstraint);
+            AppendTranslated(action.Constraint, ConstraintSection.Entry);
+            break;
+          case SqlSetDefault action:
+            AppendTranslated(node, AlterDomainSection.SetDefault);
+            action.DefaultValue.AcceptVisitor(this);
+            break;
+          case SqlDropDefault _:
+            AppendTranslated(node, AlterDomainSection.DropDefault);
+            break;
         }
         AppendTranslated(node, AlterDomainSection.Exit);
       }

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlTranslator.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlTranslator.cs
@@ -3,6 +3,7 @@
 // See the License.txt file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -1895,9 +1896,9 @@ namespace Xtensive.Sql.Compiler
     /// </summary>
     /// <param name="statements">The statements.</param>
     /// <returns>String containing the whole batch.</returns>
-    public virtual string BuildBatch(string[] statements)
+    public virtual string BuildBatch(IReadOnlyList<string> statements)
     {
-      if (statements.Length == 0)
+      if (statements.Count == 0)
         return string.Empty;
       var expectedLength = BatchBegin.Length + BatchEnd.Length +
         statements.Sum(statement => statement.Length + BatchItemDelimiter.Length + NewLine.Length);


### PR DESCRIPTION
* Avoid double search in Dictionary for Remove()
* Make BuildBatch() to accept IReadOnlyList<string> arg to avoid conversions
* Avoid ReadOnly-wrapping of Empty arrays. They are always immutable
* Use `Queue.TryDequeue()` when possible
* Avoid double casts when 'is' operator used
* Make `QueryParameterBinding`, `TypeInfoRef`, `ColumnGroup`, `ColumnInfoRef` readonly structs
* Simplify `ColumnCollection` constructor