### PR TITLE
BooleanExpressionConverter: use precise optimization

### DIFF
--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/BaseSqlVisitor.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/BaseSqlVisitor.cs
@@ -528,6 +528,7 @@ namespace Xtensive.Orm.BulkOperations
 
     public virtual void Visit(SqlMetadata node)
     {
+      VisitInternal(node.Expression);
     }
     
     #region Non-public methods

--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/BaseSqlVisitor.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/BaseSqlVisitor.cs
@@ -525,6 +525,10 @@ namespace Xtensive.Orm.BulkOperations
     public virtual void Visit(SqlComment node)
     {
     }
+
+    public virtual void Visit(SqlMetadata node)
+    {
+    }
     
     #region Non-public methods
 

--- a/Orm/Xtensive.Orm.Tests/Linq/DistinctTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/DistinctTest.cs
@@ -399,5 +399,26 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.IsTrue(expected.SequenceEqual(result));
       Assert.Greater(result.ToList().Count, 0);
     }
+
+    [Test]
+    public void DistinctByBoolExpression()
+    {
+      var result = Session.Query.All<Invoice>().Select(c => c.Status == (InvoiceStatus) 1)
+        .Distinct()
+        .ToArray();
+
+      CollectionAssert.AreEquivalent(new[] {false, true}, result);
+    }
+
+    [Test]
+    public void DistinctByBoolExpressionComplex()
+    {
+      var result = Session.Query.All<Invoice>()
+        .Select(c => c.Status == (InvoiceStatus) 1 || c.Status == (InvoiceStatus) 2)
+        .Distinct()
+        .ToArray();
+
+      CollectionAssert.AreEquivalent(new[] {false, true}, result);
+    }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Linq/GroupByTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/GroupByTest.cs
@@ -1021,6 +1021,37 @@ namespace Xtensive.Orm.Tests.Linq
       QueryDumper.Dump(query);
     }
 
+    [Test]
+    public void GroupByBoolExpression()
+    {
+      var query = Session.Query.All<Invoice>();
+      var falseResult = query.Count(c => c.Status != (InvoiceStatus) 1);
+      var trueResult = query.Count(c => c.Status == (InvoiceStatus) 1);
+
+      var result = query.GroupBy(c => c.Status == (InvoiceStatus) 1)
+        .Select(c => new {Value = c.Key, Count = c.Count()})
+        .ToArray();
+
+      Assert.AreEqual(falseResult, result.Single(i => !i.Value).Count);
+      Assert.AreEqual(trueResult, result.Single(i => i.Value).Count);
+    }
+
+    [Test]
+    public void GroupByBoolExpressionComplex()
+    {
+      var query = Session.Query.All<Invoice>();
+      var falseResult = query.Count(c => !(c.Status == (InvoiceStatus) 1 || c.Status == (InvoiceStatus) 2));
+      var trueResult = query.Count(c => c.Status == (InvoiceStatus) 1 || c.Status == (InvoiceStatus) 2);
+
+      var result = query
+        .GroupBy(c => c.Status == (InvoiceStatus) 1 || c.Status == (InvoiceStatus) 2)
+        .Select(c => new {Value = c.Key, Count = c.Count()})
+        .ToArray();
+
+      Assert.AreEqual(falseResult, result.Single(i => !i.Value).Count);
+      Assert.AreEqual(trueResult, result.Single(i => i.Value).Count);
+    }
+
     private void DumpGrouping<TKey, TValue>(IQueryable<IGrouping<TKey, TValue>> result)
     {
       DumpGrouping(result, false);

--- a/Orm/Xtensive.Orm.Tests/Linq/OrderByTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/OrderByTest.cs
@@ -320,10 +320,20 @@ namespace Xtensive.Orm.Tests.Linq
     [Test]
     public void OrderByBoolExpression()
     {
-      var result = Session.Query.All<Invoice>().OrderBy(c => c.Status == (InvoiceStatus)1)
+      var result = Session.Query.All<Invoice>().OrderBy(c => c.Status == (InvoiceStatus) 1)
         .Select(c => c.Status)
         .ToArray();
-      Assert.AreEqual(result.Last(), (InvoiceStatus)1);
+      Assert.AreEqual(result.Last(), (InvoiceStatus) 1);
+    }
+
+    [Test]
+    public void OrderByBoolExpressionComplex()
+    {
+      var result = Session.Query.All<Invoice>()
+        .OrderBy(c => c.Status == (InvoiceStatus) 1 || c.Status == (InvoiceStatus) 2)
+        .Select(c => c.Status)
+        .ToArray();
+      Assert.AreEqual(result.Last(), (InvoiceStatus) 1);
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Linq/OrderByTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/OrderByTest.cs
@@ -316,5 +316,14 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(result, Is.Not.Empty);
       Assert.IsTrue(expected.SequenceEqual(result));
     }
+
+    [Test]
+    public void OrderByBoolExpression()
+    {
+      var result = Session.Query.All<Invoice>().OrderBy(c => c.Status == (InvoiceStatus)1)
+        .Select(c => c.Status)
+        .ToArray();
+      Assert.AreEqual(result.Last(), (InvoiceStatus)1);
+    }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Linq/WhereTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/WhereTest.cs
@@ -1326,5 +1326,29 @@ Require.ProviderIsNot(StorageProvider.Sqlite, "sqlite does not support Sqrt()");
         .Where(customer => customer.Invoices.Any(i => i.Commission > 0.30m));
       Assert.IsTrue(expected.SequenceEqual(actual));
     }
