### PR TITLE
Fix caching temporary table queries

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Rse/IncludeProviderTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Rse/IncludeProviderTest.cs
@@ -1,11 +1,13 @@
-// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2022 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Alexey Gamzov
 // Created:    2009.10.27
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 using Xtensive.Core;
 using Tuple = Xtensive.Tuples.Tuple;
@@ -17,22 +19,58 @@ namespace Xtensive.Orm.Tests.Rse
 {
   [Serializable]
   [TestFixture, Category("Rse")]
-  public class IncludeProviderTest: ChinookDOModelTest
+  public class IncludeProviderTest : ChinookDOModelTest
   {
     [Test]
     public void SimpleTest()
     {
       var tracks = Session.Demand().Query.All<Track>().Take(10).ToList();
-      var ids = tracks.Select(supplier => (Tuple)Tuple.Create(supplier.TrackId));
+      var ids = tracks.Select(supplier => (Tuple) Tuple.Create(supplier.TrackId));
 
-      var trackRs = Domain.Model.Types[typeof (Track)].Indexes.PrimaryIndex.GetQuery();
-      var inRs = trackRs.Include(context => ids, "columnName", new[] {0});
-      var inIndex = inRs.Header.Columns.Count-1;
+      var trackRs = Domain.Model.Types[typeof(Track)].Indexes.PrimaryIndex.GetQuery();
+      var inRs = trackRs.Include(context => ids, "columnName", new[] { 0 });
+      var inIndex = inRs.Header.Columns.Count - 1;
       var whereRs = inRs.Filter(tuple => tuple.GetValueOrDefault<bool>(inIndex));
       var parameterContext = new ParameterContext();
       var result = whereRs.GetRecordSetReader(Session.Current, parameterContext).ToEnumerable().ToList();
       Assert.AreEqual(0, whereRs.GetRecordSetReader(Session.Current, parameterContext).ToEnumerable()
         .Select(t => t.GetValue<int>(0)).Except(tracks.Select(s => s.TrackId)).Count());
+    }
+
+    [Test]
+    public void TempTableMustNotBeCached() =>
+      Assert.AreNotEqual(ExecuteIn(ExecuteCachedIn), ExecuteIn(ExecuteCachedIn));
+
+    [Test]
+    public void TempTableMustNotBeCachedScalar() =>
+      Assert.AreNotEqual(ExecuteIn(ExecuteCachedInScalar), ExecuteIn(ExecuteCachedInScalar));
+
+    // returns temporary table Name
+    private string ExecuteIn(Action<Session> action)
+    {
+      string tempTableName = null;
+      EventHandler<DbCommandEventArgs> sqlPrinter = (o, ea) => {
+        if (Regex.Match(ea.Command.CommandText, @"#([^\]]+)") is var m && m.Success) {
+          tempTableName = m.Groups[1].Value;
+        }
+      };
+      var session = Session.Demand();
+      session.Events.DbCommandExecuted += sqlPrinter;
+      action(session);
+      session.Events.DbCommandExecuted -= sqlPrinter;
+      return tempTableName;
+    }
+
+    private void ExecuteCachedIn(Session session)
+    {
+      var ids = Enumerable.Range(0, 257).ToArray();
+      _ = session.Query.Execute("CachedInclude", q => q.All<Track>().Where(o => o.TrackId.In(ids))).Count();
+    }
+
+    private void ExecuteCachedInScalar(Session session)
+    {
+      var ids = Enumerable.Range(0, 257).ToArray();
+      _ = session.Query.Execute("CachedInclude", q => q.All<Track>().Where(o => o.TrackId.In(ids)).Count());
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Rse/SqlTemporaryDataProviderTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Rse/SqlTemporaryDataProviderTest.cs
@@ -1,0 +1,58 @@
+// Copyright (C) 2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using Xtensive.Core;
+using Tuple = Xtensive.Tuples.Tuple;
+using Xtensive.Orm.Tests.ObjectModel;
+using Xtensive.Orm.Tests.ObjectModel.ChinookDO;
+using Xtensive.Orm.Rse;
+
+namespace Xtensive.Orm.Tests.Rse
+{
+  [Serializable]
+  [TestFixture, Category("Rse")]
+  public class SqlTemporaryDataProvider : ChinookDOModelTest
+  {
+    [Test]
+    public void TempTableMustNotBeCached() =>
+      Assert.AreNotEqual(ExecuteIn(ExecuteCachedIn), ExecuteIn(ExecuteCachedIn));
+
+    [Test]
+    public void TempTableMustNotBeCachedScalar() =>
+      Assert.AreNotEqual(ExecuteIn(ExecuteCachedInScalar), ExecuteIn(ExecuteCachedInScalar));
+
+    // returns temporary table Name
+    private string ExecuteIn(Action<Session> action)
+    {
+      string tempTableName = null;
+      EventHandler<DbCommandEventArgs> sqlPrinter = (o, ea) => {
+        if (Regex.Match(ea.Command.CommandText, @"#([^\]]+)") is var m && m.Success) {
+          tempTableName = m.Groups[1].Value;
+        }
+      };
+      var session = Session.Demand();
+      session.Events.DbCommandExecuted += sqlPrinter;
+      action(session);
+      session.Events.DbCommandExecuted -= sqlPrinter;
+      return tempTableName;
+    }
+
+    private void ExecuteCachedIn(Session session)
+    {
+      var ids = Enumerable.Range(0, 257).ToArray();
+      _ = session.Query.Execute("CachedInclude", q => q.All<Track>().Where(o => o.TrackId.In(ids))).Count();
+    }
+
+    private void ExecuteCachedInScalar(Session session)
+    {
+      var ids = Enumerable.Range(0, 257).ToArray();
+      _ = session.Query.Execute("CachedInclude", q => q.All<Track>().Where(o => o.TrackId.In(ids)).Count());
+    }
+  }
+}


### PR DESCRIPTION
We check that translated query does not contain references to temporary tables. Temporary tables are filled/truncated on every query execution and are a locked resource when shared query executed parallelly by multiple callers

+ Tests