### PR TITLE
Use C#9 Covariant return types feature for Clone() implementation for type safety and reduce number of casts

### DIFF
--- a/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/Resources/Strings.Designer.cs
+++ b/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/Resources/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace Xtensive.Sql.Drivers.MySql.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {

--- a/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/Resources/Strings.Designer.cs
+++ b/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/Resources/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace Xtensive.Sql.Drivers.MySql.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {

--- a/Orm/Xtensive.Orm.SqlServer/SqlServer.Resources/Strings.Designer.cs
+++ b/Orm/Xtensive.Orm.SqlServer/SqlServer.Resources/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace Xtensive.SqlServer.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {

--- a/Orm/Xtensive.Orm.SqlServer/SqlServer.Resources/Strings.Designer.cs
+++ b/Orm/Xtensive.Orm.SqlServer/SqlServer.Resources/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace Xtensive.SqlServer.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {

--- a/Orm/Xtensive.Orm.Tests.Sql/CloneTests.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/CloneTests.cs
@@ -37,7 +37,7 @@ namespace Xtensive.Orm.Tests.Sql
     public void SqlExpressionCloneTest()
     {
       SqlExpression e = SqlDml.Literal(1);
-      SqlExpression eClone = (SqlExpression) e.Clone();
+      SqlExpression eClone = e.Clone();
       Assert.AreNotEqual(e, eClone);
       Assert.AreEqual(e.NodeType, eClone.NodeType);
     }

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/CatalogCloner.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/CatalogCloner.cs
@@ -84,7 +84,7 @@ namespace Xtensive.Orm.Upgrade.Internals
     private void CloneAssertions(Schema newSchema, Schema sourceSchema)
     {
       foreach (var assertion in sourceSchema.Assertions) {
-        var newAssertion = newSchema.CreateAssertion(assertion.Name, (SqlExpression)assertion.Condition.Clone(), assertion.IsDeferrable, assertion.IsInitiallyDeferred);
+        var newAssertion = newSchema.CreateAssertion(assertion.Name, assertion.Condition.Clone(), assertion.IsDeferrable, assertion.IsInitiallyDeferred);
         CopyDbName(newAssertion, assertion);
       }
     }
@@ -113,9 +113,9 @@ namespace Xtensive.Orm.Upgrade.Internals
         if (sourceDomain.Collation!=null)
           newDomain.Collation = collationsMap[sourceDomain.Collation];
         if (sourceDomain.DefaultValue!=null)
-          newDomain.DefaultValue = (SqlExpression)sourceDomain.DefaultValue.Clone();
+          newDomain.DefaultValue = sourceDomain.DefaultValue.Clone();
         foreach (var domainConstraint in sourceDomain.DomainConstraints) {
-          var newConstraint = newDomain.CreateConstraint(domainConstraint.Name, (SqlExpression) domainConstraint.Condition.Clone());
+          var newConstraint = newDomain.CreateConstraint(domainConstraint.Name, domainConstraint.Condition.Clone());
           CopyDbName(newConstraint, domainConstraint);
         }
       }
@@ -181,7 +181,7 @@ namespace Xtensive.Orm.Upgrade.Internals
         CopyDbName(newColumn, sourceTableColumn);
 
         if (sourceTableColumn.DefaultValue!=null)
-          newColumn.DefaultValue = (SqlExpression) sourceTableColumn.DefaultValue.Clone();
+          newColumn.DefaultValue = sourceTableColumn.DefaultValue.Clone();
 
         var schema = newTable.Schema;
         if (sourceTableColumn.Collation!=null) {
@@ -196,7 +196,7 @@ namespace Xtensive.Orm.Upgrade.Internals
         if (sourceTableColumn.Domain!=null)
           newColumn.Domain = schema.Domains[sourceTableColumn.Domain.Name];
         if (sourceTableColumn.Expression!=null)
-          newColumn.Expression = (SqlExpression) sourceTableColumn.Expression.Clone();
+          newColumn.Expression = sourceTableColumn.Expression.Clone();
         newColumn.IsNullable = sourceTableColumn.IsNullable;
         newColumn.IsPersisted = sourceTableColumn.IsPersisted;
         if (sourceTableColumn.SequenceDescriptor!=null)
@@ -251,7 +251,7 @@ namespace Xtensive.Orm.Upgrade.Internals
         ft.IsUnique = ftIndex.IsUnique;
         ft.UnderlyingUniqueIndex = ftIndex.UnderlyingUniqueIndex;
         if (ftIndex.Where!=null)
-          ft.Where = (SqlExpression) ftIndex.Where.Clone();
+          ft.Where = ftIndex.Where.Clone();
         ClonePartitionDescriptor(ft, sourceIndex);
         return;
       }
@@ -269,7 +269,7 @@ namespace Xtensive.Orm.Upgrade.Internals
         spatial.IsClustered = spatialIndex.IsClustered;
         spatial.IsUnique = spatialIndex.IsUnique;
         if (spatialIndex.Where!=null)
-          spatial.Where = (SqlExpression) spatialIndex.Where.Clone();
+          spatial.Where = spatialIndex.Where.Clone();
         ClonePartitionDescriptor(spatialIndex, sourceIndex);
         return;
       }
@@ -283,7 +283,7 @@ namespace Xtensive.Orm.Upgrade.Internals
       index.IsUnique = sourceIndex.IsUnique;
       index.IsClustered = sourceIndex.IsClustered;
       if (sourceIndex.Where!=null)
-        index.Where = (SqlExpression) sourceIndex.Where.Clone();
+        index.Where = sourceIndex.Where.Clone();
       index.NonkeyColumns.AddRange(GetNonKeyColumns(newTable, sourceIndex));
       index.IsBitmap = sourceIndex.IsBitmap;
       ClonePartitionDescriptor(index, sourceIndex);
@@ -319,7 +319,7 @@ namespace Xtensive.Orm.Upgrade.Internals
     {
       var checkConstraint = sourceConstraint as CheckConstraint;
       if (checkConstraint!=null) {
-        var c = newTable.CreateCheckConstraint(checkConstraint.Name, (SqlExpression) checkConstraint.Condition.Clone());
+        var c = newTable.CreateCheckConstraint(checkConstraint.Name, checkConstraint.Condition.Clone());
         CopyDbName(c, checkConstraint);
         return;
       }

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlAddColumn.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlAddColumn.cs
@@ -12,10 +12,9 @@ namespace Xtensive.Sql.Ddl
   {
     public TableColumn Column { get; private set; }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlAddColumn(Column);
+    internal override SqlAddColumn Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlAddColumn(t.Column));
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlAddConstraint.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlAddConstraint.cs
@@ -12,10 +12,9 @@ namespace Xtensive.Sql.Ddl
   {
     public Constraint Constraint { get; private set; }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlAddConstraint(Constraint);
+    internal override SqlAddConstraint Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlAddConstraint(t.Constraint));
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlAlterIdentityInfo.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlAlterIdentityInfo.cs
@@ -14,10 +14,9 @@ namespace Xtensive.Sql.Ddl
     public SequenceDescriptor SequenceDescriptor { get; set; }
     public SqlAlterIdentityInfoOptions InfoOption { get; set; }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlAlterIdentityInfo(Column, (SequenceDescriptor) SequenceDescriptor.Clone(), InfoOption);
+    internal override SqlAlterIdentityInfo Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlAlterIdentityInfo(t.Column, (SequenceDescriptor) t.SequenceDescriptor.Clone(), t.InfoOption));
 
     internal SqlAlterIdentityInfo(TableColumn column, SequenceDescriptor sequenceDescriptor, SqlAlterIdentityInfoOptions infoOption)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlDropColumn.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlDropColumn.cs
@@ -12,10 +12,9 @@ namespace Xtensive.Sql.Ddl
   {
     public TableColumn Column { get; private set; }
     
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlDropColumn(Column);
+    internal override SqlDropColumn Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlDropColumn(t.Column));
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlDropConstraint.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlDropConstraint.cs
@@ -12,10 +12,9 @@ namespace Xtensive.Sql.Ddl
   {
     public Constraint Constraint { get; private set; }
     
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlDropConstraint(Constraint, Cascade);
+    internal override SqlDropConstraint Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlDropConstraint(t.Constraint, t.Cascade));
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlDropDefault.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlDropDefault.cs
@@ -12,10 +12,9 @@ namespace Xtensive.Sql.Ddl
   {
     public TableColumn Column { get; private set; }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlDropDefault(Column);
+    internal override SqlDropDefault Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlDropDefault(t.Column));
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlRenameColumn.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlRenameColumn.cs
@@ -15,10 +15,9 @@ namespace Xtensive.Sql.Ddl
     public TableColumn Column { get; private set; }
     public string NewName { get; private set; }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlRenameColumn(Column, NewName);
+    internal override SqlRenameColumn Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlRenameColumn(t.Column, t.NewName));
       
 
     // Constructors

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlSetDefault.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlSetDefault.cs
@@ -14,10 +14,9 @@ namespace Xtensive.Sql.Ddl
     public TableColumn Column { get; private set; }
     public SqlExpression DefaultValue { get; private set; }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlSetDefault((SqlExpression) DefaultValue.Clone(context), Column);
+    internal override SqlSetDefault Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlSetDefault(t.DefaultValue.Clone(c), t.Column));
 
     internal SqlSetDefault(SqlExpression defaultValue, TableColumn column)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterDomain.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterDomain.cs
