### PR TITLE
Save 8/4 bytes per node instance. Use `is` operator instead of bool field

### DIFF
--- a/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/ContainerNode.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/ContainerNode.cs
@@ -153,7 +153,7 @@ namespace Xtensive.Sql.Compiler
     {
       FlushBuffer();
       children.Add(node);
-      lastNodeIsText = node.IsTextNode;
+      lastNodeIsText = node is TextNode;
     }
 
     internal override void AcceptVisitor(NodeVisitor visitor)

--- a/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/Node.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/Node.cs
@@ -9,17 +9,6 @@ namespace Xtensive.Sql.Compiler
   /// </summary>
   public abstract class Node
   {
-    internal readonly bool IsTextNode;
-
     internal abstract void AcceptVisitor(NodeVisitor visitor);
-
-    public Node()
-    {
-    }
-
-    internal Node(bool isTextNode)
-    {
-      IsTextNode = isTextNode;
-    }
   }
 }

--- a/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/TextNode.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/TextNode.cs
@@ -19,7 +19,6 @@ namespace Xtensive.Sql.Compiler
     // Constructor
 
     public TextNode(string text)
-      : base(true)
     {
       Text = text;
     }


### PR DESCRIPTION
Potentially is saves megabytes

![image](https://user-images.githubusercontent.com/1176609/212448733-8a9b0496-7339-47f7-8440-00e5ec0b2e2b.png)
