### PR TITLE
ARCH-4918: Fix translation breaking by Tags

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -331,7 +331,7 @@ namespace Xtensive.Orm.Providers
     {
       var compiledSource = Compile(provider.Source);
 
-      var query = ExtractSqlSelect(provider, compiledSource);
+      var query = compiledSource.Request.Statement;
       query.Comment = SqlComment.Join(query.Comment, new SqlComment(provider.Tag));
       
       return CreateProvider(query, provider, compiledSource);


### PR DESCRIPTION
`ExtractSqlSelect()` is complex and can change translated SQL statemement.
But tagging should have minimal impact on translation