### PR TITLE
Optimize Topological Sort for interfaces

### DIFF
--- a/Orm/Xtensive.Orm.Tests.Core/Helpers/TopologicalSorterTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Helpers/TopologicalSorterTest.cs
@@ -131,14 +131,9 @@ namespace Xtensive.Orm.Tests.Core.Helpers
 
         private void TestSort<T>(T[] data, Predicate<T, T> connector, T[] expected, T[] loops)
         {
-            List<Node<T, object>> actualLoopNodes;
-            List<T> actual = TopologicalSorter.Sort(data, connector, out actualLoopNodes).ToList();
-            T[] actualLoops = null;
-            if (actualLoopNodes != null)
-                actualLoops = actualLoopNodes
-                    .Where(n => n.OutgoingConnectionCount != 0)
-                    .Select(n => n.Item)
-                    .ToArray();
+            var (sorted, cycles) = TopologicalSorter.SortWithCycles(data, connector);
+            var actual = sorted.ToList();
+            T[] actualLoops = cycles?.ToArray();
 
             AssertEx.HasSameElements(expected, actual);
             AssertEx.HasSameElements(loops, actualLoops);

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/ModelBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/ModelBuilder.cs
@@ -536,12 +536,12 @@ namespace Xtensive.Orm.Building.Builders
 
     private IEnumerable<TypeDef> GetTypeBuildSequence()
     {
-      List<Node<Node<TypeDef>, object>> loops;
-      var result = TopologicalSorter.Sort(context.DependencyGraph.Nodes, TypeConnector, out loops);
-      if (result==null)
+      var (result, cycles) = TopologicalSorter.SortWithCycles(context.DependencyGraph.Nodes, TypeConnector);
+      if (result == null) {
         throw new DomainBuilderException(string.Format(
           Strings.ExAtLeastOneLoopHaveBeenFoundInPersistentTypeDependenciesGraphSuspiciousTypesX,
-          loops.Select(node => node.Item.Value.Name).ToCommaDelimitedString()));
+          cycles.Select(o => o.Value.Name).ToCommaDelimitedString()));
+      }
       var dependentTypes = result.Select(n => n.Value);
       var independentTypes = context.ModelDef.Types.Except(dependentTypes);
       return independentTypes.Concat(dependentTypes);

--- a/Orm/Xtensive.Orm/Sorting/TopologicalSorter.cs
+++ b/Orm/Xtensive.Orm/Sorting/TopologicalSorter.cs
@@ -6,10 +6,8 @@
 
 using System;
 using System.Collections.Generic;
-using Xtensive.Collections;
 using System.Linq;
 using Xtensive.Core;
