### PR TITLE
Optimizations of Domain build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -132,5 +132,6 @@
 
     <!-- setting env var or property 'DO_DATEONLY=false' disables DO_DATEONLY feature -->
     <DefineConstants Condition="$(TargetFramework)!='net5.0' AND '$(DO_DATEONLY)'!='false'">$(DefineConstants);DO_DATEONLY</DefineConstants>
+    <DefineConstants Condition="'$(DO_SAFE_COLLECTION_WRAPPER)'=='true'">$(DefineConstants);DO_SAFE_COLLECTION_WRAPPER</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/Orm/Xtensive.Orm.Tests.Core/Helpers/TopologicalSorterTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Helpers/TopologicalSorterTest.cs
@@ -63,7 +63,7 @@ namespace Xtensive.Orm.Tests.Core.Helpers
                 List<Node<int, int>> removedEdges;
                 var result = TopologicalSorter.Sort(nodes, out removedEdges);
                 if (!allowLoops)
-                    Assert.AreEqual(nodeCount, result.Count);
+                    Assert.AreEqual(nodeCount, result.Count());
             }
             GC.GetTotalMemory(true);
         }
@@ -132,7 +132,7 @@ namespace Xtensive.Orm.Tests.Core.Helpers
         private void TestSort<T>(T[] data, Predicate<T, T> connector, T[] expected, T[] loops)
         {
             List<Node<T, object>> actualLoopNodes;
-            List<T> actual = TopologicalSorter.Sort(data, connector, out actualLoopNodes);
+            List<T> actual = TopologicalSorter.Sort(data, connector, out actualLoopNodes).ToList();
             T[] actualLoops = null;
             if (actualLoopNodes != null)
                 actualLoops = actualLoopNodes

--- a/Orm/Xtensive.Orm/Core/Extensions/ListExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/ListExtensions.cs
@@ -8,7 +8,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-
+using System.Runtime.CompilerServices;
 
 namespace Xtensive.Core
 {
@@ -119,5 +119,29 @@ namespace Xtensive.Core
       if (index < 0 || index >= list.Count)
         throw new IndexOutOfRangeException(Strings.ExIndexOutOfRange);
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static IReadOnlyList<T> AsSafeWrapper<T>(this List<T> list) =>
+#if DO_SAFE_COLLECTION_WRAPPER
+      list.AsReadOnly();
+#else
+      list;
+#endif
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static IReadOnlyList<T> AsSafeWrapper<T>(this IReadOnlyList<T> list) =>
+#if DO_SAFE_COLLECTION_WRAPPER
+      new ReadOnlyCollection(list);
+#else
+      list;
+#endif
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static IReadOnlyList<T> AsSafeWrapper<T>(this T[] array) =>
+#if DO_SAFE_COLLECTION_WRAPPER
+      Array.AsReadOnly(array);
+#else
+      array;
+#endif
   }
 }

--- a/Orm/Xtensive.Orm/Linq/ExpressionVisitor.cs
+++ b/Orm/Xtensive.Orm/Linq/ExpressionVisitor.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq.Expressions;
+using Xtensive.Core;
 
 namespace Xtensive.Linq
 {
@@ -17,7 +18,7 @@ namespace Xtensive.Linq
   /// </summary>
   public abstract class ExpressionVisitor : ExpressionVisitor<Expression>
   {
-    protected override ReadOnlyCollection<Expression> VisitExpressionList(ReadOnlyCollection<Expression> expressions)
+    protected override IReadOnlyList<Expression> VisitExpressionList(ReadOnlyCollection<Expression> expressions)
     {
       bool isChanged = false;
       var results = new List<Expression>(expressions.Count);
@@ -27,7 +28,7 @@ namespace Xtensive.Linq
         results.Add(p);
         isChanged |= !ReferenceEquals(expression, p);
       }
-      return isChanged ? results.AsReadOnly() : expressions;
+      return isChanged ? results.AsSafeWrapper() : expressions;
     }
 
     /// <summary>
@@ -37,8 +38,8 @@ namespace Xtensive.Linq
     /// <returns>Visit result.</returns>
     protected virtual ElementInit VisitElementInitializer(ElementInit initializer)
     {
-      ReadOnlyCollection<Expression> arguments = VisitExpressionList(initializer.Arguments);
-      if (arguments!=initializer.Arguments) {
+      var arguments = VisitExpressionList(initializer.Arguments);
+      if (arguments != initializer.Arguments) {
         return Expression.ElementInit(initializer.AddMethod, arguments);
       }
       return initializer;
@@ -49,7 +50,7 @@ namespace Xtensive.Linq
     /// </summary>
     /// <param name="original">The original element initializer list.</param>
     /// <returns>Visit result.</returns>
-    protected virtual ReadOnlyCollection<ElementInit> VisitElementInitializerList(ReadOnlyCollection<ElementInit> original)
+    protected virtual IReadOnlyList<ElementInit> VisitElementInitializerList(ReadOnlyCollection<ElementInit> original)
     {
       var results = new List<ElementInit>();
       bool isChanged = false;
@@ -59,7 +60,7 @@ namespace Xtensive.Linq
         results.Add(p);
         isChanged |= !ReferenceEquals(originalIntializer, p);
       }
-      return isChanged ? results.AsReadOnly() : original;
+      return isChanged ? results.AsSafeWrapper() : original;
     }
 
     /// <inheritdoc/>
@@ -246,7 +247,7 @@ namespace Xtensive.Linq
     /// </summary>
     /// <param name="original">The original binding list.</param>
     /// <returns>Visit result.</returns>
-    protected virtual ReadOnlyCollection<MemberBinding> VisitBindingList(ReadOnlyCollection<MemberBinding> original)
+    protected virtual IReadOnlyList<MemberBinding> VisitBindingList(ReadOnlyCollection<MemberBinding> original)
     {
       var results = new List<MemberBinding>();
       bool isChanged = false;
@@ -256,7 +257,7 @@ namespace Xtensive.Linq
         results.Add(p);
         isChanged |= !ReferenceEquals(originalBinding, p);
       }
-      return isChanged ? results.AsReadOnly() : original;
+      return isChanged ? results.AsSafeWrapper() : original;
     }
 
     protected virtual MemberListBinding VisitMemberListBinding(MemberListBinding binding)

--- a/Orm/Xtensive.Orm/Linq/ExpressionVisitor{TResult}.cs
+++ b/Orm/Xtensive.Orm/Linq/ExpressionVisitor{TResult}.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq.Expressions;
 using Xtensive.Reflection;
+using Xtensive.Core;
 
 
 
@@ -139,14 +140,14 @@ namespace Xtensive.Linq
     /// </summary>
     /// <param name="expressions">The expression list.</param>
     /// <returns>Visit result.</returns>
-    protected virtual ReadOnlyCollection<TResult> VisitExpressionList(ReadOnlyCollection<Expression> expressions)
+    protected virtual IReadOnlyList<TResult> VisitExpressionList(ReadOnlyCollection<Expression> expressions)
     {
       var results = new List<TResult>(expressions.Count);
       for (int i = 0, n = expressions.Count; i < n; i++) {
         var p = Visit(expressions[i]);
         results.Add(p);
       }
-      return results.AsReadOnly();
+      return results.AsSafeWrapper();
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/AssociationBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/AssociationBuilder.cs
@@ -25,7 +25,7 @@ namespace Xtensive.Orm.Building.Builders
         fieldDef.OnOwnerRemove, fieldDef.OnTargetRemove);
       association.Name = context.NameBuilder.BuildAssociationName(association);
       context.Model.Associations.Add(association);
-      field.Associations.Add(association);
+      field.AddAssociation(association);
 
       if (!fieldDef.PairTo.IsNullOrEmpty())
         context.PairedAssociations.Add(new Pair<AssociationInfo, string>(association, fieldDef.PairTo));
@@ -40,8 +40,8 @@ namespace Xtensive.Orm.Building.Builders
         .Where(a => a.TargetType == association.TargetType)
         .ToList();
       foreach (var toRemove in associationsToRemove)
-        field.Associations.Remove(toRemove);
-      field.Associations.Add(association);
+        field.RemoveAssociation(toRemove);
+      field.AddAssociation(association);
 
       var pairTo = context.PairedAssociations.Where(p => p.First==origin).FirstOrDefault();
       if (pairTo.First!=null)
@@ -86,9 +86,9 @@ namespace Xtensive.Orm.Building.Builders
           .Where(a => a.TargetType == association.TargetType)
           .ToList();
         foreach (var toRemove in associationsToRemove)
-          field.Associations.Remove(toRemove);
+          field.RemoveAssociation(toRemove);
 
-        field.Associations.Add(association);
+        field.AddAssociation(association);
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
@@ -533,7 +533,7 @@ namespace Xtensive.Orm.Building.Builders
         & (IndexAttributes.Primary | IndexAttributes.Secondary | IndexAttributes.Unique | IndexAttributes.Abstract)
         | IndexAttributes.Filtered | IndexAttributes.Virtual;
       var result = new IndexInfo(reflectedType, attributes, indexToFilter, Array.Empty<IndexInfo>()) {
-        FilterByTypes = filterByTypes.ToList().AsReadOnly()
+        FilterByTypes = filterByTypes.ToList().AsSafeWrapper()
       };
 
       // Adding key columns
@@ -760,7 +760,7 @@ namespace Xtensive.Orm.Building.Builders
       }
 
       result.ValueColumns.AddRange(valueColumns);