@@ -25,11 +25,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlAlterDomain(domain, (SqlAction)action.Clone(context));
+    internal override SqlAlterDomain Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlAlterDomain(t.domain, (SqlAction)t.action.Clone(c)));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterPartitionFunction.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterPartitionFunction.cs
@@ -31,10 +31,9 @@ namespace Xtensive.Sql.Ddl
       set { option = value; }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlAlterPartitionFunction(partitionFunction, boundary, option);
+    internal override SqlAlterPartitionFunction Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlAlterPartitionFunction(t.partitionFunction, t.boundary, t.option));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterPartitionScheme.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterPartitionScheme.cs
@@ -25,10 +25,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlAlterPartitionScheme(partitionSchema, filegroup);
+    internal override SqlAlterPartitionScheme Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlAlterPartitionScheme(t.partitionSchema, t.filegroup));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterSequence.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterSequence.cs
@@ -35,10 +35,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlAlterSequence(sequence, (SequenceDescriptor)sequenceDescriptor.Clone(), infoOption);
+    internal override SqlAlterSequence Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlAlterSequence(t.sequence, (SequenceDescriptor)t.sequenceDescriptor.Clone(), t.infoOption));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterTable.cs
@@ -26,10 +26,9 @@ namespace Xtensive.Sql.Ddl
     }
 
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlAlterTable(table, (SqlAction)action.Clone(context));
+    internal override SqlAlterTable Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlAlterTable(t.table, (SqlAction)t.action.Clone(c)));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCommand.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCommand.cs
@@ -13,10 +13,9 @@ namespace Xtensive.Sql.Ddl
   {
     public SqlCommandType CommandType { get; private set; }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlCommand(CommandType);
+    internal override SqlCommand Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlCommand(t.CommandType));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateAssertion.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateAssertion.cs
@@ -18,10 +18,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlCreateAssertion(assertion);
+    internal override SqlCreateAssertion Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlCreateAssertion(t.assertion));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateCharcterSet.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateCharcterSet.cs
@@ -18,10 +18,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlCreateCharacterSet(characterSet);
+    internal override SqlCreateCharacterSet Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlCreateCharacterSet(t.characterSet));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateCollation.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateCollation.cs
@@ -18,10 +18,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlCreateCollation(collation);
+    internal override SqlCreateCollation Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlCreateCollation(t.collation));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateDomain.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateDomain.cs
@@ -18,10 +18,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlCreateDomain(domain);
+    internal override SqlCreateDomain Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlCreateDomain(t.domain));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateIndex.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateIndex.cs
@@ -13,10 +13,9 @@ namespace Xtensive.Sql.Ddl
   {
     public Index Index { get; private set; }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlCreateIndex(Index);
+    internal override SqlCreateIndex Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlCreateIndex(t.Index));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreatePartitionFunction.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreatePartitionFunction.cs
@@ -18,10 +18,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlCreatePartitionFunction(partitionFunction);
+    internal override SqlCreatePartitionFunction Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlCreatePartitionFunction(t.partitionFunction));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreatePartitionScheme.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreatePartitionScheme.cs
@@ -18,10 +18,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlCreatePartitionScheme(partitionSchema);
+    internal override SqlCreatePartitionScheme Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlCreatePartitionScheme(t.partitionSchema));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateSchema.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateSchema.cs
@@ -18,10 +18,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlCreateSchema(schema);
+    internal override SqlCreateSchema Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlCreateSchema(t.schema));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateSequence.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateSequence.cs
@@ -18,10 +18,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlCreateSequence(sequence);
+    internal override SqlCreateSequence Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlCreateSequence(t.sequence));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateTable.cs
@@ -18,10 +18,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlCreateTable(table);
+    internal override SqlCreateTable Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlCreateTable(t.table));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateTranslation.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateTranslation.cs
@@ -18,10 +18,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlCreateTranslation(translation);
+    internal override SqlCreateTranslation Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlCreateTranslation(t.translation));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateView.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateView.cs
@@ -18,10 +18,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlCreateView(node);
+    internal override SqlCreateView Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlCreateView(t.node));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropAssertion.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropAssertion.cs
@@ -18,10 +18,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlDropAssertion(assertion);
+    internal override SqlDropAssertion Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlDropAssertion(t.assertion));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropCharacterSet.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropCharacterSet.cs
@@ -18,10 +18,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlDropCharacterSet(characterSet);
+    internal override SqlDropCharacterSet Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlDropCharacterSet(t.characterSet));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropCollation.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropCollation.cs
@@ -18,10 +18,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlDropCollation(collation);
+    internal override SqlDropCollation Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlDropCollation(t.collation));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropDomain.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropDomain.cs
@@ -28,10 +28,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlDropDomain(domain);
+    internal override SqlDropDomain Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlDropDomain(t.domain));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropIndex.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropIndex.cs
@@ -59,10 +59,9 @@ namespace Xtensive.Sql.Ddl
     //  }
     //}
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlDropIndex(index);
+    internal override SqlDropIndex Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlDropIndex(t.index));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropPartitionFunction.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropPartitionFunction.cs
@@ -18,10 +18,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlDropPartitionFunction(partitionFunction);
+    internal override SqlDropPartitionFunction Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlDropPartitionFunction(t.partitionFunction));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropPartitionScheme.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropPartitionScheme.cs
@@ -18,10 +18,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlDropPartitionScheme(partitionSchema);
+    internal override SqlDropPartitionScheme Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlDropPartitionScheme(t.partitionSchema));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropSchema.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropSchema.cs
@@ -28,10 +28,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlDropSchema(schema);
+    internal override SqlDropSchema Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlDropSchema(t.schema));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropSequence.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropSequence.cs
@@ -28,10 +28,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlDropSequence(sequence);
+    internal override SqlDropSequence Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlDropSequence(t.sequence));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropTable.cs
@@ -28,10 +28,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlDropTable(table, cascade);
+    internal override SqlDropTable Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlDropTable(t.table, t.cascade));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropTranslation.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropTranslation.cs
@@ -18,10 +18,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlDropTranslation(translation);
+    internal override SqlDropTranslation Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlDropTranslation(t.translation));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropView.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropView.cs
@@ -28,10 +28,9 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlDropView(view);
+    internal override SqlDropView Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlDropView(t.view));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlRenameTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlRenameTable.cs
@@ -15,10 +15,9 @@ namespace Xtensive.Sql.Ddl
     public Table Table { get; private set; }
     public string NewName { get; private set; }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlRenameTable(Table, NewName);