-
 
 namespace Xtensive.Sorting
 {
@@ -18,6 +16,13 @@ namespace Xtensive.Sorting
   /// </summary>
   public static class TopologicalSorter
   {
+    private enum Color : byte
+    {
+      White,
+      Gray,
+      Black
+    }
+
     /// <summary>
     /// Sorts the specified oriented graph of the items in their topological order
     /// (following the outgoing connections provided by <paramref name="connector"/>).
@@ -26,14 +31,11 @@ namespace Xtensive.Sorting
     /// <param name="connector">The connector delegate returning <see langword="true" />
     /// if there is outgoing connection between the first and the second node.</param>
     /// <returns>
-    /// Sorting result, if there were no loops;
+    /// Sorting result, if there were no cycles;
     /// otherwise, <see langword="null"/>.
     /// </returns>
-    public static IEnumerable<TNodeItem> Sort<TNodeItem>(IEnumerable<TNodeItem> items, Predicate<TNodeItem, TNodeItem> connector)
-    {
-      List<Node<TNodeItem, object>> loops;
-      return Sort(items, connector, out loops);
-    }
+    public static IEnumerable<TNodeItem> Sort<TNodeItem>(IEnumerable<TNodeItem> items, Predicate<TNodeItem, TNodeItem> connector) =>
+      SortWithCycles(items, connector).sorted;
 
     /// <summary>
     /// Sorts the specified oriented graph of the items in their topological order
@@ -42,54 +44,61 @@ namespace Xtensive.Sorting
     /// <param name="items">The items to sort.</param>
     /// <param name="connector">The connector delegate returning <see langword="true"/>
     /// if there is outgoing connection between the first and the second node.</param>
-    /// <param name="loops">The loops, if found.</param>
+    /// <param name="cycles">The cycles, if found.</param>
     /// <returns>
-    /// Sorting result, if there were no loops;
+    /// Sorting result, if there were no cycles;
     /// otherwise, <see langword="null"/>.
-    /// In this case <paramref name="loops"/> will contain only the loop edges.
+    /// In this case <paramref name="cycles"/> will contain only the cycle edges.
     /// </returns>
-    public static IEnumerable<TNodeItem> Sort<TNodeItem>(IEnumerable<TNodeItem> items, Predicate<TNodeItem, TNodeItem> connector, out List<Node<TNodeItem, object>> loops)
+    public static (IEnumerable<TNodeItem> sorted, List<TNodeItem> cycles) SortWithCycles<TNodeItem>(IEnumerable<TNodeItem> items, Predicate<TNodeItem, TNodeItem> connector)
     {
       ArgumentValidator.EnsureArgumentNotNull(items, "items");
       ArgumentValidator.EnsureArgumentNotNull(connector, "connector");
-      List<Node<TNodeItem, object>> nodes = GetNodes(items, connector);
-      return Sort(nodes, out loops);
-    }
 
-    /// <summary>
-    /// Sorts the specified oriented graph of the items in their topological order
-    /// (following the outgoing connections provided by <paramref name="connector"/>).
-    /// </summary>
-    /// <param name="items">The items to sort.</param>
-    /// <param name="connector">The connector delegate returning <see langword="true"/>
-    /// if there is outgoing connection between the first and the second node.</param>
-    /// <param name="removedEdges">Edges removed to make graph non-cyclic.</param>
-    /// <returns>
-    /// Sorting result
-    /// </returns>
-    public static List<TNodeItem> Sort<TNodeItem>(IEnumerable<TNodeItem> items, Predicate<TNodeItem, TNodeItem> connector, out List<NodeConnection<TNodeItem, object>> removedEdges)
-    {
-      return Sort(items, connector, out removedEdges, false);
-    }
-
-    /// <summary>
-    /// Sorts the specified oriented graph of the items in their topological order
-    /// (following the outgoing connections provided by <paramref name="connector"/>).
-    /// </summary>
-    /// <param name="items">The items to sort.</param>
-    /// <param name="connector">The connector delegate returning <see langword="true"/>
-    /// if there is outgoing connection between the first and the second node.</param>
-    /// <param name="removedEdges">Edges removed to make graph non-cyclic.</param>
-    /// <param name="removeWholeNode">If <see langword="true"/> removes whole node in the case of loop, otherwise removes only one edge.</param>
-    /// <returns>
-    /// Sorting result
-    /// </returns>
-    public static List<TNodeItem> Sort<TNodeItem>(IEnumerable<TNodeItem> items, Predicate<TNodeItem, TNodeItem> connector, out List<NodeConnection<TNodeItem, object>> removedEdges, bool removeWholeNode)
-    {
-      ArgumentValidator.EnsureArgumentNotNull(items, "items");
-      ArgumentValidator.EnsureArgumentNotNull(connector, "connector");
-      List<Node<TNodeItem, object>> nodes = GetNodes(items, connector);
-      return Sort(nodes, out removedEdges, removeWholeNode);
+      List<TNodeItem> cycles = null;
+      var ar = items.ToArray();
+      var n = ar.Length;
+      var colors = new Color[n];
+      var result = new List<TNodeItem>(n);
+      var stack = new Stack<(int index, int curConn)>(n);
+      for (var i = 0; i < n; ++i) {
+        ref var cur = ref colors[i];
+        if (cur == Color.White) {
+          cur = Color.Gray;
+          stack.Push((i, -1));
+        }
+        while (stack.TryPop(out var t)) {
+          while (true) {
+            if (++t.curConn >= n) {
+              colors[t.index] = Color.Black;
+              result.Add(ar[t.index]);
+              break;
+            }
+            if (t.index != t.curConn) {
+              ref var targetColor = ref colors[t.curConn];
+              if (targetColor != Color.Black && connector(ar[t.curConn], ar[t.index])) {
+                if (targetColor == Color.Gray) {
+                  cycles ??= new();           // Cycle discovered
+                  for (int cycleStart = t.curConn; stack.TryPop(out t);) {
+                    cycles.Add(ar[t.index]);
+                    colors[t.index] = Color.Black;
+                    if (t.index == cycleStart) {
+                      break;
+                    }
+                  };
+                }
+                else {                      // targetColor == Color.White
+                  targetColor = Color.Gray;
+                  stack.Push(t);
+                  stack.Push((t.curConn, -1));
+                }
+                break;
+              }
+            }
+          }
+        }
+      }
+      return (cycles == null ? result : null, cycles);
     }
 
     /// <summary>
@@ -97,11 +106,11 @@ namespace Xtensive.Sorting
     /// (following the outgoing connections).
     /// </summary>
     /// <param name="nodes">The nodes.</param>
-    /// <param name="loops">The loops, if found.</param>
+    /// <param name="cycles">The loops, if found.</param>
     /// <returns>Sorting result, if there were no loops;
     /// otherwise, <see langword="null" />. 
     /// In this case <paramref name="nodes"/> will contain only the loop edges.</returns>
-    public static IEnumerable<TNodeItem> Sort<TNodeItem, TConnectionItem>(List<Node<TNodeItem, TConnectionItem>> nodes, out List<Node<TNodeItem, TConnectionItem>> loops)
+    public static IEnumerable<TNodeItem> Sort<TNodeItem, TConnectionItem>(List<Node<TNodeItem, TConnectionItem>> nodes, out List<Node<TNodeItem, TConnectionItem>> cycles)
     {
       ArgumentValidator.EnsureArgumentNotNull(nodes, "nodes");
       var head = new Queue<TNodeItem>();
@@ -129,16 +138,49 @@ namespace Xtensive.Sorting
           }
         }
         if (nodesToRemove.Count==0) {
-          loops = new List<Node<TNodeItem, TConnectionItem>>(nodeList);
+          cycles = new List<Node<TNodeItem, TConnectionItem>>(nodeList);
           return null;
         }
         foreach (var nodeToRemove in nodesToRemove)
           nodeList.Remove(nodeToRemove);
       }
