### PR TITLE
ARCH-3752: Disable BooleanExpressionConverter optimization for .OrderBy() and .ThenBy()  expressions

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Linq/OrderByTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/OrderByTest.cs
@@ -316,5 +316,14 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(result, Is.Not.Empty);
       Assert.IsTrue(expected.SequenceEqual(result));
     }
+
+    [Test]
+    public void OrderByBoolExpression()
+    {
+      var result = Session.Query.All<Invoice>().OrderBy(c => c.Status == (InvoiceStatus)1)
+        .Select(c => c.Status)
+        .ToArray();
+      Assert.AreEqual(result.Last(), (InvoiceStatus)1);
+    }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/BooleanExpressionConverter.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/BooleanExpressionConverter.cs
@@ -35,17 +35,17 @@ namespace Xtensive.Orm.Providers
         }
       }
 
-      return SqlDml.Equals(expression, 1);
+      return SqlDml.NotEquals(expression, 0);
     }
 
     public SqlExpression BooleanToInt(SqlExpression expression)
     {
       // optimization: omitting BooleanToInt(IntToBoolean(x)) sequences
-      if (expression.NodeType==SqlNodeType.Equals) {
+      if (expression.NodeType==SqlNodeType.NotEquals) {
         var binary = (SqlBinary) expression;
         var left = binary.Left;
         var right = binary.Right as SqlLiteral<int>;
-        if (!ReferenceEquals(right, null) && right.Value==1)
+        if (!ReferenceEquals(right, null) && right.Value==0)
           return left;
       }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/BooleanExpressionConverter.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/BooleanExpressionConverter.cs
@@ -63,10 +63,9 @@ namespace Xtensive.Orm.Providers
       // optimization: omitting BooleanToInt(IntToBoolean(x)) sequences
       if (enableEqualInt1Optimization && expression.NodeType == SqlNodeType.Equals) {
         var binary = (SqlBinary) expression;
-        var left = binary.Left;
-        var right = binary.Right as SqlLiteral<int>;
-        if (!ReferenceEquals(right, null) && right.Value == 1)
-          return left;
+        if ((binary.Right as SqlLiteral<int>)?.Value == 1) {
+          return binary.Left;
+        }
       }
 
       var result = SqlDml.Case();

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/BooleanExpressionConverter.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/BooleanExpressionConverter.cs
@@ -1,9 +1,10 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2021 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
 // Created:    2009.08.17
 
+using System;
 using System.Linq;
 using Xtensive.Reflection;
 using Xtensive.Sql;
@@ -15,12 +16,31 @@ namespace Xtensive.Orm.Providers
   {
     private readonly SqlValueType booleanType;
 
+    private bool enableEqualInt1Optimization = true;
+
+    public readonly struct DisableEqualInt1OptimizationScope : IDisposable
+    {
+      private readonly BooleanExpressionConverter converter;
+      private readonly bool prevState;
+
+      public void Dispose() =>
+        converter.enableEqualInt1Optimization = prevState;
+
+      public DisableEqualInt1OptimizationScope(BooleanExpressionConverter converter)
+      {
+        (this.converter, prevState) = (converter, converter.enableEqualInt1Optimization);
+        converter.enableEqualInt1Optimization = false;
+      }
+    }
+
+    public DisableEqualInt1OptimizationScope DisableEqualInt1Optimization() => new DisableEqualInt1OptimizationScope(this);
+
     public SqlExpression IntToBoolean(SqlExpression expression)
     {
       // optimization: omitting IntToBoolean(BooleanToInt(x)) sequences
-      if (expression.NodeType==SqlNodeType.Cast) {
+      if (expression.NodeType == SqlNodeType.Cast) {
         var operand = ((SqlCast) expression).Operand;
-        if (operand.NodeType==SqlNodeType.Case) {
+        if (operand.NodeType == SqlNodeType.Case) {
           var _case = (SqlCase) operand;
           if (_case.Count == 1) {
             var firstCaseItem = _case.First();
@@ -28,24 +48,24 @@ namespace Xtensive.Orm.Providers
             var whenFalse = _case.Else as SqlLiteral<int>;
             if (!ReferenceEquals(whenTrue, null)
              && !ReferenceEquals(whenFalse, null)
-             && whenTrue.Value==1
-             && whenFalse.Value==0)
+             && whenTrue.Value == 1
+             && whenFalse.Value == 0)
               return firstCaseItem.Key;
           }
         }
       }
 
-      return SqlDml.NotEquals(expression, 0);
+      return SqlDml.Equals(expression, 1);
     }
 
     public SqlExpression BooleanToInt(SqlExpression expression)
     {
       // optimization: omitting BooleanToInt(IntToBoolean(x)) sequences
-      if (expression.NodeType==SqlNodeType.NotEquals) {
+      if (enableEqualInt1Optimization && expression.NodeType == SqlNodeType.Equals) {
         var binary = (SqlBinary) expression;
         var left = binary.Left;
         var right = binary.Right as SqlLiteral<int>;
-        if (!ReferenceEquals(right, null) && right.Value==0)
+        if (!ReferenceEquals(right, null) && right.Value == 1)
           return left;
       }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -345,6 +345,7 @@ namespace Xtensive.Orm.Providers
     /// <inheritdoc/>
     protected override SqlProvider VisitSort(SortProvider provider)
     {
+      using var _ = booleanExpressionConverter?.DisableEqualInt1Optimization();
       var compiledSource = Compile(provider.Source);
 
       var query = ExtractSqlSelect(provider, compiledSource);


### PR DESCRIPTION
Fixes https://servicetitan.atlassian.net/browse/ARCH-3752

The optimization works incorrectly for expressions like  `.OrderBy(o => o.Status == 1)`

The fix disables the optimization for Sorting expressions
Added `OrderByBoolExpression` test to check this case