### PR TITLE
Memoize Type.GetInterfaces()

### DIFF
--- a/Orm/Xtensive.Orm.Tests.Framework/Dynamic.cs
+++ b/Orm/Xtensive.Orm.Tests.Framework/Dynamic.cs
@@ -1,4 +1,4 @@
-//Copyright (C) Microsoft Corporation.  All rights reserved.
+﻿//Copyright (C) Microsoft Corporation.  All rights reserved.
 
 using System.Collections.Generic;
 using System.Globalization;
@@ -7,7 +7,6 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Text;
 using System.Threading;
-using Xtensive.Reflection;
 
 namespace System.Linq.Dynamic
 {
@@ -1313,7 +1312,7 @@ namespace System.Linq.Dynamic
         if (type.IsGenericType && type.GetGenericTypeDefinition() == generic) return type;
         if (generic.IsInterface)
         {
-          foreach (Type intfType in type.GetInterfacesOrderByInheritance())
+          foreach (Type intfType in type.GetInterfaces())
           {
             Type found = FindGenericType(generic, intfType);
             if (found != null) return found;
@@ -1579,9 +1578,7 @@ namespace System.Linq.Dynamic
       if (!types.Contains(type))
       {
         types.Add(type);
-        foreach (Type t in type.GetInterfacesOrderByInheritance())  {
-          AddInterface(types, t);
-        }
+        foreach (Type t in type.GetInterfaces()) AddInterface(types, t);
       }
     }
 

--- a/Orm/Xtensive.Orm.Tests.Framework/Dynamic.cs
+++ b/Orm/Xtensive.Orm.Tests.Framework/Dynamic.cs
@@ -1,4 +1,4 @@
-﻿//Copyright (C) Microsoft Corporation.  All rights reserved.
+//Copyright (C) Microsoft Corporation.  All rights reserved.
 
 using System.Collections.Generic;
 using System.Globalization;
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Text;
 using System.Threading;
+using Xtensive.Reflection;
 
 namespace System.Linq.Dynamic
 {
@@ -1312,7 +1313,7 @@ namespace System.Linq.Dynamic
         if (type.IsGenericType && type.GetGenericTypeDefinition() == generic) return type;
         if (generic.IsInterface)
         {
-          foreach (Type intfType in type.GetInterfaces())
+          foreach (Type intfType in type.GetInterfacesOrderByInheritance())
           {
             Type found = FindGenericType(generic, intfType);
             if (found != null) return found;
@@ -1578,7 +1579,9 @@ namespace System.Linq.Dynamic
       if (!types.Contains(type))
       {
         types.Add(type);
-        foreach (Type t in type.GetInterfaces()) AddInterface(types, t);
+        foreach (Type t in type.GetInterfacesOrderByInheritance())  {
+          AddInterface(types, t);
+        }
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/TypeBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/TypeBuilder.cs
@@ -50,7 +50,7 @@ namespace Xtensive.Orm.Building.Builders
           MappingName = typeDef.MappingName,
           MappingDatabase = typeDef.MappingDatabase,
           MappingSchema = typeDef.MappingSchema,
-          HasVersionRoots = typeDef.UnderlyingType.GetInterfaces().Any(type => type == typeof(IHasVersionRoots)),
+          HasVersionRoots = typeDef.UnderlyingType.GetInterfacesOrderByInheritance().Any(type => type == typeof(IHasVersionRoots)),
           Validators = validators,
         };
 

--- a/Orm/Xtensive.Orm/Orm/Building/Definitions/TypeDefCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Definitions/TypeDefCollection.cs
@@ -77,7 +77,7 @@ namespace Xtensive.Orm.Building.Definitions
     {
       ArgumentValidator.EnsureArgumentNotNull(type, "type");
 
-      var interfaces = type.GetInterfaces();
+      var interfaces = type.GetInterfacesOrderByInheritance();
       return interfaces.Select(TryGetValue).Where(result => result != null);
     }
 

--- a/Orm/Xtensive.Orm/Reflection/InterfaceMapping.cs
+++ b/Orm/Xtensive.Orm/Reflection/InterfaceMapping.cs
@@ -18,27 +18,27 @@ namespace Xtensive.Reflection
   /// Faster <see cref="ReflectionInterfaceMapping"/> analogue.
   /// </summary>
   [Serializable]
-  public sealed class InterfaceMapping
+  public readonly struct InterfaceMapping
   {
     /// <summary>
     /// Gets the target type of this mapping.
     /// </summary>
-    public Type TargetType { get; private set; }
+    public Type TargetType { get; }
 
     /// <summary>
     /// Gets the interface type of this mapping.
     /// </summary>
-    public Type InterfaceType { get; private set; }
+    public Type InterfaceType { get; }
 
     /// <summary>
     /// Gets the type members of this mapping.
     /// </summary>
-    public IReadOnlyList<MethodInfo> TargetMethods { get; private set; }
+    public IReadOnlyList<MethodInfo> TargetMethods { get; }
 
     /// <summary>
     /// Gets the interface members of this mapping.
     /// </summary>
-    public IReadOnlyList<MethodInfo> InterfaceMethods { get; private set; }
+    public IReadOnlyList<MethodInfo> InterfaceMethods { get; }
 
     
     // Constructors

--- a/Orm/Xtensive.Orm/Reflection/MemberHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/MemberHelper.cs
@@ -209,7 +209,7 @@ namespace Xtensive.Reflection
         var type = mi.DeclaringType.UnderlyingSystemType;
         var methodInfoType = mi.GetType();
         var isRuntimeMethodInfo = methodInfoType.FullName == WellKnown.RuntimeMethodInfoName;
-        foreach (var iType in type.GetInterfaces()) {
+        foreach (var iType in type.GetInterfacesOrderByInheritance()) {
           var map = type.GetInterfaceMapFast(iType.UnderlyingSystemType);
           for (var i = 0; i < map.InterfaceMethods.Count; i++) {
             var tmi = map.TargetMethods[i];

--- a/Orm/Xtensive.Orm/Reflection/MemberHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/MemberHelper.cs
@@ -170,8 +170,9 @@ namespace Xtensive.Reflection
       if (member is MethodInfo mi) {
         var iType = mi.DeclaringType.UnderlyingSystemType;
         var map = implementor.GetInterfaceMapFast(iType);
-        for (var i = 0; i < map.InterfaceMethods.Count; i++) {
-          if (mi == map.InterfaceMethods[i]) {
+        var mapInterfaceMethods = map.InterfaceMethods;
+        for (int i = 0, count = mapInterfaceMethods.Count; i < count; i++) {
+          if (mi == mapInterfaceMethods[i]) {
             return map.TargetMethods[i];
           }
         }
@@ -211,15 +212,16 @@ namespace Xtensive.Reflection
         var isRuntimeMethodInfo = methodInfoType.FullName == WellKnown.RuntimeMethodInfoName;
         foreach (var iType in type.GetInterfacesOrderByInheritance()) {
           var map = type.GetInterfaceMapFast(iType.UnderlyingSystemType);
-          for (var i = 0; i < map.InterfaceMethods.Count; i++) {
+          var mapInterfaceMethods = map.InterfaceMethods;
+          for (int i = 0, count = mapInterfaceMethods.Count; i < count; i++) {
             var tmi = map.TargetMethods[i];
             if (mi == tmi) {
-              return map.InterfaceMethods[i];
+              return mapInterfaceMethods[i];
             }
             var targetMethodInfoType = tmi.GetType();
             if (isRuntimeMethodInfo && methodInfoType == targetMethodInfoType &&
                 mi.MethodHandle.Value == tmi.MethodHandle.Value) {
-              return map.InterfaceMethods[i];
+              return mapInterfaceMethods[i];
             }
           }
         }


### PR DESCRIPTION
DO already has obsolete `TypeHelper.GetInterfaces()`  but it was never used because member function `Type.GetInterfaces()` has priority.

* Change helper return type to `IReadOnlyList<Type>` for safety
* Make `InterfaceMapping` readonly struct