### PR TITLE
Enable caching of queries with inlined list like `.In(1, 2, 3)`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -1523,6 +1523,10 @@ namespace Xtensive.Orm.Linq
         case 2:
           source = mc.Arguments[1];
           match = mc.Arguments[0];
+          if (source.NodeType == ExpressionType.NewArrayInit
+              && ((NewArrayExpression) source).Expressions.Count < context.Domain.Configuration.MaxNumberOfConditions) {
+            algorithm = IncludeAlgorithm.ComplexCondition;
+          }
           break;
         case 3:
           source = mc.Arguments[2];


### PR DESCRIPTION
Avoid using TempTable SqlExpression variant branch for most typical `.In()` usage case
It enables caching of such queries