-      result.SelectColumns = columnMap.AsReadOnly();
+      result.SelectColumns = columnMap.AsSafeWrapper();
       result.Name = nameBuilder.BuildIndexName(reflectedType, result);
       result.Group = BuildColumnGroup(result);
 

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/ModelBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/ModelBuilder.cs
@@ -277,7 +277,7 @@ namespace Xtensive.Orm.Building.Builders
 
           foreach (var association in associationsToRemove) {
             context.Model.Associations.Remove(association);
-            refField.Associations.Remove(association);
+            refField.RemoveAssociation(association);
           }
           foreach (var association in associationsToKeep) {
             var interfaceAssociationsToRemove = interfaceAssociations
@@ -287,10 +287,10 @@ namespace Xtensive.Orm.Building.Builders
             foreach (var interfaceAssociation in interfaceAssociationsToRemove)
               interfaceAssociations.Remove(interfaceAssociation);
           }
-          refField.Associations.AddRange(interfaceAssociations);
+          refField.AddAssociations(interfaceAssociations);
           foreach (var association in inheritedAssociations) {
-            if (!refField.Associations.Contains(association.Name))
-              refField.Associations.Add(association);
+            if (!refField.ContainsAssociation(association.Name))
+              refField.AddAssociation(association);
             if (!context.Model.Associations.Contains(association))
               context.Model.Associations.Add(association);
           }

--- a/Orm/Xtensive.Orm/Orm/Building/BuildingContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/BuildingContext.cs
@@ -62,12 +62,12 @@ namespace Xtensive.Orm.Building
     /// <summary>
     /// Gets all available <see cref="IModule"/> implementations.
     /// </summary>
-    public ICollection<IModule> Modules { get; private set; }
+    public IReadOnlyList<IModule> Modules { get; }
 
     /// <summary>
     /// Gets all available <see cref="IModule2"/> implementations.
     /// </summary>
-    public ICollection<IModule2> Modules2 { get; private set; }
+    public IReadOnlyList<IModule2> Modules2 { get; }
 
     internal ModelDefBuilder ModelDefBuilder { get; set; }
 
@@ -85,8 +85,8 @@ namespace Xtensive.Orm.Building
       ModelInspectionResult = new ModelInspectionResult();
       DependencyGraph = new Graph<TypeDef>();
 
-      Modules = BuilderConfiguration.Services.Modules.ToList().AsReadOnly();
-      Modules2 = Modules.OfType<IModule2>().ToList().AsReadOnly();
+      Modules = BuilderConfiguration.Services.Modules.AsSafeWrapper();
+      Modules2 = Modules.OfType<IModule2>().ToList().AsSafeWrapper();
       Validator = new Validator(builderConfiguration.Services.ProviderInfo.SupportedTypes);
       DefaultSchemaInfo = builderConfiguration.DefaultSchemaInfo;
     }

--- a/Orm/Xtensive.Orm/Orm/Building/Definitions/FieldDef.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Definitions/FieldDef.cs
@@ -287,7 +287,7 @@ namespace Xtensive.Orm.Building.Definitions
     /// <summary>
     /// Gets of <see cref="IPropertyValidator"/> instances associated with this field.
     /// </summary>