+    internal override SqlRenameTable Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlRenameTable(t.Table, t.NewName));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlTruncateTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlTruncateTable.cs
@@ -12,10 +12,9 @@ namespace Xtensive.Sql.Ddl
   {
     public Table Table { get; }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlTruncateTable(Table);
+    internal override SqlTruncateTable Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlTruncateTable(t.Table));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlAggregate.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlAggregate.cs
@@ -17,7 +17,7 @@ namespace Xtensive.Sql.Dml
     /// Gets a value indicating whether this <see cref="SqlAggregate"/> is distinct.
     /// </summary>
     /// <value><see langword="true"/> if distinct; otherwise, <see langword="false"/>.</value>
-    public bool Distinct 
+    public bool Distinct
     {
       get { return distinct; }
     }
@@ -39,11 +39,10 @@ namespace Xtensive.Sql.Dml
       this.expression = replacingExpression.Expression;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlAggregate(NodeType,
-            expression is null ? null : (SqlExpression) expression.Clone(context), distinct);
+    internal override SqlAggregate Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlAggregate(t.NodeType,
+            t.expression?.Clone(c), t.distinct));
 
     internal SqlAggregate(SqlNodeType nodeType, SqlExpression expression, bool distinct) : base(nodeType)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlArray{T}.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlArray{T}.cs
@@ -41,10 +41,9 @@ namespace Xtensive.Sql.Dml
       Values = replacingExpression.Values;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlArray<T>((T[]) Values.Clone());
+    internal override SqlArray Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlArray<T>((T[]) t.Values.Clone()));
 
 
     // Constructors

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlBetween.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlBetween.cs
@@ -53,10 +53,9 @@ namespace Xtensive.Sql.Dml
       expression = replacingExpression.Expression;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlBetween(NodeType, (SqlExpression)expression.Clone(context), (SqlExpression)left.Clone(context), (SqlExpression)right.Clone(context));
+    internal override SqlBetween Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlBetween(t.NodeType, t.expression.Clone(c), t.left.Clone(c), t.right.Clone(c)));
 
     internal SqlBetween(SqlNodeType nodeType, SqlExpression expression, SqlExpression left, SqlExpression right)
       : base(nodeType)

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlBinary.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlBinary.cs
@@ -89,12 +89,11 @@ namespace Xtensive.Sql.Dml
       Right = replacingExpression.Right;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlBinary(NodeType,
-            (SqlExpression) Left.Clone(context),
-            (SqlExpression) Right.Clone(context));
+    internal override SqlBinary Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlBinary(t.NodeType,
+            t.Left.Clone(c),
+            t.Right.Clone(c)));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCase.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCase.cs
@@ -72,7 +72,7 @@ namespace Xtensive.Sql.Dml
         KeyValuePair<SqlExpression, SqlExpression> @case = new KeyValuePair<SqlExpression, SqlExpression>(key, value);
         if (index >= 0)
           cases[index] = @case;
-        else 
+        else
           cases.Add(@case);
       }
     }
@@ -103,23 +103,18 @@ namespace Xtensive.Sql.Dml
         cases.Add(pair);
     }
 
-    internal override object Clone(SqlNodeCloneContext context)
-    {
-      if (context.NodeMapping.TryGetValue(this, out var v)) {
-        return v;
-      }
+    internal override SqlCase Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) => {
+        var clone = new SqlCase(t.value?.Clone(c));
 
-      var clone = new SqlCase(value is null ? null : (SqlExpression) value.Clone(context));
+        if (t.@else is not null)
+          clone.Else = t.@else.Clone(c);
 
-      if (@else is not null)
-        clone.Else = (SqlExpression) @else.Clone(context);
+        foreach (KeyValuePair<SqlExpression, SqlExpression> pair in t.cases)
+          clone[pair.Key.Clone(c)] = pair.Value.Clone(c);
 
-      foreach (KeyValuePair<SqlExpression, SqlExpression> pair in cases)
-        clone[(SqlExpression) pair.Key.Clone(context)] = (SqlExpression) pair.Value.Clone(context);
-
-      context.NodeMapping[this] = clone;
-      return clone;
-    }
+        return clone;
+      });
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCast.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCast.cs
@@ -20,10 +20,9 @@ namespace Xtensive.Sql.Dml
       Type = replacingExpression.Type;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlCast((SqlExpression) Operand.Clone(context), Type);
+    internal override SqlCast Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlCast(t.Operand.Clone(c), t.Type));
     
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCollate.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCollate.cs
@@ -41,10 +41,9 @@ namespace Xtensive.Sql.Dml
       collation = replacingExpression.Collation;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlCollate((SqlExpression)operand.Clone(context), collation);
+    internal override SqlCollate Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlCollate(t.operand.Clone(c), t.collation));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlColumnRef.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlColumnRef.cs
@@ -23,12 +23,11 @@ namespace Xtensive.Sql.Dml
       SqlColumn = ArgumentValidator.EnsureArgumentIs<SqlColumnRef>(expression).SqlColumn;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlColumnRef(
-            SqlTable != null ? (SqlTable) SqlTable.Clone(context) : null,
-            (SqlColumn) SqlColumn.Clone(context), Name);
+    internal override SqlColumnRef Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlColumnRef(
+            t.SqlTable?.Clone(c),
+            (SqlColumn) t.SqlColumn.Clone(c), t.Name));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlColumnStub.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlColumnStub.cs
@@ -13,12 +13,11 @@ namespace Xtensive.Sql.Dml
   {
     public SqlColumn Column { get; set; }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlColumnStub(
-            SqlTable != null ? (SqlTable) SqlTable.Clone(context) : null, 
-            Column);
+    internal override SqlColumnStub Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlColumnStub(
+            t.SqlTable?.Clone(c), 
+            t.Column));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {}

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlComment.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlComment.cs
@@ -23,15 +23,9 @@ namespace Xtensive.Sql.Dml
       Text = replacingExpression.Text;
     }
 
