### PR TITLE
Avoid unnecessary CompilableProvider castings

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/SubqueryFilterRemover.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/SubqueryFilterRemover.cs
@@ -95,7 +95,7 @@ namespace Xtensive.Orm.Linq.Rewriters
 
     private readonly SubqueryFilterChecker checker;
 
-    protected override Provider VisitFilter(FilterProvider provider)
+    protected override CompilableProvider VisitFilter(FilterProvider provider)
     {
       return checker.Check(provider.Predicate.Body)
         ? provider.Source

--- a/Orm/Xtensive.Orm/Orm/Providers/SessionHandler.References.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SessionHandler.References.cs
@@ -92,7 +92,7 @@ namespace Xtensive.Orm.Providers
 
     private static (CompilableProvider, Parameter<Tuple>) BuildReferencingQuery(AssociationInfo association)
     {
-      var provider = (CompilableProvider)null;
+      CompilableProvider provider = null;
       var parameter = new Parameter<Tuple>("pTuple");
       switch (association.Multiplicity) {
         case Multiplicity.ZeroToOne:

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -377,11 +377,9 @@ namespace Xtensive.Orm.Providers
     /// <inheritdoc/>
     protected override SqlProvider VisitStore(StoreProvider provider)
     {
-      var source =
-        provider.Source as ExecutableProvider
-          ?? (provider.Source is RawProvider
-            ? (ExecutableProvider) (new Rse.Providers.ExecutableRawProvider((RawProvider) provider.Source))
-            : Compile((CompilableProvider) provider.Source));
+      var source = provider.Source is RawProvider rawProvider
+            ? (ExecutableProvider) (new Rse.Providers.ExecutableRawProvider(rawProvider))
+            : Compile(provider.Source);
       var columnNames = provider.Header.Columns.Select(column => column.Name).ToArray();
       var descriptor = DomainHandler.TemporaryTableManager
         .BuildDescriptor(Mapping, provider.Name, provider.Header.TupleDescriptor, columnNames);

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/StoreProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/StoreProvider.cs
@@ -21,12 +21,12 @@ namespace Xtensive.Orm.Rse.Providers
     /// <summary>
     /// Gets the name of saved data.
     /// </summary>
-    public string Name { get; private set; }
+    public string Name { get; }
 
     /// <summary>
     /// Source provider.
     /// </summary>
-    public Provider Source { get; private set; }
+    public CompilableProvider Source { get; }
 
     /// <inheritdoc/>
     protected override RecordSetHeader BuildHeader()
@@ -66,7 +66,7 @@ namespace Xtensive.Orm.Rse.Providers
     /// </summary>
     /// <param name="source">The <see cref="Source"/> property value.</param>
     /// <param name="name">The <see cref="Name"/> property value.</param>
-    public StoreProvider(Provider source, string name)
+    public StoreProvider(CompilableProvider source, string name)
       : base(ProviderType.Store, source)
     {
       ArgumentValidator.EnsureArgumentNotNull(source, "source");
@@ -84,7 +84,7 @@ namespace Xtensive.Orm.Rse.Providers
     /// Initializes a new instance of this class.
     /// </summary>
     /// <param name="source">The <see cref="Source"/> property value.</param>
-    public StoreProvider(Provider source)
+    public StoreProvider(CompilableProvider source)
       : base(ProviderType.Store, source)
     {
       ArgumentValidator.EnsureArgumentNotNull(source, "source");

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProviderVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProviderVisitor.cs
@@ -26,14 +26,10 @@ namespace Xtensive.Orm.Rse.Providers
     /// Visits the compilable provider.
     /// </summary>
     /// <param name="cp">The compilable provider.</param>
-    public CompilableProvider VisitCompilable(CompilableProvider cp)
-    {
-      var result = (CompilableProvider)Visit(cp);
-      return result;
-    }
+    public CompilableProvider VisitCompilable(CompilableProvider cp) => Visit(cp);
 
     /// <inheritdoc/>
-    protected override Provider VisitTake(TakeProvider provider)
+    protected override CompilableProvider VisitTake(TakeProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -44,7 +40,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitSkip(SkipProvider provider)
+    protected override CompilableProvider VisitSkip(SkipProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -55,7 +51,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitPaging(PagingProvider provider)
+    protected override CompilableProvider VisitPaging(PagingProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -66,7 +62,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitSelect(SelectProvider provider)
+    protected override CompilableProvider VisitSelect(SelectProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -77,7 +73,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitTag(TagProvider provider)
+    protected override TagProvider VisitTag(TagProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -88,7 +84,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitSeek(SeekProvider provider)
+    protected override CompilableProvider VisitSeek(SeekProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -99,13 +95,13 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitRaw(RawProvider provider)
+    protected override CompilableProvider VisitRaw(RawProvider provider)
     {
       return provider;
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitSort(SortProvider provider)
+    protected override CompilableProvider VisitSort(SortProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -116,7 +112,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitJoin(JoinProvider provider)
+    protected override CompilableProvider VisitJoin(JoinProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -129,7 +125,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitFilter(FilterProvider provider)
+    protected override CompilableProvider VisitFilter(FilterProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -141,7 +137,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitDistinct(DistinctProvider provider)
+    protected override DistinctProvider VisitDistinct(DistinctProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -152,7 +148,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitCalculate(CalculateProvider provider)
+    protected override CompilableProvider VisitCalculate(CalculateProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -171,7 +167,7 @@ namespace Xtensive.Orm.Rse.Providers
       return new CalculateProvider(source, descriptors.ToArray());
     }
 
-    protected override Provider VisitRowNumber(RowNumberProvider provider)
+    protected override CompilableProvider VisitRowNumber(RowNumberProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -183,7 +179,7 @@ namespace Xtensive.Orm.Rse.Providers
 
 
     /// <inheritdoc/>
-    protected override Provider VisitAlias(AliasProvider provider)
+    protected override AliasProvider VisitAlias(AliasProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -194,7 +190,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitAggregate(AggregateProvider provider)
+    protected override CompilableProvider VisitAggregate(AggregateProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -211,7 +207,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitStore(StoreProvider provider)
+    protected override StoreProvider VisitStore(StoreProvider provider)
     {
       var compilableSource = provider.Source as CompilableProvider;
       if (compilableSource == null)
@@ -225,7 +221,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitIndex(IndexProvider provider)
+    protected override CompilableProvider VisitIndex(IndexProvider provider)
     {
       OnRecursionEntrance(provider);
       OnRecursionExit(provider);
@@ -233,7 +229,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitFreeText(FreeTextProvider provider)
+    protected override CompilableProvider VisitFreeText(FreeTextProvider provider)
     {
       OnRecursionEntrance(provider);
       OnRecursionExit(provider);
@@ -241,7 +237,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitContainsTable(ContainsTableProvider provider)
+    protected override ContainsTableProvider VisitContainsTable(ContainsTableProvider provider)
     {
       OnRecursionEntrance(provider);
       OnRecursionExit(provider);
@@ -249,7 +245,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitPredicateJoin(PredicateJoinProvider provider)
+    protected override CompilableProvider VisitPredicateJoin(PredicateJoinProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -261,7 +257,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitExistence(ExistenceProvider provider)
+    protected override ExistenceProvider VisitExistence(ExistenceProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -272,7 +268,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitApply(ApplyProvider provider)
+    protected override CompilableProvider VisitApply(ApplyProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -284,7 +280,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitIntersect(IntersectProvider provider)
+    protected override CompilableProvider VisitIntersect(IntersectProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -296,7 +292,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitExcept(ExceptProvider provider)
+    protected override CompilableProvider VisitExcept(ExceptProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -308,7 +304,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitConcat(ConcatProvider provider)
+    protected override CompilableProvider VisitConcat(ConcatProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -320,7 +316,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitUnion(UnionProvider provider)
+    protected override CompilableProvider VisitUnion(UnionProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -332,7 +328,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitLock(LockProvider provider)
+    protected override LockProvider VisitLock(LockProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -342,7 +338,7 @@ namespace Xtensive.Orm.Rse.Providers
       return new LockProvider(source, provider.LockMode, provider.LockBehavior);
     }
 
-    protected override Provider VisitInclude(IncludeProvider provider)
+    protected override CompilableProvider VisitInclude(IncludeProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/ProviderVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/ProviderVisitor.cs
@@ -20,280 +20,217 @@ namespace Xtensive.Orm.Rse.Providers
     /// </summary>
     /// <param name="cp">The <see cref="CompilableProvider"/> to visit.</param>
     /// <returns>Visit result.</returns>
-    protected virtual Provider Visit(CompilableProvider cp)
-    {
-      if (cp==null)
-        return null;
-      Provider result;
-      ProviderType providerType = cp.Type;
-      switch (providerType) {
-        case ProviderType.Index:
-          result = VisitIndex((IndexProvider) cp);
-          break;
-        case ProviderType.Store:
-          result = VisitStore((StoreProvider) cp);
-          break;
-        case ProviderType.Aggregate:
-          result = VisitAggregate((AggregateProvider) cp);
-          break;
-        case ProviderType.Alias:
-          result = VisitAlias((AliasProvider) cp);
-          break;
-        case ProviderType.Calculate:
-          result = VisitCalculate((CalculateProvider) cp);
-          break;
-        case ProviderType.Distinct:
-          result = VisitDistinct((DistinctProvider) cp);
-          break;
-        case ProviderType.Filter:
-          result = VisitFilter((FilterProvider) cp);
-          break;
-        case ProviderType.Join:
-          result = VisitJoin((JoinProvider) cp);
-          break;
-        case ProviderType.Sort:
-          result = VisitSort((SortProvider) cp);
-          break;
-        case ProviderType.Raw:
-          result = VisitRaw((RawProvider) cp);
-          break;
-        case ProviderType.Seek:
-          result = VisitSeek((SeekProvider) cp);
-          break;
-        case ProviderType.Select:
-          result = VisitSelect((SelectProvider) cp);
-          break;
-        case ProviderType.Tag:
-          result = VisitTag((TagProvider) cp);
-          break;
-        case ProviderType.Skip:
-          result = VisitSkip((SkipProvider) cp);
-          break;
-        case ProviderType.Take:
-          result = VisitTake((TakeProvider) cp);
-          break;
-        case ProviderType.Paging:
-          result = VisitPaging((PagingProvider)cp);
-          break;
-        case ProviderType.RowNumber:
-          result = VisitRowNumber((RowNumberProvider)cp);
-          break;
-        case ProviderType.Apply:
-          result = VisitApply((ApplyProvider)cp);
-          break;
-        case ProviderType.Existence:
-          result = VisitExistence((ExistenceProvider)cp);
-          break;
-        case ProviderType.PredicateJoin:
-          result = VisitPredicateJoin((PredicateJoinProvider)cp);
-          break;
-        case ProviderType.Intersect:
-          result = VisitIntersect((IntersectProvider)cp);
-          break;
-        case ProviderType.Except:
-          result = VisitExcept((ExceptProvider)cp);
-          break;
-        case ProviderType.Concat:
-          result = VisitConcat((ConcatProvider)cp);
-          break;
-        case ProviderType.Union:
-          result = VisitUnion((UnionProvider)cp);
-          break;
-        case ProviderType.Lock:
-          result = VisitLock((LockProvider) cp);
-          break;
-        case ProviderType.Include:
-          result = VisitInclude((IncludeProvider) cp);
-          break;
-        case ProviderType.FreeText:
-          result = VisitFreeText((FreeTextProvider) cp);
-          break;
-        case ProviderType.ContainsTable:
-          result = VisitContainsTable((ContainsTableProvider) cp);
-          break;
-        case ProviderType.Void:
-          throw new NotSupportedException(Strings.ExProcessingOfVoidProviderIsNotSupported);
-        default:
-          throw new ArgumentOutOfRangeException();
-      }
-      return result;
-    }
+    protected virtual CompilableProvider Visit(CompilableProvider cp) =>
+      cp == null
+        ? null
+        : cp.Type switch {
+          ProviderType.Index => VisitIndex((IndexProvider) cp),
+          ProviderType.Store => VisitStore((StoreProvider) cp),
+          ProviderType.Aggregate => VisitAggregate((AggregateProvider) cp),
+          ProviderType.Alias => VisitAlias((AliasProvider) cp),
+          ProviderType.Calculate => VisitCalculate((CalculateProvider) cp),
+          ProviderType.Distinct => VisitDistinct((DistinctProvider) cp),
+          ProviderType.Filter => VisitFilter((FilterProvider) cp),
+          ProviderType.Join => VisitJoin((JoinProvider) cp),
+          ProviderType.Sort => VisitSort((SortProvider) cp),
+          ProviderType.Raw => VisitRaw((RawProvider) cp),
+          ProviderType.Seek => VisitSeek((SeekProvider) cp),
+          ProviderType.Select => VisitSelect((SelectProvider) cp),
+          ProviderType.Tag => VisitTag((TagProvider) cp),
+          ProviderType.Skip => VisitSkip((SkipProvider) cp),
+          ProviderType.Take => VisitTake((TakeProvider) cp),
+          ProviderType.Paging => VisitPaging((PagingProvider)cp),
+          ProviderType.RowNumber => VisitRowNumber((RowNumberProvider)cp),
+          ProviderType.Apply => VisitApply((ApplyProvider)cp),
+          ProviderType.Existence => VisitExistence((ExistenceProvider)cp),
+          ProviderType.PredicateJoin => VisitPredicateJoin((PredicateJoinProvider)cp),
+          ProviderType.Intersect => VisitIntersect((IntersectProvider)cp),
+          ProviderType.Except => VisitExcept((ExceptProvider)cp),
+          ProviderType.Concat => VisitConcat((ConcatProvider)cp),
+          ProviderType.Union => VisitUnion((UnionProvider)cp),
+          ProviderType.Lock => VisitLock((LockProvider) cp),
+          ProviderType.Include => VisitInclude((IncludeProvider) cp),
+          ProviderType.FreeText => VisitFreeText((FreeTextProvider) cp),
+          ProviderType.ContainsTable => VisitContainsTable((ContainsTableProvider) cp),
+          ProviderType.Void => throw new NotSupportedException(Strings.ExProcessingOfVoidProviderIsNotSupported),
+          _ => throw new ArgumentOutOfRangeException()
+        };
 
     /// <summary>
     /// Visits <see cref="PredicateJoinProvider"/>.
     /// </summary>
     /// <param name="provider">Predicate join provider.</param>
-    protected abstract Provider VisitPredicateJoin(PredicateJoinProvider provider);
+    protected abstract CompilableProvider VisitPredicateJoin(PredicateJoinProvider provider);
 
     /// <summary>
     /// Visits <see cref="ExistenceProvider"/>.
     /// </summary>
     /// <param name="provider">Existence provider.</param>
-    protected abstract Provider VisitExistence(ExistenceProvider provider);
+    protected abstract CompilableProvider VisitExistence(ExistenceProvider provider);
 
     /// <summary>
     /// Visits <see cref="ApplyProvider"/>.
     /// </summary>
     /// <param name="provider">Apply provider.</param>
-    protected abstract Provider VisitApply(ApplyProvider provider);
+    protected abstract CompilableProvider VisitApply(ApplyProvider provider);
 
     /// <summary>
     /// Visits <see cref="RowNumberProvider"/>.
     /// </summary>
     /// <param name="provider">Row number provider.</param>
-    protected abstract Provider VisitRowNumber(RowNumberProvider provider);
+    protected abstract CompilableProvider VisitRowNumber(RowNumberProvider provider);
 
     /// <summary>
     /// Visits <see cref="TakeProvider"/>.
     /// </summary>
     /// <param name="provider">Take provider.</param>
-    protected abstract Provider VisitTake(TakeProvider provider);
+    protected abstract CompilableProvider VisitTake(TakeProvider provider);
 
     /// <summary>
     /// Visits <see cref="SkipProvider"/>.
     /// </summary>
     /// <param name="provider">Skip provider.</param>
-    protected abstract Provider VisitSkip(SkipProvider provider);
+    protected abstract CompilableProvider VisitSkip(SkipProvider provider);
 
     /// <summary>
     /// Visits <see cref="PagingProvider"/>.
     /// </summary>
     /// <param name="provider">Paging provider.</param>
-    protected abstract Provider VisitPaging(PagingProvider provider);
+    protected abstract CompilableProvider VisitPaging(PagingProvider provider);
 
     /// <summary>
     /// Visits <see cref="SelectProvider"/>.
     /// </summary>
     /// <param name="provider">Select provider.</param>
-    protected abstract Provider VisitSelect(SelectProvider provider);
+    protected abstract CompilableProvider VisitSelect(SelectProvider provider);
 
     /// <summary>
     /// Visits <see cref="TagProvider"/>.
     /// </summary>
     /// <param name="provider">Tag provider.</param>
-    protected abstract Provider VisitTag(TagProvider provider);
+    protected abstract CompilableProvider VisitTag(TagProvider provider);
 
     /// <summary>
     /// Visits <see cref="SeekProvider"/>.
     /// </summary>
     /// <param name="provider">Seek provider.</param>
-    protected abstract Provider VisitSeek(SeekProvider provider);
+    protected abstract CompilableProvider VisitSeek(SeekProvider provider);
 
     /// <summary>
     /// Visits <see cref="RawProvider"/>.
     /// </summary>
     /// <param name="provider">Raw provider.</param>
-    protected abstract Provider VisitRaw(RawProvider provider);
+    protected abstract CompilableProvider VisitRaw(RawProvider provider);
 
     /// <summary>
     /// Visits <see cref="SortProvider"/>.
     /// </summary>
     /// <param name="provider">Sort provider.</param>
-    protected abstract Provider VisitSort(SortProvider provider);
+    protected abstract CompilableProvider VisitSort(SortProvider provider);
 
     /// <summary>
     /// Visits <see cref="JoinProvider"/>.
     /// </summary>
     /// <param name="provider">Join provider.</param>
-    protected abstract Provider VisitJoin(JoinProvider provider);
+    protected abstract CompilableProvider VisitJoin(JoinProvider provider);
 
     /// <summary>
     /// Visits <see cref="FilterProvider"/>.
     /// </summary>
     /// <param name="provider">Filter provider.</param>
-    protected abstract Provider VisitFilter(FilterProvider provider);
+    protected abstract CompilableProvider VisitFilter(FilterProvider provider);
 
     /// <summary>
     /// Visits <see cref="DistinctProvider"/>.
     /// </summary>
     /// <param name="provider">Distinct provider.</param>
-    protected abstract Provider VisitDistinct(DistinctProvider provider);
+    protected abstract CompilableProvider VisitDistinct(DistinctProvider provider);
 
     /// <summary>
     /// Visits <see cref="CalculateProvider"/>.
     /// </summary>
     /// <param name="provider">Calculate provider.</param>
-    protected abstract Provider VisitCalculate(CalculateProvider provider);
+    protected abstract CompilableProvider VisitCalculate(CalculateProvider provider);
 
     /// <summary>
     /// Visits <see cref="AliasProvider"/>.
     /// </summary>
     /// <param name="provider">Alias provider.</param>
-    protected abstract Provider VisitAlias(AliasProvider provider);
+    protected abstract CompilableProvider VisitAlias(AliasProvider provider);
 
     /// <summary>
     /// Visits <see cref="AggregateProvider"/>.
     /// </summary>
     /// <param name="provider">Aggregate provider.</param>
     /// <returns></returns>
-    protected abstract Provider VisitAggregate(AggregateProvider provider);
+    protected abstract CompilableProvider VisitAggregate(AggregateProvider provider);
 
     /// <summary>
     /// Visits <see cref="StoreProvider"/>.
     /// </summary>
     /// <param name="provider">Store provider.</param>
-    protected abstract Provider VisitStore(StoreProvider provider);
+    protected abstract CompilableProvider VisitStore(StoreProvider provider);
 
     /// <summary>
     /// Visits <see cref="IndexProvider"/>.
     /// </summary>
     /// <param name="provider">Index provider.</param>
-    protected abstract Provider VisitIndex(IndexProvider provider);
+    protected abstract CompilableProvider VisitIndex(IndexProvider provider);
 
     /// <summary>
     /// Visits the <see cref="IntersectProvider"/>.
     /// </summary>
     /// <param name="provider">Intersect provider.</param>
     /// <returns></returns>
-    protected abstract Provider VisitIntersect(IntersectProvider provider);
+    protected abstract CompilableProvider VisitIntersect(IntersectProvider provider);
 
     /// <summary>
     /// Visits the <see cref="ExceptProvider"/>.
     /// </summary>
     /// <param name="provider">Except provider.</param>
     /// <returns></returns>
-    protected abstract Provider VisitExcept(ExceptProvider provider);
+    protected abstract CompilableProvider VisitExcept(ExceptProvider provider);
 
     /// <summary>
     /// Visits the <see cref="ConcatProvider"/>.
     /// </summary>
     /// <param name="provider">Concat provider.</param>
     /// <returns></returns>
-    protected abstract Provider VisitConcat(ConcatProvider provider);
+    protected abstract CompilableProvider VisitConcat(ConcatProvider provider);
 
     /// <summary>
     /// Visits the <see cref="UnionProvider"/>.
     /// </summary>
     /// <param name="provider">Union provider.</param>
     /// <returns></returns>
-    protected abstract Provider VisitUnion(UnionProvider provider);
+    protected abstract CompilableProvider VisitUnion(UnionProvider provider);
 
     /// <summary>
     /// Visits the <see cref="LockProvider"/>.
     /// </summary>
     /// <param name="provider">Lock provider.</param>
     /// <returns></returns>
-    protected abstract Provider VisitLock(LockProvider provider);
+    protected abstract CompilableProvider VisitLock(LockProvider provider);
 
     /// <summary>
     /// Visits the <see cref="IncludeProvider"/>.
     /// </summary>
     /// <param name="provider">Include provider.</param>
     /// <returns></returns>
-    protected abstract Provider VisitInclude(IncludeProvider provider);
+    protected abstract CompilableProvider VisitInclude(IncludeProvider provider);
 
     /// <summary>
     /// Visits the <see cref="FreeTextProvider"/>.
     /// </summary>
     /// <param name="provider">FreeText provider.</param>
     /// <returns></returns>
-    protected abstract Provider VisitFreeText(FreeTextProvider provider);
+    protected abstract CompilableProvider VisitFreeText(FreeTextProvider provider);
 
     /// <summary>
     /// Visits the <see cref="FreeTextProvider"/>.
     /// </summary>
     /// <param name="provider">SearchCondition provider.</param>
     /// <returns></returns>
-    protected abstract Provider VisitContainsTable(ContainsTableProvider provider);
+    protected abstract CompilableProvider VisitContainsTable(ContainsTableProvider provider);
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
@@ -35,7 +35,7 @@ namespace Xtensive.Orm.Rse.Transformation
 
     #region Visit methods
 
-    protected override Provider VisitInclude(IncludeProvider provider)
+    protected override CompilableProvider VisitInclude(IncludeProvider provider)
     {
       var sourceLength = provider.Source.Header.Length;
       mappings[provider.Source] = Merge(mappings[provider].Where(i => i < sourceLength), provider.FilteredColumns);
@@ -51,7 +51,7 @@ namespace Xtensive.Orm.Rse.Transformation
         provider.FilterDataSource, provider.ResultColumnName, filteredColumns);
     }
 
-    protected override Provider VisitSelect(SelectProvider provider)
+    protected override CompilableProvider VisitSelect(SelectProvider provider)
     {
       var requiredColumns = mappings[provider];
       var remappedColumns = requiredColumns
@@ -82,31 +82,31 @@ namespace Xtensive.Orm.Rse.Transformation
     }
 
     /// <inheritdoc/>
-    protected override Provider VisitFreeText(FreeTextProvider provider)
+    protected override CompilableProvider VisitFreeText(FreeTextProvider provider)
     {
       mappings[provider] = CollectionUtils.RangeToList(0, provider.Header.Length);
       return provider;
     }
 
-    protected override Provider VisitContainsTable(ContainsTableProvider provider)
+    protected override ContainsTableProvider VisitContainsTable(ContainsTableProvider provider)
     {
       mappings[provider] = CollectionUtils.RangeToList(0, provider.Header.Length);
       return provider;
     }
 
-    protected override Provider VisitIndex(IndexProvider provider)
+    protected override CompilableProvider VisitIndex(IndexProvider provider)
     {
       mappings[provider] = CollectionUtils.RangeToList(0, provider.Header.Length);
       return provider;
     }
 
-    protected override Provider VisitSeek(SeekProvider provider)
+    protected override CompilableProvider VisitSeek(SeekProvider provider)
     {
       mappings[provider] = CollectionUtils.RangeToList(0, provider.Header.Length);
       return provider;
     }
 
-    protected override Provider VisitFilter(FilterProvider provider)
+    protected override CompilableProvider VisitFilter(FilterProvider provider)
     {
       mappings[provider.Source] = Merge(mappings[provider], mappingsGatherer.Gather(provider.Predicate));
       var newSourceProvider = VisitCompilable(provider.Source);
@@ -118,7 +118,7 @@ namespace Xtensive.Orm.Rse.Transformation
         : new FilterProvider(newSourceProvider, (Expression<Func<Tuple, bool>>) predicate);
     }
 
-    protected override Provider VisitJoin(JoinProvider provider)
+    protected override CompilableProvider VisitJoin(JoinProvider provider)
     {
       // split
 
@@ -146,7 +146,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return new JoinProvider(newLeftProvider, newRightProvider, provider.JoinType, newIndexes.ToArray());
     }
 
-    protected override Provider VisitPredicateJoin(PredicateJoinProvider provider)
+    protected override CompilableProvider VisitPredicateJoin(PredicateJoinProvider provider)
     {
       SplitMappings(provider, out var leftMapping, out var rightMapping);
 
@@ -167,7 +167,7 @@ namespace Xtensive.Orm.Rse.Transformation
         : new PredicateJoinProvider(newLeftProvider, newRightProvider, (Expression<Func<Tuple, Tuple, bool>>) predicate, provider.JoinType);
     }
 
-    protected override Provider VisitSort(SortProvider provider)
+    protected override CompilableProvider VisitSort(SortProvider provider)
     {
       mappings[provider.Source] = Merge(mappings[provider], provider.Order.Keys);
       var source = VisitCompilable(provider.Source);
@@ -186,7 +186,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return source == provider.Source ? provider : new SortProvider(source, order);
     }
 
-    protected override Provider VisitApply(ApplyProvider provider)
+    protected override CompilableProvider VisitApply(ApplyProvider provider)
     {
       // split
 
@@ -233,7 +233,7 @@ namespace Xtensive.Orm.Rse.Transformation
         : new ApplyProvider(applyParameter, newLeftProvider, newRightProvider, provider.IsInlined, provider.SequenceType, provider.ApplyType);
     }
 
-    protected override Provider VisitAggregate(AggregateProvider provider)
+    protected override CompilableProvider VisitAggregate(AggregateProvider provider)
     {
       var map = provider.AggregateColumns
         .Select(c => c.SourceIndex)
@@ -272,7 +272,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return new AggregateProvider(source, groupColumnIndexes, columns.ToArray());
     }
 
-    protected override Provider VisitCalculate(CalculateProvider provider)
+    protected override CompilableProvider VisitCalculate(CalculateProvider provider)
     {
       var sourceLength = provider.Source.Header.Length;
       var usedColumns = mappings[provider];
@@ -309,7 +309,7 @@ namespace Xtensive.Orm.Rse.Transformation
         : new CalculateProvider(newSourceProvider, descriptors.ToArray());
     }
 
-    protected override Provider VisitRowNumber(RowNumberProvider provider)
+    protected override CompilableProvider VisitRowNumber(RowNumberProvider provider)
     {
       var sourceLength = provider.Source.Header.Length;
       mappings[provider.Source] = mappings[provider].Where(i => i < sourceLength).ToList();
@@ -322,7 +322,7 @@ namespace Xtensive.Orm.Rse.Transformation
         : new RowNumberProvider(newSource, rowNumberColumn.Name);
     }
 
-    protected override Provider VisitStore(StoreProvider provider)
+    protected override StoreProvider VisitStore(StoreProvider provider)
     {
       if (!(provider.Source is CompilableProvider compilableSource)) {
         return provider;
@@ -344,15 +344,15 @@ namespace Xtensive.Orm.Rse.Transformation
         : new StoreProvider(source, provider.Name);
     }
 
-    protected override Provider VisitConcat(ConcatProvider provider) => VisitSetOperationProvider(provider);
+    protected override CompilableProvider VisitConcat(ConcatProvider provider) => VisitSetOperationProvider(provider);
 
-    protected override Provider VisitExcept(ExceptProvider provider) => VisitSetOperationProvider(provider);
+    protected override CompilableProvider VisitExcept(ExceptProvider provider) => VisitSetOperationProvider(provider);
 
-    protected override Provider VisitIntersect(IntersectProvider provider) => VisitSetOperationProvider(provider);
+    protected override CompilableProvider VisitIntersect(IntersectProvider provider) => VisitSetOperationProvider(provider);
 
-    protected override Provider VisitUnion(UnionProvider provider) => VisitSetOperationProvider(provider);
+    protected override CompilableProvider VisitUnion(UnionProvider provider) => VisitSetOperationProvider(provider);
 
-    private Provider VisitSetOperationProvider(BinaryProvider provider)
+    private CompilableProvider VisitSetOperationProvider(BinaryProvider provider)
     {
       var leftMapping = mappings[provider];
       var rightMapping = mappings[provider];

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyProviderCorrectorRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyProviderCorrectorRewriter.cs
@@ -146,7 +146,7 @@ namespace Xtensive.Orm.Rse.Transformation
       throw new InvalidOperationException(sb.ToString());
     }
 
-    protected override Provider VisitApply(ApplyProvider provider)
+    protected override CompilableProvider VisitApply(ApplyProvider provider)
     {
       CompilableProvider left;
       CompilableProvider right;
@@ -165,7 +165,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return InsertCalculateProviders(provider, convertedApply);
     }
 
-    protected override Provider VisitFilter(FilterProvider provider)
+    protected override CompilableProvider VisitFilter(FilterProvider provider)
     {
       var source = VisitCompilable(provider.Source);
       if (calculateProviderCollector.TryAddFilter(provider))
@@ -179,7 +179,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return newProvider;
     }
 
-    protected override Provider VisitAlias(AliasProvider provider)
+    protected override AliasProvider VisitAlias(AliasProvider provider)
     {
       var source = VisitCompilable(provider.Source);
       var newProvider = source!=provider.Source ? new AliasProvider(source, provider.Alias) : provider;
@@ -188,7 +188,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return newProvider;
     }
 
-    protected override Provider VisitSelect(SelectProvider provider)
+    protected override CompilableProvider VisitSelect(SelectProvider provider)
     {
       var source = VisitCompilable(provider.Source);
       var newProvider = provider;
@@ -199,7 +199,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return newProvider;
     }
 
-    protected override Provider VisitJoin(JoinProvider provider)
+    protected override CompilableProvider VisitJoin(JoinProvider provider)
     {
       CompilableProvider left;
       CompilableProvider right;
@@ -213,7 +213,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return provider;
     }
 
-    protected override Provider VisitPredicateJoin(PredicateJoinProvider provider)
+    protected override CompilableProvider VisitPredicateJoin(PredicateJoinProvider provider)
     {
       CompilableProvider left;
       CompilableProvider right;
@@ -227,7 +227,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return provider;
     }
 
-    protected override Provider VisitIntersect(IntersectProvider provider)
+    protected override CompilableProvider VisitIntersect(IntersectProvider provider)
     {
       CompilableProvider left;
       CompilableProvider right;
@@ -237,7 +237,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return provider;
     }
 
-    protected override Provider VisitExcept(ExceptProvider provider)
+    protected override CompilableProvider VisitExcept(ExceptProvider provider)
     {
       CompilableProvider left;
       CompilableProvider right;
@@ -247,7 +247,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return provider;
     }
 
-    protected override Provider VisitConcat(ConcatProvider provider)
+    protected override ConcatProvider VisitConcat(ConcatProvider provider)
     {
       CompilableProvider left;
       CompilableProvider right;
@@ -257,7 +257,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return provider;
     }
 
-    protected override Provider VisitUnion(UnionProvider provider)
+    protected override CompilableProvider VisitUnion(UnionProvider provider)
     {
       CompilableProvider left;
       CompilableProvider right;
@@ -267,7 +267,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return provider;
     }
 
-    protected override Provider VisitAggregate(AggregateProvider provider)
+    protected override CompilableProvider VisitAggregate(AggregateProvider provider)
     {
       var source = VisitCompilable(provider.Source);
       var newProvider = provider;
@@ -277,7 +277,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return newProvider;
     }
 
-    protected override Provider VisitCalculate(CalculateProvider provider)
+    protected override CompilableProvider VisitCalculate(CalculateProvider provider)
     {
       var source = VisitCompilable(provider.Source);
       var newProvider = provider;
@@ -286,7 +286,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return calculateProviderCollector.TryAdd(newProvider) ? source : newProvider;
     }
 
-    protected override Provider VisitTake(TakeProvider provider)
+    protected override CompilableProvider VisitTake(TakeProvider provider)
     {
       var source = VisitCompilable(provider.Source);
       EnsureAbsenceOfApplyProviderRequiringConversion();
@@ -295,7 +295,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return provider;
     }
 
-    protected override Provider VisitSkip(SkipProvider provider)
+    protected override CompilableProvider VisitSkip(SkipProvider provider)
     {
       var source = VisitCompilable(provider.Source);
       EnsureAbsenceOfApplyProviderRequiringConversion();
@@ -316,7 +316,7 @@ namespace Xtensive.Orm.Rse.Transformation
         right = VisitCompilable(provider.Right);
     }
     
-    private Provider ProcesSelfConvertibleApply(ApplyProvider provider, CompilableProvider left,
+    private CompilableProvider ProcesSelfConvertibleApply(ApplyProvider provider, CompilableProvider left,
       CompilableProvider right)
     {
       State.Predicates.Remove(provider.ApplyParameter);
@@ -343,7 +343,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return new PredicateJoinProvider(left, right, concatenatedPredicate, provider.ApplyType);
     }
 
-    private Provider InsertCalculateProviders(ApplyProvider provider, CompilableProvider convertedApply)
+    private CompilableProvider InsertCalculateProviders(ApplyProvider provider, CompilableProvider convertedApply)
     {
       if (!State.CalculateProviders.TryGetValue(provider.ApplyParameter, out var providers)) {
         return convertedApply;

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/OrderingRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/OrderingRewriter.cs
@@ -37,14 +37,14 @@ namespace Xtensive.Orm.Rse.Transformation
       return rewriter.InsertSortProvider(visited);
     }
 
-    protected override Provider Visit(CompilableProvider cp)
+    protected override CompilableProvider Visit(CompilableProvider cp)
     {
       var prevConsumerDescriptor = consumerDescriptor;
       consumerDescriptor = descriptor;
       descriptor = descriptorResolver(cp);
 
       var prevDescriptor = descriptor;
-      var visited = (CompilableProvider)base.Visit(cp);
+      var visited = base.Visit(cp);
       descriptor = prevDescriptor;
       visited = CorrectOrder(visited);
 
@@ -53,7 +53,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return visited;
     }
 
-    protected override Provider VisitSort(SortProvider provider)
+    protected override CompilableProvider VisitSort(SortProvider provider)
     {
       var source = VisitCompilable(provider.Source);
       sortOrder = provider.Order;
@@ -62,7 +62,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return source;
     }
 
-    protected override Provider VisitSelect(SelectProvider provider)
+    protected override SelectProvider VisitSelect(SelectProvider provider)
     {
       var result = provider;
       var source = VisitCompilable(provider.Source);
@@ -93,7 +93,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return result;
     }
 
-    protected override Provider VisitAggregate(AggregateProvider provider)
+    protected override AggregateProvider VisitAggregate(AggregateProvider provider)
     {
       var result = provider;
       var source = VisitCompilable(provider.Source);
@@ -119,37 +119,37 @@ namespace Xtensive.Orm.Rse.Transformation
       return result;
     }
 
-    protected override Provider VisitIndex(IndexProvider provider)
+    protected override IndexProvider VisitIndex(IndexProvider provider)
     {
       sortOrder = new DirectionCollection<int>();
       return provider;
     }
 
-    protected override Provider VisitFreeText(FreeTextProvider provider)
+    protected override FreeTextProvider VisitFreeText(FreeTextProvider provider)
     {
       sortOrder = new DirectionCollection<int>();
       return provider;
     }
 
-    protected override Provider VisitContainsTable(ContainsTableProvider provider)
+    protected override ContainsTableProvider VisitContainsTable(ContainsTableProvider provider)
     {
       sortOrder = new DirectionCollection<int>();
       return provider;
     }
 
-    protected override Provider VisitRaw(RawProvider provider)
+    protected override RawProvider VisitRaw(RawProvider provider)
     {
       sortOrder = new DirectionCollection<int>();
       return provider;
     }
 
-    protected override Provider VisitStore(StoreProvider provider)
+    protected override StoreProvider VisitStore(StoreProvider provider)
     {
       sortOrder = new DirectionCollection<int>();
       return provider;
     }
 
-    protected override Provider VisitApply(ApplyProvider provider)
+    protected override ApplyProvider VisitApply(ApplyProvider provider)
     {
       var left = VisitCompilable(provider.Left);
       var leftOrder = sortOrder;
@@ -162,7 +162,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return result;
     }
 
-    protected override Provider VisitJoin(JoinProvider provider)
+    protected override JoinProvider VisitJoin(JoinProvider provider)
     {
       var left = VisitCompilable(provider.Left);
       var leftOrder = sortOrder;
@@ -175,7 +175,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return result;
     }
 
-    protected override Provider VisitPredicateJoin(PredicateJoinProvider provider)
+    protected override PredicateJoinProvider VisitPredicateJoin(PredicateJoinProvider provider)
     {
       var left = VisitCompilable(provider.Left);
       var leftOrder = sortOrder;

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/SkipTakeRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/SkipTakeRewriter.cs
@@ -27,11 +27,11 @@ namespace Xtensive.Orm.Rse.Transformation
       return VisitCompilable(origin);
     }
 
-    protected override Provider Visit(CompilableProvider cp)
+    protected override CompilableProvider Visit(CompilableProvider cp)
     {
       var isPagingProvider = cp.Type is ProviderType.Take or ProviderType.Skip or ProviderType.Paging;
       if (isPagingProvider && !State.IsSkipTakeChain) {
-        var visitedProvider = (CompilableProvider) base.Visit(cp);
+        var visitedProvider = base.Visit(cp);
 
         var requiresRowNumber = (State.Take!=null && !takeSupported) || (State.Skip!=null && !skipSupported);
 
@@ -67,7 +67,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return base.Visit(cp);
     }
 
-    protected override Provider VisitSkip(SkipProvider provider)
+    protected override CompilableProvider VisitSkip(SkipProvider provider)
     {
       State.IsSkipTakeChain = true;
       var visitedSource = VisitCompilable(provider.Source);
@@ -75,7 +75,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return visitedSource;
     }
 
-    protected override Provider VisitTake(TakeProvider provider)
+    protected override CompilableProvider VisitTake(TakeProvider provider)
     {
       State.IsSkipTakeChain = true;
       var visitedSource = VisitCompilable(provider.Source);
@@ -83,7 +83,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return visitedSource;
     }
 
-    protected override Provider VisitPaging(PagingProvider provider)
+    protected override CompilableProvider VisitPaging(PagingProvider provider)
     {
       State.IsSkipTakeChain = true;
       var visitedSource = VisitCompilable(provider.Source);

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/RedundantColumnRemover.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/RedundantColumnRemover.cs
@@ -36,7 +36,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return new Pair<CompilableProvider, List<int>>(selectProvider, requestedMapping);
     }
 
-    protected override Provider VisitRaw(RawProvider provider)
+    protected override CompilableProvider VisitRaw(RawProvider provider)
     {
       var mapping = mappings[provider];
       if (mapping.SequenceEqual(Enumerable.Range(0, provider.Header.Length)))


### PR DESCRIPTION
Most `.VisitX()` functions return descandands of `CompilableProvider` and callers rely on it.
We are changing return type to CompilableProvider to avoid explicit casts from `Provider`