-    public IList<IPropertyValidator> Validators { get; private set; }
+    public List<IPropertyValidator> Validators { get; } = new();
 
     internal bool IsDeclaredAsNullable
     {
@@ -325,7 +325,6 @@ namespace Xtensive.Orm.Building.Definitions
       if ((valueType.IsClass || valueType.IsInterface) && !IsStructure)
         attributes |= FieldAttributes.Nullable;
       ValueType = valueType;
-      Validators = new List<IPropertyValidator>();
 
       // Nullable<T>
       if (valueType.IsNullable()) {

--- a/Orm/Xtensive.Orm/Orm/Building/Definitions/TypeDef.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Definitions/TypeDef.cs
@@ -119,7 +119,7 @@ namespace Xtensive.Orm.Building.Definitions
     /// <summary>
     /// Gets <see cref="IObjectValidator"/> instances associated with this type.
     /// </summary>
-    public IList<IObjectValidator> Validators { get; private set; }
+    public List<IObjectValidator> Validators { get; } = new();
 
     /// <summary>
     /// Gets or sets the type discriminator value.
@@ -225,8 +225,6 @@ namespace Xtensive.Orm.Building.Definitions
       implementors = IsInterface
         ? new NodeCollection<TypeDef>(this, "Implementors")
         : NodeCollection<TypeDef>.Empty;
-
-      Validators = new List<IObjectValidator>();
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/IHasNestedNodes.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/IHasNestedNodes.cs
@@ -11,10 +11,10 @@ namespace Xtensive.Orm.Internals.Prefetch
 {
   internal interface IHasNestedNodes
   {
-    ReadOnlyCollection<BaseFieldNode> NestedNodes { get; }
+    IReadOnlyList<BaseFieldNode> NestedNodes { get; }
 
     IReadOnlyCollection<Key> ExtractKeys(object target);
 
-    IHasNestedNodes ReplaceNestedNodes(ReadOnlyCollection<BaseFieldNode> nestedNodes);
+    IHasNestedNodes ReplaceNestedNodes(IReadOnlyList<BaseFieldNode> nestedNodes);
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/KeyExtractorNode.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/KeyExtractorNode.cs
@@ -15,7 +15,7 @@ namespace Xtensive.Orm.Internals.Prefetch
   {
     public Func<T, IReadOnlyCollection<Key>> KeyExtractor { get; }
 
-    public ReadOnlyCollection<BaseFieldNode> NestedNodes { get; }
+    public IReadOnlyList<BaseFieldNode> NestedNodes { get; }
 
     IReadOnlyCollection<Key> IHasNestedNodes.ExtractKeys(object target)
     {
@@ -27,10 +27,8 @@ namespace Xtensive.Orm.Internals.Prefetch
       return KeyExtractor.Invoke(target);
     }
 
-    public IHasNestedNodes ReplaceNestedNodes(ReadOnlyCollection<BaseFieldNode> nestedNodes)
-    {
-      return new KeyExtractorNode<T>(KeyExtractor, nestedNodes);
-    }
+    public IHasNestedNodes ReplaceNestedNodes(IReadOnlyList<BaseFieldNode> nestedNodes) =>
+      new KeyExtractorNode<T>(KeyExtractor, nestedNodes);
 
     public override Node Accept(NodeVisitor visitor)
     {
@@ -42,7 +40,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       return $"KeyExtraction<{typeof(T).Name}>";
     }
 
-    public KeyExtractorNode(Func<T, IReadOnlyCollection<Key>> extractor, ReadOnlyCollection<BaseFieldNode> nestedNodes)
+    public KeyExtractorNode(Func<T, IReadOnlyCollection<Key>> extractor, IReadOnlyList<BaseFieldNode> nestedNodes)
       : base("*")
     {
       ArgumentValidator.EnsureArgumentNotNull(extractor, nameof(extractor));

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/NodeAggregator.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/NodeAggregator.cs
@@ -7,6 +7,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Xtensive.Core;
 
 namespace Xtensive.Orm.Internals.Prefetch
 {
@@ -26,7 +27,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       return result;
     }
 
-    public override ReadOnlyCollection<BaseFieldNode> VisitNodeList(ReadOnlyCollection<BaseFieldNode> nodes)
+    public override IReadOnlyList<BaseFieldNode> VisitNodeList(IReadOnlyList<BaseFieldNode> nodes)
     {
       var result = new List<BaseFieldNode>();
       foreach (var group in nodes.Where(n => n!=null).GroupBy(n => n.Path)) {
@@ -36,11 +37,11 @@ namespace Xtensive.Orm.Internals.Prefetch
           result.Add(node);
         else {
           var nodeToVisit = (BaseFieldNode) container.ReplaceNestedNodes(
-            new ReadOnlyCollection<BaseFieldNode>(group.Cast<IHasNestedNodes>().SelectMany(c => c.NestedNodes).ToList()));
+            group.Cast<IHasNestedNodes>().SelectMany(c => c.NestedNodes).ToList().AsSafeWrapper());
           result.Add((BaseFieldNode) Visit(nodeToVisit));
         }
       }
-      return new ReadOnlyCollection<BaseFieldNode>(result);
+      return result.AsSafeWrapper();
     }
 
     // Constructor

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/NodeBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/NodeBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2012-2020 Xtensive LLC.
+// Copyright (C) 2012-2020 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -119,9 +119,9 @@ namespace Xtensive.Orm.Internals.Prefetch
       return EnumerableUtils.One(result);
     }
 
-    private static ObjectModel.ReadOnlyCollection<BaseFieldNode> WrapNodes(IEnumerable<BaseFieldNode> nodes)
+    private static IReadOnlyList<BaseFieldNode> WrapNodes(IEnumerable<BaseFieldNode> nodes)
     {
-      return nodes.ToList().AsReadOnly();
+      return nodes.ToList().AsSafeWrapper();
     }
 
     private IEnumerable<BaseFieldNode> VisitChildren(Expression expression)

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/NodeVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/NodeVisitor.cs
@@ -4,7 +4,9 @@
 // Created by: Alexis Kochetov
 // Created:    2011.01.14
 
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using Xtensive.Core;
 
 namespace Xtensive.Orm.Internals.Prefetch
 {
@@ -17,7 +19,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       return node.Accept(this);
     }
 
-    public virtual ReadOnlyCollection<BaseFieldNode> VisitNodeList(ReadOnlyCollection<BaseFieldNode> nodes)
+    public virtual IReadOnlyList<BaseFieldNode> VisitNodeList(IReadOnlyList<BaseFieldNode> nodes)
     {
       BaseFieldNode[] list = null;
       var index = 0;
@@ -35,9 +37,7 @@ namespace Xtensive.Orm.Internals.Prefetch
         }
         index++;
       }
-      return list==null
-        ? nodes
-        : new ReadOnlyCollection<BaseFieldNode>(list);
+      return list?.AsSafeWrapper() ?? nodes;
     }
 
     public virtual Node VisitKeyExtractorNode<T>(KeyExtractorNode<T> keyExtractorNode)

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/ReferenceNode.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/ReferenceNode.cs
@@ -15,7 +15,7 @@ namespace Xtensive.Orm.Internals.Prefetch
   {
     public TypeInfo ReferenceType { get; private set; }
 
-    public ReadOnlyCollection<BaseFieldNode> NestedNodes { get; private set; }
+    public IReadOnlyList<BaseFieldNode> NestedNodes { get; private set; }
 
     public IReadOnlyCollection<Key> ExtractKeys(object target)
     {
@@ -30,10 +30,8 @@ namespace Xtensive.Orm.Internals.Prefetch
         : new[] {referenceKey};
     }
 
-    public IHasNestedNodes ReplaceNestedNodes(ReadOnlyCollection<BaseFieldNode> nestedNodes)
-    {
-      return new ReferenceNode(Path, Field, ReferenceType, NestedNodes);
-    }
+    public IHasNestedNodes ReplaceNestedNodes(IReadOnlyList<BaseFieldNode> nestedNodes) =>
+      new ReferenceNode(Path, Field, ReferenceType, NestedNodes);
 
     public override Node Accept(NodeVisitor visitor)
     {
@@ -42,7 +40,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     // Constructors
 
-    public ReferenceNode(string path, FieldInfo field, TypeInfo referenceType, ReadOnlyCollection<BaseFieldNode> nestedNodes)
+    public ReferenceNode(string path, FieldInfo field, TypeInfo referenceType, IReadOnlyList<BaseFieldNode> nestedNodes)
       : base(path, field)
     {
       ReferenceType = referenceType;

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/SetNode.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/SetNode.cs
@@ -14,7 +14,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 {
   internal class SetNode : BaseFieldNode, IHasNestedNodes
   {
-    public ReadOnlyCollection<BaseFieldNode> NestedNodes { get; }
+    public IReadOnlyList<BaseFieldNode> NestedNodes { get; }
 
     public TypeInfo ElementType { get; }
 
@@ -30,7 +30,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       return fetchedKeys.ToArray(fetchedKeys.Count);
     }
 
-    public IHasNestedNodes ReplaceNestedNodes(ReadOnlyCollection<BaseFieldNode> nestedNodes) =>
+    public IHasNestedNodes ReplaceNestedNodes(IReadOnlyList<BaseFieldNode> nestedNodes) =>
       new SetNode(Path, Field, ElementType, NestedNodes);
 
     public override Node Accept(NodeVisitor visitor) => visitor.VisitSetNode(this);
@@ -38,7 +38,7 @@ namespace Xtensive.Orm.Internals.Prefetch
     // Constructors
 
 
-    public SetNode(string path, FieldInfo field, TypeInfo elementType, ReadOnlyCollection<BaseFieldNode> nestedNodes)
+    public SetNode(string path, FieldInfo field, TypeInfo elementType, IReadOnlyList<BaseFieldNode> nestedNodes)
       : base(path, field)
     {
       ElementType = elementType;

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
@@ -90,9 +90,8 @@ namespace Xtensive.Orm.Linq
       if (usedColumns.Count == 0)
         usedColumns.Add(0);
       if (usedColumns.Count < origin.ItemProjector.DataSource.Header.Length) {
-        var usedColumnsArray = usedColumns.ToArray();
-        var resultProvider = new SelectProvider(originProvider, usedColumnsArray);
-        var itemProjector = origin.ItemProjector.Remap(resultProvider, usedColumnsArray);
+        var resultProvider = new SelectProvider(originProvider, usedColumns);
+        var itemProjector = origin.ItemProjector.Remap(resultProvider, usedColumns);
         var result = origin.Apply(itemProjector);
         return result;
       }

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnIndexMap.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnIndexMap.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using Xtensive.Core;
 
 
 namespace Xtensive.Orm.Model
@@ -14,22 +15,22 @@ namespace Xtensive.Orm.Model
   /// A map of useful column indexes.
   /// </summary>
   [Serializable]
-  public sealed class ColumnIndexMap
+  public readonly struct ColumnIndexMap
   {
     /// <summary>
     /// Gets or sets positions of system columns within <see cref="IndexInfo"/>.
     /// </summary>
-    public IList<int> System { get; private set; }
+    public IReadOnlyList<int> System { get; }
 
     /// <summary>
     /// Gets or sets positions of lazy load columns within <see cref="IndexInfo"/>.
     /// </summary>
-    public IList<int> LazyLoad { get; private set; }
+    public IReadOnlyList<int> LazyLoad { get; }
 
     /// <summary>
     /// Gets or sets positions of regular columns (not system and not lazy load) within <see cref="IndexInfo"/>.
     /// </summary>
-    public IList<int> Regular { get; private set; }
+    public IReadOnlyList<int> Regular { get; }
 
 
     // Constructors
@@ -40,11 +41,11 @@ namespace Xtensive.Orm.Model
     /// <param name="system">The system columns.</param>
     /// <param name="lazyLoad">The regular columns.</param>
     /// <param name="regular">The lazy load columns.</param>
-    public ColumnIndexMap(List<int> system, List<int> regular, List<int> lazyLoad)
+    public ColumnIndexMap(IReadOnlyList<int> system, IReadOnlyList<int> regular, IReadOnlyList<int> lazyLoad)
     {
-      System = system.AsReadOnly();
-      LazyLoad = lazyLoad.AsReadOnly();
-      Regular = regular.AsReadOnly();
+      System = system.AsSafeWrapper();
+      LazyLoad = lazyLoad.AsSafeWrapper();
+      Regular = regular.AsSafeWrapper();
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
@@ -60,7 +60,6 @@ namespace Xtensive.Orm.Model
     private int fieldId;
     private int? cachedHashCode;
 
-    private IList<IPropertyValidator> validators;
     private Segment<int> mappingInfo;
 
     #region IsXxx properties
@@ -582,14 +581,7 @@ namespace Xtensive.Orm.Model
     /// Gets <see cref="IPropertyValidator"/> instances
     /// associated with this field.
     /// </summary>
-    public IList<IPropertyValidator> Validators
-    {
-      get { return validators; }
-      internal set {
-        EnsureNotLocked();
-        validators = value;
-      }
-    }
+    public IReadOnlyList<IPropertyValidator> Validators { get; init; }
 
     /// <summary>
     /// Gets value indicating if this field
@@ -658,7 +650,7 @@ namespace Xtensive.Orm.Model
       columns?.Clear();           // To prevent event handler leak
       columns = null;
 
-      HasImmediateValidators = validators.Count > 0 && validators.Any(v => v.IsImmediate);
+      HasImmediateValidators = Validators.Count > 0 && Validators.Any(v => v.IsImmediate);
 
       CreateMappingInfo();
     }
@@ -669,7 +661,6 @@ namespace Xtensive.Orm.Model
       base.Lock(recursive);
       if (!recursive)
         return;
-      validators = Array.AsReadOnly(validators.ToArray());
       Fields.Lock(true);
       if (column != null)
         column.Lock(true);
@@ -778,7 +769,7 @@ namespace Xtensive.Orm.Model
         defaultValue = defaultValue,
         defaultSqlExpression = defaultSqlExpression,
         DeclaringField = DeclaringField,
-        Validators = Validators.Select(v => v.CreateNew()).ToList(),
+        Validators = Validators.Select(v => v.CreateNew()).ToArray(),
       };
       clone.Associations.AddRange(associations);
       return clone;

--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
@@ -544,11 +544,12 @@ namespace Xtensive.Orm.Model
     /// <param name="targetType"></param>
     public AssociationInfo GetAssociation(TypeInfo targetType)
     {
-      if (associations.Count == 0)
-        return null;
-
-      if (associations.Count == 1)
-        return associations[0];
+      switch (Associations.Count) {
+        case 0:
+          return null;
+        case 1:
+          return associations[0];
+      }
 
       var ordered = IsLocked
         ? associations
@@ -558,10 +559,25 @@ namespace Xtensive.Orm.Model
         a => a.TargetType.UnderlyingType.IsAssignableFrom(targetType.UnderlyingType));
     }
 
-    public NodeCollection<AssociationInfo> Associations
+    public IReadOnlyList<AssociationInfo> Associations => (IReadOnlyList<AssociationInfo>)associations ?? Array.Empty<AssociationInfo>();
+
+    public bool ContainsAssociation(string associationName) => associations?.Contains(associationName) == true;
+
+    public void AddAssociation(AssociationInfo association) =>
+      EnsureAssociations().Add(association);
+
+    public void AddAssociations(IReadOnlyList<AssociationInfo> range)
     {
-      get { return associations; }
+      if (range.Count > 0) {
+        EnsureAssociations().AddRange(range);
+      }
     }
+
+    public void RemoveAssociation(AssociationInfo association) =>
+      _ = EnsureAssociations().Remove(association);
+
+    private NodeCollection<AssociationInfo> EnsureAssociations() =>
+      associations ??= new NodeCollection<AssociationInfo>(this, "Associations");
 
     /// <summary>
     /// Gets or sets field's adapter index.
@@ -664,12 +680,12 @@ namespace Xtensive.Orm.Model
       Fields.Lock(true);
       if (column != null)
         column.Lock(true);
-      if (associations.Count > 1) {
+      if (Associations.Count > 1) {
         var sorted = associations.Reorder();
         associations = new NodeCollection<AssociationInfo>(associations.Owner, associations.Name);
         associations.AddRange(sorted);
       }
-      associations.Lock(false);
+      associations?.Lock(false);
     }
 
     private void CreateMappingInfo()
@@ -771,7 +787,7 @@ namespace Xtensive.Orm.Model
         DeclaringField = DeclaringField,
         Validators = Validators.Select(v => v.CreateNew()).ToArray(),
       };
-      clone.Associations.AddRange(associations);
+      clone.AddAssociations(Associations);
       return clone;
     }
 
@@ -799,7 +815,6 @@ namespace Xtensive.Orm.Model
       Fields = IsEntity || IsStructure
         ? new FieldInfoCollection(this, "Fields")
         : FieldInfoCollection.Empty;
-      associations = new NodeCollection<AssociationInfo>(this, "Associations");
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Model/HierarchyInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/HierarchyInfo.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using Xtensive.Core;
 
 namespace Xtensive.Orm.Model
 {
@@ -47,7 +48,7 @@ namespace Xtensive.Orm.Model
       Key.UpdateState();
       var list = new List<TypeInfo> {Root};
       list.AddRange(Root.RecursiveDescendants);
-      Types = list.AsReadOnly();
+      Types = list.AsSafeWrapper();
       if (Types.Count == 1)
         InheritanceSchema = InheritanceSchema.ConcreteTable;
       if (TypeDiscriminatorMap != null)

--- a/Orm/Xtensive.Orm/Orm/Model/IndexInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/IndexInfo.cs
@@ -35,11 +35,11 @@ namespace Xtensive.Orm.Model
     private readonly IndexInfo declaringIndex;
     private double fillFactor;
     private string shortName;
-    private ReadOnlyCollection<ColumnInfo> columns;
+    private IReadOnlyList<ColumnInfo> columns;
     private TupleDescriptor tupleDescriptor;
     private TupleDescriptor keyTupleDescriptor;
-    private IList<TypeInfo> filterByTypes;
-    private IList<int> selectColumns;
+    private IReadOnlyList<TypeInfo> filterByTypes;
+    private IReadOnlyList<int> selectColumns;
     private List<Pair<int, List<int>>> valueColumnsMap;
     private LambdaExpression filterExpression;
     private PartialIndexFilterInfo filter;
@@ -173,7 +173,7 @@ namespace Xtensive.Orm.Model
     /// <summary>
     /// Gets the types for <see cref="IndexAttributes.Filtered"/> index.
     /// </summary>
-    public IList<TypeInfo> FilterByTypes
+    public IReadOnlyList<TypeInfo> FilterByTypes
     {
       get { return filterByTypes; }
       set
@@ -214,7 +214,7 @@ namespace Xtensive.Orm.Model
     /// <summary>
     /// Gets the column indexes for <see cref="IndexAttributes.View"/> index.
     /// </summary>
-    public IList<int> SelectColumns
+    public IReadOnlyList<int> SelectColumns
     {
       get { return selectColumns; }
       set
@@ -392,7 +392,7 @@ namespace Xtensive.Orm.Model
     {
       var result = new List<ColumnInfo>(keyColumns.Select(pair => pair.Key));
       result.AddRange(valueColumns);
-      columns = result.AsReadOnly();
+      columns = result.AsSafeWrapper();
     }
 
 

--- a/Orm/Xtensive.Orm/Orm/Model/IndexInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/IndexInfo.cs
@@ -339,7 +339,7 @@ namespace Xtensive.Orm.Model
       var lazy = new List<int>();
       var regular = new List<int>();
 
-      for (int i = 0; i < columns.Count; i++) {
+      for (int i = 0, count = columns.Count; i < count; i++) {
         var item = columns[i];
         if (item.IsPrimaryKey || item.IsSystem)
           system.Add(i);

--- a/Orm/Xtensive.Orm/Orm/Model/PartialIndexFilterInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/PartialIndexFilterInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2011 Xtensive LLC.
+// Copyright (C) 2011 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Denis Krjuchkov
@@ -32,12 +32,12 @@ namespace Xtensive.Orm.Model
       }
     }
 
-    private IList<FieldInfo> fields;
+    private IReadOnlyList<FieldInfo> fields;
 
     /// <summary>
     /// Fields used in <see cref="Expression"/>.
     /// </summary>
-    public IList<FieldInfo> Fields
+    public IReadOnlyList<FieldInfo> Fields
     {
       get { return fields; }
       set
@@ -56,7 +56,6 @@ namespace Xtensive.Orm.Model
         throw Exceptions.NotInitialized("Expression");
       if (Fields==null)
         throw Exceptions.NotInitialized("Fields");
-      fields = fields.ToList().AsReadOnly();
       base.Lock(recursive);
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Model/TypeIndexInfoCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeIndexInfoCollection.cs
@@ -8,6 +8,7 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Collections.Generic;
+using Xtensive.Core;
 
 namespace Xtensive.Orm.Model
 {
@@ -39,7 +40,7 @@ namespace Xtensive.Orm.Model
       get {
         return IsLocked 
           ? realPrimaryIndexes
-          : FindRealPrimaryIndexes(PrimaryIndex).AsReadOnly();
+          : FindRealPrimaryIndexes(PrimaryIndex).AsSafeWrapper();
       }
     }
 
@@ -84,8 +85,8 @@ namespace Xtensive.Orm.Model
     {
       base.UpdateState();
       primaryIndex = FindPrimaryIndex();
-      realPrimaryIndexes = FindRealPrimaryIndexes(primaryIndex).AsReadOnly();
-      indexesContainingAllData = FindIndexesContainingAllData().AsReadOnly();
+      realPrimaryIndexes = FindRealPrimaryIndexes(primaryIndex).AsSafeWrapper();
+      indexesContainingAllData = FindIndexesContainingAllData().AsSafeWrapper();
     }
 
     private IndexInfo GetIndex(IEnumerable<FieldInfo> fields)
@@ -126,7 +127,7 @@ namespace Xtensive.Orm.Model
     {
       return IsLocked
         ? indexesContainingAllData
-        : FindIndexesContainingAllData().AsReadOnly();
+        : FindIndexesContainingAllData().AsSafeWrapper();
     }
 
     private List<IndexInfo> FindIndexesContainingAllData()

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
@@ -557,7 +557,7 @@ namespace Xtensive.Orm.Model
         if (!IsLocked) {
           return result;
         }
-        targetAssociations = result.ToList().AsReadOnly();
+        targetAssociations = result.ToList().AsSafeWrapper();
       }
       return targetAssociations;
     }
@@ -572,7 +572,7 @@ namespace Xtensive.Orm.Model
         if (!IsLocked) {
           return result;
         }
-        ownerAssociations = result.ToList().AsReadOnly();
+        ownerAssociations = result.ToList().AsSafeWrapper();
       }
       return ownerAssociations;
     }
@@ -745,7 +745,7 @@ namespace Xtensive.Orm.Model
 
       var sortedRemovalSequence = sequence.Where(a => a.Ancestors.Count > 0).ToList();
       if (sortedRemovalSequence.Count == 0) {
-        removalSequence = sequence.AsReadOnly();
+        removalSequence = sequence.AsSafeWrapper();
       }
       else {
         var sequenceSize = sequence.Count;
@@ -753,7 +753,7 @@ namespace Xtensive.Orm.Model
           sortedRemovalSequence.Capacity = sequenceSize;
         }
         sortedRemovalSequence.AddRange(sequence.Where(a => a.Ancestors.Count == 0));
-        removalSequence = sortedRemovalSequence.AsReadOnly();
+        removalSequence = sortedRemovalSequence.AsSafeWrapper();
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
@@ -52,7 +52,6 @@ namespace Xtensive.Orm.Model
     private IReadOnlyList<AssociationInfo> removalSequence;
     private IReadOnlyList<FieldInfo> versionFields;
     private IReadOnlyList<ColumnInfo> versionColumns;
-    private IList<IObjectValidator> validators;
     private Type underlyingType;
     private HierarchyInfo hierarchy;
     private int typeId = NoTypeId;
@@ -504,14 +503,7 @@ namespace Xtensive.Orm.Model
     /// Gets <see cref="IObjectValidator"/> instances
     /// associated with this type.
     /// </summary>
-    public IList<IObjectValidator> Validators
-    {
-      get { return validators; }
-      internal set {
-        EnsureNotLocked();
-        validators = value;
-      }
-    }
+    public IReadOnlyList<IObjectValidator> Validators { get; init; }
 
     /// <summary>
     /// Gets value indicating if this type has validators (including field validators).
@@ -694,7 +686,7 @@ namespace Xtensive.Orm.Model
         }
       }
 
-      HasValidators = validators.Count > 0 || fields.Any(f => f.HasValidators);
+      HasValidators = Validators.Count > 0 || fields.Any(static f => f.HasValidators);
 
       // Selecting master parts from paired associations & single associations
       var associations = model.Associations.Find(this)
@@ -781,8 +773,6 @@ namespace Xtensive.Orm.Model
 
       if (!recursive)
         return;
-
-      validators = Array.AsReadOnly(validators.ToArray());
 
       affectedIndexes.Lock(true);
       indexes.Lock(true);

--- a/Orm/Xtensive.Orm/Orm/Providers/Persister.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Persister.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2012 Xtensive LLC.
+// Copyright (C) 2012 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Denis Krjuchkov
@@ -93,11 +93,10 @@ namespace Xtensive.Orm.Providers
       }
     }
 