-    internal override object Clone(SqlNodeCloneContext context)
-    {
-      if (context.NodeMapping.TryGetValue(this, out var node))
-        return node;
-
-      var clone = new SqlComment(Text);
-      context.NodeMapping[this] = clone;
-      return clone;
-    }
+    internal override SqlComment Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlComment(t.Text));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlConcat.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlConcat.cs
@@ -14,15 +14,15 @@ namespace Xtensive.Sql.Dml
   [Serializable]
   public class SqlConcat : SqlExpressionList
   {
-    internal override object Clone(SqlNodeCloneContext context)
+    internal override SqlConcat Clone(SqlNodeCloneContext context)
     {
       if (context.NodeMapping.TryGetValue(this, out var value)) {
-        return value;
+        return (SqlConcat)value;
       }
 
       var expressionsClone = new List<SqlExpression>();
       foreach (var e in expressions)
-        expressionsClone.Add((SqlExpression) e.Clone(context));
+        expressionsClone.Add(e.Clone(context));
 
       var clone = new SqlConcat(expressionsClone);
       return clone;

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlContainer.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlContainer.cs
@@ -27,10 +27,9 @@ namespace Xtensive.Sql.Dml
       Value = replacingExpression.Value;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlContainer(Value);
+    internal override SqlContainer Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlContainer(t.Value));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCursor.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCursor.cs
@@ -168,7 +168,7 @@ namespace Xtensive.Sql.Dml
       throw new NotImplementedException();
     }
 
-    internal override object Clone(SqlNodeCloneContext context)
+    internal override SqlCursor Clone(SqlNodeCloneContext context)
     {
       throw new NotImplementedException();
     }

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCustomFunctionCall.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCustomFunctionCall.cs
@@ -28,13 +28,9 @@ namespace Xtensive.Sql.Dml
       Arguments = replacingExpression.Arguments;
     }
 
-    internal override object Clone(SqlNodeCloneContext context)
-    {
-      if (!context.NodeMapping.TryGetValue(this, out var clone)) {
-        context.NodeMapping[this] = clone= new SqlCustomFunctionCall(FunctionType, Arguments.Select(o => (SqlExpression) o.Clone(context)).ToArray(Arguments.Count));
-      }
-      return clone;
-    }
+    internal override SqlCustomFunctionCall Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlCustomFunctionCall(t.FunctionType, t.Arguments.Select(o => o.Clone(c)).ToArray(t.Arguments.Count)));
 
     public override void AcceptVisitor(ISqlVisitor visitor) => visitor.Visit(this);
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlDefaultValue.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlDefaultValue.cs
@@ -16,7 +16,7 @@ namespace Xtensive.Sql.Dml
       ArgumentValidator.EnsureArgumentIs<SqlDefaultValue>(expression);
     }
     
-    internal override object Clone(SqlNodeCloneContext context)
+    internal override SqlDefaultValue Clone(SqlNodeCloneContext context)
     {
       return this;
     }

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlDynamicFilter.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlDynamicFilter.cs
@@ -15,19 +15,15 @@ namespace Xtensive.Sql.Dml
 
     public List<SqlExpression> Expressions { get; private set; }
 
-    internal override object Clone(SqlNodeCloneContext context)
-    {
-      if (context.NodeMapping.TryGetValue(this, out var value)) {
-        return value;
-      }
-      var clone = new SqlDynamicFilter(Id);
-      foreach (var expression in Expressions) {
-        clone.Expressions.Add((SqlExpression) expression.Clone(context));
-      }
+    internal override SqlDynamicFilter Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) => {
+        var clone = new SqlDynamicFilter(t.Id);
+        foreach (var expression in t.Expressions) {
+          clone.Expressions.Add(expression.Clone(c));
+        }
 
-      context.NodeMapping[this] = clone;
-      return clone;
-    }
+        return clone;
+      });
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlExpression.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlExpression.cs
@@ -231,6 +231,10 @@ namespace Xtensive.Sql.Dml
 
     public sealed override bool Equals(object obj) => ReferenceEquals(this, obj);
 
+    public override SqlExpression Clone() => Clone(new SqlNodeCloneContext(false));
+
+    internal override abstract SqlExpression Clone(SqlNodeCloneContext context);
+
     // Constructor
 
     protected SqlExpression(SqlNodeType nodeType) : base(nodeType)

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlExtract.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlExtract.cs
@@ -27,14 +27,13 @@ namespace Xtensive.Sql.Dml
       Operand = replacingExpression.Operand;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = DateTimePart!=SqlDateTimePart.Nothing
-          ? new SqlExtract(DateTimePart, (SqlExpression) Operand.Clone(context))
-          : IntervalPart!=SqlIntervalPart.Nothing
-            ? new SqlExtract(IntervalPart, (SqlExpression) Operand.Clone(context))
-            : new SqlExtract(DateTimeOffsetPart, (SqlExpression) Operand.Clone(context));
+    internal override SqlExtract Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        t.DateTimePart != SqlDateTimePart.Nothing
+          ? new SqlExtract(t.DateTimePart, t.Operand.Clone(c))
+          : t.IntervalPart != SqlIntervalPart.Nothing
+            ? new SqlExtract(t.IntervalPart, t.Operand.Clone(c))
+            : new SqlExtract(t.DateTimeOffsetPart, t.Operand.Clone(c)));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlFunctionCall.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlFunctionCall.cs
@@ -46,13 +46,9 @@ namespace Xtensive.Sql.Dml
       Arguments = replacingExpression.Arguments;
     }
 
-    internal override object Clone(SqlNodeCloneContext context)
-    {
-      if (!context.NodeMapping.TryGetValue(this, out var clone)) {
-        context.NodeMapping[this] = clone= new SqlFunctionCall(FunctionType, Arguments.Select(o => (SqlExpression) o.Clone(context)).ToArray(Arguments.Count));
-      }
-      return clone;
-    }
+    internal override SqlFunctionCall Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlFunctionCall(t.FunctionType, t.Arguments.Select(o => o.Clone(c)).ToArray(t.Arguments.Count)));
 
     public override void AcceptVisitor(ISqlVisitor visitor) => visitor.Visit(this);
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlLike.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlLike.cs
@@ -63,12 +63,11 @@ namespace Xtensive.Sql.Dml
       not = replacingExpression.Not;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlLike((SqlExpression) expression.Clone(context),
-            (SqlExpression) pattern.Clone(context),
-            escape is null ? null : (SqlExpression) escape.Clone(context), not);
+    internal override SqlLike Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlLike(t.expression.Clone(c),
+            t.pattern.Clone(c),
+            t.escape?.Clone(c), t.not));
 
     internal SqlLike(SqlExpression expression, SqlExpression pattern, SqlExpression escape, bool not) : base (SqlNodeType.Like)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlLiteral{T}.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlLiteral{T}.cs
@@ -32,10 +32,9 @@ namespace Xtensive.Sql.Dml
       Value = replacingExpression.Value;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlLiteral<T>(Value);
+    internal override SqlLiteral<T> Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlLiteral<T>(t.Value));
 
     // Constructor
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlMatch.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlMatch.cs
@@ -59,13 +59,12 @@ namespace Xtensive.Sql.Dml
       unique = replacingExpression.Unique;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlMatch((SqlExpression)value.Clone(context),
-                                    (SqlSubQuery)subQuery.Clone(context),
-                                    unique,
-                                    matchType);
+    internal override SqlMatch Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlMatch(t.value.Clone(c),
+                                    t.subQuery.Clone(c),
+                                    t.unique,
+                                    t.matchType));
 
     internal SqlMatch(SqlExpression value, SqlSubQuery subQuery, bool unique, SqlMatchType matchType)
       : base(SqlNodeType.Match)

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlMetadata.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlMetadata.cs
@@ -23,10 +23,9 @@ namespace Xtensive.Sql.Dml
       Value = source.Value;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlMetadata((SqlExpression) Expression.Clone(context), Value);
