### PR TITLE
`Transaction.Timeout` property

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
@@ -436,6 +436,7 @@ namespace Xtensive.Orm.Providers
         SqlLog.Info(nameof(Strings.LogSessionXQueryY), session.ToStringSafely(), command.ToHumanReadableString());
       }
 
+      session?.Transaction?.CheckForTimeout(command);
       session?.Events.NotifyDbCommandExecuting(command);
 
       TResult result;
@@ -462,6 +463,7 @@ namespace Xtensive.Orm.Providers
       }
 
       cancellationToken.ThrowIfCancellationRequested();
+      session?.Transaction?.CheckForTimeout(command);
       session?.Events.NotifyDbCommandExecuting(command);
 
       TResult result;

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
@@ -466,7 +466,7 @@ namespace Xtensive.Orm.Providers
       DbCommand command, CommandBehavior commandBehavior,
       CancellationToken cancellationToken, Func<DbCommand, CommandBehavior, CancellationToken, Task<TResult>> action)
     {
-      PreDbCommandExecuting(session, command);
+      PreDbCommandExecuting(session, command, cancellationToken);
 
       TResult result;
       try {

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
@@ -397,14 +397,14 @@ namespace Xtensive.Orm.Providers
     #region Sync Execute methods
 
     public int ExecuteNonQuery(Session session, DbCommand command) =>
-      ExecuteCommand(session, command, CommandBehavior.Default, (c, cb) => c.ExecuteNonQuery());
+      ExecuteCommand(session, command, CommandBehavior.Default, static (c, cb) => c.ExecuteNonQuery());
 
     public object ExecuteScalar(Session session, DbCommand command) =>
-      ExecuteCommand(session, command, CommandBehavior.Default, (c, cb) => c.ExecuteScalar());
+      ExecuteCommand(session, command, CommandBehavior.Default, static (c, cb) => c.ExecuteScalar());
 
     public DbDataReader ExecuteReader(Session session, DbCommand command,
       CommandBehavior behavior = CommandBehavior.Default) =>
-      ExecuteCommand(session, command, behavior, (c, cb) => c.ExecuteReader(cb));
+      ExecuteCommand(session, command, behavior, static (c, cb) => c.ExecuteReader(cb));
 
     #endregion
 
@@ -412,11 +412,11 @@ namespace Xtensive.Orm.Providers
 
     public Task<int> ExecuteNonQueryAsync(Session session, DbCommand command, CancellationToken cancellationToken = default) =>
       ExecuteCommandAsync(session, command, CommandBehavior.Default, cancellationToken,
-        (c, cb, ct) => c.ExecuteNonQueryAsync(ct));
+        static (c, cb, ct) => c.ExecuteNonQueryAsync(ct));
 
     public Task<object> ExecuteScalarAsync(Session session, DbCommand command, CancellationToken cancellationToken = default) =>
       ExecuteCommandAsync(session, command, CommandBehavior.Default, cancellationToken,
-        (c, cb, ct) => c.ExecuteScalarAsync(ct));
+        static (c, cb, ct) => c.ExecuteScalarAsync(ct));
 
     public Task<DbDataReader> ExecuteReaderAsync(Session session, DbCommand command,
       CancellationToken cancellationToken = default) =>
@@ -425,19 +425,27 @@ namespace Xtensive.Orm.Providers
     public Task<DbDataReader> ExecuteReaderAsync(
       Session session, DbCommand command, CommandBehavior behavior, CancellationToken cancellationToken = default) =>
       ExecuteCommandAsync(session, command, behavior, cancellationToken,
-        (c, cb, ct) => c.ExecuteReaderAsync(cb, ct));
+        static (c, cb, ct) => c.ExecuteReaderAsync(cb, ct));
 
     #endregion
 
