### PR TITLE
Optimize VisitMemberAccess()

### DIFF
--- a/Orm/Xtensive.Orm/Linq/ExpressionVisitor.cs
+++ b/Orm/Xtensive.Orm/Linq/ExpressionVisitor.cs
@@ -18,7 +18,7 @@ namespace Xtensive.Linq
   /// </summary>
   public abstract class ExpressionVisitor : ExpressionVisitor<Expression>
   {
-    protected override IReadOnlyList<Expression> VisitExpressionList(ReadOnlyCollection<Expression> expressions) =>
+    protected override IReadOnlyList<Expression> VisitExpressionList(IReadOnlyList<Expression> expressions) =>
       VisitList(expressions, Visit);
 
     /// <summary>
@@ -231,7 +231,7 @@ namespace Xtensive.Linq
     protected virtual IReadOnlyList<MemberBinding> VisitBindingList(ReadOnlyCollection<MemberBinding> original) =>
       VisitList(original, VisitBinding);
 
-    public static IReadOnlyList<T> VisitList<T>(ReadOnlyCollection<T> original, Func<T, T> func) where T : class
+    public static IReadOnlyList<T> VisitList<T>(IReadOnlyList<T> original, Func<T, T> func) where T : class
     {
       T[] ar = null;
       for (int i = 0, n = original.Count; i < n; i++) {

--- a/Orm/Xtensive.Orm/Linq/ExpressionVisitor{TResult}.cs
+++ b/Orm/Xtensive.Orm/Linq/ExpressionVisitor{TResult}.cs
@@ -101,7 +101,7 @@ namespace Xtensive.Linq
     /// </summary>
     /// <param name="expressions">The expression list.</param>
     /// <returns>Visit result.</returns>
-    protected virtual IReadOnlyList<TResult> VisitExpressionList(ReadOnlyCollection<Expression> expressions)
+    protected virtual IReadOnlyList<TResult> VisitExpressionList(IReadOnlyList<Expression> expressions)
     {
       var n = expressions.Count;
       var results = new TResult[n];

--- a/Orm/Xtensive.Orm/Linq/ExpressionWriter.cs
+++ b/Orm/Xtensive.Orm/Linq/ExpressionWriter.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -445,8 +446,8 @@ namespace Xtensive.Linq
     }
 
     /// <inheritdoc/>
-    protected override System.Collections.ObjectModel.ReadOnlyCollection<Expression> VisitExpressionList(
-      System.Collections.ObjectModel.ReadOnlyCollection<Expression> expressions)
+    protected override IReadOnlyList<Expression> VisitExpressionList(
+      IReadOnlyList<Expression> expressions)
     {
       for (int i = 0, n = expressions.Count; i < n; i++) {
         Visit(expressions[i]);

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
@@ -21,13 +21,13 @@ namespace Xtensive.Orm.Linq
   internal class ConstructorExpression : ParameterizedExpression,
     IMappedExpression
   {
-    public Dictionary<MemberInfo, Expression> Bindings { get; private set; }
+    public Dictionary<MemberInfo, Expression> Bindings { get; }
 
     public Dictionary<MemberInfo, Expression> NativeBindings { get; private set; }
 
     public ConstructorInfo Constructor { get; private set; }
 
-    public IEnumerable<Expression> ConstructorArguments { get; private set; }
+    public IReadOnlyList<Expression> ConstructorArguments { get; }
 
     public Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
@@ -50,7 +50,7 @@ namespace Xtensive.Orm.Linq
         Bindings.ToDictionary(kvp => kvp.Key, kvp => genericRemover(kvp.Value)),
         NativeBindings = NativeBindings.ToDictionary(kvp => kvp.Key, kvp => genericRemover(kvp.Value)),
         Constructor,
-        ConstructorArguments.Select(genericRemover).ToList());
+        ConstructorArguments.Select(genericRemover).ToArray());
       return result;
     }
 
@@ -63,7 +63,8 @@ namespace Xtensive.Orm.Linq
         return (Expression) mapped;
       };
       var newBindings = Bindings.ToDictionary(kvp => kvp.Key, kvp => GenericExpressionVisitor<IMappedExpression>.Process(kvp.Value, remapper));
-      var newConstructorArguments = ConstructorArguments.Select(arg =>  GenericExpressionVisitor<IMappedExpression>.Process(arg, remapper));
+      var newConstructorArguments = ConstructorArguments
+        .Select(arg => GenericExpressionVisitor<IMappedExpression>.Process(arg, remapper)).ToArray();
       var newNativeBindings = NativeBindings.ToDictionary(kvp => kvp.Key, kvp => GenericExpressionVisitor<IMappedExpression>.Process(kvp.Value, remapper));
       var result = new ConstructorExpression(
         Type,
@@ -83,17 +84,17 @@ namespace Xtensive.Orm.Linq
         return (Expression) mapped;
       };
       var newBindings = Bindings.ToDictionary(kvp => kvp.Key, kvp => GenericExpressionVisitor<IMappedExpression>.Process(kvp.Value, remapper));
-      var newConstructorArguments = ConstructorArguments.Select(arg =>  GenericExpressionVisitor<IMappedExpression>.Process(arg, remapper));
+      var newConstructorArguments = ConstructorArguments.Select(arg => GenericExpressionVisitor<IMappedExpression>.Process(arg, remapper)).ToArray();
       var newNativeBindings = NativeBindings.ToDictionary(kvp => kvp.Key, kvp => GenericExpressionVisitor<IMappedExpression>.Process(kvp.Value, remapper));
       return new ConstructorExpression(Type, newBindings, newNativeBindings, Constructor, newConstructorArguments);
     }
 
-    public ConstructorExpression(Type type, Dictionary<MemberInfo, Expression> bindings, Dictionary<MemberInfo, Expression> nativeBindings, ConstructorInfo constructor, IEnumerable<Expression> constructorArguments)
+    public ConstructorExpression(Type type, Dictionary<MemberInfo, Expression> bindings, Dictionary<MemberInfo, Expression> nativeBindings, ConstructorInfo constructor, IReadOnlyList<Expression> constructorArguments)
       : base(ExtendedExpressionType.Constructor, type, null, false)
     {
       Bindings = bindings ?? new Dictionary<MemberInfo, Expression>();
       NativeBindings = nativeBindings;
-      ConstructorArguments = constructorArguments ?? Enumerable.Empty<Expression>();
+      ConstructorArguments = constructorArguments ?? Array.Empty<Expression>();
       Constructor = constructor;
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
@@ -25,7 +25,7 @@ namespace Xtensive.Orm.Linq
 
     public Dictionary<MemberInfo, Expression> NativeBindings { get; private set; }
 
-    public ConstructorInfo Constructor { get; private set; }
+    public ConstructorInfo Constructor { get; }
 
     public IReadOnlyList<Expression> ConstructorArguments { get; }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/OwnerRemover.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/OwnerRemover.cs
@@ -48,7 +48,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       var oldConstructorArguments = expression.ConstructorArguments;
       var newConstructorArguments = VisitExpressionList(oldConstructorArguments);
 
-      var oldBindings = expression.Bindings.Select(b => b.Value).ToList().AsReadOnly();
+      var oldBindings = expression.Bindings.Values.ToArray(expression.Bindings.Count);
       var newBindings = VisitExpressionList(oldBindings);
 
       var oldNativeBindings = expression.NativeBindings.Select(b => b.Value).ToList().AsReadOnly();

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/OwnerRemover.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/OwnerRemover.cs
@@ -45,7 +45,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
 
     protected override Expression VisitConstructorExpression(ConstructorExpression expression)
     {
-      var oldConstructorArguments = expression.ConstructorArguments.ToList().AsReadOnly();
+      var oldConstructorArguments = expression.ConstructorArguments;
       var newConstructorArguments = VisitExpressionList(oldConstructorArguments);
 
       var oldBindings = expression.Bindings.Select(b => b.Value).ToList().AsReadOnly();

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -321,41 +321,43 @@ namespace Xtensive.Orm.Linq
 
     protected override Expression VisitMemberAccess(MemberExpression ma)
     {
-      if (ma.Expression != null)
-        if (ma.Expression.Type != ma.Member.ReflectedType
-          && ma.Member is PropertyInfo
-          && !ma.Member.ReflectedType.IsInterface)
-          ma = Expression.MakeMemberAccess(
-            ma.Expression, ma.Expression.Type.GetProperty(ma.Member.Name, ma.Member.GetBindingFlags()));
-      var customCompiler = context.CustomCompilerProvider.GetCompiler(ma.Member);
+      var maExpression = ma.Expression;
+      var maMember = ma.Member;
+      if (maExpression != null
+            && maExpression.Type != maMember.ReflectedType
+            && maMember is PropertyInfo
+            && !maMember.ReflectedType.IsInterface) {
+          ma = Expression.MakeMemberAccess(maExpression, maExpression.Type.GetProperty(maMember.Name, maMember.GetBindingFlags()));
+          maExpression = ma.Expression;
+          maMember = ma.Member;
+      }
+      var customCompiler = context.CustomCompilerProvider.GetCompiler(maMember);
 
       // Reflected type doesn't have custom compiler defined, so falling back to base class compiler
-      var declaringType = ma.Member.DeclaringType;
-      Type reflectedType = ma.Member.ReflectedType;
+      var declaringType = maMember.DeclaringType;
+      Type reflectedType = maMember.ReflectedType;
       if (customCompiler == null && declaringType != reflectedType && declaringType.IsAssignableFrom(reflectedType)) {
         var root = declaringType;
         var current = reflectedType;
         while (current != root && customCompiler == null) {
           current = current.BaseType;
-          var member = current.GetProperty(ma.Member.Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+          var member = current.GetProperty(maMember.Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
           customCompiler = context.CustomCompilerProvider.GetCompiler(member);
         }
       }
 
       if (customCompiler != null) {
-        var member = ma.Member;
-        var expression = customCompiler.Invoke(ma.Expression, Array.Empty<Expression>());
+        var expression = customCompiler.Invoke(maExpression, Array.Empty<Expression>());
         if (expression == null) {
-          if (member.ReflectedType.IsInterface)
+          if (maMember.ReflectedType.IsInterface)
             return Visit(BuildInterfaceExpression(ma));
-          if (member.ReflectedType.IsClass)
+          if (maMember.ReflectedType.IsClass)
             return Visit(BuildHierarchyExpression(ma));
         }
         else
           return Visit(expression);
       }
 
-      var expressionMember = ma.Member;
       if (context.Evaluator.CanBeEvaluated(ma) && context.ParameterExtractor.IsParameter(ma)) {
         if (WellKnownInterfaces.Queryable.IsAssignableFrom(ma.Type)) {
           Func<IQueryable> lambda = FastExpression.Lambda<Func<IQueryable>>(ma).CachingCompile();
@@ -365,7 +367,7 @@ namespace Xtensive.Orm.Linq
         }
         return ma;
       }
-      if (ma.Expression == null) {
+      if (maExpression == null) {
         if (WellKnownInterfaces.Queryable.IsAssignableFrom(ma.Type)) {
           var lambda = FastExpression.Lambda<Func<IQueryable>>(ma).CachingCompile();
           var rootPoint = lambda();
@@ -373,21 +375,21 @@ namespace Xtensive.Orm.Linq
             return VisitSequence(rootPoint.Expression);
         }
       }
-      else if (ma.Expression.NodeType == ExpressionType.Constant) {
-        if (expressionMember is FieldInfo rfi && rfi.FieldType.IsGenericType && WellKnownInterfaces.Queryable.IsAssignableFrom(rfi.FieldType)) {
+      else if (maExpression.NodeType == ExpressionType.Constant) {
+        if (maMember is FieldInfo rfi && rfi.FieldType.IsGenericType && WellKnownInterfaces.Queryable.IsAssignableFrom(rfi.FieldType)) {
           var lambda = FastExpression.Lambda<Func<IQueryable>>(ma).CachingCompile();
           var rootPoint = lambda();
           if (rootPoint != null)
             return VisitSequence(rootPoint.Expression);
         }
       }
-      else if (ma.Expression.GetMemberType() == MemberType.Entity && expressionMember.Name != "Key") {
-        var type = ma.Expression.Type;
-        if (ma.Expression is ParameterExpression parameter) {
+      else if (maExpression.GetMemberType() == MemberType.Entity && maMember.Name != "Key") {
+        var type = maExpression.Type;
+        if (maExpression is ParameterExpression parameter) {
           var projection = context.Bindings[parameter];
           type = projection.ItemProjector.Item.Type;
         }
-        var fieldName = context.Domain.Handlers.NameBuilder.BuildFieldName((PropertyInfo) expressionMember);
+        var fieldName = context.Domain.Handlers.NameBuilder.BuildFieldName((PropertyInfo) maMember);
         if (!context.Model.Types[type].Fields.Contains(fieldName) && fieldName != "TypeInfo") {
           throw new NotSupportedException(String.Format(Strings.ExFieldMustBePersistent, ma.ToString(true)));
         }
@@ -397,7 +399,7 @@ namespace Xtensive.Orm.Linq
         source = Visit(ma.Expression);
       }
 
-      var result = GetMember(source, expressionMember, ma);
+      var result = GetMember(source, maMember, ma);
       return result ?? base.VisitMemberAccess(ma);
     }
 
@@ -707,7 +709,7 @@ namespace Xtensive.Orm.Linq
 
     #region Private helper methods
 
-    private Dictionary<MemberInfo, Expression> GetBindingsForConstructor(ParameterInfo[] constructorParameters, IList<Expression> constructorArguments, Expression newExpression)
+    private Dictionary<MemberInfo, Expression> GetBindingsForConstructor(ParameterInfo[] constructorParameters, IReadOnlyList<Expression> constructorArguments, Expression newExpression)
     {
       var bindings = new Dictionary<MemberInfo, Expression>();
       var duplicateMembers = new HashSet<MemberInfo>();
@@ -1296,13 +1298,15 @@ namespace Xtensive.Orm.Linq
     protected override Expression VisitMemberInit(MemberInitExpression mi)
     {
       var newExpression = mi.NewExpression;
-      var arguments = VisitNewExpressionArguments(newExpression);
+      var _ = VisitNewExpressionArguments(newExpression);
       var bindings = VisitBindingList(mi.Bindings).Cast<MemberAssignment>();
-      var constructorExpression = (ConstructorExpression) VisitNew(mi.NewExpression);
+      var miNewExpression = mi.NewExpression;
+      var constructorExpression = (ConstructorExpression) VisitNew(miNewExpression);
       foreach (var binding in bindings) {
-        var member = binding.Member.MemberType == MemberTypes.Property
-          ? TryGetActualPropertyInfo((PropertyInfo) binding.Member, mi.NewExpression.Type)
-          : binding.Member;
+        var member = binding.Member;
+        if (member.MemberType == MemberTypes.Property) {
+          member = TryGetActualPropertyInfo((PropertyInfo) member, miNewExpression.Type);
+        }
         constructorExpression.Bindings[member] = binding.Expression;
         constructorExpression.NativeBindings[member] = binding.Expression;
       }

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -662,11 +662,11 @@ namespace Xtensive.Orm.Linq
       // ReSharper disable ConditionIsAlwaysTrueOrFalse
 
       var strippedMarkersExpression = newExpression.StripMarkers();
-      if (newExpression.Members == null) {
-        if (strippedMarkersExpression.IsGroupingExpression()
-          || strippedMarkersExpression.IsSubqueryExpression()
-          || newExpression.IsNewExpressionSupportedByStorage())
-          return base.VisitNew(newExpression);
+      var newExpressionMembers = newExpression.Members;
+      if (newExpressionMembers is null && (strippedMarkersExpression.IsGroupingExpression()
+                                           || strippedMarkersExpression.IsSubqueryExpression()
+                                           || newExpression.IsNewExpressionSupportedByStorage())) {
+        return base.VisitNew(newExpression);
       }
 
       // ReSharper restore ConditionIsAlwaysTrueOrFalse
@@ -674,9 +674,9 @@ namespace Xtensive.Orm.Linq
 
       var arguments = VisitNewExpressionArguments(newExpression);
       if (strippedMarkersExpression.IsAnonymousConstructor()) {
-        return newExpression.Members == null
+        return newExpressionMembers is null
           ? Expression.New(newExpression.Constructor, arguments)
-          : Expression.New(newExpression.Constructor, arguments, newExpression.Members);
+          : Expression.New(newExpression.Constructor, arguments, newExpressionMembers);
       }
 
       var constructorParameters = newExpression.GetConstructorParameters();

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
@@ -161,10 +161,9 @@ namespace Xtensive.Orm.Linq
         using (CreateScope(new TranslatorState(State) { CalculateExpressions = false })) {
           body = Visit(argument);
         }
-        body = body.StripMarkers().IsProjection()
+        arguments[i++] = body.StripMarkers().IsProjection()
           ? BuildSubqueryResult((ProjectionExpression) body, argument.Type)
           : ProcessProjectionElement(body);
-        arguments[i++] = body;
       }
       var constructorParameters = n.GetConstructorParameters();
       for (i = 0; i < count; i++) {

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
@@ -152,9 +152,10 @@ namespace Xtensive.Orm.Linq
       return new Materializer(projectorExpression.CachingCompile());
     }
 
-    private List<Expression> VisitNewExpressionArguments(NewExpression n)
+    private IReadOnlyList<Expression> VisitNewExpressionArguments(NewExpression n)
     {
-      var arguments = new List<Expression>();
+      int i = 0, count = n.Arguments.Count;
+      var arguments = new Expression[count];
       foreach (var argument in n.Arguments) {
         Expression body;
         using (CreateScope(new TranslatorState(State) { CalculateExpressions = false })) {
@@ -163,12 +164,15 @@ namespace Xtensive.Orm.Linq
         body = body.StripMarkers().IsProjection()
           ? BuildSubqueryResult((ProjectionExpression) body, argument.Type)
           : ProcessProjectionElement(body);
-        arguments.Add(body);
+        arguments[i++] = body;
       }
       var constructorParameters = n.GetConstructorParameters();
-      for (int i = 0; i < arguments.Count; i++) {
-        if (arguments[i].Type != constructorParameters[i].ParameterType)
-          arguments[i] = Expression.Convert(arguments[i], constructorParameters[i].ParameterType);
+      for (i = 0; i < count; i++) {
+        var parameterType = constructorParameters[i].ParameterType;
+        ref var argument = ref arguments[i];
+        if (argument.Type != parameterType) {
+          argument = Expression.Convert(argument, parameterType);
+        }
       }
       return arguments;
     }


### PR DESCRIPTION
* Don't invoke the same Expression properties multiple times
* Replace `ReadOnlyCollection` by `IReadOnlyList<>` implemented as by array