+    internal override SqlMetadata Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlMetadata(t.Expression.Clone(c), t.Value));
 
     public override void AcceptVisitor(ISqlVisitor visitor) => visitor.Visit(this);
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlNative.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlNative.cs
@@ -21,10 +21,9 @@ namespace Xtensive.Sql.Dml
       Value = replacingExpression.Value;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlNative(Value);
+    internal override SqlNative Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlNative(t.Value));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlNextValue.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlNextValue.cs
@@ -42,10 +42,9 @@ namespace Xtensive.Sql.Dml
       increment = replacingExpression.Increment;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlNextValue(sequence, increment);
+    internal override SqlNextValue Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlNextValue(t.sequence, t.increment));
 
     internal SqlNextValue(Sequence sequence) : base(SqlNodeType.NextValue)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlNull.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlNull.cs
@@ -16,7 +16,7 @@ namespace Xtensive.Sql.Dml
       ArgumentValidator.EnsureArgumentIs<SqlNull>(expression);
     }
     
-    internal override object Clone(SqlNodeCloneContext context)
+    internal override SqlNull Clone(SqlNodeCloneContext context)
     {
       return this;
     }

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlParameterRef.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlParameterRef.cs
@@ -23,12 +23,11 @@ namespace Xtensive.Sql.Dml
       Parameter = replacingExpression.Parameter;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = Name != null
-            ? new SqlParameterRef(Name)
-            : new SqlParameterRef(Parameter);
+    internal override SqlParameterRef Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        t.Name != null
+            ? new SqlParameterRef(t.Name)
+            : new SqlParameterRef(t.Parameter));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlPlaceholder.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlPlaceholder.cs
@@ -12,10 +12,9 @@ namespace Xtensive.Sql.Dml
   {
     public object Id { get; private set; }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlPlaceholder(Id);
+    internal override SqlPlaceholder Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlPlaceholder(t.Id));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlRound.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlRound.cs
@@ -16,7 +16,7 @@ namespace Xtensive.Sql.Dml
     public SqlExpression Length { get; private set; }
     public TypeCode Type { get; private set; }
     public MidpointRounding Mode { get; private set; }
-    
+
     public override void ReplaceWith(SqlExpression expression)
     {
       var replacingExpression = ArgumentValidator.EnsureArgumentIs<SqlRound>(expression);
@@ -26,13 +26,12 @@ namespace Xtensive.Sql.Dml
       Mode = replacingExpression.Mode;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlRound(
-            (SqlExpression) Argument.Clone(context),
-            Length is null ? null : (SqlExpression) Length.Clone(context),
-            Type, Mode);
+    internal override SqlRound Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlRound(
+            t.Argument.Clone(c),
+            t.Length?.Clone(c),
+            t.Type, t.Mode));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlRow.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlRow.cs
@@ -12,15 +12,15 @@ namespace Xtensive.Sql.Dml
   [Serializable]
   public class SqlRow: SqlExpressionList
   {
-    internal override object Clone(SqlNodeCloneContext context)
+    internal override SqlRow Clone(SqlNodeCloneContext context)
     {
-      if (context.NodeMapping.TryGetValue(this, out var value)) {
+      if (context.TryGet(this) is SqlRow value) {
         return value;
       }
 
       var expressionsClone = new List<SqlExpression>(expressions.Count);
       foreach (var e in expressions)
-        expressionsClone.Add((SqlExpression) e.Clone(context));
+        expressionsClone.Add(e.Clone(context));
 
       var clone = new SqlRow(expressionsClone);
       return clone;

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlRowNumber.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlRowNumber.cs
@@ -12,17 +12,13 @@ namespace Xtensive.Sql.Dml
   {
     public SqlOrderCollection OrderBy { get; private set; }
 
-    internal override object Clone(SqlNodeCloneContext context)
-    {
-      if (context.NodeMapping.TryGetValue(this, out var value)) {
-        return value;
-      }
-      var clone = new SqlRowNumber();
-      foreach (SqlOrder so in OrderBy)
-        clone.OrderBy.Add((SqlOrder) so.Clone(context));
-      context.NodeMapping[this] = clone;
-      return clone;
-    }
+    internal override SqlRowNumber Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) => {
+        var clone = new SqlRowNumber();
+        foreach (SqlOrder so in t.OrderBy)
+          clone.OrderBy.Add(so.Clone(c));
+        return clone;
+      });
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlSubQuery.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlSubQuery.cs
@@ -31,22 +31,17 @@ namespace Xtensive.Sql.Dml
       query = replacingExpression.Query;
     }
 
-    internal override object Clone(SqlNodeCloneContext context)
-    {
-      if (context.NodeMapping.TryGetValue(this, out var value)) {
-        return value;
-      }
-
-      SqlSubQuery clone;
-      SqlSelect select = query as SqlSelect;
-      SqlQueryExpression expression = query as SqlQueryExpression;
-      if (select != null)
-        clone = new SqlSubQuery((SqlSelect)select.Clone(context));
-      else 
-        clone = new SqlSubQuery((SqlQueryExpression)expression.Clone(context));
-      context.NodeMapping[this] = clone;
-      return clone;
-    }
+    internal override SqlSubQuery Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) => {
+        SqlSubQuery clone;
+        SqlSelect select = t.query as SqlSelect;
+        SqlQueryExpression expression = t.query as SqlQueryExpression;
+        if (select != null)
+          clone = new SqlSubQuery(select.Clone(c));
+        else 
+          clone = new SqlSubQuery(expression.Clone(c));
+        return clone;
+      });
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlTableColumn.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlTableColumn.cs
@@ -22,22 +22,17 @@ namespace Xtensive.Sql.Dml
       base.ReplaceWith(expression);
     }
 
-    internal override object Clone(SqlNodeCloneContext context)
-    {
-      if (context.NodeMapping.TryGetValue(this, out var value)) {
-        return value;
-      }
-
-      var table = SqlTable;
-      SqlNode clonedTable;
-      if (context.NodeMapping.TryGetValue(SqlTable, out clonedTable)) {
-        table = (SqlTable) clonedTable;
-      }
+    internal override SqlTableColumn Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) => {
+        var table = t.SqlTable;
+        SqlNode clonedTable;
+        if (c.NodeMapping.TryGetValue(t.SqlTable, out clonedTable)) {
+          table = (SqlTable) clonedTable;
+        }
       
-      var clone = new SqlTableColumn(table, Name);
-      context.NodeMapping[this] = clone;
-      return clone;
-    }
+        var clone = new SqlTableColumn(table, t.Name);
+        return clone;
+      });
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlTrim.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlTrim.cs
@@ -49,10 +49,9 @@ namespace Xtensive.Sql.Dml
       trimType = replacingExpression.TrimType;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlTrim((SqlExpression) expression.Clone(context), trimCharacters, trimType);
+    internal override SqlTrim Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlTrim(t.expression.Clone(c), t.trimCharacters, t.trimType));
 
     internal SqlTrim(SqlExpression expression, string trimCharacters, SqlTrimType trimType) : base (SqlNodeType.Trim)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlUnary.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlUnary.cs
@@ -26,10 +26,9 @@ namespace Xtensive.Sql.Dml
       Operand = replacingExpression.Operand;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlUnary(NodeType, (SqlExpression) Operand.Clone(context));
+    internal override SqlUnary Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlUnary(t.NodeType, t.Operand.Clone(c)));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlUserColumn.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlUserColumn.cs
@@ -27,10 +27,9 @@ namespace Xtensive.Sql.Dml
       this.expression = replacingExpression.Expression;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlUserColumn((SqlExpression)expression.Clone(context));