-      loops = null;
+      cycles = null;
       return head.Concat(tail.Reverse());
     }
 
+    /// <summary>
+    /// Sorts the specified oriented graph of the items in their topological order
+    /// (following the outgoing connections provided by <paramref name="connector"/>).
+    /// </summary>
+    /// <param name="items">The items to sort.</param>
+    /// <param name="connector">The connector delegate returning <see langword="true"/>
+    /// if there is outgoing connection between the first and the second node.</param>
+    /// <param name="removedEdges">Edges removed to make graph non-cyclic.</param>
+    /// <returns>
+    /// Sorting result
+    /// </returns>
+    public static List<TNodeItem> Sort<TNodeItem>(IEnumerable<TNodeItem> items, Predicate<TNodeItem, TNodeItem> connector, out List<NodeConnection<TNodeItem, object>> removedEdges) =>
+      Sort(items, connector, out removedEdges, false);
+
+    /// <summary>
+    /// Sorts the specified oriented graph of the items in their topological order
+    /// (following the outgoing connections provided by <paramref name="connector"/>).
+    /// </summary>
+    /// <param name="items">The items to sort.</param>
+    /// <param name="connector">The connector delegate returning <see langword="true"/>
+    /// if there is outgoing connection between the first and the second node.</param>
+    /// <param name="removedEdges">Edges removed to make graph non-cyclic.</param>
+    /// <param name="removeWholeNode">If <see langword="true"/> removes whole node in the case of cycle, otherwise removes only one edge.</param>
+    /// <returns>
+    /// Sorting result
+    /// </returns>
+    public static List<TNodeItem> Sort<TNodeItem>(IEnumerable<TNodeItem> items, Predicate<TNodeItem, TNodeItem> connector, out List<NodeConnection<TNodeItem, object>> removedEdges, bool removeWholeNode)
+    {
+      ArgumentValidator.EnsureArgumentNotNull(items, "items");
+      ArgumentValidator.EnsureArgumentNotNull(connector, "connector");
+      List<Node<TNodeItem, object>> nodes = GetNodes(items, connector);
+      return Sort(nodes, out removedEdges, removeWholeNode);
+    }
 
     /// <summary>
     /// Sorts the specified oriented graph of the nodes in their topological order
@@ -158,7 +200,7 @@ namespace Xtensive.Sorting
     /// </summary>
     /// <param name="nodes">The nodes.</param>
     /// <param name="removedEdges">Edges removed to make graph non-cyclic.</param>