-    private ICollection<PersistRequest> GetOrBuildRequest(StorageNode node, PersistRequestBuilderTask task)
+    private IReadOnlyList<PersistRequest> GetOrBuildRequest(StorageNode node, PersistRequestBuilderTask task)
     {
       var cache = node.PersistRequestCache;
-      ICollection<PersistRequest> result;
-      if (cache.TryGetValue(task, out result))
+      if (cache.TryGetValue(task, out var result))
         return result;
       result = requestBuilder.Build(node, task);
       return cache.TryAdd(task, result) ? result : cache[task];

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilder.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using Xtensive.Core;
 using Xtensive.Orm.Configuration;
 using Xtensive.Orm.Model;
 using Xtensive.Sql;
@@ -23,7 +24,7 @@ namespace Xtensive.Orm.Providers
     private ProviderInfo providerInfo;
     private StorageDriver driver;
 
-    internal ICollection<PersistRequest> Build(StorageNode node, PersistRequestBuilderTask task)
+    internal IReadOnlyList<PersistRequest> Build(StorageNode node, PersistRequestBuilderTask task)
     {
       var context = new PersistRequestBuilderContext(task, node.Mapping, node.Configuration);
       List<PersistRequest> result;
@@ -52,14 +53,14 @@ namespace Xtensive.Orm.Providers
         }
         var batchRequest = CreatePersistRequest(batch, bindings, node.Configuration);
         batchRequest.Prepare();
-        return new List<PersistRequest> {batchRequest}.AsReadOnly();
+        return new List<PersistRequest> { batchRequest }.AsSafeWrapper();
       }
 
       foreach (var item in result) {
         item.Prepare();
       }
 