+    internal override SqlUserColumn Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlUserColumn(t.expression.Clone(c)));
 
     // Constructor
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlUserFunctionCall.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlUserFunctionCall.cs
@@ -25,13 +25,9 @@ namespace Xtensive.Sql.Dml
       Arguments = replacingExpression.Arguments;
     }
 
-    internal override object Clone(SqlNodeCloneContext context)
-    {
-      if (!context.NodeMapping.TryGetValue(this, out var clone)) {
-        context.NodeMapping[this] = clone = new SqlUserFunctionCall(Name, Arguments.Select(o => (SqlExpression) o.Clone(context)).ToArray(Arguments.Count));
-      }
-      return clone;
-    }
+    internal override SqlUserFunctionCall Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlUserFunctionCall(t.Name, t.Arguments.Select(o => o.Clone(c)).ToArray(t.Arguments.Count)));
 
     internal SqlUserFunctionCall(string name, IEnumerable<SqlExpression> arguments)
       : base(SqlFunctionType.UserDefined, arguments)

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlVariable.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlVariable.cs
@@ -42,10 +42,9 @@ namespace Xtensive.Sql.Dml
       name = replacingExpression.Name;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlVariable(name, type);
+    internal override SqlVariable Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlVariable(t.name, t.type));
 
     internal SqlVariable(string name, SqlValueType type)
       : base(SqlNodeType.Variable)

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlVariant.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlVariant.cs
@@ -22,10 +22,9 @@ namespace Xtensive.Sql.Dml
       Id = replacingExpression.Id;
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlVariant(Id, (SqlExpression) Main.Clone(context), (SqlExpression) Alternative.Clone(context));
+    internal override SqlVariant Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlVariant(t.Id, t.Main.Clone(c), t.Alternative.Clone(c)));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlFastFirstRowsHint.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlFastFirstRowsHint.cs
@@ -15,10 +15,9 @@ namespace Xtensive.Sql.Dml
     /// <value>The row amount.</value>
     public int Amount { get; private set; }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlFastFirstRowsHint(Amount);
+    internal override SqlFastFirstRowsHint Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlFastFirstRowsHint(t.Amount));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlForceJoinOrderHint.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlForceJoinOrderHint.cs
@@ -18,10 +18,9 @@ namespace Xtensive.Sql.Dml
     /// </summary>
     public IEnumerable<SqlTable> Tables { get { return tables; } }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlForceJoinOrderHint(tables?.Select(table => (SqlTable) table.Clone()).ToArray());
+    internal override SqlForceJoinOrderHint Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlForceJoinOrderHint(t.tables?.Select(table => (SqlTable) table.Clone()).ToArray()));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlJoinHint.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlJoinHint.cs
@@ -23,10 +23,9 @@ namespace Xtensive.Sql.Dml
     /// </summary>
     public SqlTable Table { get; private set; }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlJoinHint(Method, (SqlTable) Table.Clone());
+    internal override SqlJoinHint Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlJoinHint(t.Method, (SqlTable) t.Table.Clone()));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlNativeHint.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlNativeHint.cs
@@ -15,10 +15,9 @@ namespace Xtensive.Sql.Dml
     /// <value>The hint text.</value>
     public string HintText { get; private set; }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlNativeHint(HintText);
+    internal override SqlNativeHint Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlNativeHint(t.HintText));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlContainsTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlContainsTable.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xtensive.Collections;
@@ -17,7 +17,7 @@ namespace Xtensive.Sql.Dml
 
     public SqlExpression TopNByRank { get; private set; }
 
-    internal override object Clone(SqlNodeCloneContext context)
+    internal override SqlContainsTable Clone(SqlNodeCloneContext context)
     {
       throw new NotImplementedException();
     }

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlFragment.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlFragment.cs
@@ -10,10 +10,9 @@ namespace Xtensive.Sql.Dml
   {
     public SqlExpression Expression { get; private set; }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlFragment((SqlExpression) Expression.Clone(context));
+    internal override SqlFragment Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlFragment(t.Expression.Clone(c)));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlFreeTextTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlFreeTextTable.cs
@@ -23,7 +23,7 @@ namespace Xtensive.Sql.Dml
 
     public SqlExpression TopNByRank { get; private set; }
 
-    internal override object Clone(SqlNodeCloneContext context)
+    internal override SqlFreeTextTable Clone(SqlNodeCloneContext context)
     {
       throw new NotImplementedException();
     }

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlJoinExpression.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlJoinExpression.cs
@@ -34,13 +34,12 @@ namespace Xtensive.Sql.Dml
     /// <value>The expression.</value>
     public SqlExpression Expression { get; private set; }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlJoinExpression(JoinType,
-            Left==null ? null : (SqlTable) Left.Clone(context),
-            Right==null ? null : (SqlTable) Right.Clone(context),
-            Expression==null ? null : (SqlExpression) Expression.Clone(context));
+    internal override SqlJoinExpression Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlJoinExpression(t.JoinType,
+            t.Left?.Clone(c),
+            t.Right?.Clone(c),
+            t.Expression?.Clone(c)));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlJoinedTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlJoinedTable.cs
@@ -27,12 +27,11 @@ namespace Xtensive.Sql.Dml
     /// <value>Aliased columns.</value>
     public SqlColumnCollection AliasedColumns { get; private set; }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlJoinedTable((SqlJoinExpression) joinExpression.Clone(context)) {
-            AliasedColumns = new SqlColumnCollection(new List<SqlColumn>(AliasedColumns))
-          };
+    internal override SqlJoinedTable Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlJoinedTable(t.joinExpression.Clone(c)) {
+            AliasedColumns = new SqlColumnCollection(new List<SqlColumn>(t.AliasedColumns))
+          });
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlOrder.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlOrder.cs
@@ -30,12 +30,11 @@ namespace Xtensive.Sql.Dml
     /// <value><see langword="true"/> if ascending; otherwise, <see langword="false"/>.</value>
     public bool Ascending { get; private set; }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = (Expression is null
-            ? new SqlOrder(Position, Ascending)
-            : new SqlOrder((SqlExpression)Expression.Clone(context), Ascending));
+    internal override SqlOrder Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        t.Expression is null
+            ? new SqlOrder(t.Position, t.Ascending)
+            : new SqlOrder(t.Expression.Clone(c), t.Ascending));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlQueryRef.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlQueryRef.cs
@@ -22,12 +22,11 @@ namespace Xtensive.Sql.Dml
       get { return query; }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = query is SqlSelect ss
-          ? new SqlQueryRef((SqlSelect) ss.Clone(context), Name)
-          : new SqlQueryRef((SqlQueryExpression) ((SqlQueryExpression) query).Clone(context), Name);
+    internal override SqlQueryRef Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        t.query is SqlSelect ss
+          ? new SqlQueryRef(ss.Clone(c), t.Name)
+          : new SqlQueryRef(((SqlQueryExpression) t.query).Clone(c), t.Name));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlTable.cs
@@ -139,6 +139,7 @@ namespace Xtensive.Sql.Dml
       return GetEnumerator();
     }
 
+    internal abstract override SqlTable Clone(SqlNodeCloneContext context);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlTableRef.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlTableRef.cs
@@ -29,9 +29,9 @@ namespace Xtensive.Sql.Dml
     /// <value>The table.</value>
     public DataTable DataTable { get; private set; }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
+    internal override SqlTableRef Clone(SqlNodeCloneContext context) =>
       context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