-    /// <param name="removeWholeNode">If <see langword="true"/> removes whole node in the case of loop, otherwise removes only one edge.</param>
+    /// <param name="removeWholeNode">If <see langword="true"/> removes whole node in the case of cycle, otherwise removes only one edge.</param>
     /// <returns>Sorting result.</returns>
     public static List<TNodeItem> Sort<TNodeItem, TConnectionItem>(IEnumerable<Node<TNodeItem, TConnectionItem>> nodes, out List<NodeConnection<TNodeItem, TConnectionItem>> removedEdges, bool removeWholeNode)
     {
@@ -170,10 +212,10 @@ namespace Xtensive.Sorting
       var nodesToRemove = new List<Node<TNodeItem, TConnectionItem>>();
       while (nodeList.Count > 0) {
         nodesToRemove.Clear();
-        Node<TNodeItem, TConnectionItem> nodeToBreakLoop = null;
-        NodeConnection<TNodeItem, TConnectionItem> edgeToBreakLoop = null;
+        Node<TNodeItem, TConnectionItem> nodeToBreakCycle = null;
+        NodeConnection<TNodeItem, TConnectionItem> edgeToBreakCycle = null;
         foreach (var node in nodeList) {
-          if (node.IncomingConnectionCount==0) {
+          if (node.IncomingConnectionCount == 0) {
             // Add to head
             head.Enqueue(node.Item);
             nodesToRemove.Add(node);
@@ -181,7 +223,7 @@ namespace Xtensive.Sorting
             foreach (var connection in connections)
               connection.UnbindFromNodes();
           }
-          else if (node.OutgoingConnectionCount==0) {
+          else if (node.OutgoingConnectionCount == 0) {
             // Add to tail
             tail.Enqueue(node.Item);
             nodesToRemove.Add(node);
@@ -191,32 +233,32 @@ namespace Xtensive.Sorting
           }
           else {
             if (removeWholeNode) {
-              if (node.PermanentOutgoingConnectionCount==0 && (nodeToBreakLoop==null || node.OutgoingConnectionCount > nodeToBreakLoop.OutgoingConnectionCount))
-                nodeToBreakLoop = node;
+              if (node.PermanentOutgoingConnectionCount == 0 && (nodeToBreakCycle == null || node.OutgoingConnectionCount > nodeToBreakCycle.OutgoingConnectionCount))
+                nodeToBreakCycle = node;
             }
             else {
-              if (node.BreakableOutgoingConnectionCount>0 && edgeToBreakLoop==null)
-                edgeToBreakLoop = node.OutgoingConnections.First(connection=>connection.ConnectionType==ConnectionType.Breakable);
+              if (node.BreakableOutgoingConnectionCount > 0 && edgeToBreakCycle == null)
+                edgeToBreakCycle = node.OutgoingConnections.First(connection => connection.ConnectionType == ConnectionType.Breakable);
             }
           }
         }
-        if (nodesToRemove.Count==0) {
-          if (nodeToBreakLoop!=null) {
+        if (nodesToRemove.Count == 0) {
+          if (nodeToBreakCycle != null) {
             // Remove node
-            var connections = nodeToBreakLoop.OutgoingConnections.ToArray();
+            var connections = nodeToBreakCycle.OutgoingConnections.ToArray();
             foreach (var connection in connections)
               connection.UnbindFromNodes();
-            foreach (var connection in nodeToBreakLoop.IncomingConnections.ToArray())
+            foreach (var connection in nodeToBreakCycle.IncomingConnections.ToArray())
               connection.UnbindFromNodes();
             removedEdges.AddRange(connections);
-            tail.Enqueue(nodeToBreakLoop.Item);
-            nodeList.Remove(nodeToBreakLoop);
+            tail.Enqueue(nodeToBreakCycle.Item);
+            nodeList.Remove(nodeToBreakCycle);
           }
-          else if (edgeToBreakLoop!=null) {
-              // remove edge
-              removedEdges.Add(edgeToBreakLoop);
-              edgeToBreakLoop.UnbindFromNodes();
-            }
+          else if (edgeToBreakCycle != null) {
+            // remove edge
+            removedEdges.Add(edgeToBreakCycle);
+            edgeToBreakCycle.UnbindFromNodes();
+          }
           else {
             throw new InvalidOperationException(Strings.ExOnlyBreakableNodesSadSmile);
           }
@@ -236,7 +278,7 @@ namespace Xtensive.Sorting
       // Adding connections
       foreach (var nodeA in nodes)
         foreach (var nodeB in nodes) {
-          if (nodeA==nodeB)
+          if (nodeA == nodeB)
             continue;
           if (connector.Invoke(nodeA.Item, nodeB.Item))
             nodeA.AddConnection(nodeB, null);


### PR DESCRIPTION
The benchmark for sorting `.GetInterfaces()` over all model types
```
|             Method |         Mean | Error |          Min |          Max |    Gen 0 |  Allocated |
|------------------- |-------------:|------:|-------------:|-------------:|---------:|-----------:|
| OldTopologicalSort |    18.342 ms |    NA |    18.342 ms |    18.342 ms |        - |   6,308 KB |
| NewTopologicalSort |     3.939 ms |    NA |     3.939 ms |     3.939 ms |        - |     644 KB |
```

Also renamed `loops` param to `cycles`, because in Graph theory  "loop" means zero-length cycle

Existing Topological Sort algorithms remain in codebase because they are used in places, which cannot be easy converted to use the new algorithm with callback predicate and returning removed edges.