-      return result.AsReadOnly();
+      return result.AsSafeWrapper();
     }
 
     protected virtual List<PersistRequest> BuildInsertRequest(PersistRequestBuilderContext context)

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Index.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Index.cs
@@ -224,7 +224,7 @@ namespace Xtensive.Orm.Providers
       SqlExpression filter = null;
       var type = index.ReflectedType;
       var discriminatorMap = type.Hierarchy.TypeDiscriminatorMap;
-      var filterByTypes = index.FilterByTypes.ToList();
+      var filterByTypes = index.FilterByTypes;
       var filterByTypesCount = filterByTypes.Count;
       if (underlyingIndex.IsTyped && discriminatorMap != null) {
         var columnType = discriminatorMap.Column.ValueType;

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/SelectProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/SelectProvider.cs
@@ -44,17 +44,7 @@ namespace Xtensive.Orm.Rse.Providers
     public SelectProvider(CompilableProvider provider, IReadOnlyList<int> columnIndexes)
       : base(ProviderType.Select, provider)
     {
-      switch (columnIndexes) {
-        case int[] indexArray:
-          ColumnIndexes = Array.AsReadOnly(indexArray);
-          break;
-        case List<int> indexList:
-          ColumnIndexes = indexList.AsReadOnly();
-          break;
-        default:
-          ColumnIndexes = columnIndexes;
-          break;
-      }
+      ColumnIndexes = columnIndexes.AsSafeWrapper();
 
       Initialize();
     }

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/RedundantColumnRemover.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/RedundantColumnRemover.cs
@@ -27,13 +27,13 @@ namespace Xtensive.Orm.Rse.Transformation
         && methodInfo.GetParameters()[1].ParameterType.GetGenericTypeDefinition() == WellKnownTypes.FuncOfTArgTResultType)
       .CachedMakeGenericMethod(WellKnownOrmTypes.Tuple, WellKnownOrmTypes.Tuple);
 