+        ? (SqlTableRef)clone
         : CreateClone(context);
 
     private SqlTableRef CreateClone(SqlNodeCloneContext context)

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlAssignment.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlAssignment.cs
@@ -30,10 +30,9 @@ namespace Xtensive.Sql.Dml
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlAssignment((ISqlLValue)left.Clone(), (SqlExpression)right.Clone(context));
+    internal override SqlAssignment Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlAssignment((ISqlLValue)t.left.Clone(), t.right.Clone(c)));
 
     internal SqlAssignment(ISqlLValue left, SqlExpression right)
       : base(SqlNodeType.Assign)

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlBatch.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlBatch.cs
@@ -105,18 +105,13 @@ namespace Xtensive.Sql.Dml
 
     #endregion
 
-    internal override object Clone(SqlNodeCloneContext context)
-    {
-      if (context.NodeMapping.TryGetValue(this, out var value)) {
-        return value;
-      }
-
-      var clone = new SqlBatch();
-      foreach (SqlStatement s in statements)
-        clone.Add((SqlStatement) s.Clone(context));
-      context.NodeMapping[this] = clone;
-      return clone;
-    }
+    internal override SqlBatch Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) => {
+        var clone = new SqlBatch();
+        foreach (SqlStatement s in t.statements)
+          clone.Add((SqlStatement) s.Clone(c));
+        return clone;
+      });
 
     /// <inheritdoc/>
     public override void AcceptVisitor(ISqlVisitor visitor)

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlBreak.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlBreak.cs
@@ -9,10 +9,7 @@ namespace Xtensive.Sql.Dml
   [Serializable]
   public class SqlBreak : SqlStatement
   {
-    internal override object Clone(SqlNodeCloneContext context)
-    {
-      return this;
-    }
+    internal override SqlBreak Clone(SqlNodeCloneContext context) => this;
 
     internal SqlBreak()
       : base(SqlNodeType.Break)

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlCloseCursor.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlCloseCursor.cs
@@ -21,10 +21,7 @@ namespace Xtensive.Sql.Dml
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context)
-    {
-      throw new NotImplementedException();
-    }
+    internal override SqlCloseCursor Clone(SqlNodeCloneContext context) => throw new NotImplementedException();
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlContinue.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlContinue.cs
@@ -9,10 +9,7 @@ namespace Xtensive.Sql.Dml
   [Serializable]
   public class SqlContinue : SqlStatement
   {
-    internal override object Clone(SqlNodeCloneContext context)
-    {
-      return this;
-    }
+    internal override SqlContinue Clone(SqlNodeCloneContext context) => this;
 
     internal SqlContinue()
       : base(SqlNodeType.Continue)

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlDeclareCursor.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlDeclareCursor.cs
@@ -17,10 +17,7 @@ namespace Xtensive.Sql.Dml
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context)
-    {
-      throw new NotImplementedException();
-    }
+    internal override SqlDeclareCursor Clone(SqlNodeCloneContext context) => throw new NotImplementedException();
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlDeclareVariable.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlDeclareVariable.cs
@@ -20,10 +20,9 @@ namespace Xtensive.Sql.Dml
       get { return variable; }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlDeclareVariable(variable);
+    internal override SqlDeclareVariable Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlDeclareVariable(t.variable));
 
     internal SqlDeclareVariable(SqlVariable variable)
       : base(SqlNodeType.DeclareVariable)

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlDelete.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlDelete.cs
@@ -45,7 +45,7 @@ namespace Xtensive.Sql.Dml
     /// <summary>
     /// Gets or sets the FROM clause expression.
     /// </summary>
-    public SqlTable From 
+    public SqlTable From
     {
       get { return from;}
       set { from = value; }
@@ -60,27 +60,22 @@ namespace Xtensive.Sql.Dml
       set { limit = value; }
     }
 
-    internal override object Clone(SqlNodeCloneContext context)
-    {
-      if (context.NodeMapping.TryGetValue(this, out var value)) {
-        return value;
-      }
+    internal override SqlDelete Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) => {
+        SqlDelete clone = new SqlDelete();
+        if (t.Delete != null)
+          clone.Delete = t.Delete.Clone(c);
+        if (t.from != null)
+          clone.From = (SqlQueryRef) t.from.Clone(c);
+        if (t.where is not null)
+          clone.Where = t.where.Clone(c);
 
-      SqlDelete clone = new SqlDelete();
-      if (Delete!=null)
-        clone.Delete = (SqlTableRef)Delete.Clone(context);
-      if (from!=null)
-        clone.From = (SqlQueryRef)from.Clone(context);
-      if (where is not null)
-        clone.Where = (SqlExpression) where.Clone(context);
+        if (t.Hints.Count > 0)
+          foreach (SqlHint hint in t.Hints)
+            clone.Hints.Add((SqlHint) hint.Clone(c));
 
-      if (Hints.Count>0)
-        foreach (SqlHint hint in Hints)
-          clone.Hints.Add((SqlHint)hint.Clone(context));
-
-      context.NodeMapping[this] = clone;
-      return clone;
-    }
+        return clone;
+      });
 
     // Constructor
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlFetch.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlFetch.cs
@@ -53,10 +53,7 @@ namespace Xtensive.Sql.Dml
       get { return targets; }
     }
 
-    internal override object Clone(SqlNodeCloneContext context)
-    {
-      throw new NotImplementedException();
-    }
+    internal override SqlFetch Clone(SqlNodeCloneContext context) => throw new NotImplementedException();
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlIf.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlIf.cs
@@ -56,12 +56,11 @@ namespace Xtensive.Sql.Dml
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlIf((SqlExpression) condition.Clone(context),
-            (SqlStatement) trueStatement.Clone(context),
-            falseStatement == null ? null : (SqlStatement) falseStatement.Clone(context));
+    internal override SqlIf Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlIf(t.condition.Clone(c),
+            (SqlStatement) t.trueStatement.Clone(c),
+            t.falseStatement == null ? null : (SqlStatement) t.falseStatement.Clone(c)));
 
     internal SqlIf(SqlExpression condition, SqlStatement trueStatement, SqlStatement falseStatement)
       : base(SqlNodeType.Conditional)

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlInsert.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlInsert.cs
@@ -76,24 +76,19 @@ namespace Xtensive.Sql.Dml
     /// </summary>
     public SqlSelect From { get; set; }
 
-    internal override object Clone(SqlNodeCloneContext context)
-    {
-      if (context.NodeMapping.TryGetValue(this, out var value)) {
-        return value;
-      }
+    internal override SqlInsert Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) => {
+        SqlInsert clone = new SqlInsert();
+        clone.Into = t.Into?.Clone(c);
+        clone.From = t.From?.Clone(c);
+        clone.Values = t.Values.Clone(c);
 
-      SqlInsert clone = new SqlInsert();
-      clone.Into = (SqlTableRef) Into?.Clone(context);
-      clone.From = (SqlSelect) From?.Clone(context);
-      clone.Values = Values.Clone(context);
+        if (t.Hints.Count > 0)
+          foreach (SqlHint hint in t.Hints)
+            clone.Hints.Add((SqlHint) hint.Clone(c));
 
-      if (Hints.Count > 0)
-        foreach (SqlHint hint in Hints)
-          clone.Hints.Add((SqlHint) hint.Clone(context));
-
-      context.NodeMapping[this] = clone;
-      return clone;
-    }
+        return clone;
+      });
 
     // Constructor
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlOpenCursor.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlOpenCursor.cs
@@ -21,10 +21,7 @@ namespace Xtensive.Sql.Dml
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context)
-    {
-      throw new NotImplementedException();
-    }
+    internal override SqlOpenCursor Clone(SqlNodeCloneContext context) => throw new NotImplementedException();
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlQueryExpression.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlQueryExpression.cs
@@ -32,12 +32,11 @@ namespace Xtensive.Sql.Dml
       get { return all; }
     }
 