-    private TResult ExecuteCommand<TResult>(
-      Session session, DbCommand command, CommandBehavior commandBehavior, Func<DbCommand, CommandBehavior, TResult> action)
+    private void PreDbCommandExecuting(Session session, DbCommand command, CancellationToken ct = default)
     {
       if (isLoggingEnabled) {
         SqlLog.Info(nameof(Strings.LogSessionXQueryY), session.ToStringSafely(), command.ToHumanReadableString());
       }
 
-      session?.Transaction?.CheckForTimeout(command);
-      session?.Events.NotifyDbCommandExecuting(command);
+      ct.ThrowIfCancellationRequested();
+      if (session is not null) {
+        session.Transaction?.CheckForTimeout(command);
+        session.Events.NotifyDbCommandExecuting(command);
+      }
+    }
+
+    private TResult ExecuteCommand<TResult>(
+      Session session, DbCommand command, CommandBehavior commandBehavior, Func<DbCommand, CommandBehavior, TResult> action)
+    {
+      PreDbCommandExecuting(session, command);
 
       TResult result;
       try {
@@ -458,13 +466,7 @@ namespace Xtensive.Orm.Providers
       DbCommand command, CommandBehavior commandBehavior,
       CancellationToken cancellationToken, Func<DbCommand, CommandBehavior, CancellationToken, Task<TResult>> action)
     {
-      if (isLoggingEnabled) {
-        SqlLog.Info(nameof(Strings.LogSessionXQueryY), session.ToStringSafely(), command.ToHumanReadableString());
-      }
-
-      cancellationToken.ThrowIfCancellationRequested();
-      session?.Transaction?.CheckForTimeout(command);
-      session?.Events.NotifyDbCommandExecuting(command);
+      PreDbCommandExecuting(session, command);
 
       TResult result;
       try {

--- a/Orm/Xtensive.Orm/Orm/Session.Transactions.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.Transactions.cs
@@ -18,8 +18,6 @@ namespace Xtensive.Orm
 {
   public partial class Session
   {
-    private const string SavepointNameFormat = "s{0}";
-
     private readonly StateLifetimeToken sessionLifetimeToken = new StateLifetimeToken();
     private int nextSavepoint;
 
@@ -407,10 +405,7 @@ namespace Xtensive.Orm
       throw new InvalidOperationException(Strings.ExCanNotReuseOpenedTransactionRequestedIsolationLevelIsDifferent);
     }
 
-    private string GetNextSavepointName()
-    {
-      return string.Format(SavepointNameFormat, nextSavepoint++);
-    }
+    private string GetNextSavepointName() => $"s{nextSavepoint++}";
 
     private void ClearChangeRegistry()
     {

--- a/Orm/Xtensive.Orm/Orm/Transaction.cs
+++ b/Orm/Xtensive.Orm/Orm/Transaction.cs
@@ -56,7 +56,7 @@ namespace Xtensive.Orm
 
     #endregion
 
-    private readonly List<StateLifetimeToken> lifetimeTokens;
+    private readonly List<StateLifetimeToken> lifetimeTokens = new(1);
 
     private ExtensionCollection extensions;
     private Transaction inner;
@@ -92,7 +92,7 @@ namespace Xtensive.Orm
     /// <summary>
     /// Gets the state of the transaction.
     /// </summary>
-    public TransactionState State { get; private set; }
+    public TransactionState State { get; private set; } = TransactionState.NotActivated;
 
     /// <summary>
     /// Gets the outer transaction.
@@ -107,7 +107,7 @@ namespace Xtensive.Orm
     /// <summary>
     /// Gets the start time of this transaction.
     /// </summary>
-    public DateTime TimeStamp { get; }
+    public DateTime TimeStamp { get; } = DateTime.UtcNow;
 
     private TimeSpan? timeout;
     /// <summary>
@@ -128,7 +128,7 @@ namespace Xtensive.Orm
     /// <summary>
     /// Gets <see cref="StateLifetimeToken"/> associated with this transaction.
     /// </summary>
-    public StateLifetimeToken LifetimeToken { get; private set; }
+    public StateLifetimeToken LifetimeToken { get; private set; } = new();
 
     #region IHasExtensions Members
 
@@ -292,22 +292,14 @@ namespace Xtensive.Orm
 
     // Constructors
 
-    internal Transaction(Session session, IsolationLevel isolationLevel, bool isAutomatic)
-      : this(session, isolationLevel, isAutomatic, null, null)
+    internal Transaction(Session session, IsolationLevel isolationLevel, bool isAutomatic, Transaction outer = null,
+      string savepointName = null)
     {
-    }
-
-    internal Transaction(Session session, IsolationLevel isolationLevel, bool isAutomatic, Transaction outer,
-      string savepointName)
-    {
-      State = TransactionState.NotActivated;
       Session = session;
       IsolationLevel = isolationLevel;
       IsAutomatic = isAutomatic;
       IsDisconnected = session.IsDisconnected;
-      TimeStamp = DateTime.UtcNow;
-      LifetimeToken = new StateLifetimeToken();
-      lifetimeTokens = new List<StateLifetimeToken> { LifetimeToken };
+      lifetimeTokens.Add(LifetimeToken);
 
       if (outer != null) {
         Outer = outer;

--- a/Orm/Xtensive.Orm/Orm/Transaction.cs
+++ b/Orm/Xtensive.Orm/Orm/Transaction.cs
@@ -300,8 +300,6 @@ namespace Xtensive.Orm
     internal Transaction(Session session, IsolationLevel isolationLevel, bool isAutomatic, Transaction outer,
       string savepointName)
     {
-      lifetimeTokens = new List<StateLifetimeToken>();
-
       State = TransactionState.NotActivated;
       Session = session;
       IsolationLevel = isolationLevel;
@@ -309,7 +307,7 @@ namespace Xtensive.Orm
       IsDisconnected = session.IsDisconnected;
       TimeStamp = DateTime.UtcNow;
       LifetimeToken = new StateLifetimeToken();
-      lifetimeTokens.Add(LifetimeToken);
+      lifetimeTokens = new List<StateLifetimeToken> { LifetimeToken };
 
       if (outer != null) {
         Outer = outer;

--- a/Orm/Xtensive.Orm/Orm/Transaction.cs
+++ b/Orm/Xtensive.Orm/Orm/Transaction.cs
@@ -103,7 +103,7 @@ namespace Xtensive.Orm
     /// <summary>
     /// Gets the outermost transaction.
     /// </summary>
-    public Transaction Outermost { get; }
+    public Transaction Outermost => Outer?.Outermost ?? this;
 
     /// <summary>
     /// Gets the start time of this transaction.
@@ -304,11 +304,7 @@ namespace Xtensive.Orm
 
       if (outer != null) {
         Outer = outer;
-        Outermost = outer.Outermost;
         SavepointName = savepointName;
-      }
-      else {
-        Outermost = this;
       }
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Transaction.cs
+++ b/Orm/Xtensive.Orm/Orm/Transaction.cs
@@ -72,12 +72,13 @@ namespace Xtensive.Orm
     /// </summary>
     public bool IsDisconnected { get; }
 
+    private Guid? guid;
     /// <summary>
     /// Gets the unique identifier of this transaction.
     /// Nested transactions have the same <see cref="Guid"/> 
     /// as their outermost.
     /// </summary>
-    public Guid Guid { get; }
+    public Guid Guid => Outer?.Guid ?? (guid ??= Guid.NewGuid());
 
     /// <summary>
     /// Gets the session this transaction is bound to.
@@ -303,12 +304,10 @@ namespace Xtensive.Orm
 
       if (outer != null) {
         Outer = outer;
-        Guid = outer.Guid;
         Outermost = outer.Outermost;
         SavepointName = savepointName;
       }
       else {
-        Guid = Guid.NewGuid();
         Outermost = this;
       }
     }

--- a/Orm/Xtensive.Orm/Strings.Designer.cs
+++ b/Orm/Xtensive.Orm/Strings.Designer.cs
@@ -1360,7 +1360,7 @@ namespace Xtensive {
                 return ResourceManager.GetString("ExDateOnlyToStringMethodIsNotSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to DateTime.ToString() method is not supported, use the DateTime.ToString(&quot;s&quot;)..
         /// </summary>
@@ -1974,7 +1974,7 @@ namespace Xtensive {
                 return ResourceManager.GetString("ExIgnoreRuleIsAlreadyConfiguredForX", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Ignore rule &apos;{0}&apos; must be applied to column, index or table..
         /// </summary>
@@ -2848,7 +2848,7 @@ namespace Xtensive {
                 return ResourceManager.GetString("ExMaxNumberOfConditionsShouldBeBetweenXAndY", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Measurement is already completed..
         /// </summary>
@@ -3081,6 +3081,15 @@ namespace Xtensive {
         internal static string ExNestedFieldXIsNotSupported {
             get {
                 return ResourceManager.GetString("ExNestedFieldXIsNotSupported", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Nested transaction cannot have timeout.
+        /// </summary>
+        internal static string ExNestedTransactionTimeout {
+            get {
+                return ResourceManager.GetString("ExNestedTransactionTimeout", resourceCulture);
             }
         }
 
@@ -4325,7 +4334,7 @@ namespace Xtensive {
                 return ResourceManager.GetString("ExTimeOnlyToStringMethodIsNotSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Transaction is not active..
         /// </summary>
@@ -4354,6 +4363,15 @@ namespace Xtensive {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Transaction is longer than {0}.
+        /// </summary>
+        internal static string ExTransactionTimeout {
+            get {
+                return ResourceManager.GetString("ExTransactionTimeout", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Translation of DateOnly.ToString(string) with arbitrary arguments is not supported. Use DateOnly.ToString(&quot;s&quot;)..
         /// </summary>
         internal static string ExTranslationOfDateOnlyToStringWithArbitraryArgumentIsNotSupported {
@@ -4361,7 +4379,7 @@ namespace Xtensive {
                 return ResourceManager.GetString("ExTranslationOfDateOnlyToStringWithArbitraryArgumentIsNotSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Translation of DateTime.ToString(string) with arbitrary arguments is not supported. Use DateTime.ToString(&quot;s&quot;)..
         /// </summary>
@@ -4397,7 +4415,7 @@ namespace Xtensive {
                 return ResourceManager.GetString("ExTranslationOfTimeOnlyToStringWithArbitraryArgumentIsNotSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Translation of {0} method does not support any parameter type, but {1}..
         /// </summary>
@@ -4659,7 +4677,7 @@ namespace Xtensive {
                 return ResourceManager.GetString("ExUnableToActualizeSchemaNodeInQuery", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Unable to apply VersionAttribute with VersionMode.Auto or Version.Mode.Manual mode set on field {0} of type {1}. Only VersionMode.Skip is allowed..
         /// </summary>

--- a/Orm/Xtensive.Orm/Strings.resx
+++ b/Orm/Xtensive.Orm/Strings.resx
@@ -2603,4 +2603,10 @@ Error: {1}</value>
   <data name="ExMaxNumberOfConditionsShouldBeBetweenXAndY" xml:space="preserve">
     <value>DomainConfiguration.MaxNumberOfConditions should be between {0} and {1} (included).</value>
   </data>
+  <data name="ExNestedTransactionTimeout" xml:space="preserve">
+    <value>Nested transaction cannot have timeout</value>
+  </data>
+  <data name="ExTransactionTimeout" xml:space="preserve">
+    <value>Transaction is longer than {0}</value>
+  </data>
 </root>


### PR DESCRIPTION
Transactions with this property assign `DbCommand.CommandTimeout` to time, remaining until the end of entire transaction
If the timeout already come then throws `TimeoutException`.

Also:
* refactor `Transaction` class
* Make generating `Transaction.Guid` lazy (it is not used in typical case)