### PR TITLE
ARCH-5738: Optimization: Don't clear internal collections in `Session.Dispose()`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Session.Persist.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.Persist.cs
@@ -357,9 +357,10 @@ namespace Xtensive.Orm
 
     private void ProcessChangesOfEntitySets(Action<EntitySetState> action)
     {
-      var itemsToProcess = EntitySetChangeRegistry.GetItems();
-      foreach (var entitySet in itemsToProcess)
-        action.Invoke(entitySet);
+      if (EntitySetChangeRegistry is not null) {
+        foreach (var entitySet in EntitySetChangeRegistry.GetItems())
+          action.Invoke(entitySet);
+      }
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Session.Transactions.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.Transactions.cs
@@ -311,8 +311,8 @@ namespace Xtensive.Orm
             if(!persistingIsFailed || !Configuration.Supports(SessionOptions.NonTransactionalReads)) {
               CancelEntitySetsChanges();
               ClearChangeRegistry();
-              NonPairedReferencesRegistry.Clear();
-              EntitySetChangeRegistry.Clear();
+              NonPairedReferencesRegistry?.Clear();
+              EntitySetChangeRegistry?.Clear();
             }
             persistingIsFailed = false;
           }
@@ -414,12 +414,18 @@ namespace Xtensive.Orm
 
     private void ClearChangeRegistry()
     {
-      foreach (var item in EntityChangeRegistry.GetItems(PersistenceState.New))
+      if (EntityChangeRegistry is null) {
+        return;
+      }
+      foreach (var item in EntityChangeRegistry.GetItems(PersistenceState.New)) {
         item.PersistenceState = PersistenceState.Synchronized;
-      foreach (var item in EntityChangeRegistry.GetItems(PersistenceState.Modified))
+      }
+      foreach (var item in EntityChangeRegistry.GetItems(PersistenceState.Modified)) {
         item.PersistenceState = PersistenceState.Synchronized;
-      foreach (var item in EntityChangeRegistry.GetItems(PersistenceState.Removed))
+      }
+      foreach (var item in EntityChangeRegistry.GetItems(PersistenceState.Removed)) {
         item.PersistenceState = PersistenceState.Synchronized;
+      }
       EntityChangeRegistry.Clear();
     }
 

--- a/Orm/Xtensive.Orm/Orm/Session.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.cs
@@ -89,6 +89,7 @@ namespace Xtensive.Orm
     private readonly Pinner pinner;
 
     private int? commandTimeout;
+    private volatile int isDisposing; // To prevent double-disposing
     private volatile bool isDisposed;
 
     /// <summary>
@@ -121,22 +122,22 @@ namespace Xtensive.Orm
     {
       get {
         return Configuration.Supports(SessionOptions.NonTransactionalEntityStates) &&
-          !Configuration.Supports(SessionOptions.AutoSaveChanges);
+               !Configuration.Supports(SessionOptions.AutoSaveChanges);
       }
     }
 
     /// <summary>
     /// Indicates whether instance is disposed.
     /// </summary>
-    public bool IsDisposed
-    {
-      get => isDisposed;
-    }
+    public bool IsDisposed => isDisposed;
 
     /// <summary>
     /// Indicates whether lazy generation of keys is enabled.
     /// </summary>
-    internal bool LazyKeyGenerationIsEnabled { get { return Configuration.Supports(SessionOptions.LazyKeyGeneration); } }
+    internal bool LazyKeyGenerationIsEnabled
+    {
+      get { return Configuration.Supports(SessionOptions.LazyKeyGeneration); }
+    }
 
     /// <summary>
     /// Gets the operations registry of this <see cref="Session"/>.
@@ -262,7 +263,8 @@ namespace Xtensive.Orm
       return new Providers.EnumerationContext(this, parameterContext, GetEnumerationContextOptions());
     }
 
-    internal async Task<EnumerationContext> CreateEnumerationContextAsync(ParameterContext parameterContext, CancellationToken token)
+    internal async Task<EnumerationContext> CreateEnumerationContextAsync(ParameterContext parameterContext,
+      CancellationToken token)
     {
       await PersistAsync(PersistReason.Query, token).ConfigureAwait(false);
       _ = await ProcessUserDefinedDelayedQueriesAsync(true, token).ConfigureAwait(false);
@@ -282,7 +284,8 @@ namespace Xtensive.Orm
       if (currentSession.Transaction == null || (allowSwitching && currentSession.allowSwitching)) {
         return;
       }
-      throw new InvalidOperationException(string.Format(Strings.ExAttemptToAutomaticallyActivateSessionXInsideSessionYIsBlocked, this, currentSession));
+      throw new InvalidOperationException(
+        string.Format(Strings.ExAttemptToAutomaticallyActivateSessionXInsideSessionYIsBlocked, this, currentSession));
     }
 
     private EnumerationContextOptions GetEnumerationContextOptions()
@@ -307,7 +310,7 @@ namespace Xtensive.Orm
 
     private IServiceContainer CreateSystemServices()
     {
-      var registrations = new List<ServiceRegistration>{
+      var registrations = new List<ServiceRegistration> {
         new ServiceRegistration(typeofSession, this),
         new ServiceRegistration(typeofSessionConfiguration, Configuration),
         new ServiceRegistration(typeofSessionHandler, Handler),
@@ -620,7 +623,7 @@ namespace Xtensive.Orm
 
     private async ValueTask DisposeImpl(bool isAsync)
     {
-      if (isDisposed) {
+      if (isDisposed || Interlocked.Exchange(ref isDisposing, 1) == 1) {
         return;
       }
 
@@ -645,14 +648,14 @@ namespace Xtensive.Orm
 
         Domain.ReleaseSingleConnection();
 
-        disposableSet.DisposeSafely();
+        disposableSet?.DisposeSafely();
         disposableSet = null;
 
-        EntityChangeRegistry.Clear();
-        EntitySetChangeRegistry.Clear();
-        EntityStateCache.Clear();
-        ReferenceFieldsChangesRegistry.Clear();
-        NonPairedReferencesRegistry.Clear();
+        EntityChangeRegistry = null;
+        EntitySetChangeRegistry = null;
+        EntityStateCache = null;
+        ReferenceFieldsChangesRegistry = null;
+        NonPairedReferencesRegistry = null;
         Extensions.Clear();
       }
       finally {

--- a/Orm/Xtensive.Orm/Orm/Session.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.cs
@@ -623,7 +623,7 @@ namespace Xtensive.Orm
 
     private async ValueTask DisposeImpl(bool isAsync)
     {
-      if (isDisposed || Interlocked.Exchange(ref isDisposing, 1) == 1) {
+      if (Interlocked.Exchange(ref isDisposing, 1) == 1) {
         return;
       }
 


### PR DESCRIPTION
Just set references to them to null.
Clearing is waste of time. GC will free them anyway

Also add `isDisposing` field to prevent concurrent disposing

It can resolve https://servicetitan.atlassian.net/browse/ARCH-5738 error:
```
[InvalidOperationException] The LinkedList node does not belong to current LinkedList.
```
```
 at Xtensive.Caching.LruCache`2.Clear()
   at Xtensive.Orm.Session.DisposeImpl(Boolean isAsync)
```