-    internal override object Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? clone
-        : context.NodeMapping[this] = new SqlQueryExpression(NodeType,
-          (ISqlQueryExpression)((SqlNode) left).Clone(context),
-          (ISqlQueryExpression)((SqlNode) right).Clone(context), all);
+    internal override SqlQueryExpression Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new SqlQueryExpression(t.NodeType,
+          (ISqlQueryExpression)((SqlNode) t.left).Clone(c),
+          (ISqlQueryExpression)((SqlNode) t.right).Clone(c), t.all));
 
     #region IEnumerable<ISqlQueryExpression> Members
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlStatementBlock.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlStatementBlock.cs
@@ -98,18 +98,13 @@ namespace Xtensive.Sql.Dml
 
     #endregion
 
-    internal override object Clone(SqlNodeCloneContext context)
-    {
-      if (context.NodeMapping.TryGetValue(this, out var value)) {
-        return value;
-      }
-
-      SqlStatementBlock clone = new SqlStatementBlock();
-      foreach (SqlStatement s in statements)
-        clone.Add((SqlStatement) s.Clone(context));
-      context.NodeMapping[this] = clone;
-      return clone;
-    }
+    internal override SqlStatementBlock Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) => {
+        SqlStatementBlock clone = new SqlStatementBlock();
+        foreach (SqlStatement s in t.statements)
+          clone.Add((SqlStatement) s.Clone(c));
+        return clone;
+      });
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlUpdate.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlUpdate.cs
@@ -52,7 +52,7 @@ namespace Xtensive.Sql.Dml
     /// <summary>
     /// Gets or sets the FROM clause expression.
     /// </summary>
-    public SqlTable From 
+    public SqlTable From
     {
       get { return from;}
       set { from = value; }
@@ -67,31 +67,26 @@ namespace Xtensive.Sql.Dml
       set { limit = value; }
     }
 
-    internal override object Clone(SqlNodeCloneContext context)
-    {
-      if (context.NodeMapping.TryGetValue(this, out var value)) {
-        return value;
-      }
+    internal override SqlUpdate Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) => {
+        var clone = new SqlUpdate();
+        if (t.update != null)
+          clone.Update = t.Update.Clone(c);
+        if (t.from != null)
+          clone.From = (SqlQueryRef) t.from.Clone(c);
+        foreach (KeyValuePair<ISqlLValue, SqlExpression> p in t.values)
+          clone.Values[(ISqlLValue) ((SqlExpression) p.Key).Clone(c)] =
+            p.Value?.Clone(c);
+        if (t.where is not null)
+          clone.Where = t.where.Clone(c);
+        if (t.limit is not null)
+          clone.Limit = t.where.Clone(c);
+        if (t.Hints.Count > 0)
+          foreach (SqlHint hint in t.Hints)
+            clone.Hints.Add((SqlHint) hint.Clone(c));
 
-      var clone = new SqlUpdate();
-      if (update!=null)
-        clone.Update = (SqlTableRef)Update.Clone(context);
-      if (from!=null)
-        clone.From = (SqlQueryRef)from.Clone(context);
-      foreach (KeyValuePair<ISqlLValue, SqlExpression> p in values)
-        clone.Values[(ISqlLValue) ((SqlExpression) p.Key).Clone(context)] =
-          p.Value is null ? null : (SqlExpression) p.Value.Clone(context);
-      if (where is not null)
-        clone.Where = (SqlExpression)where.Clone(context);
-      if (limit is not null)
-        clone.Limit = (SqlExpression)where.Clone(context);
-      if (Hints.Count>0)
-        foreach (SqlHint hint in Hints)
-          clone.Hints.Add((SqlHint)hint.Clone(context));
-
-      context.NodeMapping[this] = clone;
-      return clone;
-    }
+        return clone;
+      });
 
     // Constructor
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlWhile.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlWhile.cs
@@ -43,19 +43,13 @@ namespace Xtensive.Sql.Dml
       }
     }
 
-    internal override object Clone(SqlNodeCloneContext context)
-    {
-      if (context.NodeMapping.TryGetValue(this, out var value)) {
-        return value;
-      }
-      
-      SqlWhile clone = new SqlWhile((SqlExpression)condition.Clone(context));
-      if (statement!=null)
-        clone.Statement = (SqlStatement) statement.Clone(context);
-      context.NodeMapping[this] = clone;
-
-      return clone;
-    }
+    internal override SqlWhile Clone(SqlNodeCloneContext context) =>
+      context.GetOrAdd(this, static (t, c) => {
+        SqlWhile clone = new SqlWhile(t.condition.Clone(c));
+        if (t.statement!=null)
+          clone.Statement = (SqlStatement) t.statement.Clone(c);
+        return clone;
+      });
     
     internal SqlWhile(SqlExpression condition) : base(SqlNodeType.While)
     {

--- a/Orm/Xtensive.Orm/Sql/Internals/SqlNodeCloneContext.cs
+++ b/Orm/Xtensive.Orm/Sql/Internals/SqlNodeCloneContext.cs
@@ -1,19 +1,35 @@
-// Copyright (C) 2003-2010 Xtensive LLC.
-// All rights reserved.
-// For conditions of distribution and use, see license.
+// Copyright (C) 2003-2022 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 
 namespace Xtensive.Sql
 {
-  internal class SqlNodeCloneContext
+  internal readonly struct SqlNodeCloneContext
   {
-    private Dictionary<SqlNode, SqlNode> nodeMapping = new Dictionary<SqlNode, SqlNode>();
+    private readonly Dictionary<SqlNode, SqlNode> nodeMapping;
+    public Dictionary<SqlNode, SqlNode> NodeMapping => nodeMapping;
 
-    public Dictionary<SqlNode, SqlNode> NodeMapping {
-      get {
-        return nodeMapping;
+    public T TryGet<T>(T node) where T : SqlNode =>
+      NodeMapping.TryGetValue(node, out var clone)
+        ? (T) clone
+        : null;
+
+    public T GetOrAdd<T>(T node, Func<T, SqlNodeCloneContext, T> factory) where T : SqlNode
+    {
+      if (NodeMapping.TryGetValue(node, out var clone)) {
+        return (T)clone;
       }
+      var result = factory(node, this);
+      NodeMapping[node] = result;
+      return result;
+    }
+
+    public SqlNodeCloneContext(bool _)
+    {
+      nodeMapping = new();
     }
   }
 }

--- a/Orm/Xtensive.Orm/Sql/SqlNode.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlNode.cs
@@ -24,13 +24,11 @@ namespace Xtensive.Sql
     /// <returns>
     /// A new object that is a copy of this instance.
     /// </returns>
-    public object Clone()
-    {
-      var context = new SqlNodeCloneContext();
-      return Clone(context);
-    }
+    public virtual SqlNode Clone() => Clone(new SqlNodeCloneContext(false));
 
-    internal abstract object Clone(SqlNodeCloneContext context);
+    object ICloneable.Clone() => Clone(new SqlNodeCloneContext(false));
+
+    internal abstract SqlNode Clone(SqlNodeCloneContext context);
 
     internal SqlNode(SqlNodeType nodeType)
     {


### PR DESCRIPTION
Our own clone of https://github.com/DataObjects-NET/dataobjects-net/pull/261