-    protected override Pair<CompilableProvider, List<int>> OverrideRightApplySource(ApplyProvider applyProvider, CompilableProvider provider, List<int> requestedMapping)
+    protected override (CompilableProvider, List<int>) OverrideRightApplySource(ApplyProvider applyProvider, CompilableProvider provider, List<int> requestedMapping)
     {
       var currentMapping = mappings[applyProvider.Right];
       if (currentMapping.SequenceEqual(requestedMapping))
         return base.OverrideRightApplySource(applyProvider, provider, requestedMapping);
       var selectProvider = new SelectProvider(provider, requestedMapping.ToArray());
-      return new Pair<CompilableProvider, List<int>>(selectProvider, requestedMapping);
+      return (selectProvider, requestedMapping);
     }
 
     protected override Provider VisitRaw(RawProvider provider)

--- a/Orm/Xtensive.Orm/Orm/StorageNode.cs
+++ b/Orm/Xtensive.Orm/Orm/StorageNode.cs
@@ -72,7 +72,7 @@ namespace Xtensive.Orm
     /// </summary>
     internal ConcurrentDictionary<AssociationInfo, (CompilableProvider, Parameter<Xtensive.Tuples.Tuple>)> RefsToEntityQueryCache { get; }
     internal ConcurrentDictionary<SequenceInfo, object> KeySequencesCache { get; }
