### PR TITLE
Intern short (1..2 chars) contents of TextNode

### DIFF
--- a/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/ContainerNode.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/ContainerNode.cs
@@ -164,7 +164,11 @@ namespace Xtensive.Sql.Compiler
     internal void FlushBuffer()
     {
       if (stringBuilder.Length > 0) {
-        children.Add(new TextNode(stringBuilder.ToString()));
+        var s = stringBuilder.ToString();
+        if (s.Length < 3) {
+          s = string.Intern(s);
+        }
+        children.Add(new TextNode(s));
         lastNodeIsText = true;
         lastChar = stringBuilder[^1];
         _ = stringBuilder.Clear();


### PR DESCRIPTION
Most typical TextNode is  `comma+space`
Cached queries may contain Megabytes of them:
![image](https://user-images.githubusercontent.com/1176609/211781775-36fc5964-3467-4386-886d-c8cdb576817d.png)