+
+    [Test]
+    public void WhereBoolEquals()
+    {
+      var expected = Session.Query.All<Invoice>().Count(c => c.Status != (InvoiceStatus) 1);
+      // ReSharper disable once ReplaceWithSingleCallToCount
+      var actual = Session.Query.All<Invoice>().Where(c => (c.Status == (InvoiceStatus) 1) == false).Count();
+
+      Assert.AreEqual(expected, actual);
+    }
+
+    [Test]
+    public void WhereBoolEqualsComplex()
+    {
+      var expected = Session.Query.All<Invoice>()
+        .Count(c => !(c.Status == (InvoiceStatus) 1 || c.Status == (InvoiceStatus) 2));
+
+      // ReSharper disable once ReplaceWithSingleCallToCount
+      var actual = Session.Query.All<Invoice>()
+        .Where(c => (c.Status == (InvoiceStatus) 1 || c.Status == (InvoiceStatus) 2) == false)
+        .Count();
+
+      Assert.AreEqual(expected, actual);
+    }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlSelectProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlSelectProcessor.cs
@@ -499,6 +499,11 @@ namespace Xtensive.Orm.Providers
         Visit(node.Operand);
     }
 
+    public void Visit(SqlMetadata node)
+    {
+      Visit(node.Expression);
+    }
+
     public void Visit(SqlUpdate node)
     {
       if (node.From!=null)

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlCompiler.cs
@@ -1405,6 +1405,11 @@ namespace Xtensive.Sql.Compiler
       }
     }
 
+    public virtual void Visit(SqlMetadata node)
+    {
+      node.Expression.AcceptVisitor(this);
+    }
+
     public virtual void Visit(SqlUpdate node)
     {
       VisitUpdateDefault(node);

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlMetadata.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlMetadata.cs
@@ -1,0 +1,39 @@
+using Xtensive.Core;
+
+namespace Xtensive.Sql.Dml
+{
+  /// <summary>
+  /// Arbitrary metadata that could be attached to SQL expression tree.
+  /// </summary>
+  public class SqlMetadata : SqlExpression
+  {
+    public SqlExpression Expression { get; private set; }
+
+    public object Value { get; private set; }
+
+    public override void ReplaceWith(SqlExpression expression)
+    {
+      ArgumentValidator.EnsureArgumentNotNull(expression, nameof(expression));
+      ArgumentValidator.EnsureArgumentIs<SqlMetadata>(expression, nameof(expression));
+      var source = (SqlMetadata) expression;
+      NodeType = source.NodeType;
+      Expression = source.Expression;
+      Value = source.Value;
+    }
+
+    internal override object Clone(SqlNodeCloneContext context) =>
+      context.NodeMapping.TryGetValue(this, out var clone)
+        ? clone
+        : context.NodeMapping[this] = new SqlMetadata((SqlExpression) Expression.Clone(context), Value);
+
+    public override void AcceptVisitor(ISqlVisitor visitor) => visitor.Visit(this);
+
+    // Constructors
+
+    internal SqlMetadata(SqlExpression expression, object value) : base(SqlNodeType.Metadata)
+    {
+      Expression = expression;
+      Value = value;
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Sql/Interfaces/ISqlVisitor.cs
+++ b/Orm/Xtensive.Orm/Sql/Interfaces/ISqlVisitor.cs
@@ -98,6 +98,7 @@ namespace Xtensive.Sql
     void Visit(SqlSelect node);
     void Visit(SqlSubQuery node);
     void Visit(SqlUnary node);
+    void Visit(SqlMetadata node);
     void Visit(SqlUpdate node);
     void Visit(SqlUserColumn node);
     void Visit(SqlUserFunctionCall node);

--- a/Orm/Xtensive.Orm/Sql/Internals/SqlValidator.cs
+++ b/Orm/Xtensive.Orm/Sql/Internals/SqlValidator.cs
@@ -117,6 +117,7 @@ namespace Xtensive.Sql
         case SqlNodeType.Unique:
         case SqlNodeType.Variable:
         case SqlNodeType.Placeholder:
+        case SqlNodeType.Metadata:
         case SqlNodeType.DynamicFilter:
           return true;
         case SqlNodeType.Cast:
@@ -168,6 +169,7 @@ namespace Xtensive.Sql
         case SqlNodeType.Extract:
         case SqlNodeType.Round:
         case SqlNodeType.Placeholder:
+        case SqlNodeType.Metadata:
         case SqlNodeType.DateTimeMinusInterval:
         case SqlNodeType.DateTimePlusInterval:
         case SqlNodeType.DateTimeMinusDateTime:
@@ -206,6 +208,7 @@ namespace Xtensive.Sql
         case SqlNodeType.Trim:
         case SqlNodeType.Variable:
         case SqlNodeType.Placeholder:
+        case SqlNodeType.Metadata:
           return true;
         case SqlNodeType.Variant:
           var variant = (SqlVariant)node;

--- a/Orm/Xtensive.Orm/Sql/SqlDml.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlDml.cs
@@ -1247,6 +1247,12 @@ namespace Xtensive.Sql
       return new SqlNative(value);
     }
 
+    public static SqlMetadata Metadata(SqlExpression expression, object value)
+    {
+      ArgumentValidator.EnsureArgumentNotNull(expression, nameof(expression));
+      return new SqlMetadata(expression, value);
+    }
+
     public static SqlSubQuery SubQuery(ISqlQueryExpression operand)
     {
       ArgumentValidator.EnsureArgumentNotNull(operand, "operand");

--- a/Orm/Xtensive.Orm/Sql/SqlNodeType.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlNodeType.cs
@@ -112,5 +112,6 @@ namespace Xtensive.Sql
     DeclareVariable,
     While,
     Fragment,
+    Metadata,
   }
 }


### PR DESCRIPTION
Introduce new SQL DOM node `SqlMetadata`. It allows to insert arbitrary object into expression tree.
Use this to annotate expressions produced by `BooleanExpressionConverter`.
This allows to avoid false matches like `SomeColumn = 1`