-    internal ConcurrentDictionary<PersistRequestBuilderTask, ICollection<PersistRequest>> PersistRequestCache { get; }
+    internal ConcurrentDictionary<PersistRequestBuilderTask, IReadOnlyList<PersistRequest>> PersistRequestCache { get; } = new();
 
     /// <inheritdoc/>
     public Session OpenSession() =>
@@ -127,7 +127,6 @@ namespace Xtensive.Orm
       EntitySetTypeStateCache = new ConcurrentDictionary<Xtensive.Orm.Model.FieldInfo, EntitySetTypeState>();
       RefsToEntityQueryCache = new ConcurrentDictionary<AssociationInfo, (CompilableProvider, Parameter<Xtensive.Tuples.Tuple>)>();
       KeySequencesCache = new ConcurrentDictionary<SequenceInfo, object>();
-      PersistRequestCache = new ConcurrentDictionary<PersistRequestBuilderTask, ICollection<PersistRequest>>();
 
       this.domain = domain;
       Configuration = configuration;

--- a/Orm/Xtensive.Orm/Reflection/InterfaceMapping.cs
+++ b/Orm/Xtensive.Orm/Reflection/InterfaceMapping.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using ReflectionInterfaceMapping=System.Reflection.InterfaceMapping;
 using System.Linq;
 using System.Collections.Generic;
+using Xtensive.Core;
 
 namespace Xtensive.Reflection
 {
@@ -50,8 +51,8 @@ namespace Xtensive.Reflection
     {
       TargetType = source.TargetType;
       InterfaceType = source.InterfaceType;
-      TargetMethods = Array.AsReadOnly(source.TargetMethods);
-      InterfaceMethods = Array.AsReadOnly(source.InterfaceMethods);
+      TargetMethods = source.TargetMethods.AsSafeWrapper();
+      InterfaceMethods = source.InterfaceMethods.AsSafeWrapper();
     }
   }
 }

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -703,8 +703,8 @@ namespace Xtensive.Reflection
     /// </summary>
     /// <param name="types">The types to sort.</param>
     /// <returns>The list of <paramref name="types"/> ordered by their inheritance.</returns>
-    public static List<Type> OrderByInheritance(this IEnumerable<Type> types) =>
-      TopologicalSorter.Sort(types, (t1, t2) => t1.IsAssignableFrom(t2));
+    public static IEnumerable<Type> OrderByInheritance(this IEnumerable<Type> types) =>
+      TopologicalSorter.Sort(types, static (t1, t2) => t1.IsAssignableFrom(t2));
 
     /// <summary>
     /// Fast analogue of <see cref="Type.GetInterfaceMap"/>.
