### PR TITLE
Optimize Type-dependency operations

### DIFF
--- a/Orm/Xtensive.Orm.Tests.Framework/DomainModelExtensions.cs
+++ b/Orm/Xtensive.Orm.Tests.Framework/DomainModelExtensions.cs
@@ -81,7 +81,7 @@ namespace Xtensive.Orm.Tests
 
     public static void DumpAncestor(this TypeInfo target, int indent)
     {
-      TypeInfo ancestor = target.GetAncestor();
+      TypeInfo ancestor = target.Ancestor;
       if (ancestor!=null)
         WriteLine(indent + 1, "Ancestor: " + ancestor.Name);
       else {
@@ -92,8 +92,8 @@ namespace Xtensive.Orm.Tests
     public static void DumpDescendants(this TypeInfo target, int indent)
     {
       WriteLine(indent, "Descendants:");
-      HashSet<TypeInfo> direct = new HashSet<TypeInfo>(target.GetDescendants());
-      foreach (TypeInfo descendant in target.GetDescendants(true)) {
+      HashSet<TypeInfo> direct = new HashSet<TypeInfo>(target.Descendants);
+      foreach (TypeInfo descendant in target.RecursiveDescendants) {
         if (direct.Contains(descendant))
           WriteLine(indent + 1, descendant.Name + " (direct)");
         else
@@ -104,8 +104,8 @@ namespace Xtensive.Orm.Tests
     public static void DumpInterfaces(this TypeInfo target, int indent)
     {
       WriteLine(indent, "Interfaces:");
-      HashSet<TypeInfo> direct = new HashSet<TypeInfo>(target.GetInterfaces());
-      foreach (TypeInfo @interface in target.GetInterfaces(true)) {
+      var direct = target.Interfaces;
+      foreach (TypeInfo @interface in target.RecursiveInterfaces) {
         if (direct.Contains(@interface))
           WriteLine(indent + 1, @interface.Name + " (direct)");
         else
@@ -116,8 +116,8 @@ namespace Xtensive.Orm.Tests
     public static void DumpImplementors(this TypeInfo target, int indent)
     {
       WriteLine(indent, "Implementors:");
-      HashSet<TypeInfo> direct = new HashSet<TypeInfo>(target.GetImplementors());
-      foreach (TypeInfo implementor in target.GetImplementors(true)) {
+      HashSet<TypeInfo> direct = new HashSet<TypeInfo>(target.Implementors);
+      foreach (TypeInfo implementor in target.RecursiveImplementors) {
         if (direct.Contains(implementor))
           WriteLine(indent + 1, implementor.Name + " (direct)");
         else
@@ -163,10 +163,10 @@ namespace Xtensive.Orm.Tests
       if (target.IsEntity) {
         WriteLine(indent, "Hierarchy: " + target.Hierarchy.Root.Name);
         if (target.Hierarchy.Root!=target)
-          WriteLine(indent, "Ancestor: " + target.GetAncestor().Name);
+          WriteLine(indent, "Ancestor: " + target.Ancestor.Name);
       }
       else if (target.IsInterface) {
-        WriteLine(indent, "Implementors: " + target.GetImplementors().Select(t => t.Name).ToCommaDelimitedString());
+        WriteLine(indent, "Implementors: " + target.Implementors.Select(t => t.Name).ToCommaDelimitedString());
       }
 
       target.DumpMappingName(indent);

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0117_FKStructureTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0117_FKStructureTest.cs
@@ -96,7 +96,7 @@ namespace Xtensive.Orm.Tests.Storage
     public void AssociationThroughStructureTest()
     {
       var type = Domain.Model.Types[typeof (Owner1)];
-      Assert.AreEqual(2, type.GetOwnerAssociations().Count);
+      Assert.AreEqual(2, type.GetOwnerAssociations().Count());
       Assert.AreEqual(8, Domain.Model.Associations.Count);
     }
 

--- a/Orm/Xtensive.Orm.Tests/Model/LibraryTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Model/LibraryTest.cs
@@ -393,18 +393,18 @@ namespace Xtensive.Orm.Tests.Model
     private static void VerifyModel(Domain domain)
     {
       TypeInfoCollection types = domain.Model.Types;
-      Assert.AreEqual(types.FindAncestor(types[typeof (Person)]), null);
-      Assert.AreEqual(types.FindAncestor(types[typeof (Book)]), null);
-      Assert.AreEqual(types.FindAncestor(types[typeof (BookReview)]), null);
-      Assert.AreEqual(types.FindAncestor(types[typeof (Author)]), types[typeof (Person)]);
+      Assert.AreEqual(types[typeof (Person)].Ancestor, null);
+      Assert.AreEqual(types[typeof (Book)].Ancestor, null);
+      Assert.AreEqual(types[typeof (BookReview)].Ancestor, null);
+      Assert.AreEqual(types[typeof (Author)].Ancestor, types[typeof (Person)]);
 
-      Assert.AreEqual(types[typeof (Person)].GetAncestor(), null);
-      Assert.AreEqual(types[typeof (Book)].GetAncestor(), null);
-      Assert.AreEqual(types[typeof (BookReview)].GetAncestor(), null);
-      Assert.AreEqual(types[typeof (Author)].GetAncestor(), types[typeof (Person)]);
+      Assert.AreEqual(types[typeof (Person)].Ancestor, null);
+      Assert.AreEqual(types[typeof (Book)].Ancestor, null);
+      Assert.AreEqual(types[typeof (BookReview)].Ancestor, null);
+      Assert.AreEqual(types[typeof (Author)].Ancestor, types[typeof (Person)]);
 
-      ICollection<TypeInfo> collection = types.Structures;
-      Assert.IsTrue(collection.Count > 0);
+      var collection = types.Structures;
+      Assert.IsTrue(collection.Any());
       foreach (TypeInfo item in collection) {
         Assert.IsTrue(item.IsStructure);
         Assert.IsFalse(item.IsInterface);
@@ -412,7 +412,7 @@ namespace Xtensive.Orm.Tests.Model
       }
 
       collection = types.Interfaces;
-      Assert.IsFalse(collection.Count > 0);
+      Assert.IsFalse(collection.Any());
       foreach (TypeInfo item in collection) {
         Assert.IsTrue(item.IsInterface);
         Assert.IsFalse(item.IsStructure);
@@ -420,7 +420,7 @@ namespace Xtensive.Orm.Tests.Model
       }
 
       collection = types.Entities;
-      Assert.IsTrue(collection.Count > 0);
+      Assert.IsTrue(collection.Any());
       foreach (TypeInfo item in collection) {
         Assert.IsTrue(item.IsEntity);
         Assert.IsFalse(item.IsInterface);
@@ -555,8 +555,8 @@ namespace Xtensive.Orm.Tests.Model
       Assert.AreEqual(true, typeInfo.Fields["Books"].IsNullable);
       Assert.AreEqual("Books", typeInfo.Fields["Books"].Name);
 
-      Assert.AreEqual(2, typeInfo.Fields.Find(FieldAttributes.Declared).Count);
-      Assert.AreEqual(9, typeInfo.Fields.Find(FieldAttributes.Inherited).Count);
+      Assert.AreEqual(2, typeInfo.Fields.Find(FieldAttributes.Declared).Count());
+      Assert.AreEqual(9, typeInfo.Fields.Find(FieldAttributes.Inherited).Count());
 
       // KeyColumns
       Assert.IsNotNull(typeInfo.Columns["PassportNumber"]);

--- a/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchTestHelper.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchTestHelper.cs
@@ -42,8 +42,8 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
       var state = session.EntityStateCache[key, true];
       var realType = state.Key.TypeInfo;
       Assert.IsTrue(realType.Equals(type) 
-        || realType.GetAncestors().Contains(type) 
-        || (type.IsInterface && realType.GetInterfaces(true).Contains(type)));
+        || realType.Ancestors.Contains(type) 
+        || (type.IsInterface && realType.RecursiveInterfaces.Contains(type)));
       var tuple = state.Tuple;
       Assert.IsNotNull(tuple);
       foreach (var field in type.Fields) {

--- a/Orm/Xtensive.Orm.Tests/Storage/VersionBehaviorTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/VersionBehaviorTest.cs
@@ -5,6 +5,7 @@
 // Created:    2010.08.05
 
 using System;
+using System.Linq;
 using System.Diagnostics;
 using NUnit.Framework;
 using Xtensive.Orm.Tests;
@@ -186,8 +187,8 @@ namespace Xtensive.Orm.Tests.Storage
       var domain = Domain.Build(config);
       var defaultTypeInfo = domain.Model.Types[typeof(Default)];
       var defaultInheritorTypeInfo = domain.Model.Types[typeof(DefaultInheritor)];
-      Assert.AreEqual(3, defaultTypeInfo.GetVersionColumns().Count);
-      Assert.AreEqual(4, defaultInheritorTypeInfo.GetVersionColumns().Count);
+      Assert.AreEqual(3, defaultTypeInfo.GetVersionColumns().Count());
+      Assert.AreEqual(4, defaultInheritorTypeInfo.GetVersionColumns().Count());
       using (var session = domain.OpenSession()) {
         var versions = new VersionSet();
         var updatedVersions = new VersionSet();
@@ -256,10 +257,10 @@ namespace Xtensive.Orm.Tests.Storage
       var anotherManualTypeInfo = domain.Model.Types[typeof(AnotherManual)];
       var manualInheritorTypeInfo = domain.Model.Types[typeof(ManualInheritor)];
       var anotherManualInheritorTypeInfo = domain.Model.Types[typeof(AnotherManualInheritor)];
-      Assert.AreEqual(1, manualTypeInfo.GetVersionColumns().Count);
-      Assert.AreEqual(2, anotherManualTypeInfo.GetVersionColumns().Count);
-      Assert.AreEqual(1, manualInheritorTypeInfo.GetVersionColumns().Count);
-      Assert.AreEqual(2, anotherManualInheritorTypeInfo.GetVersionColumns().Count);
+      Assert.AreEqual(1, manualTypeInfo.GetVersionColumns().Count());
+      Assert.AreEqual(2, anotherManualTypeInfo.GetVersionColumns().Count());
+      Assert.AreEqual(1, manualInheritorTypeInfo.GetVersionColumns().Count());
+      Assert.AreEqual(2, anotherManualInheritorTypeInfo.GetVersionColumns().Count());
       using (var session = domain.OpenSession()) {
         var versions = new VersionSet();
         var updatedVersions = new VersionSet();
@@ -322,8 +323,8 @@ namespace Xtensive.Orm.Tests.Storage
       var domain = Domain.Build(config);
       var autoTypeInfo = domain.Model.Types[typeof(Auto)];
       var autoInheritorTypeInfo = domain.Model.Types[typeof(AutoInheritor)];
-      Assert.AreEqual(1, autoTypeInfo.GetVersionColumns().Count);
-      Assert.AreEqual(2, autoInheritorTypeInfo.GetVersionColumns().Count);
+      Assert.AreEqual(1, autoTypeInfo.GetVersionColumns().Count());
+      Assert.AreEqual(2, autoInheritorTypeInfo.GetVersionColumns().Count());
       using (var session = domain.OpenSession()) {
         var versions = new VersionSet();
         var updatedVersions = new VersionSet();
@@ -400,9 +401,9 @@ namespace Xtensive.Orm.Tests.Storage
       var skipTypeInfo = domain.Model.Types[typeof(Skip)];
       var hasVersionTypeInfo = domain.Model.Types[typeof(HasVersion)];
       var hasSkipVersionTypeInfo = domain.Model.Types[typeof(HasSkipVersion)];
-      Assert.AreEqual(2, skipTypeInfo.GetVersionColumns().Count);
-      Assert.AreEqual(2, hasVersionTypeInfo.GetVersionColumns().Count);
-      Assert.AreEqual(2, hasSkipVersionTypeInfo.GetVersionColumns().Count);
+      Assert.AreEqual(2, skipTypeInfo.GetVersionColumns().Count());
+      Assert.AreEqual(2, hasVersionTypeInfo.GetVersionColumns().Count());
+      Assert.AreEqual(2, hasSkipVersionTypeInfo.GetVersionColumns().Count());
       using (var session = domain.OpenSession()) {
         var versions = new VersionSet();
         var updatedVersions = new VersionSet();

--- a/Orm/Xtensive.Orm/Collections/Interfaces/IFilterable.cs
+++ b/Orm/Xtensive.Orm/Collections/Interfaces/IFilterable.cs
@@ -20,7 +20,7 @@ namespace Xtensive.Collections
     /// Finds the items from initial collection according to specified filter <paramref name="criteria"/>.
     /// </summary>
     /// <param name="criteria">The object to filter initial collection with.</param>
-    /// <returns><see cref="ICollection{TItem}"/> object.</returns>
+    /// <returns><see cref="IEnumerable{TItem}"/> object.</returns>
     IEnumerable<TItem> Find(TFilter criteria);
 
     /// <summary>
@@ -28,7 +28,7 @@ namespace Xtensive.Collections
     /// </summary>
     /// <param name="criteria">The object to filter initial collection with.</param>
     /// <param name="matchType">Type of the match.</param>
-    /// <returns><see cref="ICollection{TItem}"/> object.</returns>
+    /// <returns><see cref="IEnumerable{TItem}"/> object.</returns>
     IEnumerable<TItem> Find(TFilter criteria, MatchType matchType);
   }
 }

--- a/Orm/Xtensive.Orm/Collections/Interfaces/IFilterable.cs
+++ b/Orm/Xtensive.Orm/Collections/Interfaces/IFilterable.cs
@@ -21,7 +21,7 @@ namespace Xtensive.Collections
     /// </summary>
     /// <param name="criteria">The object to filter initial collection with.</param>
     /// <returns><see cref="ICollection{TItem}"/> object.</returns>
-    ICollection<TItem> Find(TFilter criteria);
+    IEnumerable<TItem> Find(TFilter criteria);
 
     /// <summary>
     /// Finds the items from initial collection according to specified filter <paramref name="criteria"/>.
@@ -29,6 +29,6 @@ namespace Xtensive.Collections
     /// <param name="criteria">The object to filter initial collection with.</param>
     /// <param name="matchType">Type of the match.</param>
     /// <returns><see cref="ICollection{TItem}"/> object.</returns>
-    ICollection<TItem> Find(TFilter criteria, MatchType matchType);
+    IEnumerable<TItem> Find(TFilter criteria, MatchType matchType);
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.ClassTable.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.ClassTable.cs
@@ -24,8 +24,8 @@ namespace Xtensive.Orm.Building.Builders
 
       var root = type.Hierarchy.Root;
       var typeDef = context.ModelDef.Types[type.UnderlyingType];
-      var ancestors = type.GetAncestors().ToList();
-      var interfaces = type.GetInterfaces();
+      var ancestors = type.Ancestors;
+      var interfaces = type.Interfaces;
       
       // Building declared indexes both secondary and primary (for root of the hierarchy only)
       foreach (var indexDescriptor in typeDef.Indexes) {
@@ -42,7 +42,7 @@ namespace Xtensive.Orm.Building.Builders
       }
 
       // Building primary index for non root entities
-      var parent = type.GetAncestor();
+      var parent = type.Ancestor;
       if (parent != null) {
         var parentPrimaryIndex = parent.Indexes.FindFirst(IndexAttributes.Primary | IndexAttributes.Real);
         var inheritedIndex = BuildInheritedIndex(type, parentPrimaryIndex, false);
@@ -80,14 +80,14 @@ namespace Xtensive.Orm.Building.Builders
         }
 
       // Build indexes for descendants
-      foreach (var descendant in type.GetDescendants())
+      foreach (var descendant in type.Descendants)
         BuildClassTableIndexes(descendant);
 
       // Import inherited indexes
       var primaryIndex = type.Indexes.FindFirst(IndexAttributes.Primary | IndexAttributes.Real);
       if (untypedIndexes.Contains(primaryIndex) && primaryIndex.ReflectedType == root)
         primaryIndex = type.Indexes.Single(i => i.DeclaringIndex == primaryIndex.DeclaringIndex && i.IsTyped);
-      var filterByTypes = type.GetDescendants(true).Append(type).ToList();
+      var filterByTypes = type.RecursiveDescendants.Append(type).ToList();
 
       // Build virtual primary index
       if (ancestors.Count > 0) {

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.ClusteredIndexes.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.ClusteredIndexes.cs
@@ -23,7 +23,7 @@ namespace Xtensive.Orm.Building.Builders
         var clusteredIndexesMap = new Dictionary<TypeInfo, IndexInfo>();
         queue.Enqueue(hierarchy.Root);
         while (queue.TryDequeue(out var type)) {
-          foreach (var decendant in type.GetDescendants())
+          foreach (var decendant in type.Descendants)
             queue.Enqueue(decendant);
           var clusteredIndexes = type.Indexes
             .Where(index => index.IsClustered && index.IsSecondary)
@@ -108,7 +108,7 @@ namespace Xtensive.Orm.Building.Builders
 
       // We need to choose index that is clustered in parent type.
 
-      var parentClusteredIndex = clusteredIndexesMap[type.GetAncestor()];
+      var parentClusteredIndex = clusteredIndexesMap[type.Ancestor];
       if (parentClusteredIndex == null)
         throw Exceptions.InternalError("inheritedIndexes is not empty, but parentClusteredIndex is not specified", BuildLog.Instance);
 

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.ConcreteTable.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.ConcreteTable.cs
@@ -41,7 +41,7 @@ namespace Xtensive.Orm.Building.Builders
       }
 
       // Building primary index for non root entities
-      var parent = type.GetAncestor();
+      var parent = type.Ancestor;
       if (parent != null) {
         var parentPrimaryIndex = parent.Indexes.FindFirst(IndexAttributes.Primary | IndexAttributes.Real);
         var inheritedIndex = BuildInheritedIndex(type, parentPrimaryIndex, type.IsAbstract);
@@ -53,7 +53,7 @@ namespace Xtensive.Orm.Building.Builders
       }
 
       // Building inherited from interfaces indexes
-      foreach (var @interface in type.GetInterfaces(true)) {
+      foreach (var @interface in type.RecursiveInterfaces) {
         foreach (var parentIndex in @interface.Indexes.Find(IndexAttributes.Primary, MatchType.None)) {
           if (parentIndex.DeclaringIndex != parentIndex) 
             continue;
@@ -75,11 +75,11 @@ namespace Xtensive.Orm.Building.Builders
       }
 
       // Build indexes for descendants
-      foreach (var descendant in type.GetDescendants())
+      foreach (var descendant in type.Descendants)
         BuildConcreteTableIndexes(descendant);
 
-      var ancestors = type.GetAncestors().ToList();
-      var descendants = type.GetDescendants(true).ToList();
+      var ancestors = type.Ancestors;
+      var descendants = type.RecursiveDescendants;
 
       // Build primary virtual union index
       if (descendants.Count > 0) {

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.FullText.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.FullText.cs
@@ -44,7 +44,7 @@ namespace Xtensive.Orm.Building.Builders
       var indexesToDefine = hierarchyIndexes.ToList();
       if (indexesToDefine.Any(fti => fti.Type.UnderlyingType != root.UnderlyingType) || indexesToDefine.Count > 1)
         throw new DomainBuilderException(string.Format(Strings.ExUnableToBuildFulltextIndexesForHierarchyWithInheritanceSchemaClassTable, root.Name));
-      var descendants = root.GetDescendants(true).Append(root);
+      var descendants = root.RecursiveDescendants.Append(root);
       var indexDef = indexesToDefine[0];
       var primaryIndex = root.Indexes.Single(i => i.IsPrimary && !i.IsVirtual);
       var name = context.NameBuilder.BuildFullTextIndexName(root);
@@ -68,7 +68,7 @@ namespace Xtensive.Orm.Building.Builders
       foreach (var fullTextIndexDef in hierarchyIndexes) {
         var type = model.Types[fullTextIndexDef.Type.UnderlyingType];
         types.Add(type);
-        foreach (var descendant in type.GetDescendants(true))
+        foreach (var descendant in type.RecursiveDescendants)
           types.Add(descendant);
         foreach (var fullTextFieldDef in fullTextIndexDef.Fields) {
           var fullTextColumn = GetFullTextColumn(type, fullTextFieldDef);
@@ -120,7 +120,7 @@ namespace Xtensive.Orm.Building.Builders
     {
       var model = context.Model;
       var processQueue = new Queue<TypeInfo>();
-      foreach (var type in root.GetDescendants())
+      foreach (var type in root.Descendants)
         processQueue.Enqueue(type);
 
       var indexDefs = hierarchyIndexes.ToDictionary(
@@ -131,7 +131,7 @@ namespace Xtensive.Orm.Building.Builders
         List<FullTextIndexDef> indexes;
         List<FullTextIndexDef> parentIndexes;
         var typeHasIndexDef = indexDefs.TryGetValue(type, out indexes);
-        if (indexDefs.TryGetValue(type.GetAncestor(), out parentIndexes)) {
+        if (indexDefs.TryGetValue(type.Ancestor, out parentIndexes)) {
           if (typeHasIndexDef)
             indexes.AddRange(parentIndexes);
           else {
@@ -141,7 +141,7 @@ namespace Xtensive.Orm.Building.Builders
           }
         }
         if (typeHasIndexDef)
-          foreach (var descendant in type.GetDescendants())
+          foreach (var descendant in type.Descendants)
             processQueue.Enqueue(descendant);
       }
       return indexDefs;

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.SingleTable.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.SingleTable.cs
@@ -68,12 +68,12 @@ namespace Xtensive.Orm.Building.Builders
       }
 
       // Build indexes for descendants
-      var directDescendants = type.Descendants.ToList();
-      foreach (var descendant in directDescendants)
+      foreach (var descendant in type.Descendants) {
         BuildSingleTableIndexes(descendant);
+      }
 
       if (type == root) return;
-      var descendants = type.RecursiveDescendants.ToList();
+      var descendants = type.RecursiveDescendants;
 
       var primaryIndexFilterTypes = new List<TypeInfo>();
       if (!type.IsAbstract)

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.SingleTable.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.SingleTable.cs
@@ -40,9 +40,9 @@ namespace Xtensive.Orm.Building.Builders
         context.Model.RealIndexes.Add(declaredIndex);
       }
 
-      var parent = type.GetAncestor();
+      var parent = type.Ancestor;
       // Building inherited from interfaces indexes
-      foreach (var @interface in type.GetInterfaces()) {
+      foreach (var @interface in type.Interfaces) {
         foreach (var interfaceIndex in @interface.Indexes.Find(IndexAttributes.Primary, MatchType.None)) {
           if (root.Indexes.Any(i => i.DeclaringIndex == interfaceIndex.DeclaringIndex && i.ReflectedType == type))
             continue;
@@ -52,7 +52,7 @@ namespace Xtensive.Orm.Building.Builders
         }
       }
 
-      var types = type.GetAncestors().ToHashSet();
+      var types = type.Ancestors.ToHashSet();
       types.Add(type);
 
       // Build typed indexes
@@ -68,12 +68,12 @@ namespace Xtensive.Orm.Building.Builders
       }
 
       // Build indexes for descendants
-      var directDescendants = type.GetDescendants().ToList();
+      var directDescendants = type.Descendants.ToList();
       foreach (var descendant in directDescendants)
         BuildSingleTableIndexes(descendant);
 
       if (type == root) return;
-      var descendants = type.GetDescendants(true).ToList();
+      var descendants = type.RecursiveDescendants.ToList();
 
       var primaryIndexFilterTypes = new List<TypeInfo>();
       if (!type.IsAbstract)
@@ -96,7 +96,7 @@ namespace Xtensive.Orm.Building.Builders
           continue;
         if (ancestorIndex.DeclaringType.IsInterface) {
           var filteredDescendants = descendants
-            .Where(t => !t.IsAbstract && !t.GetInterfaces().Contains(ancestorIndex.DeclaringType));
+            .Where(t => !t.IsAbstract && !t.Interfaces.Contains(ancestorIndex.DeclaringType));
           var filterByTypes = new List<TypeInfo>();
           if (!type.IsAbstract)
             filterByTypes.Add(type);

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
@@ -373,7 +373,7 @@ namespace Xtensive.Orm.Building.Builders
         }
         else {
           result.ValueColumns.AddRange(GatherValueColumns(columns));
-        }        
+        }
       }
       else {
         foreach (var column in typeInfo.Columns.Where(c => c.IsPrimaryKey)) {

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
@@ -80,7 +80,7 @@ namespace Xtensive.Orm.Building.Builders
           context.Model.RealIndexes.Add(index);
       }
 
-      var interfaces = @interface.GetInterfaces();
+      var interfaces = @interface.Interfaces;
       foreach (var typeInfo in interfaces)
         CreateInterfaceIndexes(typeInfo, processedInterfaces);
 
@@ -100,11 +100,11 @@ namespace Xtensive.Orm.Building.Builders
     private void BuildInterfaceIndexes()
     {
       foreach (var @interface in context.Model.Types.Find(TypeAttributes.Interface)) {
-        var implementors = @interface.GetImplementors(false).ToList();
+        var implementors = @interface.Implementors;
 
         // Building primary indexes
-        if (implementors.Count==1) {
-          var primaryIndex = implementors[0].Indexes.PrimaryIndex;
+        if (implementors.Count == 1) {
+          var primaryIndex = implementors.First().Indexes.PrimaryIndex;
           var indexView = BuildViewIndex(@interface, primaryIndex);
           @interface.Indexes.Add(indexView);
         }
@@ -151,7 +151,7 @@ namespace Xtensive.Orm.Building.Builders
                       foreach (var foundField in foundFields)
                         interfaceFields.Remove(foundField);
                     }
-                    type = type.GetAncestor();
+                    type = type.Ancestor;
                   }
                   var filterByTypes = new List<TypeInfo>();
                   if (!implementor.IsAbstract)
@@ -188,7 +188,7 @@ namespace Xtensive.Orm.Building.Builders
               }
               case InheritanceSchema.ConcreteTable: {
                 var grouping = hierarchy;
-                var allImplementors = @interface.GetImplementors(true)
+                var allImplementors = @interface.RecursiveImplementors
                   .Where(t => t.Hierarchy == grouping.Key && !t.IsAbstract)
                   .ToList();
                 var primaryIndexes = allImplementors
@@ -231,7 +231,7 @@ namespace Xtensive.Orm.Building.Builders
                   var filterByTypes = new List<TypeInfo>();
                   if (!implementor.IsAbstract)
                     filterByTypes.Add(implementor);
-                  var subHierarchyNodeCount = implementor.GetDescendants(true).Count() + filterByTypes.Count;
+                  var subHierarchyNodeCount = implementor.RecursiveDescendants.Count() + filterByTypes.Count;
                   filterByTypes.AddRange(GatherDescendants(implementor, hierarchyImplementors));
                   if (filterByTypes.Count != subHierarchyNodeCount)
                     index = BuildFilterIndex(implementor, index, filterByTypes);
@@ -258,7 +258,7 @@ namespace Xtensive.Orm.Building.Builders
                 break;
               }
               case InheritanceSchema.ConcreteTable: {
-                var indexes = @interface.GetImplementors(true)
+                var indexes = @interface.RecursiveImplementors
                   .Where(t => t.Hierarchy == grouping.Key)
                   .Select(t => (Index: t.Indexes.Single(i => i.DeclaringIndex == localIndex.DeclaringIndex && !i.IsVirtual), Type: t))
                   .Select(p => untypedIndexes.Contains(p.Index)
@@ -349,41 +349,31 @@ namespace Xtensive.Orm.Building.Builders
 
       // Adding value columns
       if (indexDef.IsPrimary) {
-        IEnumerable<TypeInfo> types;
-        if (typeInfo.IsInterface)
-          types = typeInfo.GetInterfaces().Union(new[] { typeInfo });
-        else {
-          var root = typeInfo.Hierarchy.Root;
-          var schema = typeInfo.Hierarchy.InheritanceSchema;
-          switch (schema) {
-            case InheritanceSchema.SingleTable:
-              types = new[] {typeInfo}.Union(root.GetDescendants(true));
-              break;
-            case InheritanceSchema.ConcreteTable:
-              types = typeInfo.GetAncestors().Union(new[] {typeInfo});
-              break;
-            default:
-              types = new[] {typeInfo};
-              break;
-          }
-        }
+        var typeInfoAsArray = new[] { typeInfo };
+        var types = typeInfo.IsInterface
+          ? typeInfo.Interfaces.Union(typeInfoAsArray)
+          : typeInfo.Hierarchy.InheritanceSchema switch {
+            InheritanceSchema.SingleTable => typeInfoAsArray.Concat(typeInfo.Hierarchy.Root.RecursiveDescendants.Except(typeInfoAsArray)), // Order does matter. typeInfo must be first.
+            InheritanceSchema.ConcreteTable => typeInfo.Ancestors.Union(typeInfoAsArray),
+            _ => typeInfoAsArray
+          };
 
-        var columns = new List<ColumnInfo>();
-        columns.AddRange(result.IncludedColumns);
-        columns.AddRange(types.SelectMany(t => t.Columns
-          .Find(ColumnAttributes.Inherited | ColumnAttributes.PrimaryKey, MatchType.None)
-          .Where(c => skipTypeId ? !(c.Field.IsTypeId && c.IsSystem) : true)));
+        var columns = result.IncludedColumns
+          .Concat(types.SelectMany(t => t.Columns
+            .Find(ColumnAttributes.Inherited | ColumnAttributes.PrimaryKey, MatchType.None)
+            .Where(c => !skipTypeId || !(c.Field.IsTypeId && c.IsSystem)))
+          );
 
         // There might be difference in columns order of type and columns list
         // so we have to reorder them in correct sequence.
         if (typeInfo.IsInterface) {
-          var indexedColumns = columns.Select((column, i) => (i, j: typeInfo.Columns.IndexOf(column), column)).ToList();
+          var indexedColumns = columns.Select((column, i) => (i, j: typeInfo.Columns.IndexOf(column), column));
           var orderedColumns = indexedColumns.OrderBy(el => el.j).Select(el => el.column).Distinct();
           result.ValueColumns.AddRange(GatherValueColumns(orderedColumns));
         }
-        else 
+        else {
           result.ValueColumns.AddRange(GatherValueColumns(columns));
-        
+        }        
       }
       else {
         foreach (var column in typeInfo.Columns.Where(c => c.IsPrimaryKey)) {
@@ -590,11 +580,11 @@ namespace Xtensive.Orm.Building.Builders
       }
 
       // Adding value columns
-      var typeOrder = reflectedType.GetAncestors()
+      var typeOrder = reflectedType.Ancestors
         .Append(reflectedType)
         .Select((t, i) => (Type: t, Index: i))
         .ToDictionary(a => a.Type, a => a.Index);
-      var types = reflectedType.GetAncestors().ToHashSet();
+      var types = reflectedType.Ancestors.ToHashSet();
       types.Add(reflectedType);
 
       var valueColumnMap = new List<List<int>>();
@@ -617,7 +607,7 @@ namespace Xtensive.Orm.Building.Builders
                 skip = ancestorField.IsDeclared;
               if (skip)
                 break;
-              ancestor = ancestor.GetAncestor();
+              ancestor = ancestor.Ancestor;
             }
             if (skip)
               continue;
@@ -709,10 +699,10 @@ namespace Xtensive.Orm.Building.Builders
 
       // Adding value columns
       var types = (reflectedType.IsInterface
-        ? indexToApplyView.ReflectedType.GetAncestors().Append(indexToApplyView.ReflectedType)
-        : reflectedType.GetAncestors().Append(reflectedType)).ToHashSet();
+        ? indexToApplyView.ReflectedType.Ancestors.Append(indexToApplyView.ReflectedType)
+        : reflectedType.Ancestors.Append(reflectedType)).ToHashSet();
       var interfaces = (reflectedType.IsInterface
-        ? reflectedType.GetInterfaces(true).Append(reflectedType)
+        ? reflectedType.RecursiveInterfaces.Append(reflectedType)
         : Enumerable.Empty<TypeInfo>()).ToHashSet();
 
       var indexReflectedType = indexToApplyView.ReflectedType;
@@ -747,7 +737,7 @@ namespace Xtensive.Orm.Building.Builders
                 skip = ancestorField.IsDeclared;
               if (skip)
                 break;
-              ancestor = ancestor.GetAncestor();
+              ancestor = ancestor.Ancestor;
             }
             if (skip)
               continue;
@@ -784,7 +774,7 @@ namespace Xtensive.Orm.Building.Builders
 
     private static IEnumerable<TypeInfo> GatherDescendants(TypeInfo type, ICollection<TypeInfo> hierarchyImplementors)
     {
-      return type.GetDescendants(true).Where(t => !t.IsAbstract).Except(hierarchyImplementors);
+      return type.RecursiveDescendants.Where(t => !t.IsAbstract).Except(hierarchyImplementors);
     }
 
     private IEnumerable<ColumnInfo> GatherValueColumns(IEnumerable<ColumnInfo> columns)
@@ -898,7 +888,7 @@ namespace Xtensive.Orm.Building.Builders
     private void BuildAffectedIndexesForMaterializedInterface(TypeInfo typeInfo)
     {
       var primaryIndex = typeInfo.Indexes.PrimaryIndex;
-      foreach (var descendant in typeInfo.GetDescendants(true).Where(t => t.IsEntity).Distinct()) {
+      foreach (var descendant in typeInfo.RecursiveDescendants.Where(t => t.IsEntity).Distinct()) {
         descendant.AffectedIndexes.Add(primaryIndex);
         foreach (var indexInfo in typeInfo.Indexes.Find(IndexAttributes.Primary, MatchType.None)) {
           var descendantIndex = descendant.Indexes.Where(i => i.DeclaringIndex==indexInfo.DeclaringIndex).FirstOrDefault();
@@ -918,25 +908,21 @@ namespace Xtensive.Orm.Building.Builders
 
     private void ProcessAncestors(TypeInfo typeInfo, Action<TypeInfo> ancestorProcessor)
     {
-      
       var root = typeInfo.Hierarchy.Root;
-      if (root==typeInfo)
+      if (root == typeInfo) {
         return;
-      var ancestor = context.Model.Types.FindAncestor(typeInfo);
-      if (ancestor==null)
-        return;
-      do {
+      }
+      foreach (var ancestor in typeInfo.AncestorChain) {
         ancestorProcessor.Invoke(ancestor);
-        if (ancestor==root)
+        if (ancestor == root) {
           break;
-        ancestor = context.Model.Types.FindAncestor(ancestor);
-      } while (ancestor!=null);
+        }
+      }
     }
 
     private void BuildFiltersForPartialIndexes()
     {
-      
-      foreach (var index in context.Model.RealIndexes.Where(index => index.FilterExpression!=null))
+      foreach (var index in context.Model.RealIndexes.Where(index => index.FilterExpression != null))
         PartialIndexFilterBuilder.BuildFilter(index);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/ModelBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/ModelBuilder.cs
@@ -222,7 +222,7 @@ namespace Xtensive.Orm.Building.Builders
             }
           }
           if (refField.IsInherited) {
-            var ancestor = typeInfo.GetAncestor();
+            var ancestor = typeInfo.Ancestor;
             var field = ancestor.Fields[refField.Name];
             inheritedAssociations.AddRange(field.Associations);
             parentIsPaired |= context.PairedAssociations.Any(pa => field.Associations.Contains(pa.First));
@@ -477,8 +477,8 @@ namespace Xtensive.Orm.Building.Builders
     private void RegiserReferences(Dictionary<TypeInfo, int> referenceRegistrator, params TypeInfo[] typesToRegisterReferences)
     {
       foreach (var type in typesToRegisterReferences) {
-        var typeImplementors = type.GetImplementors();
-        var descendantTypes = type.GetDescendants(true);
+        var typeImplementors = type.Implementors;
+        var descendantTypes = type.RecursiveDescendants;
         if (typeImplementors.Any())
         {
           foreach (var implementor in typeImplementors)

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingValidator.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingValidator.cs
@@ -69,12 +69,13 @@ namespace Xtensive.Orm.Building.Builders
     private void EnsureIntefacesAreImplementedWithinSingleDatabase()
     {
       foreach (var @interface in model.Types.Where(t => t.IsInterface)) {
-        var implementors = @interface.RecursiveImplementors.ToList();
-        if (implementors.Count==0)
+        var implementors = @interface.RecursiveImplementors;
+        if (implementors.Count == 0) {
           continue; // shouldn't reach here, but it's safer to do check anyway
+        }
         var firstImplementor = implementors[0];
         foreach (var implementor in implementors.Skip(1))
-          if (firstImplementor.MappingDatabase!=implementor.MappingDatabase)
+          if (firstImplementor.MappingDatabase != implementor.MappingDatabase)
             throw new DomainBuilderException(string.Format(
               Strings.ExInterfaceXIsImplementedByTypesMappedToDifferentDatabasesYZ,
               @interface.UnderlyingType.GetShortName(),

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingValidator.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingValidator.cs
@@ -69,7 +69,7 @@ namespace Xtensive.Orm.Building.Builders
     private void EnsureIntefacesAreImplementedWithinSingleDatabase()
     {
       foreach (var @interface in model.Types.Where(t => t.IsInterface)) {
-        var implementors = @interface.GetImplementors(true).ToList();
+        var implementors = @interface.RecursiveImplementors.ToList();
         if (implementors.Count==0)
           continue; // shouldn't reach here, but it's safer to do check anyway
         var firstImplementor = implementors[0];

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/TypeBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/TypeBuilder.cs
@@ -134,7 +134,7 @@ namespace Xtensive.Orm.Building.Builders
     public void BuildFields(TypeDef typeDef, TypeInfo typeInfo)
     {
       if (typeInfo.IsInterface) {
-        var sourceFields = typeInfo.GetInterfaces()
+        var sourceFields = typeInfo.Interfaces
           .SelectMany(i => i.Fields)
           .Where(f => !f.IsPrimaryKey && f.Parent == null);
         foreach (var srcField in sourceFields) {
@@ -144,7 +144,7 @@ namespace Xtensive.Orm.Building.Builders
         }
       }
       else {
-        var ancestor = typeInfo.GetAncestor();
+        var ancestor = typeInfo.Ancestor;
         if (ancestor != null) {
           foreach (var srcField in ancestor.Fields.Where(f => !f.IsPrimaryKey && f.Parent == null)) {
             if (typeDef.Fields.TryGetValue(srcField.Name, out var fieldDef)) {
@@ -186,7 +186,7 @@ namespace Xtensive.Orm.Building.Builders
       typeInfo.Columns.AddRange(typeInfo.Fields.Where(f => f.Column != null).Select(f => f.Column));
 
       if (typeInfo.IsEntity && !IsAuxiliaryType(typeInfo)) {
-        foreach (var @interface in typeInfo.GetInterfaces()) {
+        foreach (var @interface in typeInfo.Interfaces) {
           BuildFieldMap(@interface, typeInfo);
         }
       }

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchManager.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchManager.cs
@@ -294,8 +294,8 @@ namespace Xtensive.Orm.Internals.Prefetch
         }
       }
 
-      if (type.GetInterfaces(true).Contains(key.TypeReference.Type)
-        || key.TypeReference.Type.GetInterfaces(true).Contains(type)) {
+      if (type.RecursiveInterfaces.Contains(key.TypeReference.Type)
+        || key.TypeReference.Type.RecursiveInterfaces.Contains(type)) {
         return;
       }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -62,8 +62,8 @@ namespace Xtensive.Orm.Linq
           && WellKnownOrmInterfaces.Entity.IsAssignableFrom(operandType)) {
         TypeInfo type = context.Model.Types[operandType];
 
-        var typeInfos = type.GetDescendants(true).ToHashSet();
-        typeInfos.UnionWith(type.GetImplementors(true));
+        var typeInfos = type.RecursiveDescendants.ToHashSet();
+        typeInfos.UnionWith(type.RecursiveImplementors);
         typeInfos.Add(type);
         Expression memberExpression = Expression.MakeMemberAccess(expression, WellKnownMembers.TypeId);
 
@@ -1645,7 +1645,7 @@ namespace Xtensive.Orm.Linq
     {
       var @interface = ma.Expression.Type;
       var property = (PropertyInfo)ma.Member;
-      var implementors = context.Model.Types[@interface].GetImplementors(true);
+      var implementors = context.Model.Types[@interface].RecursiveImplementors;
       var fields = implementors
         .Select(im => im.UnderlyingType.GetProperty(property.Name, BindingFlags.Instance|BindingFlags.Public))
         .Concat(implementors
@@ -1659,7 +1659,7 @@ namespace Xtensive.Orm.Linq
     {
       var ancestor = ma.Expression.Type;
       var property = (PropertyInfo)ma.Member;
-      var descendants = context.Model.Types[ancestor].GetDescendants(true);
+      var descendants = context.Model.Types[ancestor].RecursiveDescendants;
       var fields = descendants
         .Select(im => im.UnderlyingType.GetProperty(property.Name, BindingFlags.Instance|BindingFlags.Public|BindingFlags.NonPublic))
         .Where(f => f != null);

--- a/Orm/Xtensive.Orm/Orm/Model/AssociationInfoCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/AssociationInfoCollection.cs
@@ -23,10 +23,8 @@ namespace Xtensive.Orm.Model
     /// <returns></returns>
     public IEnumerable<AssociationInfo> Find(TypeInfo type)
     {
-      var candidates = new HashSet<TypeInfo>(type.GetAncestors());
-      candidates.UnionWith(type.GetInterfaces(true));
-      candidates.Add(type);
-      return this.Where(a => (candidates.Contains(a.TargetType) || candidates.Contains(a.OwnerType)));
+      var candidates = type.TypeWithAncestorsAndInterfaces;
+      return this.Where(a => candidates.Contains(a.TargetType) || candidates.Contains(a.OwnerType));
     }
 
     /// <summary>
@@ -37,12 +35,12 @@ namespace Xtensive.Orm.Model
     /// <returns></returns>
     public IEnumerable<AssociationInfo> Find(TypeInfo type, bool target)
     {
-      var candidates = new HashSet<TypeInfo>(type.GetAncestors());
-      candidates.UnionWith(type.GetInterfaces(true));
-      candidates.Add(type);
+      var candidates = type.TypeWithAncestorsAndInterfaces;
 
-      var filter = target ? (Func<AssociationInfo, TypeInfo>) (a => a.TargetType) : (a => a.OwnerType);
-      return this.Where(a => candidates.Contains(filter(a)));
+      Func<AssociationInfo, bool> filter = target
+        ? a => candidates.Contains(a.TargetType)
+        : a => candidates.Contains(a.OwnerType);
+      return this.Where(filter);
     }
 
 

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnInfoCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnInfoCollection.cs
@@ -21,12 +21,12 @@ namespace Xtensive.Orm.Model
   {
     #region IFilterable<ColumnAttributes,ColumnInfo> Members
 
-    public ICollection<ColumnInfo> Find(ColumnAttributes criteria)
+    public IEnumerable<ColumnInfo> Find(ColumnAttributes criteria)
     {
       return Find(criteria, MatchType.Partial);
     }
 
-    public ICollection<ColumnInfo> Find(ColumnAttributes criteria, MatchType matchType)
+    public IEnumerable<ColumnInfo> Find(ColumnAttributes criteria, MatchType matchType)
     {
       // We don't have any instance that has attributes == FieldAttributes.None
       if (criteria == ColumnAttributes.None)

--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfoCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfoCollection.cs
@@ -24,13 +24,10 @@ namespace Xtensive.Orm.Model
     internal new static readonly FieldInfoCollection Empty;
 
     /// <inheritdoc/>
-    public ICollection<FieldInfo> Find(FieldAttributes criteria)
-    {
-      return Find(criteria, MatchType.Partial);
-    }
+    public IEnumerable<FieldInfo> Find(FieldAttributes criteria) => Find(criteria, MatchType.Partial);
 
     /// <inheritdoc/>
-    public ICollection<FieldInfo> Find(FieldAttributes criteria, MatchType matchType)
+    public IEnumerable<FieldInfo> Find(FieldAttributes criteria, MatchType matchType)
     {
       // We don't have any instance that has attributes == FieldAttributes.None
       if (criteria == FieldAttributes.None)

--- a/Orm/Xtensive.Orm/Orm/Model/HierarchyInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/HierarchyInfo.cs
@@ -46,7 +46,7 @@ namespace Xtensive.Orm.Model
       base.UpdateState();
       Key.UpdateState();
       var list = new List<TypeInfo> {Root};
-      list.AddRange(Root.GetDescendants(true));
+      list.AddRange(Root.RecursiveDescendants);
       Types = list.AsReadOnly();
       if (Types.Count == 1)
         InheritanceSchema = InheritanceSchema.ConcreteTable;

--- a/Orm/Xtensive.Orm/Orm/Model/IndexInfoCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/IndexInfoCollection.cs
@@ -24,7 +24,7 @@ namespace Xtensive.Orm.Model
     /// </summary>
     /// <param name="criteria">The criteria.</param>
     /// <returns>A sequence of found objects.</returns>
-    public ICollection<IndexInfo> Find(IndexAttributes criteria)
+    public IEnumerable<IndexInfo> Find(IndexAttributes criteria)
     {
       return Find(criteria, MatchType.Full);
     }
@@ -35,7 +35,7 @@ namespace Xtensive.Orm.Model
     /// <param name="criteria">The criteria.</param>
     /// <param name="matchType">Type of the match.</param>
     /// <returns>A sequence of found objects.</returns>
-    public ICollection<IndexInfo> Find(IndexAttributes criteria, MatchType matchType)
+    public IEnumerable<IndexInfo> Find(IndexAttributes criteria, MatchType matchType)
     {
       if (criteria == IndexAttributes.None)
         return Array.Empty<IndexInfo>();

--- a/Orm/Xtensive.Orm/Orm/Model/Stored/Internals/ConverterToStoredModel.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/Stored/Internals/ConverterToStoredModel.cs
@@ -33,7 +33,7 @@ namespace Xtensive.Orm.Model.Stored
       var declaredFields = source.Fields
         .Where(field => field.IsDeclared && !field.IsNested)
         .ToArray();
-      var sourceAncestor = source.GetAncestor();
+      var sourceAncestor = source.Ancestor;
       string hierarchyRoot = null;
       if (source.Hierarchy!=null && source.Hierarchy.Root==source)
         hierarchyRoot = source.Hierarchy.InheritanceSchema.ToString();

--- a/Orm/Xtensive.Orm/Orm/Model/TypeIndexInfoCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeIndexInfoCollection.cs
@@ -46,7 +46,7 @@ namespace Xtensive.Orm.Model
     public IndexInfo FindFirst(IndexAttributes indexAttributes)
     {
       var result = Find(indexAttributes);
-      if (result.Count!=0) {
+      if (result.Any()) {
         var enumerator = result.GetEnumerator();
         enumerator.MoveNext();
         return enumerator.Current;

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
@@ -114,23 +114,9 @@ namespace Xtensive.Orm.Model
     private HashSet<TypeInfo> interfaces;
     public IReadOnlySet<TypeInfo> Interfaces => interfaces ?? EmptyTypes;
 
-    private IReadOnlySet<TypeInfo> recursiveInterfaces;
-    public IReadOnlySet<TypeInfo> RecursiveInterfaces
-    {
-      get {
-        if (recursiveInterfaces == null) {
-          if (IsInterface) {
-            recursiveInterfaces = Interfaces;
-          }
-          else {
-            var set = new HashSet<TypeInfo>(Interfaces);
-            set.UnionWith(Ancestors.SelectMany(static o => o.Interfaces));
-            recursiveInterfaces = set;
-          }
-        }
-        return recursiveInterfaces;
-      }
-    }
+    private IReadOnlyList<TypeInfo> recursiveInterfaces;
+    public IReadOnlyList<TypeInfo> RecursiveInterfaces =>
+      recursiveInterfaces ??= (IsInterface ? Interfaces : Interfaces.Concat(AncestorChain.SelectMany(static o => o.Interfaces))).ToList();
 
     private HashSet<TypeInfo> implementors;
 

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
@@ -38,33 +38,172 @@ namespace Xtensive.Orm.Model
     /// </summary>
     public const int MinTypeId = 100;
 
-    private readonly ColumnInfoCollection      columns;
-    private readonly FieldMap                  fieldMap;
-    private readonly FieldInfoCollection       fields;
-    private readonly TypeIndexInfoCollection   indexes;
+    private static readonly IReadOnlySet<TypeInfo> EmptyTypes = new HashSet<TypeInfo>();
+
+    private readonly ColumnInfoCollection columns;
+    private readonly FieldMap fieldMap;
+    private readonly FieldInfoCollection fields;
+    private readonly TypeIndexInfoCollection indexes;
     private readonly NodeCollection<IndexInfo> affectedIndexes;
-    private readonly DomainModel               model;
-    private TypeAttributes                     attributes;
-    private IReadOnlyList<TypeInfo>             ancestors;
-    private IReadOnlyList<AssociationInfo>      targetAssociations;
-    private IReadOnlyList<AssociationInfo>      ownerAssociations;
-    private IReadOnlyList<AssociationInfo>      removalSequence;
-    private IReadOnlyList<FieldInfo>            versionFields;
+    private readonly DomainModel model;
+    private TypeAttributes attributes;
+    private IReadOnlyList<AssociationInfo> targetAssociations;
+    private IReadOnlyList<AssociationInfo> ownerAssociations;
+    private IReadOnlyList<AssociationInfo> removalSequence;
+    private IReadOnlyList<FieldInfo> versionFields;
     private IReadOnlyList<ColumnInfo> versionColumns;
     private IList<IObjectValidator> validators;
-    private Type                               underlyingType;
-    private HierarchyInfo                      hierarchy;
-    private int                                typeId = NoTypeId;
-    private object                             typeDiscriminatorValue;
-    private MapTransform                       primaryKeyInjector;
-    private bool                               isLeaf;
-    private bool                               isOutboundOnly;
-    private bool                               isInboundOnly;
-    private KeyInfo                            key;
-    private bool                               hasVersionRoots;
+    private Type underlyingType;
+    private HierarchyInfo hierarchy;
+    private int typeId = NoTypeId;
+    private object typeDiscriminatorValue;
+    private MapTransform primaryKeyInjector;
+    private bool isLeaf;
+    private bool isOutboundOnly;
+    private bool isInboundOnly;
+    private KeyInfo key;
+    private bool hasVersionRoots;
     private IDictionary<Pair<FieldInfo>, FieldInfo> structureFieldMapping;
-    private List<AssociationInfo>              overridenAssociations;
+    private List<AssociationInfo> overridenAssociations;
     private FieldInfo typeIdField;
+
+    public TypeInfo Ancestor { get; internal set; }
+
+    /// <summary>
+    /// Gets the ancestors recursively. Inheritor-to-root order.
+    /// </summary>
+    /// <returns>The ancestor</returns>
+    public IEnumerable<TypeInfo> AncestorChain
+    {
+      get {
+        for (var ancestor = Ancestor; ancestor != null; ancestor = ancestor.Ancestor) {
+          yield return ancestor;
+        }
+      }
+    }
+
+    private IReadOnlyList<TypeInfo> ancestors;
+
+    /// <summary>
+    /// Gets the ancestors recursively. Root-to-inheritor order. Reverse of AncestorChain.
+    /// </summary>
+    /// <returns>The ancestor</returns>
+    public IReadOnlyList<TypeInfo> Ancestors => ancestors ??= AncestorChain.Reverse().ToList();
+
+    private HashSet<TypeInfo> descendants;
+    public IReadOnlySet<TypeInfo> Descendants => descendants ?? EmptyTypes;
+
+    private IReadOnlySet<TypeInfo> recursiveDescendants;
+    public IReadOnlySet<TypeInfo> RecursiveDescendants
+    {
+      get {
+        if (recursiveDescendants == null) {
+          if (Descendants.Count == 0) {
+            recursiveDescendants = Descendants;
+          }
+          else {
+            var set = new HashSet<TypeInfo>(Descendants);
+            set.UnionWith(Descendants.SelectMany(static o => o.RecursiveDescendants));
+            recursiveDescendants = set;
+          }
+        }
+        return recursiveDescendants;
+      }
+    }
+
+    private HashSet<TypeInfo> interfaces;
+    public IReadOnlySet<TypeInfo> Interfaces => interfaces ?? EmptyTypes;
+
+    private IReadOnlySet<TypeInfo> recursiveInterfaces;
+    public IReadOnlySet<TypeInfo> RecursiveInterfaces
+    {
+      get {
+        if (recursiveInterfaces == null) {
+          if (IsInterface) {
+            recursiveInterfaces = Interfaces;
+          }
+          else {
+            var set = new HashSet<TypeInfo>(Interfaces);
+            set.UnionWith(Ancestors.SelectMany(static o => o.Interfaces));
+            recursiveInterfaces = set;
+          }
+        }
+        return recursiveInterfaces;
+      }
+    }
+
+    private HashSet<TypeInfo> implementors;
+
+    /// <summary>
+    /// Gets the direct implementors of this instance.
+    /// </summary>
+    public IReadOnlySet<TypeInfo> Implementors => implementors ?? EmptyTypes;
+
+    private IReadOnlyList<TypeInfo> recursiveImplementors;
+    public IReadOnlyList<TypeInfo> RecursiveImplementors
+    {
+      get {
+        if (recursiveImplementors == null) {
+          if (Implementors.Count == 0) {
+            recursiveImplementors = Array.Empty<TypeInfo>();
+          }
+          else {
+            var list = new List<TypeInfo>(Implementors.Count);
+            foreach (var item in Implementors) {
+              list.Add(item);
+              if (!item.IsInterface) {
+                list.AddRange(item.RecursiveDescendants);
+              }
+            }
+            recursiveImplementors = list;
+          }
+        }
+        return recursiveImplementors;
+      }
+    }
+
+    /// <summary>
+    /// Gets the direct implementors of this instance.
+    /// </summary>
+    /// <param name="recursive">if set to <see langword="true"/> then both direct and non-direct implementors will be returned.</param>
+    [Obsolete("Use Implementors/RecursiveImplementors properties instead")]
+    public IEnumerable<TypeInfo> GetImplementors(bool recursive = false) => recursive ? RecursiveImplementors : Implementors;
+
+    /// <summary>
+    /// Gets the persistent interfaces this instance implements.
+    /// </summary>
+    /// <param name="recursive">if set to <see langword="true"/> then both direct and non-direct implemented interfaces will be returned.</param>
+    [Obsolete("Use Interfaces/RecursiveInterfaces properties instead")]
+    public IEnumerable<TypeInfo> GetInterfaces(bool recursive = false) => recursive ? RecursiveInterfaces : Interfaces;
+
+    /// <summary>
+    /// Gets descendants of this instance.
+    /// </summary>
+    /// <param name="recursive">if set to <see langword="true"/> then both direct and nested descendants will be returned.</param>
+    /// <returns></returns>
+    [Obsolete("Use Descendants/RecursiveDescendants properties instead")]
+    public IEnumerable<TypeInfo> GetDescendants(bool recursive) => recursive ? RecursiveDescendants : Descendants;
+
+    /// <summary>
+    /// Gets the ancestors recursively. Root-to-inheritor order.
+    /// </summary>
+    /// <returns>The ancestor</returns>
+    [Obsolete("Use Ancestors property instead")]
+    public IReadOnlyList<TypeInfo> GetAncestors() => Ancestors;
+
+    private IReadOnlySet<TypeInfo> typeWithAncestorsAndInterfaces;
+    public IReadOnlySet<TypeInfo> TypeWithAncestorsAndInterfaces
+    {
+      get {
+        if (typeWithAncestorsAndInterfaces == null) {
+          var candidates = new HashSet<TypeInfo>(Ancestors);
+          candidates.UnionWith(RecursiveInterfaces);
+          candidates.Add(this);
+          typeWithAncestorsAndInterfaces = candidates;
+        }
+        return typeWithAncestorsAndInterfaces;
+      }
+    }
 
     #region IsXxx properties
 
@@ -139,8 +278,7 @@ namespace Xtensive.Orm.Model
     public bool IsOutboundOnly
     {
       get { return isOutboundOnly; }
-      set
-      {
+      set {
         EnsureNotLocked();
         isOutboundOnly = value;
       }
@@ -153,8 +291,7 @@ namespace Xtensive.Orm.Model
     public bool IsInboundOnly
     {
       get { return isInboundOnly; }
-      set
-      {
+      set {
         EnsureNotLocked();
         isInboundOnly = value;
       }
@@ -201,9 +338,8 @@ namespace Xtensive.Orm.Model
     {
       [DebuggerStepThrough]
       get { return typeId; }
-      set
-      {
-        if (typeId!=NoTypeId)
+      set {
+        if (typeId != NoTypeId)
           throw Exceptions.AlreadyInitialized("TypeId");
         typeId = value;
       }
@@ -216,8 +352,7 @@ namespace Xtensive.Orm.Model
     {
       [DebuggerStepThrough]
       get { return underlyingType; }
-      set
-      {
+      set {
         EnsureNotLocked();
         underlyingType = value;
       }
@@ -262,8 +397,7 @@ namespace Xtensive.Orm.Model
     public FullTextIndexInfo FullTextIndex
     {
       [DebuggerStepThrough]
-      get
-      {
+      get {
         FullTextIndexInfo fullTextIndexInfo;
         model.FullTextIndexes.TryGetValue(this, out fullTextIndexInfo);
         return fullTextIndexInfo;
@@ -321,7 +455,8 @@ namespace Xtensive.Orm.Model
     /// <summary>
     /// Gets or sets the type discriminator value.
     /// </summary>
-    public object TypeDiscriminatorValue {
+    public object TypeDiscriminatorValue
+    {
       get { return typeDiscriminatorValue; }
       set {
         EnsureNotLocked();
@@ -357,7 +492,8 @@ namespace Xtensive.Orm.Model
     /// <summary>
     /// Gets or sets a value indicating whether this instance has version roots.
     /// </summary>
-    public bool HasVersionRoots {
+    public bool HasVersionRoots
+    {
       [DebuggerStepThrough]
       get { return hasVersionRoots; }
       [DebuggerStepThrough]
@@ -385,8 +521,7 @@ namespace Xtensive.Orm.Model
     public IList<IObjectValidator> Validators
     {
       get { return validators; }
-      internal set
-      {
+      internal set {
         EnsureNotLocked();
         validators = value;
       }
@@ -410,7 +545,7 @@ namespace Xtensive.Orm.Model
     public Tuple CreateEntityTuple(Tuple primaryKey, int typeIdValue)
     {
       var result = primaryKeyInjector.Apply(TupleTransformType.Tuple, primaryKey, TuplePrototype);
-      if (typeIdField!=null)
+      if (typeIdField != null)
         result.SetValue(typeIdField.MappingInfo.Offset, typeIdValue);
       return result;
     }
@@ -429,97 +564,13 @@ namespace Xtensive.Orm.Model
       return primaryKeyInjector.Apply(TupleTransformType.Tuple, primaryKey, entityTuple);
     }
 
-    /// <summary>
-    /// Gets the direct descendants of this instance.
-    /// </summary>
-    public IEnumerable<TypeInfo> GetDescendants()
-    {
-      return GetDescendants(false);
-    }
 
-    /// <summary>
-    /// Gets descendants of this instance.
-    /// </summary>
-    /// <param name="recursive">if set to <see langword="true"/> then both direct and nested descendants will be returned.</param>
-    /// <returns></returns>
-    public IEnumerable<TypeInfo> GetDescendants(bool recursive)
-    {
-      return model.Types.FindDescendants(this, recursive);
-    }
-
-    /// <summary>
-    /// Gets the direct persistent interfaces this instance implements.
-    /// </summary>
-    public IEnumerable<TypeInfo> GetInterfaces()
-    {
-      return model.Types.FindInterfaces(this);
-    }
-
-    /// <summary>
-    /// Gets the persistent interfaces this instance implements.
-    /// </summary>
-    /// <param name="recursive">if set to <see langword="true"/> then both direct and non-direct implemented interfaces will be returned.</param>
-    public IEnumerable<TypeInfo> GetInterfaces(bool recursive)
-    {
-      return model.Types.FindInterfaces(this, recursive);
-    }
-
-    /// <summary>
-    /// Gets the direct implementors of this instance.
-    /// </summary>
-    public IEnumerable<TypeInfo> GetImplementors()
-    {
-      return model.Types.FindImplementors(this);
-    }
-
-    /// <summary>
-    /// Gets the direct implementors of this instance.
-    /// </summary>
-    /// <param name="recursive">if set to <see langword="true"/> then both direct and non-direct implementors will be returned.</param>
-    public IEnumerable<TypeInfo> GetImplementors(bool recursive)
-    {
-      return model.Types.FindImplementors(this, recursive);
-    }
-
-    /// <summary>
-    /// Gets the ancestor.
-    /// </summary>
-    /// <returns>The ancestor</returns>
-    public TypeInfo GetAncestor()
-    {
-      return model.Types.FindAncestor(this);
-    }
-
-    /// <summary>
-    /// Gets the ancestors recursively. Root-to-inheritor order.
-    /// </summary>
-    /// <returns>The ancestor</returns>
-    public IReadOnlyList<TypeInfo> GetAncestors() => IsLocked ? ancestors : InnerGetAncestors();
-
-    private List<TypeInfo> InnerGetAncestors()
-    {
-      static void EnlistAncestors(List<TypeInfo> ancestors, TypeInfoCollection types, TypeInfo type)
-      {
-        var ancestor = types.FindAncestor(type);
-        if (ancestor != null) {
-          EnlistAncestors(ancestors, types, ancestor);
-          ancestors.Add(ancestor);
-        }
-      }
-
-      var result = new List<TypeInfo>();
-      EnlistAncestors(result, model.Types, this);
-      return result;
-    }
-
-    /// <summary>
-    /// Gets the root of the hierarchy.
     /// </summary>
     /// <returns>The hierarchy root.</returns>
-    public TypeInfo GetRoot()
-    {
-      return model.Types.FindRoot(this);
-    }
+    public TypeInfo GetRoot() =>
+      IsInterface || IsStructure
+        ? null
+        : (Ancestors.FirstOrDefault() ?? this);
 
     /// <summary>
     /// Gets the associations this instance is participating in as target (it is referenced by other entities).
@@ -586,10 +637,6 @@ namespace Xtensive.Orm.Model
     {
       base.UpdateState();
 
-      ancestors = InnerGetAncestors().AsReadOnly();
-      targetAssociations = InnerGetTargetAssociations().AsReadOnly();
-      ownerAssociations = InnerGetOwnerAssociations().AsReadOnly();
-
       var adapterIndex = 0;
       foreach (var field in Fields) {
         if (field.IsStructure || field.IsEntitySet) {
@@ -614,8 +661,7 @@ namespace Xtensive.Orm.Model
           versionColumns = Array.Empty<ColumnInfo>();
         }
         else {
-          versionFields = InnerGetVersionFields().AsReadOnly();
-          versionColumns = InnerGetVersionColumns().AsReadOnly();
+          versionFields = InnerGetVersionFields().ToList();
         }
         HasVersionFields = versionFields.Count > 0;
         HasExplicitVersionFields = versionFields.Any(f => f.ManualVersion || f.AutoVersion);
@@ -625,7 +671,7 @@ namespace Xtensive.Orm.Model
         // Collect mapping information from the first implementor (if any)
         // We'll check that all implementors are mapped to the same database later.
         // MappingSchema is not important: it's copied for consistency.
-        var firstImplementor = GetImplementors().FirstOrDefault();
+        var firstImplementor = Implementors.FirstOrDefault();
         if (firstImplementor != null) {
           MappingDatabase = firstImplementor.MappingDatabase;
           MappingSchema = firstImplementor.MappingSchema;
@@ -651,12 +697,12 @@ namespace Xtensive.Orm.Model
 
       overridenAssociations = associations
         .Where(a =>
-          (a.Ancestors.Count > 0 && ((a.OwnerType==this && a.Ancestors.All(an => an.OwnerType!=this) || (a.TargetType==this && a.Ancestors.All(an => an.TargetType!=this))))) ||
-          (a.Reversed!=null && (a.Reversed.Ancestors.Count > 0 && ((a.Reversed.OwnerType==this && a.Reversed.Ancestors.All(an => an.OwnerType!=this) || (a.Reversed.TargetType==this && a.Reversed.Ancestors.All(an => an.TargetType!=this)))))))
-        .SelectMany(a => a.Ancestors.Concat(a.Reversed==null ? Enumerable.Empty<AssociationInfo>() : a.Reversed.Ancestors))
+          (a.Ancestors.Count > 0 && ((a.OwnerType == this && a.Ancestors.All(an => an.OwnerType != this) || (a.TargetType == this && a.Ancestors.All(an => an.TargetType != this))))) ||
+          (a.Reversed != null && (a.Reversed.Ancestors.Count > 0 && ((a.Reversed.OwnerType == this && a.Reversed.Ancestors.All(an => an.OwnerType != this) || (a.Reversed.TargetType == this && a.Reversed.Ancestors.All(an => an.TargetType != this)))))))
+        .SelectMany(a => a.Ancestors.Concat(a.Reversed == null ? Enumerable.Empty<AssociationInfo>() : a.Reversed.Ancestors))
         .ToList();
-      var ancestor = GetAncestor();
-      if (ancestor!=null && ancestor.overridenAssociations!=null)
+      var ancestor = Ancestor;
+      if (ancestor != null && ancestor.overridenAssociations != null)
         overridenAssociations.AddRange(ancestor.overridenAssociations);
 
       foreach (var ancestorAssociation in overridenAssociations)
@@ -681,12 +727,12 @@ namespace Xtensive.Orm.Model
       //
       var sequence = new List<AssociationInfo>(associations.Count);
       var b = associations.Where(
-        a => (a.OnOwnerRemove==OnRemoveAction.Deny && a.OwnerType.UnderlyingType.IsAssignableFrom(UnderlyingType)) ||
-          (a.OnTargetRemove==OnRemoveAction.Deny && a.TargetType.UnderlyingType.IsAssignableFrom(UnderlyingType)) ||
-          (a.OnOwnerRemove==OnRemoveAction.Clear && a.OwnerType.UnderlyingType.IsAssignableFrom(UnderlyingType)) ||
-          (a.OnTargetRemove==OnRemoveAction.Clear && a.TargetType.UnderlyingType.IsAssignableFrom(UnderlyingType)) ||
-          (a.OnOwnerRemove==OnRemoveAction.Cascade && a.OwnerType.UnderlyingType.IsAssignableFrom(UnderlyingType)) ||
-          (a.OnTargetRemove==OnRemoveAction.Cascade && a.TargetType.UnderlyingType.IsAssignableFrom(UnderlyingType)));
+        a => (a.OnOwnerRemove == OnRemoveAction.Deny && a.OwnerType.UnderlyingType.IsAssignableFrom(UnderlyingType)) ||
+          (a.OnTargetRemove == OnRemoveAction.Deny && a.TargetType.UnderlyingType.IsAssignableFrom(UnderlyingType)) ||
+          (a.OnOwnerRemove == OnRemoveAction.Clear && a.OwnerType.UnderlyingType.IsAssignableFrom(UnderlyingType)) ||
+          (a.OnTargetRemove == OnRemoveAction.Clear && a.TargetType.UnderlyingType.IsAssignableFrom(UnderlyingType)) ||
+          (a.OnOwnerRemove == OnRemoveAction.Cascade && a.OwnerType.UnderlyingType.IsAssignableFrom(UnderlyingType)) ||
+          (a.OnTargetRemove == OnRemoveAction.Cascade && a.TargetType.UnderlyingType.IsAssignableFrom(UnderlyingType)));
       sequence.AddRange(b);
 
       var sortedRemovalSequence = sequence.Where(a => a.Ancestors.Count > 0).ToList();
@@ -731,19 +777,13 @@ namespace Xtensive.Orm.Model
 
     #region Private / internal methods
 
-    private KeyInfo GetKey()
-    {
-      if (Hierarchy==null)
-        return IsInterface
-          ? GetImplementors().First().Hierarchy.Key
-          : null;
-      return Hierarchy.Key;
-    }
+    private KeyInfo GetKey() =>
+      Hierarchy != null ? Hierarchy.Key
+        : IsInterface ? Implementors.First().Hierarchy.Key
+        : null;
 
-    private bool GetIsLeaf()
-    {
-      return IsEntity && !GetDescendants().Any();
-    }
+    private bool GetIsLeaf() =>
+      IsEntity && Descendants.Count == 0;
 
     private void CreateTupleDescriptor()
     {
@@ -763,7 +803,7 @@ namespace Xtensive.Orm.Model
         nullabilityMap[i++] = column.IsNullable;
 
       // fixing reference fields that are marked as not nullable
-      foreach (var field in Fields.Where(f => f.IsEntity && !f.IsPrimaryKey && f.IsNullable==false)) {
+      foreach (var field in Fields.Where(f => f.IsEntity && !f.IsPrimaryKey && f.IsNullable == false)) {
         var segment = field.MappingInfo;
         for (int j = segment.Offset; j < segment.EndOffset; j++) {
           nullabilityMap[j] = true;
@@ -777,7 +817,7 @@ namespace Xtensive.Orm.Model
       // Initializing defaults
       i = 0;
       foreach (var column in Columns) {
-        if (column.DefaultValue!=null) {
+        if (column.DefaultValue != null) {
           try {
             tuple.SetValue(i, column.DefaultValue);
           }
@@ -792,7 +832,7 @@ namespace Xtensive.Orm.Model
       // Aditional initialization for entities
       if (IsEntity) {
         // Setting type discriminator column
-        if (Hierarchy.TypeDiscriminatorMap!=null)
+        if (Hierarchy.TypeDiscriminatorMap != null)
           tuple.SetValue(Hierarchy.TypeDiscriminatorMap.Field.MappingInfo.Offset, typeDiscriminatorValue);
 
         // Building primary key injector
@@ -811,7 +851,7 @@ namespace Xtensive.Orm.Model
       // Building version tuple extractor
       var versionColumns = GetVersionColumns();
       var versionColumnsCount = versionColumns?.Count ?? 0;
-      if (versionColumns==null || versionColumnsCount==0) {
+      if (versionColumns == null || versionColumnsCount == 0) {
         VersionExtractor = null;
         return;
       }
@@ -841,6 +881,14 @@ namespace Xtensive.Orm.Model
       return Name;
     }
 
+    internal void AddDescendant(TypeInfo descendant) =>
+         (descendants ??= new()).Add(descendant);
+
+    internal void AddInterface(TypeInfo iface) =>
+      (interfaces ??= new()).Add(iface);
+
+    internal void AddImplementor(TypeInfo implementor) =>
+      (implementors ??= new()).Add(implementor);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfoCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfoCollection.cs
@@ -21,12 +21,8 @@ namespace Xtensive.Orm.Model
     : NodeCollection<TypeInfo>,
       IFilterable<TypeAttributes, TypeInfo>
   {
-    private readonly Dictionary<Type, TypeInfo> typeTable = new Dictionary<Type, TypeInfo>();
-    private readonly Dictionary<string, TypeInfo> fullNameTable = new Dictionary<string, TypeInfo>();
-    private readonly Dictionary<TypeInfo, TypeInfo> ancestorTable = new Dictionary<TypeInfo, TypeInfo>();
-    private readonly Dictionary<TypeInfo, HashSet<TypeInfo>> descendantTable = new Dictionary<TypeInfo, HashSet<TypeInfo>>();
-    private readonly Dictionary<TypeInfo, HashSet<TypeInfo>> interfaceTable = new Dictionary<TypeInfo, HashSet<TypeInfo>>();
-    private readonly Dictionary<TypeInfo, HashSet<TypeInfo>> implementorTable = new Dictionary<TypeInfo, HashSet<TypeInfo>>();
+    private readonly Dictionary<Type, TypeInfo> typeTable = new();
+    private readonly Dictionary<string, TypeInfo> fullNameTable = new();
 
     private TypeIdRegistry typeIdRegistry;
 
@@ -56,26 +52,17 @@ namespace Xtensive.Orm.Model
     /// <summary>
     /// Gets the structures that are contained in this collection.
     /// </summary>
-    public ICollection<TypeInfo> Structures
-    {
-      get { return Find(TypeAttributes.Structure); }
-    }
+    public IEnumerable<TypeInfo> Structures => Find(TypeAttributes.Structure);
 
     /// <summary>
     /// Gets the entities that are contained in this collection.
     /// </summary>
-    public ICollection<TypeInfo> Entities
-    {
-      get { return Find(TypeAttributes.Entity); }
-    }
+    public IEnumerable<TypeInfo> Entities => Find(TypeAttributes.Entity);
 
     /// <summary>
     /// Gets the interfaces that are contained in this collection.
     /// </summary>
-    public ICollection<TypeInfo> Interfaces
-    {
-      get { return Find(TypeAttributes.Interface); }
-    }
+    public IEnumerable<TypeInfo> Interfaces => Find(TypeAttributes.Interface);
 
     internal TypeIdRegistry TypeIdRegistry
     {
@@ -181,148 +168,6 @@ namespace Xtensive.Orm.Model
     }
 
     /// <summary>
-    /// Finds the ancestor of the specified <paramref name="item"/>.
-    /// </summary>
-    /// <param name="item">The type to search ancestor for.</param>
-    /// <returns><see cref="TypeInfo"/> instance that is ancestor of specified <paramref name="item"/> or
-    /// <see langword="null"/> if the ancestor is not found in this collection.</returns>
-    /// <exception cref="ArgumentNullException">When <paramref name="item"/> is <see langword="null"/>.</exception>
-    public TypeInfo FindAncestor(TypeInfo item)
-    {
-      ArgumentValidator.EnsureArgumentNotNull(item, "item");
-      TypeInfo result;
-      return ancestorTable.TryGetValue(item, out result) ? result : null;
-    }
-
-    /// <summary>
-    /// Finds the set of direct descendants of the specified <paramref name="item"/>.
-    /// </summary>
-    /// <param name="item">The type to search descendants for.</param>
-    /// <returns><see cref="IEnumerable{T}"/> of <see cref="TypeInfo"/> instance that are descendants of specified <paramref name="item"/>.</returns>
-    /// <exception cref="ArgumentNullException">When <paramref name="item"/> is <see langword="null"/>.</exception>
-    public IEnumerable<TypeInfo> FindDescendants(TypeInfo item)
-    {
-      return FindDescendants(item, false);
-    }
-
-    /// <summary>
-    /// Finds the set of descendants of the specified <paramref name="item"/>.
-    /// </summary>
-    /// <param name="item">The type to search descendants for.</param>
-    /// <param name="recursive">if set to <see langword="true"/> then both direct and nested descendants will be returned.</param>
-    /// <returns>
-    ///   <see cref="IEnumerable{T}"/> of <see cref="TypeInfo"/> instance that are descendants of specified <paramref name="item"/>.
-    /// </returns>
-    /// <exception cref="ArgumentNullException">When <paramref name="item"/> is <see langword="null"/>.</exception>
-    public IEnumerable<TypeInfo> FindDescendants(TypeInfo item, bool recursive)
-    {
-      ArgumentValidator.EnsureArgumentNotNull(item, "item");
-
-      if (descendantTable.TryGetValue(item, out var result)) {
-        foreach (var item1 in result) {
-          yield return item1;
-          if (recursive)
-            foreach (var item2 in FindDescendants(item1, true))
-              yield return item2;
-        }
-      }
-    }
-
-    /// <summary>
-    /// Find the <see cref="IList{T}"/> of interfaces that specified <paramref name="item"/> implements.
-    /// </summary>
-    /// <param name="item">The type to search interfaces for.</param>
-    /// <returns><see cref="IEnumerable{T}"/> of <see cref="TypeInfo"/> instance that are implemented by specified <paramref name="item"/>.</returns>
-    /// <exception cref="ArgumentNullException">When <paramref name="item"/> is <see langword="null"/>.</exception>
-    public IEnumerable<TypeInfo> FindInterfaces(TypeInfo item)
-    {
-      return FindInterfaces(item, false);
-    }
-
-    /// <summary>
-    /// Find the <see cref="IList{T}"/> of interfaces that specified <paramref name="item"/> implements.
-    /// </summary>
-    /// <param name="item">The type to search interfaces for.</param>
-    /// <param name="recursive">if set to <see langword="true"/> then both direct and non-direct implemented interfaces will be returned.</param>
-    /// <returns><see cref="IEnumerable{T}"/> of <see cref="TypeInfo"/> instance that are implemented by specified <paramref name="item"/>.</returns>
-    /// <exception cref="ArgumentNullException">When <paramref name="item"/> is <see langword="null"/>.</exception>
-    public IEnumerable<TypeInfo> FindInterfaces(TypeInfo item, bool recursive)
-    {
-      ArgumentValidator.EnsureArgumentNotNull(item, "item");
-
-      if (interfaceTable.TryGetValue(item, out var result)) {
-        foreach (var item1 in result)
-          yield return item1;
-      }
-
-      if (!recursive || item.IsInterface)
-        yield break;
-
-      var ancestor = FindAncestor(item);
-      while (ancestor != null) {
-        foreach (var @interface in FindInterfaces(ancestor))
-          yield return @interface;
-        ancestor = FindAncestor(ancestor);
-      }
-    }
-
-    /// <summary>
-    /// Finds the set of direct implementors of the specified <paramref name="item"/>.
-    /// </summary>
-    /// <param name="item">The type to search implementors for.</param>
-    /// <returns><see cref="IEnumerable{T}"/> of <see cref="TypeInfo"/> instance that are implementors of specified <paramref name="item"/>.</returns>
-    /// <exception cref="ArgumentNullException">When <paramref name="item"/> is <see langword="null"/>.</exception>
-    public IEnumerable<TypeInfo> FindImplementors(TypeInfo item)
-    {
-      return FindImplementors(item, false);
-    }
-
-    /// <summary>
-    /// Finds the set of implementors of the specified <paramref name="item"/>.
-    /// </summary>
-    /// <param name="item">The type to search implementors for.</param>
-    /// <param name="recursive">if set to <see langword="true"/> then both direct and nested implementors will be returned.</param>
-    /// <returns>
-    ///   <see cref="IEnumerable{T}"/> of <see cref="TypeInfo"/> instance that are implementors of specified <paramref name="item"/>.
-    /// </returns>
-    /// <exception cref="ArgumentNullException">When <paramref name="item"/> is <see langword="null"/>.</exception>
-    public IEnumerable<TypeInfo> FindImplementors(TypeInfo item, bool recursive)
-    {
-      ArgumentValidator.EnsureArgumentNotNull(item, "item");
-
-      if (implementorTable.TryGetValue(item, out var result)) {
-        foreach (var item1 in result) {
-          yield return item1;
-          if (recursive && !item1.IsInterface)
-            foreach (var item2 in FindDescendants(item1, true))
-              yield return item2;
-        }
-      }
-    }
-
-    /// <summary>
-    /// Finds the root of the specified <paramref name="item"/>.
-    /// </summary>
-    /// <param name="item">The type to search root for.</param>
-    /// <returns><see cref="TypeInfo"/> instance that is root of specified <paramref name="item"/>.</returns>
-    /// <exception cref="ArgumentNullException">When <paramref name="item"/> is <see langword="null"/>.</exception>
-    public TypeInfo FindRoot(TypeInfo item)
-    {
-      ArgumentValidator.EnsureArgumentNotNull(item, "item");
-
-      if (item.IsInterface || item.IsStructure)
-        return null;
-
-      var candidate = item;
-      while (true) {
-        var ancestor = FindAncestor(candidate);
-        if (ancestor == null)
-          return candidate;
-        candidate = ancestor;
-      }
-    }
-
-    /// <summary>
     /// Finds the ancestor of the specified <paramref name="type"/>.
     /// </summary>
     /// <param name="type">The type to search ancestor for.</param>
@@ -349,26 +194,19 @@ namespace Xtensive.Orm.Model
     /// </summary>
     /// <param name="criteria">The attributes.</param>
     /// <returns><see cref="ICollection{TItem}"/> that contains all found instances.</returns>
-    public ICollection<TypeInfo> Find(TypeAttributes criteria)
+    public IEnumerable<TypeInfo> Find(TypeAttributes criteria) => Find(criteria, MatchType.Partial);
+
+    public IEnumerable<TypeInfo> Find(TypeAttributes criteria, MatchType matchType)
     {
-      // We don't have any instance that has attributes == TypeAttributes.None
       if (criteria == TypeAttributes.None)
         return Array.Empty<TypeInfo>();
-
-      return Find(criteria, MatchType.Partial);
-    }
-
-    public ICollection<TypeInfo> Find(TypeAttributes criteria, MatchType matchType)
-    {
-      if (criteria==TypeAttributes.None)
-        return Array.Empty<TypeInfo>();
       switch (matchType) {
-      case MatchType.Partial:
-        return this.Where(f => (f.Attributes & criteria) > 0).ToList();
-      case MatchType.Full:
-        return this.Where(f => (f.Attributes & criteria)==criteria).ToList();
-      default:
-        return this.Where(f => (f.Attributes & criteria)==0).ToList();
+        case MatchType.Partial:
+          return this.Where(f => (f.Attributes & criteria) > 0);
+        case MatchType.Full:
+          return this.Where(f => (f.Attributes & criteria) == criteria);
+        default:
+          return this.Where(f => (f.Attributes & criteria) == 0);
       }
     }
 
@@ -384,22 +222,13 @@ namespace Xtensive.Orm.Model
       EnsureNotLocked();
 
       if (ancestor.IsInterface) {
-        HashSet<TypeInfo> interfaces;
-        if (!interfaceTable.TryGetValue(descendant, out interfaces)) {
-          interfaces = new HashSet<TypeInfo>();
-          interfaceTable[descendant] = interfaces;
-        }
-        interfaces.Add(ancestor);
+        descendant.AddInterface(ancestor);
       }
-      else
-        ancestorTable[descendant] = ancestor;
+      else {
+        descendant.Ancestor = ancestor;
+      }
 
-      HashSet<TypeInfo> descendants;
-      if (!descendantTable.TryGetValue(ancestor, out descendants)) {
-        descendants = new HashSet<TypeInfo>();
-        descendantTable[ancestor] = descendants;
-      }
-      descendants.Add(descendant);
+      ancestor.AddDescendant(descendant);
     }
 
     /// <summary>
@@ -411,19 +240,8 @@ namespace Xtensive.Orm.Model
     {
       EnsureNotLocked();
 
-      HashSet<TypeInfo> interfaces;
-      if (!interfaceTable.TryGetValue(implementor, out interfaces)) {
-        interfaces = new HashSet<TypeInfo>();
-        interfaceTable[implementor] = interfaces;
-      }
-      interfaces.Add(@interface);
-
-      HashSet<TypeInfo> implementors;
-      if (!implementorTable.TryGetValue(@interface, out implementors)) {
-        implementors = new HashSet<TypeInfo>();
-        implementorTable[@interface] = implementors;
-      }
-      implementors.Add(implementor);
+      implementor.AddInterface(@interface);
+      @interface.AddImplementor(implementor);
     }
 
     protected override string GetExceptionMessage(string key)

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfoCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfoCollection.cs
@@ -193,7 +193,7 @@ namespace Xtensive.Orm.Model
     /// Finds all <see cref="TypeInfo"/> instances according to specified criteria.
     /// </summary>
     /// <param name="criteria">The attributes.</param>
-    /// <returns><see cref="ICollection{TItem}"/> that contains all found instances.</returns>
+    /// <returns><see cref="IEnumerable{TItem}"/> that contains all found instances.</returns>
     public IEnumerable<TypeInfo> Find(TypeAttributes criteria) => Find(criteria, MatchType.Partial);
 
     public IEnumerable<TypeInfo> Find(TypeAttributes criteria, MatchType matchType)

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilderContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilderContext.cs
@@ -44,9 +44,9 @@ namespace Xtensive.Orm.Providers
 
       var affectedIndexes = Type.AffectedIndexes.Where(index => index.IsPrimary).ToList();
       affectedIndexes.Sort((left, right) => {
-        if (left.ReflectedType.GetAncestors().Contains(right.ReflectedType))
+        if (left.ReflectedType.Ancestors.Contains(right.ReflectedType))
           return 1;
-        if (right.ReflectedType.GetAncestors().Contains(left.ReflectedType))
+        if (right.ReflectedType.Ancestors.Contains(left.ReflectedType))
           return -1;
         return 0;
       });

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/DomainModelConverter.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/DomainModelConverter.cs
@@ -116,7 +116,7 @@ namespace Xtensive.Orm.Upgrade
         if (type.Hierarchy==null || type.Hierarchy.InheritanceSchema==InheritanceSchema.ConcreteTable)
           continue;
         if (type.Indexes.PrimaryIndex.IsVirtual) {
-          Dictionary<TypeInfo, int> typeOrder = type.GetAncestors()
+          Dictionary<TypeInfo, int> typeOrder = type.Ancestors
             .Append(type)
             .Select((t, i) => (Type: t, Index: i))
             .ToDictionary(a => a.Type, a => a.Index);
@@ -218,7 +218,7 @@ namespace Xtensive.Orm.Upgrade
         if (!IsValidForeignKeyTarget(association.TargetType))
           return null;
         if (association.OwnerType.IsInterface) {
-          foreach (var implementorType in association.OwnerType.GetImplementors().SelectMany(GetForeignKeyOwners)) {
+          foreach (var implementorType in association.OwnerType.Implementors.SelectMany(GetForeignKeyOwners)) {
             var implementorField = implementorType.FieldMap[association.OwnerField];
             ProcessDirectAssociation(implementorType, implementorField, association.TargetType);
           }
@@ -506,7 +506,7 @@ namespace Xtensive.Orm.Upgrade
         yield break;
       yield return type;
       if (type.Hierarchy.InheritanceSchema == InheritanceSchema.ConcreteTable)
-        foreach (var descendant in type.GetDescendants(true).Where(descendant => descendant.Indexes.PrimaryIndex != null))
+        foreach (var descendant in type.RecursiveDescendants.Where(descendant => descendant.Indexes.PrimaryIndex != null))
           yield return descendant;
     }
 

--- a/Version.props
+++ b/Version.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.1.0.66</DoVersion>
+    <DoVersion>7.1.0.67</DoVersion>
     <DoVersionSuffix>servicetitan-test</DoVersionSuffix>
 </PropertyGroup>
 

--- a/Version.props
+++ b/Version.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.1.0.65</DoVersion>
+    <DoVersion>7.1.0.66</DoVersion>
     <DoVersionSuffix>servicetitan-test</DoVersionSuffix>
 </PropertyGroup>
 

--- a/Version.props
+++ b/Version.props
@@ -2,8 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.1.0.68</DoVersion>
-    <DoVersionSuffix>servicetitan-test</DoVersionSuffix>
+    <DoVersion>7.1.0.64</DoVersion>
+    <DoVersionSuffix>servicetitan</DoVersionSuffix>
 </PropertyGroup>
 
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -2,8 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.1.0.64</DoVersion>
-    <DoVersionSuffix>servicetitan</DoVersionSuffix>
+    <DoVersion>7.1.0.65</DoVersion>
+    <DoVersionSuffix>servicetitan-test</DoVersionSuffix>
 </PropertyGroup>
 
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.1.0.67</DoVersion>
+    <DoVersion>7.1.0.68</DoVersion>
     <DoVersionSuffix>servicetitan-test</DoVersionSuffix>
 </PropertyGroup>
 


### PR DESCRIPTION
This is subset of https://github.com/DataObjects-NET/dataobjects-net/pull/242 

Improvements:
* Get rid of intermediate dictionaries `TypeInfo` -> `Interfaces/Descendants/Ancestors`.  These lists/sets are now fields of `TypeInfo`
* Split `GetInterfaces/GetAncestors(recursive)` into properties: `Interfaces`/`RecursiveInterfaces` ... to avoid unnecessary branching baceuse caller side invokes the methods with constant argument