@@ -723,7 +723,7 @@ namespace Xtensive.Reflection
     /// <param name="type">The type to get the interfaces of.</param>
     [Obsolete("Use GetInterfacesOrderByInheritance instead")]
     public static Type[] GetInterfaces(this Type type) =>
-      OrderedInterfaces.GetOrAdd(type, t => t.GetInterfaces().OrderByInheritance().ToArray());
+      OrderedInterfaces.GetOrAdd(type, static t => t.GetInterfaces().OrderByInheritance().ToArray());
 
     /// <summary>
     /// Gets the interfaces of the specified type.
@@ -731,7 +731,7 @@ namespace Xtensive.Reflection
     /// </summary>
     /// <param name="type">The type to get the interfaces of.</param>
     public static Type[] GetInterfacesOrderByInheritance(this Type type) =>
-      OrderedInterfaces.GetOrAdd(type, t => t.GetInterfaces().OrderByInheritance().ToArray());
+      OrderedInterfaces.GetOrAdd(type, static t => t.GetInterfaces().OrderByInheritance().ToArray());
 
     /// <summary>
     /// Gets the sequence of type itself, all its base types and interfaces.

--- a/Orm/Xtensive.Orm/Sorting/Node.cs
+++ b/Orm/Xtensive.Orm/Sorting/Node.cs
@@ -10,7 +10,6 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using Xtensive.Core;
 
-
 namespace Xtensive.Sorting
 {
   /// <summary>
@@ -22,9 +21,9 @@ namespace Xtensive.Sorting
   public class Node<TNodeItem, TConnectionItem>
   {
     private List<NodeConnection<TNodeItem, TConnectionItem>> incomingConnections;
-    private ReadOnlyCollection<NodeConnection<TNodeItem, TConnectionItem>> incomingConnectionsReadOnlyList;
+    private IReadOnlyList<NodeConnection<TNodeItem, TConnectionItem>> incomingConnectionsReadOnlyList;
     private List<NodeConnection<TNodeItem, TConnectionItem>> outgoingConnections;
-    private ReadOnlyCollection<NodeConnection<TNodeItem, TConnectionItem>> outgoingConnectionsReadOnlyList;
+    private IReadOnlyList<NodeConnection<TNodeItem, TConnectionItem>> outgoingConnectionsReadOnlyList;
 
     /// <summary>
     /// Gets node item.
@@ -166,18 +165,14 @@ namespace Xtensive.Sorting
 
     private void EnsureIncomingConnections()
     {
-      if (incomingConnectionsReadOnlyList==null) {
-        incomingConnections = new List<NodeConnection<TNodeItem, TConnectionItem>>();
-        incomingConnectionsReadOnlyList = incomingConnections.AsReadOnly();
-      }
+      incomingConnectionsReadOnlyList ??=
+        (incomingConnections = new List<NodeConnection<TNodeItem, TConnectionItem>>()).AsSafeWrapper();
     }
 
     private void EnsureOutgoingConnections()
     {
-      if (outgoingConnectionsReadOnlyList==null) {
-        outgoingConnections = new List<NodeConnection<TNodeItem, TConnectionItem>>();
-        outgoingConnectionsReadOnlyList = outgoingConnections.AsReadOnly();
-      }
+      outgoingConnectionsReadOnlyList ??=
+        (outgoingConnections = new List<NodeConnection<TNodeItem, TConnectionItem>>()).AsSafeWrapper();
     }
 
     // Constructors

--- a/Orm/Xtensive.Orm/Sorting/TopologicalSorter.cs
+++ b/Orm/Xtensive.Orm/Sorting/TopologicalSorter.cs
@@ -29,7 +29,7 @@ namespace Xtensive.Sorting
     /// Sorting result, if there were no loops;
     /// otherwise, <see langword="null"/>.
     /// </returns>
-    public static List<TNodeItem> Sort<TNodeItem>(IEnumerable<TNodeItem> items, Predicate<TNodeItem, TNodeItem> connector)
+    public static IEnumerable<TNodeItem> Sort<TNodeItem>(IEnumerable<TNodeItem> items, Predicate<TNodeItem, TNodeItem> connector)
     {
       List<Node<TNodeItem, object>> loops;
       return Sort(items, connector, out loops);
@@ -48,7 +48,7 @@ namespace Xtensive.Sorting
     /// otherwise, <see langword="null"/>.
     /// In this case <paramref name="loops"/> will contain only the loop edges.
     /// </returns>
-    public static List<TNodeItem> Sort<TNodeItem>(IEnumerable<TNodeItem> items, Predicate<TNodeItem, TNodeItem> connector, out List<Node<TNodeItem, object>> loops)
+    public static IEnumerable<TNodeItem> Sort<TNodeItem>(IEnumerable<TNodeItem> items, Predicate<TNodeItem, TNodeItem> connector, out List<Node<TNodeItem, object>> loops)
     {
       ArgumentValidator.EnsureArgumentNotNull(items, "items");
       ArgumentValidator.EnsureArgumentNotNull(connector, "connector");
@@ -101,7 +101,7 @@ namespace Xtensive.Sorting
     /// <returns>Sorting result, if there were no loops;
     /// otherwise, <see langword="null" />. 
     /// In this case <paramref name="nodes"/> will contain only the loop edges.</returns>
-    public static List<TNodeItem> Sort<TNodeItem, TConnectionItem>(List<Node<TNodeItem, TConnectionItem>> nodes, out List<Node<TNodeItem, TConnectionItem>> loops)
+    public static IEnumerable<TNodeItem> Sort<TNodeItem, TConnectionItem>(List<Node<TNodeItem, TConnectionItem>> nodes, out List<Node<TNodeItem, TConnectionItem>> loops)
     {
       ArgumentValidator.EnsureArgumentNotNull(nodes, "nodes");
       var head = new Queue<TNodeItem>();
@@ -136,7 +136,7 @@ namespace Xtensive.Sorting
           nodeList.Remove(nodeToRemove);
       }
       loops = null;
-      return head.Concat(tail.Reverse()).ToList();
+      return head.Concat(tail.Reverse());
     }
 
 


### PR DESCRIPTION
* Wrap internal collections into `ReadOnlyCollection` only if `DO_SAFE_COLLECTION_WRAPPER` is defined (default Upstream DataObjects policy is "always wrap public available lists and array"). In our build we need not to define `DO_SAFE_COLLECTION_WRAPPER`. Use new `.AsSafeWrapper()` instead of `.AsReadOnly()` where possible

* Avoid unnecessary `.ToList()` in `TopologicalSorter.Sort()`
* Create `FieldInfo.Associations` collection on demaind. Most fields don't have associations
* Optimize `TypeInfo.Validators` lists
* readonly struct `ColumnIndexMap`