### PR TITLE
Proposes changes on top of DataObjects-NET#274

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ExtendedExpressionReplacer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ExtendedExpressionReplacer.cs
@@ -72,7 +72,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       return expression;
     }
 
-    private Expression TranslateExpression(Provider provider, Expression original)
+    private Expression TranslateExpression(CompilableProvider provider, Expression original)
     {
       var result = Visit(original);
       return result ?? original;

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/ApplyParameterToTupleParameterRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/ApplyParameterToTupleParameterRewriter.cs
@@ -74,7 +74,7 @@ namespace Xtensive.Orm.Linq.Rewriters
       return expression;
     }
 
-    private Expression RewriteExpression(Provider provider, Expression expression)
+    private Expression RewriteExpression(CompilableProvider provider, Expression expression)
     {
       return Visit(expression);
     }

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProviderVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProviderVisitor.cs
@@ -18,7 +18,7 @@ namespace Xtensive.Orm.Rse.Providers
   /// <see cref="CompilableProvider"/> visitor class. Result is <see cref="CompilableProvider"/>.
   /// </summary>
   [Serializable]
-  public class CompilableProviderVisitor
+  public class CompilableProviderVisitor : ProviderVisitor
   {
     protected Func<CompilableProvider, Expression, Expression> translate;
 
@@ -28,52 +28,8 @@ namespace Xtensive.Orm.Rse.Providers
     /// <param name="cp">The compilable provider.</param>
     public CompilableProvider VisitCompilable(CompilableProvider cp) => Visit(cp);
 
-    /// <summary>
-    /// Visits the specified <paramref name="cp"/>.
-    /// </summary>
-    /// <param name="cp">The <see cref="CompilableProvider"/> to visit.</param>
-    /// <returns>Visit result.</returns>
-    protected virtual CompilableProvider Visit(CompilableProvider cp) =>
-      cp == null
-        ? null
-        : cp.Type switch {
-          ProviderType.Index => VisitIndex((IndexProvider) cp),
-          ProviderType.Store => VisitStore((StoreProvider) cp),
-          ProviderType.Aggregate => VisitAggregate((AggregateProvider) cp),
-          ProviderType.Alias => VisitAlias((AliasProvider) cp),
-          ProviderType.Calculate => VisitCalculate((CalculateProvider) cp),
-          ProviderType.Distinct => VisitDistinct((DistinctProvider) cp),
-          ProviderType.Filter => VisitFilter((FilterProvider) cp),
-          ProviderType.Join => VisitJoin((JoinProvider) cp),
-          ProviderType.Sort => VisitSort((SortProvider) cp),
-          ProviderType.Raw => VisitRaw((RawProvider) cp),
-          ProviderType.Seek => VisitSeek((SeekProvider) cp),
-          ProviderType.Select => VisitSelect((SelectProvider) cp),
-          ProviderType.Tag => VisitTag((TagProvider) cp),
-          ProviderType.Skip => VisitSkip((SkipProvider) cp),
-          ProviderType.Take => VisitTake((TakeProvider) cp),
-          ProviderType.Paging => VisitPaging((PagingProvider) cp),
-          ProviderType.RowNumber => VisitRowNumber((RowNumberProvider) cp),
-          ProviderType.Apply => VisitApply((ApplyProvider) cp),
-          ProviderType.Existence => VisitExistence((ExistenceProvider) cp),
-          ProviderType.PredicateJoin => VisitPredicateJoin((PredicateJoinProvider) cp),
-          ProviderType.Intersect => VisitIntersect((IntersectProvider) cp),
-          ProviderType.Except => VisitExcept((ExceptProvider) cp),
-          ProviderType.Concat => VisitConcat((ConcatProvider) cp),
-          ProviderType.Union => VisitUnion((UnionProvider) cp),
-          ProviderType.Lock => VisitLock((LockProvider) cp),
-          ProviderType.Include => VisitInclude((IncludeProvider) cp),
-          ProviderType.FreeText => VisitFreeText((FreeTextProvider) cp),
-          ProviderType.ContainsTable => VisitContainsTable((ContainsTableProvider) cp),
-          ProviderType.Void => throw new NotSupportedException(Strings.ExProcessingOfVoidProviderIsNotSupported),
-          _ => throw new ArgumentOutOfRangeException()
-        };
-
-    /// <summary>
-    /// Visits <see cref="TakeProvider"/>.
-    /// </summary>
-    /// <param name="provider">Take provider.</param>
-    protected virtual CompilableProvider VisitTake(TakeProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitTake(TakeProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -81,11 +37,8 @@ namespace Xtensive.Orm.Rse.Providers
       return source == provider.Source ? provider : new TakeProvider(source, provider.Count);
     }
 
-    /// <summary>
-    /// Visits <see cref="SkipProvider"/>.
-    /// </summary>
-    /// <param name="provider">Skip provider.</param>
-    protected virtual CompilableProvider VisitSkip(SkipProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitSkip(SkipProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -93,11 +46,8 @@ namespace Xtensive.Orm.Rse.Providers
       return source == provider.Source ? provider : new SkipProvider(source, provider.Count);
     }
 
-    /// <summary>
-    /// Visits <see cref="PagingProvider"/>.
-    /// </summary>
-    /// <param name="provider">Paging provider.</param>
-    protected virtual CompilableProvider VisitPaging(PagingProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitPaging(PagingProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -105,11 +55,8 @@ namespace Xtensive.Orm.Rse.Providers
       return source == provider.Source ? provider : new PagingProvider(source, provider);
     }
 
-    /// <summary>
-    /// Visits <see cref="SelectProvider"/>.
-    /// </summary>
-    /// <param name="provider">Select provider.</param>
-    protected virtual CompilableProvider VisitSelect(SelectProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitSelect(SelectProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -119,11 +66,8 @@ namespace Xtensive.Orm.Rse.Providers
         : new SelectProvider(source, columnIndexes ?? provider.ColumnIndexes);
     }
 
-    /// <summary>
-    /// Visits <see cref="TagProvider"/>.
-    /// </summary>
-    /// <param name="provider">Tag provider.</param>
-    protected virtual CompilableProvider VisitTag(TagProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitTag(TagProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -131,11 +75,8 @@ namespace Xtensive.Orm.Rse.Providers
       return source == provider.Source ? provider : new TagProvider(source, provider.Tag);
     }
 
-    /// <summary>
-    /// Visits <see cref="SeekProvider"/>.
-    /// </summary>
-    /// <param name="provider">Seek provider.</param>
-    protected virtual CompilableProvider VisitSeek(SeekProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitSeek(SeekProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -143,20 +84,14 @@ namespace Xtensive.Orm.Rse.Providers
       return source == provider.Source ? provider : new SeekProvider(source, provider.Key);
     }
 
-    /// <summary>
-    /// Visits <see cref="RawProvider"/>.
-    /// </summary>
-    /// <param name="provider">Raw provider.</param>
-    protected virtual CompilableProvider VisitRaw(RawProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitRaw(RawProvider provider)
     {
       return provider;
     }
 
-    /// <summary>
-    /// Visits <see cref="SortProvider"/>.
-    /// </summary>
-    /// <param name="provider">Sort provider.</param>
-    protected virtual CompilableProvider VisitSort(SortProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitSort(SortProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -166,11 +101,8 @@ namespace Xtensive.Orm.Rse.Providers
         : new SortProvider(source, (order == null) ? provider.Order : (DirectionCollection<int>)order);
     }
 
-    /// <summary>
-    /// Visits <see cref="JoinProvider"/>.
-    /// </summary>
-    /// <param name="provider">Join provider.</param>
-    protected virtual CompilableProvider VisitJoin(JoinProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitJoin(JoinProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -182,11 +114,8 @@ namespace Xtensive.Orm.Rse.Providers
             equalIndexes != null ? (Pair<int>[])equalIndexes : provider.EqualIndexes);
     }
 
-    /// <summary>
-    /// Visits <see cref="FilterProvider"/>.
-    /// </summary>
-    /// <param name="provider">Filter provider.</param>
-    protected virtual CompilableProvider VisitFilter(FilterProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitFilter(FilterProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -197,11 +126,8 @@ namespace Xtensive.Orm.Rse.Providers
         : new FilterProvider(source, (Expression<Func<Tuple, bool>>) predicate);
     }
 
-    /// <summary>
-    /// Visits <see cref="DistinctProvider"/>.
-    /// </summary>
-    /// <param name="provider">Distinct provider.</param>
-    protected virtual CompilableProvider VisitDistinct(DistinctProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitDistinct(DistinctProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -209,11 +135,8 @@ namespace Xtensive.Orm.Rse.Providers
       return source == provider.Source ? provider : new DistinctProvider(source);
     }
 
-    /// <summary>
-    /// Visits <see cref="CalculateProvider"/>.
-    /// </summary>
-    /// <param name="provider">Calculate provider.</param>
-    protected virtual CompilableProvider VisitCalculate(CalculateProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitCalculate(CalculateProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -232,11 +155,8 @@ namespace Xtensive.Orm.Rse.Providers
         : new CalculateProvider(source, descriptors.ToArray());
     }
 
-    /// <summary>
-    /// Visits <see cref="RowNumberProvider"/>.
-    /// </summary>
-    /// <param name="provider">Row number provider.</param>
-    protected virtual CompilableProvider VisitRowNumber(RowNumberProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitRowNumber(RowNumberProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -245,11 +165,8 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
 
-    /// <summary>
-    /// Visits <see cref="AliasProvider"/>.
-    /// </summary>
-    /// <param name="provider">Alias provider.</param>
-    protected virtual CompilableProvider VisitAlias(AliasProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitAlias(AliasProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -257,12 +174,8 @@ namespace Xtensive.Orm.Rse.Providers
       return source == provider.Source ? provider : new AliasProvider(source, provider.Alias);
     }
 
-    /// <summary>
-    /// Visits <see cref="AggregateProvider"/>.
-    /// </summary>
-    /// <param name="provider">Aggregate provider.</param>
-    /// <returns></returns>
-    protected virtual CompilableProvider VisitAggregate(AggregateProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitAggregate(AggregateProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -278,11 +191,8 @@ namespace Xtensive.Orm.Rse.Providers
       return new AggregateProvider(source, result.First, result.Second);
     }
 
-    /// <summary>
-    /// Visits <see cref="StoreProvider"/>.
-    /// </summary>
-    /// <param name="provider">Store provider.</param>
-    protected virtual CompilableProvider VisitStore(StoreProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitStore(StoreProvider provider)
     {
       var compilableSource = provider.Source;
       OnRecursionEntrance(provider);
@@ -291,46 +201,32 @@ namespace Xtensive.Orm.Rse.Providers
       return source == compilableSource ? provider : new StoreProvider(source, provider.Name);
     }
 
-    /// <summary>
-    /// Visits <see cref="IndexProvider"/>.
-    /// </summary>
-    /// <param name="provider">Index provider.</param>
-    protected virtual CompilableProvider VisitIndex(IndexProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitIndex(IndexProvider provider)
     {
       OnRecursionEntrance(provider);
       _ = OnRecursionExit(provider);
       return provider;
     }
 
-    /// <summary>
-    /// Visits the <see cref="FreeTextProvider"/>.
-    /// </summary>
-    /// <param name="provider">FreeText provider.</param>
-    /// <returns></returns>
-    protected virtual CompilableProvider VisitFreeText(FreeTextProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitFreeText(FreeTextProvider provider)
     {
       OnRecursionEntrance(provider);
       _ = OnRecursionExit(provider);
       return provider;
     }
 
-    /// <summary>
-    /// Visits the <see cref="ContainsTableProvider"/>.
-    /// </summary>
-    /// <param name="provider">SearchCondition provider.</param>
-    /// <returns></returns>
-    protected virtual CompilableProvider VisitContainsTable(ContainsTableProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitContainsTable(ContainsTableProvider provider)
     {
       OnRecursionEntrance(provider);
       _ = OnRecursionExit(provider);
       return provider;
     }
 
-    /// <summary>
-    /// Visits <see cref="PredicateJoinProvider"/>.
-    /// </summary>
-    /// <param name="provider">Predicate join provider.</param>
-    protected virtual CompilableProvider VisitPredicateJoin(PredicateJoinProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitPredicateJoin(PredicateJoinProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -341,11 +237,8 @@ namespace Xtensive.Orm.Rse.Providers
         : new PredicateJoinProvider(left, right, predicate ?? provider.Predicate, provider.JoinType);
     }
 
-    /// <summary>
-    /// Visits <see cref="ExistenceProvider"/>.
-    /// </summary>
-    /// <param name="provider">Existence provider.</param>
-    protected virtual CompilableProvider VisitExistence(ExistenceProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitExistence(ExistenceProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -353,11 +246,8 @@ namespace Xtensive.Orm.Rse.Providers
       return source == provider.Source ? provider : new ExistenceProvider(source, provider.ExistenceColumnName);
     }
 
-    /// <summary>
-    /// Visits <see cref="ApplyProvider"/>.
-    /// </summary>
-    /// <param name="provider">Apply provider.</param>
-    protected virtual CompilableProvider VisitApply(ApplyProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitApply(ApplyProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -369,12 +259,8 @@ namespace Xtensive.Orm.Rse.Providers
             provider.IsInlined, provider.SequenceType, provider.ApplyType);
     }
 
-    /// <summary>
-    /// Visits the <see cref="IntersectProvider"/>.
-    /// </summary>
-    /// <param name="provider">Intersect provider.</param>
-    /// <returns></returns>
-    protected virtual CompilableProvider VisitIntersect(IntersectProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitIntersect(IntersectProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -385,12 +271,8 @@ namespace Xtensive.Orm.Rse.Providers
         : new IntersectProvider(left, right);
     }
 
-    /// <summary>
-    /// Visits the <see cref="ExceptProvider"/>.
-    /// </summary>
-    /// <param name="provider">Except provider.</param>
-    /// <returns></returns>
-    protected virtual CompilableProvider VisitExcept(ExceptProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitExcept(ExceptProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -401,12 +283,8 @@ namespace Xtensive.Orm.Rse.Providers
         : new ExceptProvider(left, right);
     }
 
-    /// <summary>
-    /// Visits the <see cref="ConcatProvider"/>.
-    /// </summary>
-    /// <param name="provider">Concat provider.</param>
-    /// <returns></returns>
-    protected virtual CompilableProvider VisitConcat(ConcatProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitConcat(ConcatProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -417,12 +295,8 @@ namespace Xtensive.Orm.Rse.Providers
         : new ConcatProvider(left, right);
     }
 
-    /// <summary>
-    /// Visits the <see cref="UnionProvider"/>.
-    /// </summary>
-    /// <param name="provider">Union provider.</param>
-    /// <returns></returns>
-    protected virtual CompilableProvider VisitUnion(UnionProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitUnion(UnionProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -433,12 +307,8 @@ namespace Xtensive.Orm.Rse.Providers
         : new UnionProvider(left, right);
     }
 
-    /// <summary>
-    /// Visits the <see cref="LockProvider"/>.
-    /// </summary>
-    /// <param name="provider">Lock provider.</param>
-    /// <returns></returns>
-    protected virtual CompilableProvider VisitLock(LockProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitLock(LockProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -446,12 +316,8 @@ namespace Xtensive.Orm.Rse.Providers
       return source == provider.Source ? provider : new LockProvider(source, provider.LockMode, provider.LockBehavior);
     }
 
-    /// <summary>
-    /// Visits the <see cref="IncludeProvider"/>.
-    /// </summary>
-    /// <param name="provider">Include provider.</param>
-    /// <returns></returns>
-    protected virtual CompilableProvider VisitInclude(IncludeProvider provider)
+    /// <inheritdoc/>
+    protected override CompilableProvider VisitInclude(IncludeProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProviderVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProviderVisitor.cs
@@ -18,9 +18,9 @@ namespace Xtensive.Orm.Rse.Providers
   /// <see cref="CompilableProvider"/> visitor class. Result is <see cref="CompilableProvider"/>.
   /// </summary>
   [Serializable]
-  public class CompilableProviderVisitor : ProviderVisitor
+  public class CompilableProviderVisitor
   {
-    protected Func<Provider, Expression, Expression> translate;
+    protected Func<CompilableProvider, Expression, Expression> translate;
 
     /// <summary>
     /// Visits the compilable provider.
@@ -28,41 +28,94 @@ namespace Xtensive.Orm.Rse.Providers
     /// <param name="cp">The compilable provider.</param>
     public CompilableProvider VisitCompilable(CompilableProvider cp) => Visit(cp);
 
-    /// <inheritdoc/>
-    protected override CompilableProvider VisitTake(TakeProvider provider)
+    /// <summary>
+    /// Visits the specified <paramref name="cp"/>.
+    /// </summary>
+    /// <param name="cp">The <see cref="CompilableProvider"/> to visit.</param>
+    /// <returns>Visit result.</returns>
+    protected virtual CompilableProvider Visit(CompilableProvider cp) =>
+      cp == null
+        ? null
+        : cp.Type switch {
+          ProviderType.Index => VisitIndex((IndexProvider) cp),
+          ProviderType.Store => VisitStore((StoreProvider) cp),
+          ProviderType.Aggregate => VisitAggregate((AggregateProvider) cp),
+          ProviderType.Alias => VisitAlias((AliasProvider) cp),
+          ProviderType.Calculate => VisitCalculate((CalculateProvider) cp),
+          ProviderType.Distinct => VisitDistinct((DistinctProvider) cp),
+          ProviderType.Filter => VisitFilter((FilterProvider) cp),
+          ProviderType.Join => VisitJoin((JoinProvider) cp),
+          ProviderType.Sort => VisitSort((SortProvider) cp),
+          ProviderType.Raw => VisitRaw((RawProvider) cp),
+          ProviderType.Seek => VisitSeek((SeekProvider) cp),
+          ProviderType.Select => VisitSelect((SelectProvider) cp),
+          ProviderType.Tag => VisitTag((TagProvider) cp),
+          ProviderType.Skip => VisitSkip((SkipProvider) cp),
+          ProviderType.Take => VisitTake((TakeProvider) cp),
+          ProviderType.Paging => VisitPaging((PagingProvider) cp),
+          ProviderType.RowNumber => VisitRowNumber((RowNumberProvider) cp),
+          ProviderType.Apply => VisitApply((ApplyProvider) cp),
+          ProviderType.Existence => VisitExistence((ExistenceProvider) cp),
+          ProviderType.PredicateJoin => VisitPredicateJoin((PredicateJoinProvider) cp),
+          ProviderType.Intersect => VisitIntersect((IntersectProvider) cp),
+          ProviderType.Except => VisitExcept((ExceptProvider) cp),
+          ProviderType.Concat => VisitConcat((ConcatProvider) cp),
+          ProviderType.Union => VisitUnion((UnionProvider) cp),
+          ProviderType.Lock => VisitLock((LockProvider) cp),
+          ProviderType.Include => VisitInclude((IncludeProvider) cp),
+          ProviderType.FreeText => VisitFreeText((FreeTextProvider) cp),
+          ProviderType.ContainsTable => VisitContainsTable((ContainsTableProvider) cp),
+          ProviderType.Void => throw new NotSupportedException(Strings.ExProcessingOfVoidProviderIsNotSupported),
+          _ => throw new ArgumentOutOfRangeException()
+        };
+
+    /// <summary>
+    /// Visits <see cref="TakeProvider"/>.
+    /// </summary>
+    /// <param name="provider">Take provider.</param>
+    protected virtual CompilableProvider VisitTake(TakeProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       if (source == provider.Source)
         return provider;
       return new TakeProvider(source, provider.Count);
     }
 
-    /// <inheritdoc/>
-    protected override CompilableProvider VisitSkip(SkipProvider provider)
+    /// <summary>
+    /// Visits <see cref="SkipProvider"/>.
+    /// </summary>
+    /// <param name="provider">Skip provider.</param>
+    protected virtual CompilableProvider VisitSkip(SkipProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       if (source == provider.Source)
         return provider;
       return new SkipProvider(source, provider.Count);
     }
 
-    /// <inheritdoc/>
-    protected override CompilableProvider VisitPaging(PagingProvider provider)
+    /// <summary>
+    /// Visits <see cref="PagingProvider"/>.
+    /// </summary>
+    /// <param name="provider">Paging provider.</param>
+    protected virtual CompilableProvider VisitPaging(PagingProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       if (source == provider.Source)
         return provider;
       return new PagingProvider(source, provider);
     }
 
-    /// <inheritdoc/>
-    protected override CompilableProvider VisitSelect(SelectProvider provider)
+    /// <summary>
+    /// Visits <see cref="SelectProvider"/>.
+    /// </summary>
+    /// <param name="provider">Select provider.</param>
+    protected virtual CompilableProvider VisitSelect(SelectProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -72,36 +125,48 @@ namespace Xtensive.Orm.Rse.Providers
       return new SelectProvider(source, columnIndexes ?? provider.ColumnIndexes);
     }
 
-    /// <inheritdoc/>
-    protected override TagProvider VisitTag(TagProvider provider)
+    /// <summary>
+    /// Visits <see cref="TagProvider"/>.
+    /// </summary>
+    /// <param name="provider">Tag provider.</param>
+    protected virtual CompilableProvider VisitTag(TagProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       if (source == provider.Source)
         return provider;
       return new TagProvider(source, provider.Tag);
     }
 
-    /// <inheritdoc/>
-    protected override CompilableProvider VisitSeek(SeekProvider provider)
+    /// <summary>
+    /// Visits <see cref="SeekProvider"/>.
+    /// </summary>
+    /// <param name="provider">Seek provider.</param>
+    protected virtual CompilableProvider VisitSeek(SeekProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       if (source==provider.Source)
         return provider;
       return new SeekProvider(source, provider.Key);
     }
 
-    /// <inheritdoc/>
-    protected override CompilableProvider VisitRaw(RawProvider provider)
+    /// <summary>
+    /// Visits <see cref="RawProvider"/>.
+    /// </summary>
+    /// <param name="provider">Raw provider.</param>
+    protected virtual CompilableProvider VisitRaw(RawProvider provider)
     {
       return provider;
     }
 
-    /// <inheritdoc/>
-    protected override CompilableProvider VisitSort(SortProvider provider)
+    /// <summary>
+    /// Visits <see cref="SortProvider"/>.
+    /// </summary>
+    /// <param name="provider">Sort provider.</param>
+    protected virtual CompilableProvider VisitSort(SortProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -111,8 +176,11 @@ namespace Xtensive.Orm.Rse.Providers
       return new SortProvider(source, (order == null) ? provider.Order : (DirectionCollection<int>)order);
     }
 
-    /// <inheritdoc/>
-    protected override CompilableProvider VisitJoin(JoinProvider provider)
+    /// <summary>
+    /// Visits <see cref="JoinProvider"/>.
+    /// </summary>
+    /// <param name="provider">Join provider.</param>
+    protected virtual CompilableProvider VisitJoin(JoinProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -124,35 +192,44 @@ namespace Xtensive.Orm.Rse.Providers
         equalIndexes != null ? (Pair<int>[])equalIndexes : provider.EqualIndexes);
     }
 
-    /// <inheritdoc/>
-    protected override CompilableProvider VisitFilter(FilterProvider provider)
+    /// <summary>
+    /// Visits <see cref="FilterProvider"/>.
+    /// </summary>
+    /// <param name="provider">Filter provider.</param>
+    protected virtual CompilableProvider VisitFilter(FilterProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       var predicate = translate(provider, provider.Predicate);
       if (source == provider.Source && predicate == provider.Predicate)
         return provider;
       return new FilterProvider(source, (Expression<Func<Tuple, bool>>) predicate);
     }
 
-    /// <inheritdoc/>
-    protected override DistinctProvider VisitDistinct(DistinctProvider provider)
+    /// <summary>
+    /// Visits <see cref="DistinctProvider"/>.
+    /// </summary>
+    /// <param name="provider">Distinct provider.</param>
+    protected virtual CompilableProvider VisitDistinct(DistinctProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       if (source == provider.Source)
         return provider;
       return new DistinctProvider(source);
     }
 
-    /// <inheritdoc/>
-    protected override CompilableProvider VisitCalculate(CalculateProvider provider)
+    /// <summary>
+    /// Visits <see cref="CalculateProvider"/>.
+    /// </summary>
+    /// <param name="provider">Calculate provider.</param>
+    protected virtual CompilableProvider VisitCalculate(CalculateProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       var translated = false;
       var descriptors = new List<CalculatedColumnDescriptor>(provider.CalculatedColumns.Length);
       foreach (var column in provider.CalculatedColumns) {
@@ -167,30 +244,41 @@ namespace Xtensive.Orm.Rse.Providers
       return new CalculateProvider(source, descriptors.ToArray());
     }
 
-    protected override CompilableProvider VisitRowNumber(RowNumberProvider provider)
+    /// <summary>
+    /// Visits <see cref="RowNumberProvider"/>.
+    /// </summary>
+    /// <param name="provider">Row number provider.</param>
+    protected virtual CompilableProvider VisitRowNumber(RowNumberProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       if (source == provider.Source)
         return provider;
       return new RowNumberProvider(source, provider.SystemColumn.Name);
     }
 
 
-    /// <inheritdoc/>
-    protected override AliasProvider VisitAlias(AliasProvider provider)
+    /// <summary>
+    /// Visits <see cref="AliasProvider"/>.
+    /// </summary>
+    /// <param name="provider">Alias provider.</param>
+    protected virtual CompilableProvider VisitAlias(AliasProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       if (source == provider.Source)
         return provider;
       return new AliasProvider(source, provider.Alias);
     }
 
-    /// <inheritdoc/>
-    protected override CompilableProvider VisitAggregate(AggregateProvider provider)
+    /// <summary>
+    /// Visits <see cref="AggregateProvider"/>.
+    /// </summary>
+    /// <param name="provider">Aggregate provider.</param>
+    /// <returns></returns>
+    protected virtual CompilableProvider VisitAggregate(AggregateProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -206,46 +294,61 @@ namespace Xtensive.Orm.Rse.Providers
       return new AggregateProvider(source, result.First, result.Second);
     }
 
-    /// <inheritdoc/>
-    protected override StoreProvider VisitStore(StoreProvider provider)
+    /// <summary>
+    /// Visits <see cref="StoreProvider"/>.
+    /// </summary>
+    /// <param name="provider">Store provider.</param>
+    protected virtual CompilableProvider VisitStore(StoreProvider provider)
     {
-      var compilableSource = provider.Source as CompilableProvider;
-      if (compilableSource == null)
-        return provider;
+      var compilableSource = provider.Source;
       OnRecursionEntrance(provider);
       var source = VisitCompilable(compilableSource);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       if (source == compilableSource)
         return provider;
       return new StoreProvider(source, provider.Name);
     }
 
-    /// <inheritdoc/>
-    protected override CompilableProvider VisitIndex(IndexProvider provider)
+    /// <summary>
+    /// Visits <see cref="IndexProvider"/>.
+    /// </summary>
+    /// <param name="provider">Index provider.</param>
+    protected virtual CompilableProvider VisitIndex(IndexProvider provider)
     {
       OnRecursionEntrance(provider);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       return provider;
     }
 
-    /// <inheritdoc/>
-    protected override CompilableProvider VisitFreeText(FreeTextProvider provider)
+    /// <summary>
+    /// Visits the <see cref="FreeTextProvider"/>.
+    /// </summary>
+    /// <param name="provider">FreeText provider.</param>
+    /// <returns></returns>
+    protected virtual CompilableProvider VisitFreeText(FreeTextProvider provider)
     {
       OnRecursionEntrance(provider);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       return provider;
     }
 
-    /// <inheritdoc/>
-    protected override ContainsTableProvider VisitContainsTable(ContainsTableProvider provider)
+    /// <summary>
+    /// Visits the <see cref="ContainsTableProvider"/>.
+    /// </summary>
+    /// <param name="provider">SearchCondition provider.</param>
+    /// <returns></returns>
+    protected virtual CompilableProvider VisitContainsTable(ContainsTableProvider provider)
     {
       OnRecursionEntrance(provider);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       return provider;
     }
 
-    /// <inheritdoc/>
-    protected override CompilableProvider VisitPredicateJoin(PredicateJoinProvider provider)
+    /// <summary>
+    /// Visits <see cref="PredicateJoinProvider"/>.
+    /// </summary>
+    /// <param name="provider">Predicate join provider.</param>
+    protected virtual CompilableProvider VisitPredicateJoin(PredicateJoinProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -256,102 +359,128 @@ namespace Xtensive.Orm.Rse.Providers
       return new PredicateJoinProvider(left, right, predicate ?? provider.Predicate, provider.JoinType);
     }
 
-    /// <inheritdoc/>
-    protected override ExistenceProvider VisitExistence(ExistenceProvider provider)
+    /// <summary>
+    /// Visits <see cref="ExistenceProvider"/>.
+    /// </summary>
+    /// <param name="provider">Existence provider.</param>
+    protected virtual CompilableProvider VisitExistence(ExistenceProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       if (source == provider.Source)
         return provider;
       return new ExistenceProvider(source, provider.ExistenceColumnName);
     }
 
-    /// <inheritdoc/>
-    protected override CompilableProvider VisitApply(ApplyProvider provider)
+    /// <summary>
+    /// Visits <see cref="ApplyProvider"/>.
+    /// </summary>
+    /// <param name="provider">Apply provider.</param>
+    protected virtual CompilableProvider VisitApply(ApplyProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
       var right = VisitCompilable(provider.Right);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       if (left == provider.Left && right == provider.Right)
         return provider;
       return new ApplyProvider(provider.ApplyParameter, left, right, provider.IsInlined, provider.SequenceType, provider.ApplyType);
     }
 
-    /// <inheritdoc/>
-    protected override CompilableProvider VisitIntersect(IntersectProvider provider)
+    /// <summary>
+    /// Visits the <see cref="IntersectProvider"/>.
+    /// </summary>
+    /// <param name="provider">Intersect provider.</param>
+    /// <returns></returns>
+    protected virtual CompilableProvider VisitIntersect(IntersectProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
       var right = VisitCompilable(provider.Right);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       if (left == provider.Left && right == provider.Right)
         return provider;
       return new IntersectProvider(left, right);
     }
 
-    /// <inheritdoc/>
-    protected override CompilableProvider VisitExcept(ExceptProvider provider)
+    /// <summary>
+    /// Visits the <see cref="ExceptProvider"/>.
+    /// </summary>
+    /// <param name="provider">Except provider.</param>
+    /// <returns></returns>
+    protected virtual CompilableProvider VisitExcept(ExceptProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
       var right = VisitCompilable(provider.Right);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       if (left == provider.Left && right == provider.Right)
         return provider;
       return new ExceptProvider(left, right);
     }
 
-    /// <inheritdoc/>
-    protected override CompilableProvider VisitConcat(ConcatProvider provider)
+    /// <summary>
+    /// Visits the <see cref="ConcatProvider"/>.
+    /// </summary>
+    /// <param name="provider">Concat provider.</param>
+    /// <returns></returns>
+    protected virtual CompilableProvider VisitConcat(ConcatProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
       var right = VisitCompilable(provider.Right);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       if (left == provider.Left && right == provider.Right)
         return provider;
       return new ConcatProvider(left, right);
     }
 
-    /// <inheritdoc/>
-    protected override CompilableProvider VisitUnion(UnionProvider provider)
+    /// <summary>
+    /// Visits the <see cref="UnionProvider"/>.
+    /// </summary>
+    /// <param name="provider">Union provider.</param>
+    /// <returns></returns>
+    protected virtual CompilableProvider VisitUnion(UnionProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
       var right = VisitCompilable(provider.Right);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       if (left == provider.Left && right == provider.Right)
         return provider;
       return new UnionProvider(left, right);
     }
 
-    /// <inheritdoc/>
-    protected override LockProvider VisitLock(LockProvider provider)
+    /// <summary>
+    /// Visits the <see cref="LockProvider"/>.
+    /// </summary>
+    /// <param name="provider">Lock provider.</param>
+    /// <returns></returns>
+    protected virtual CompilableProvider VisitLock(LockProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       if (source == provider.Source)
         return provider;
       return new LockProvider(source, provider.LockMode, provider.LockBehavior);
     }
 
-    protected override CompilableProvider VisitInclude(IncludeProvider provider)
+    /// <summary>
+    /// Visits the <see cref="IncludeProvider"/>.
+    /// </summary>
+    /// <param name="provider">Include provider.</param>
+    /// <returns></returns>
+    protected virtual CompilableProvider VisitInclude(IncludeProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
-      OnRecursionExit(provider);
+      _ = OnRecursionExit(provider);
       if (source == provider.Source)
         return provider;
       return new IncludeProvider(source, provider.Algorithm, provider.IsInlined,
         provider.FilterDataSource, provider.ResultColumnName, provider.FilteredColumns);
-    }
-    
-    private static Expression DefaultExpressionTranslator(Provider p, Expression e)
-    {
-      return e;
     }
 
     /// <summary>
@@ -369,6 +498,8 @@ namespace Xtensive.Orm.Rse.Providers
     {
     }
 
+    private static Expression DefaultExpressionTranslator(CompilableProvider p, Expression e) => e;
+
     // Constructors
 
     /// <inheritdoc/>
@@ -379,7 +510,7 @@ namespace Xtensive.Orm.Rse.Providers
 
     /// <inheritdoc/>
     /// <param name="expressionTranslator">Expression translator.</param>
-    public CompilableProviderVisitor(Func<Provider, Expression, Expression> expressionTranslator)
+    public CompilableProviderVisitor(Func<CompilableProvider, Expression, Expression> expressionTranslator)
     {
       translate = expressionTranslator;
     }

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProviderVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProviderVisitor.cs
@@ -78,9 +78,7 @@ namespace Xtensive.Orm.Rse.Providers
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
       _ = OnRecursionExit(provider);
-      if (source == provider.Source)
-        return provider;
-      return new TakeProvider(source, provider.Count);
+      return source == provider.Source ? provider : new TakeProvider(source, provider.Count);
     }
 
     /// <summary>
@@ -92,9 +90,7 @@ namespace Xtensive.Orm.Rse.Providers
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
       _ = OnRecursionExit(provider);
-      if (source == provider.Source)
-        return provider;
-      return new SkipProvider(source, provider.Count);
+      return source == provider.Source ? provider : new SkipProvider(source, provider.Count);
     }
 
     /// <summary>
@@ -106,9 +102,7 @@ namespace Xtensive.Orm.Rse.Providers
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
       _ = OnRecursionExit(provider);
-      if (source == provider.Source)
-        return provider;
-      return new PagingProvider(source, provider);
+      return source == provider.Source ? provider : new PagingProvider(source, provider);
     }
 
     /// <summary>
@@ -120,9 +114,9 @@ namespace Xtensive.Orm.Rse.Providers
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
       var columnIndexes = (int[])OnRecursionExit(provider);
-      if (source == provider.Source)
-        return provider;
-      return new SelectProvider(source, columnIndexes ?? provider.ColumnIndexes);
+      return source == provider.Source
+        ? provider
+        : new SelectProvider(source, columnIndexes ?? provider.ColumnIndexes);
     }
 
     /// <summary>
@@ -134,9 +128,7 @@ namespace Xtensive.Orm.Rse.Providers
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
       _ = OnRecursionExit(provider);
-      if (source == provider.Source)
-        return provider;
-      return new TagProvider(source, provider.Tag);
+      return source == provider.Source ? provider : new TagProvider(source, provider.Tag);
     }
 
     /// <summary>
@@ -148,9 +140,7 @@ namespace Xtensive.Orm.Rse.Providers
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
       _ = OnRecursionExit(provider);
-      if (source==provider.Source)
-        return provider;
-      return new SeekProvider(source, provider.Key);
+      return source == provider.Source ? provider : new SeekProvider(source, provider.Key);
     }
 
     /// <summary>
@@ -171,9 +161,9 @@ namespace Xtensive.Orm.Rse.Providers
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
       var order = OnRecursionExit(provider);
-      if (source == provider.Source)
-        return provider;
-      return new SortProvider(source, (order == null) ? provider.Order : (DirectionCollection<int>)order);
+      return source == provider.Source
+        ? provider
+        : new SortProvider(source, (order == null) ? provider.Order : (DirectionCollection<int>)order);
     }
 
     /// <summary>
@@ -186,10 +176,10 @@ namespace Xtensive.Orm.Rse.Providers
       var left = VisitCompilable(provider.Left);
       var right = VisitCompilable(provider.Right);
       var equalIndexes = OnRecursionExit(provider);
-      if (left == provider.Left && right == provider.Right)
-        return provider;
-      return new JoinProvider(left, right, provider.JoinType,
-        equalIndexes != null ? (Pair<int>[])equalIndexes : provider.EqualIndexes);
+      return left == provider.Left && right == provider.Right
+        ? provider
+        : new JoinProvider(left, right, provider.JoinType,
+            equalIndexes != null ? (Pair<int>[])equalIndexes : provider.EqualIndexes);
     }
 
     /// <summary>
@@ -202,9 +192,9 @@ namespace Xtensive.Orm.Rse.Providers
       var source = VisitCompilable(provider.Source);
       _ = OnRecursionExit(provider);
       var predicate = translate(provider, provider.Predicate);
-      if (source == provider.Source && predicate == provider.Predicate)
-        return provider;
-      return new FilterProvider(source, (Expression<Func<Tuple, bool>>) predicate);
+      return source == provider.Source && predicate == provider.Predicate
+        ? provider
+        : new FilterProvider(source, (Expression<Func<Tuple, bool>>) predicate);
     }
 
     /// <summary>
@@ -216,9 +206,7 @@ namespace Xtensive.Orm.Rse.Providers
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
       _ = OnRecursionExit(provider);
-      if (source == provider.Source)
-        return provider;
-      return new DistinctProvider(source);
+      return source == provider.Source ? provider : new DistinctProvider(source);
     }
 
     /// <summary>
@@ -239,9 +227,9 @@ namespace Xtensive.Orm.Rse.Providers
         var ccd = new CalculatedColumnDescriptor(column.Name, column.Type, (Expression<Func<Tuple, object>>) expression);
         descriptors.Add(ccd);
       }
-      if (!translated && source == provider.Source)
-        return provider;
-      return new CalculateProvider(source, descriptors.ToArray());
+      return !translated && source == provider.Source
+        ? provider
+        : new CalculateProvider(source, descriptors.ToArray());
     }
 
     /// <summary>
@@ -253,9 +241,7 @@ namespace Xtensive.Orm.Rse.Providers
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
       _ = OnRecursionExit(provider);
-      if (source == provider.Source)
-        return provider;
-      return new RowNumberProvider(source, provider.SystemColumn.Name);
+      return source == provider.Source ? provider : new RowNumberProvider(source, provider.SystemColumn.Name);
     }
 
 
@@ -268,9 +254,7 @@ namespace Xtensive.Orm.Rse.Providers
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
       _ = OnRecursionExit(provider);
-      if (source == provider.Source)
-        return provider;
-      return new AliasProvider(source, provider.Alias);
+      return source == provider.Source ? provider : new AliasProvider(source, provider.Alias);
     }
 
     /// <summary>
@@ -304,9 +288,7 @@ namespace Xtensive.Orm.Rse.Providers
       OnRecursionEntrance(provider);
       var source = VisitCompilable(compilableSource);
       _ = OnRecursionExit(provider);
-      if (source == compilableSource)
-        return provider;
-      return new StoreProvider(source, provider.Name);
+      return source == compilableSource ? provider : new StoreProvider(source, provider.Name);
     }
 
     /// <summary>
@@ -354,9 +336,9 @@ namespace Xtensive.Orm.Rse.Providers
       var left = VisitCompilable(provider.Left);
       var right = VisitCompilable(provider.Right);
       var predicate = (Expression<Func<Tuple, Tuple, bool>>)OnRecursionExit(provider);
-      if (left == provider.Left && right == provider.Right)
-        return provider;
-      return new PredicateJoinProvider(left, right, predicate ?? provider.Predicate, provider.JoinType);
+      return left == provider.Left && right == provider.Right
+        ? provider
+        : new PredicateJoinProvider(left, right, predicate ?? provider.Predicate, provider.JoinType);
     }
 
     /// <summary>
@@ -368,9 +350,7 @@ namespace Xtensive.Orm.Rse.Providers
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
       _ = OnRecursionExit(provider);
-      if (source == provider.Source)
-        return provider;
-      return new ExistenceProvider(source, provider.ExistenceColumnName);
+      return source == provider.Source ? provider : new ExistenceProvider(source, provider.ExistenceColumnName);
     }
 
     /// <summary>
@@ -383,9 +363,10 @@ namespace Xtensive.Orm.Rse.Providers
       var left = VisitCompilable(provider.Left);
       var right = VisitCompilable(provider.Right);
       _ = OnRecursionExit(provider);
-      if (left == provider.Left && right == provider.Right)
-        return provider;
-      return new ApplyProvider(provider.ApplyParameter, left, right, provider.IsInlined, provider.SequenceType, provider.ApplyType);
+      return left == provider.Left && right == provider.Right
+        ? provider
+        : new ApplyProvider(provider.ApplyParameter, left, right,
+            provider.IsInlined, provider.SequenceType, provider.ApplyType);
     }
 
     /// <summary>
@@ -399,9 +380,9 @@ namespace Xtensive.Orm.Rse.Providers
       var left = VisitCompilable(provider.Left);
       var right = VisitCompilable(provider.Right);
       _ = OnRecursionExit(provider);
-      if (left == provider.Left && right == provider.Right)
-        return provider;
-      return new IntersectProvider(left, right);
+      return left == provider.Left && right == provider.Right
+        ? provider
+        : new IntersectProvider(left, right);
     }
 
     /// <summary>
@@ -415,9 +396,9 @@ namespace Xtensive.Orm.Rse.Providers
       var left = VisitCompilable(provider.Left);
       var right = VisitCompilable(provider.Right);
       _ = OnRecursionExit(provider);
-      if (left == provider.Left && right == provider.Right)
-        return provider;
-      return new ExceptProvider(left, right);
+      return left == provider.Left && right == provider.Right
+        ? provider
+        : new ExceptProvider(left, right);
     }
 
     /// <summary>
@@ -431,9 +412,9 @@ namespace Xtensive.Orm.Rse.Providers
       var left = VisitCompilable(provider.Left);
       var right = VisitCompilable(provider.Right);
       _ = OnRecursionExit(provider);
-      if (left == provider.Left && right == provider.Right)
-        return provider;
-      return new ConcatProvider(left, right);
+      return left == provider.Left && right == provider.Right
+        ? provider
+        : new ConcatProvider(left, right);
     }
 
     /// <summary>
@@ -447,9 +428,9 @@ namespace Xtensive.Orm.Rse.Providers
       var left = VisitCompilable(provider.Left);
       var right = VisitCompilable(provider.Right);
       _ = OnRecursionExit(provider);
-      if (left == provider.Left && right == provider.Right)
-        return provider;
-      return new UnionProvider(left, right);
+      return left == provider.Left && right == provider.Right
+        ? provider
+        : new UnionProvider(left, right);
     }
 
     /// <summary>
@@ -462,9 +443,7 @@ namespace Xtensive.Orm.Rse.Providers
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
       _ = OnRecursionExit(provider);
-      if (source == provider.Source)
-        return provider;
-      return new LockProvider(source, provider.LockMode, provider.LockBehavior);
+      return source == provider.Source ? provider : new LockProvider(source, provider.LockMode, provider.LockBehavior);
     }
 
     /// <summary>
@@ -477,10 +456,10 @@ namespace Xtensive.Orm.Rse.Providers
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
       _ = OnRecursionExit(provider);
-      if (source == provider.Source)
-        return provider;
-      return new IncludeProvider(source, provider.Algorithm, provider.IsInlined,
-        provider.FilterDataSource, provider.ResultColumnName, provider.FilteredColumns);
+      return source == provider.Source
+        ? provider
+        : new IncludeProvider(source, provider.Algorithm, provider.IsInlined,
+            provider.FilterDataSource, provider.ResultColumnName, provider.FilteredColumns);
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/ProviderVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/ProviderVisitor.cs
@@ -13,6 +13,7 @@ namespace Xtensive.Orm.Rse.Providers
   /// Abstract <see cref="CompilableProvider"/> visitor class.
   /// </summary>
   [Serializable]
+  [Obsolete("No longer parent class of anything. Use CompilableProviderVisitor as base type instead.")]
   public abstract class ProviderVisitor
   {
     /// <summary>
@@ -20,89 +21,149 @@ namespace Xtensive.Orm.Rse.Providers
     /// </summary>
     /// <param name="cp">The <see cref="CompilableProvider"/> to visit.</param>
     /// <returns>Visit result.</returns>
-    protected virtual CompilableProvider Visit(CompilableProvider cp) =>
-      cp == null
-        ? null
-        : cp.Type switch {
-          ProviderType.Index => VisitIndex((IndexProvider) cp),
-          ProviderType.Store => VisitStore((StoreProvider) cp),
-          ProviderType.Aggregate => VisitAggregate((AggregateProvider) cp),
-          ProviderType.Alias => VisitAlias((AliasProvider) cp),
-          ProviderType.Calculate => VisitCalculate((CalculateProvider) cp),
-          ProviderType.Distinct => VisitDistinct((DistinctProvider) cp),
-          ProviderType.Filter => VisitFilter((FilterProvider) cp),
-          ProviderType.Join => VisitJoin((JoinProvider) cp),
-          ProviderType.Sort => VisitSort((SortProvider) cp),
-          ProviderType.Raw => VisitRaw((RawProvider) cp),
-          ProviderType.Seek => VisitSeek((SeekProvider) cp),
-          ProviderType.Select => VisitSelect((SelectProvider) cp),
-          ProviderType.Tag => VisitTag((TagProvider) cp),
-          ProviderType.Skip => VisitSkip((SkipProvider) cp),
-          ProviderType.Take => VisitTake((TakeProvider) cp),
-          ProviderType.Paging => VisitPaging((PagingProvider)cp),
-          ProviderType.RowNumber => VisitRowNumber((RowNumberProvider)cp),
-          ProviderType.Apply => VisitApply((ApplyProvider)cp),
-          ProviderType.Existence => VisitExistence((ExistenceProvider)cp),
-          ProviderType.PredicateJoin => VisitPredicateJoin((PredicateJoinProvider)cp),
-          ProviderType.Intersect => VisitIntersect((IntersectProvider)cp),
-          ProviderType.Except => VisitExcept((ExceptProvider)cp),
-          ProviderType.Concat => VisitConcat((ConcatProvider)cp),
-          ProviderType.Union => VisitUnion((UnionProvider)cp),
-          ProviderType.Lock => VisitLock((LockProvider) cp),
-          ProviderType.Include => VisitInclude((IncludeProvider) cp),
-          ProviderType.FreeText => VisitFreeText((FreeTextProvider) cp),
-          ProviderType.ContainsTable => VisitContainsTable((ContainsTableProvider) cp),
-          ProviderType.Void => throw new NotSupportedException(Strings.ExProcessingOfVoidProviderIsNotSupported),
-          _ => throw new ArgumentOutOfRangeException()
-        };
+    protected virtual Provider Visit(CompilableProvider cp)
+    {
+      if (cp == null)
+        return null;
+      Provider result;
+      ProviderType providerType = cp.Type;
+      switch (providerType) {
+        case ProviderType.Index:
+          result = VisitIndex((IndexProvider) cp);
+          break;
+        case ProviderType.Store:
+          result = VisitStore((StoreProvider) cp);
+          break;
+        case ProviderType.Aggregate:
+          result = VisitAggregate((AggregateProvider) cp);
+          break;
+        case ProviderType.Alias:
+          result = VisitAlias((AliasProvider) cp);
+          break;
+        case ProviderType.Calculate:
+          result = VisitCalculate((CalculateProvider) cp);
+          break;
+        case ProviderType.Distinct:
+          result = VisitDistinct((DistinctProvider) cp);
+          break;
+        case ProviderType.Filter:
+          result = VisitFilter((FilterProvider) cp);
+          break;
+        case ProviderType.Join:
+          result = VisitJoin((JoinProvider) cp);
+          break;
+        case ProviderType.Sort:
+          result = VisitSort((SortProvider) cp);
+          break;
+        case ProviderType.Raw:
+          result = VisitRaw((RawProvider) cp);
+          break;
+        case ProviderType.Seek:
+          result = VisitSeek((SeekProvider) cp);
+          break;
+        case ProviderType.Select:
+          result = VisitSelect((SelectProvider) cp);
+          break;
+        case ProviderType.Skip:
+          result = VisitSkip((SkipProvider) cp);
+          break;
+        case ProviderType.Take:
+          result = VisitTake((TakeProvider) cp);
+          break;
+        case ProviderType.Paging:
+          result = VisitPaging((PagingProvider) cp);
+          break;
+        case ProviderType.RowNumber:
+          result = VisitRowNumber((RowNumberProvider) cp);
+          break;
+        case ProviderType.Apply:
+          result = VisitApply((ApplyProvider) cp);
+          break;
+        case ProviderType.Existence:
+          result = VisitExistence((ExistenceProvider) cp);
+          break;
+        case ProviderType.PredicateJoin:
+          result = VisitPredicateJoin((PredicateJoinProvider) cp);
+          break;
+        case ProviderType.Intersect:
+          result = VisitIntersect((IntersectProvider) cp);
+          break;
+        case ProviderType.Except:
+          result = VisitExcept((ExceptProvider) cp);
+          break;
+        case ProviderType.Concat:
+          result = VisitConcat((ConcatProvider) cp);
+          break;
+        case ProviderType.Union:
+          result = VisitUnion((UnionProvider) cp);
+          break;
+        case ProviderType.Lock:
+          result = VisitLock((LockProvider) cp);
+          break;
+        case ProviderType.Include:
+          result = VisitInclude((IncludeProvider) cp);
+          break;
+        case ProviderType.FreeText:
+          result = VisitFreeText((FreeTextProvider) cp);
+          break;
+        case ProviderType.ContainsTable:
+          result = VisitContainsTable((ContainsTableProvider) cp);
+          break;
+        case ProviderType.Void:
+          throw new NotSupportedException(Strings.ExProcessingOfVoidProviderIsNotSupported);
+        default:
+          throw new ArgumentOutOfRangeException();
+      }
+      return result;
+    }
 
     /// <summary>
     /// Visits <see cref="PredicateJoinProvider"/>.
     /// </summary>
     /// <param name="provider">Predicate join provider.</param>
-    protected abstract CompilableProvider VisitPredicateJoin(PredicateJoinProvider provider);
+    protected abstract Provider VisitPredicateJoin(PredicateJoinProvider provider);
 
     /// <summary>
     /// Visits <see cref="ExistenceProvider"/>.
     /// </summary>
     /// <param name="provider">Existence provider.</param>
-    protected abstract CompilableProvider VisitExistence(ExistenceProvider provider);
+    protected abstract Provider VisitExistence(ExistenceProvider provider);
 
     /// <summary>
     /// Visits <see cref="ApplyProvider"/>.
     /// </summary>
     /// <param name="provider">Apply provider.</param>
-    protected abstract CompilableProvider VisitApply(ApplyProvider provider);
+    protected abstract Provider VisitApply(ApplyProvider provider);
 
     /// <summary>
     /// Visits <see cref="RowNumberProvider"/>.
     /// </summary>
     /// <param name="provider">Row number provider.</param>
-    protected abstract CompilableProvider VisitRowNumber(RowNumberProvider provider);
+    protected abstract Provider VisitRowNumber(RowNumberProvider provider);
 
     /// <summary>
     /// Visits <see cref="TakeProvider"/>.
     /// </summary>
     /// <param name="provider">Take provider.</param>
-    protected abstract CompilableProvider VisitTake(TakeProvider provider);
+    protected abstract Provider VisitTake(TakeProvider provider);
 
     /// <summary>
     /// Visits <see cref="SkipProvider"/>.
     /// </summary>
     /// <param name="provider">Skip provider.</param>
-    protected abstract CompilableProvider VisitSkip(SkipProvider provider);
+    protected abstract Provider VisitSkip(SkipProvider provider);
 
     /// <summary>
     /// Visits <see cref="PagingProvider"/>.
     /// </summary>
     /// <param name="provider">Paging provider.</param>
-    protected abstract CompilableProvider VisitPaging(PagingProvider provider);
+    protected abstract Provider VisitPaging(PagingProvider provider);
 
     /// <summary>
     /// Visits <see cref="SelectProvider"/>.
     /// </summary>
     /// <param name="provider">Select provider.</param>
-    protected abstract CompilableProvider VisitSelect(SelectProvider provider);
+    protected abstract Provider VisitSelect(SelectProvider provider);
 
     /// <summary>
     /// Visits <see cref="TagProvider"/>.
@@ -114,123 +175,123 @@ namespace Xtensive.Orm.Rse.Providers
     /// Visits <see cref="SeekProvider"/>.
     /// </summary>
     /// <param name="provider">Seek provider.</param>
-    protected abstract CompilableProvider VisitSeek(SeekProvider provider);
+    protected abstract Provider VisitSeek(SeekProvider provider);
 
     /// <summary>
     /// Visits <see cref="RawProvider"/>.
     /// </summary>
     /// <param name="provider">Raw provider.</param>
-    protected abstract CompilableProvider VisitRaw(RawProvider provider);
+    protected abstract Provider VisitRaw(RawProvider provider);
 
     /// <summary>
     /// Visits <see cref="SortProvider"/>.
     /// </summary>
     /// <param name="provider">Sort provider.</param>
-    protected abstract CompilableProvider VisitSort(SortProvider provider);
+    protected abstract Provider VisitSort(SortProvider provider);
 
     /// <summary>
     /// Visits <see cref="JoinProvider"/>.
     /// </summary>
     /// <param name="provider">Join provider.</param>
-    protected abstract CompilableProvider VisitJoin(JoinProvider provider);
+    protected abstract Provider VisitJoin(JoinProvider provider);
 
     /// <summary>
     /// Visits <see cref="FilterProvider"/>.
     /// </summary>
     /// <param name="provider">Filter provider.</param>
-    protected abstract CompilableProvider VisitFilter(FilterProvider provider);
+    protected abstract Provider VisitFilter(FilterProvider provider);
 
     /// <summary>
     /// Visits <see cref="DistinctProvider"/>.
     /// </summary>
     /// <param name="provider">Distinct provider.</param>
-    protected abstract CompilableProvider VisitDistinct(DistinctProvider provider);
+    protected abstract Provider VisitDistinct(DistinctProvider provider);
 
     /// <summary>
     /// Visits <see cref="CalculateProvider"/>.
     /// </summary>
     /// <param name="provider">Calculate provider.</param>
-    protected abstract CompilableProvider VisitCalculate(CalculateProvider provider);
+    protected abstract Provider VisitCalculate(CalculateProvider provider);
 
     /// <summary>
     /// Visits <see cref="AliasProvider"/>.
     /// </summary>
     /// <param name="provider">Alias provider.</param>
-    protected abstract CompilableProvider VisitAlias(AliasProvider provider);
+    protected abstract Provider VisitAlias(AliasProvider provider);
 
     /// <summary>
     /// Visits <see cref="AggregateProvider"/>.
     /// </summary>
     /// <param name="provider">Aggregate provider.</param>
     /// <returns></returns>
-    protected abstract CompilableProvider VisitAggregate(AggregateProvider provider);
+    protected abstract Provider VisitAggregate(AggregateProvider provider);
 
     /// <summary>
     /// Visits <see cref="StoreProvider"/>.
     /// </summary>
     /// <param name="provider">Store provider.</param>
-    protected abstract CompilableProvider VisitStore(StoreProvider provider);
+    protected abstract Provider VisitStore(StoreProvider provider);
 
     /// <summary>
     /// Visits <see cref="IndexProvider"/>.
     /// </summary>
     /// <param name="provider">Index provider.</param>
-    protected abstract CompilableProvider VisitIndex(IndexProvider provider);
+    protected abstract Provider VisitIndex(IndexProvider provider);
 
     /// <summary>
     /// Visits the <see cref="IntersectProvider"/>.
     /// </summary>
     /// <param name="provider">Intersect provider.</param>
     /// <returns></returns>
-    protected abstract CompilableProvider VisitIntersect(IntersectProvider provider);
+    protected abstract Provider VisitIntersect(IntersectProvider provider);
 
     /// <summary>
     /// Visits the <see cref="ExceptProvider"/>.
     /// </summary>
     /// <param name="provider">Except provider.</param>
     /// <returns></returns>
-    protected abstract CompilableProvider VisitExcept(ExceptProvider provider);
+    protected abstract Provider VisitExcept(ExceptProvider provider);
 
     /// <summary>
     /// Visits the <see cref="ConcatProvider"/>.
     /// </summary>
     /// <param name="provider">Concat provider.</param>
     /// <returns></returns>
-    protected abstract CompilableProvider VisitConcat(ConcatProvider provider);
+    protected abstract Provider VisitConcat(ConcatProvider provider);
 
     /// <summary>
     /// Visits the <see cref="UnionProvider"/>.
     /// </summary>
     /// <param name="provider">Union provider.</param>
     /// <returns></returns>
-    protected abstract CompilableProvider VisitUnion(UnionProvider provider);
+    protected abstract Provider VisitUnion(UnionProvider provider);
 
     /// <summary>
     /// Visits the <see cref="LockProvider"/>.
     /// </summary>
     /// <param name="provider">Lock provider.</param>
     /// <returns></returns>
-    protected abstract CompilableProvider VisitLock(LockProvider provider);
+    protected abstract Provider VisitLock(LockProvider provider);
 
     /// <summary>
     /// Visits the <see cref="IncludeProvider"/>.
     /// </summary>
     /// <param name="provider">Include provider.</param>
     /// <returns></returns>
-    protected abstract CompilableProvider VisitInclude(IncludeProvider provider);
+    protected abstract Provider VisitInclude(IncludeProvider provider);
 
     /// <summary>
     /// Visits the <see cref="FreeTextProvider"/>.
     /// </summary>
     /// <param name="provider">FreeText provider.</param>
     /// <returns></returns>
-    protected abstract CompilableProvider VisitFreeText(FreeTextProvider provider);
+    protected abstract Provider VisitFreeText(FreeTextProvider provider);
 
     /// <summary>
     /// Visits the <see cref="FreeTextProvider"/>.
     /// </summary>
     /// <param name="provider">SearchCondition provider.</param>
     /// <returns></returns>
-    protected abstract CompilableProvider VisitContainsTable(ContainsTableProvider provider);
+    protected abstract Provider VisitContainsTable(ContainsTableProvider provider);
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/ProviderVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/ProviderVisitor.cs
@@ -13,7 +13,6 @@ namespace Xtensive.Orm.Rse.Providers
   /// Abstract <see cref="CompilableProvider"/> visitor class.
   /// </summary>
   [Serializable]
-  [Obsolete("No longer parent class of anything. Use CompilableProviderVisitor as base type instead.")]
   public abstract class ProviderVisitor
   {
     /// <summary>
@@ -21,149 +20,89 @@ namespace Xtensive.Orm.Rse.Providers
     /// </summary>
     /// <param name="cp">The <see cref="CompilableProvider"/> to visit.</param>
     /// <returns>Visit result.</returns>
-    protected virtual Provider Visit(CompilableProvider cp)
-    {
-      if (cp == null)
-        return null;
-      Provider result;
-      ProviderType providerType = cp.Type;
-      switch (providerType) {
-        case ProviderType.Index:
-          result = VisitIndex((IndexProvider) cp);
-          break;
-        case ProviderType.Store:
-          result = VisitStore((StoreProvider) cp);
-          break;
-        case ProviderType.Aggregate:
-          result = VisitAggregate((AggregateProvider) cp);
-          break;
-        case ProviderType.Alias:
-          result = VisitAlias((AliasProvider) cp);
-          break;
-        case ProviderType.Calculate:
-          result = VisitCalculate((CalculateProvider) cp);
-          break;
-        case ProviderType.Distinct:
-          result = VisitDistinct((DistinctProvider) cp);
-          break;
-        case ProviderType.Filter:
-          result = VisitFilter((FilterProvider) cp);
-          break;
-        case ProviderType.Join:
-          result = VisitJoin((JoinProvider) cp);
-          break;
-        case ProviderType.Sort:
-          result = VisitSort((SortProvider) cp);
-          break;
-        case ProviderType.Raw:
-          result = VisitRaw((RawProvider) cp);
-          break;
-        case ProviderType.Seek:
-          result = VisitSeek((SeekProvider) cp);
-          break;
-        case ProviderType.Select:
-          result = VisitSelect((SelectProvider) cp);
-          break;
-        case ProviderType.Skip:
-          result = VisitSkip((SkipProvider) cp);
-          break;
-        case ProviderType.Take:
-          result = VisitTake((TakeProvider) cp);
-          break;
-        case ProviderType.Paging:
-          result = VisitPaging((PagingProvider) cp);
-          break;
-        case ProviderType.RowNumber:
-          result = VisitRowNumber((RowNumberProvider) cp);
-          break;
-        case ProviderType.Apply:
-          result = VisitApply((ApplyProvider) cp);
-          break;
-        case ProviderType.Existence:
-          result = VisitExistence((ExistenceProvider) cp);
-          break;
-        case ProviderType.PredicateJoin:
-          result = VisitPredicateJoin((PredicateJoinProvider) cp);
-          break;
-        case ProviderType.Intersect:
-          result = VisitIntersect((IntersectProvider) cp);
-          break;
-        case ProviderType.Except:
-          result = VisitExcept((ExceptProvider) cp);
-          break;
-        case ProviderType.Concat:
-          result = VisitConcat((ConcatProvider) cp);
-          break;
-        case ProviderType.Union:
-          result = VisitUnion((UnionProvider) cp);
-          break;
-        case ProviderType.Lock:
-          result = VisitLock((LockProvider) cp);
-          break;
-        case ProviderType.Include:
-          result = VisitInclude((IncludeProvider) cp);
-          break;
-        case ProviderType.FreeText:
-          result = VisitFreeText((FreeTextProvider) cp);
-          break;
-        case ProviderType.ContainsTable:
-          result = VisitContainsTable((ContainsTableProvider) cp);
-          break;
-        case ProviderType.Void:
-          throw new NotSupportedException(Strings.ExProcessingOfVoidProviderIsNotSupported);
-        default:
-          throw new ArgumentOutOfRangeException();
-      }
-      return result;
-    }
+    protected virtual CompilableProvider Visit(CompilableProvider cp) =>
+      cp == null
+        ? null
+        : cp.Type switch {
+          ProviderType.Index => VisitIndex((IndexProvider) cp),
+          ProviderType.Store => VisitStore((StoreProvider) cp),
+          ProviderType.Aggregate => VisitAggregate((AggregateProvider) cp),
+          ProviderType.Alias => VisitAlias((AliasProvider) cp),
+          ProviderType.Calculate => VisitCalculate((CalculateProvider) cp),
+          ProviderType.Distinct => VisitDistinct((DistinctProvider) cp),
+          ProviderType.Filter => VisitFilter((FilterProvider) cp),
+          ProviderType.Join => VisitJoin((JoinProvider) cp),
+          ProviderType.Sort => VisitSort((SortProvider) cp),
+          ProviderType.Raw => VisitRaw((RawProvider) cp),
+          ProviderType.Seek => VisitSeek((SeekProvider) cp),
+          ProviderType.Select => VisitSelect((SelectProvider) cp),
+          ProviderType.Tag => VisitTag((TagProvider) cp),
+          ProviderType.Skip => VisitSkip((SkipProvider) cp),
+          ProviderType.Take => VisitTake((TakeProvider) cp),
+          ProviderType.Paging => VisitPaging((PagingProvider) cp),
+          ProviderType.RowNumber => VisitRowNumber((RowNumberProvider) cp),
+          ProviderType.Apply => VisitApply((ApplyProvider) cp),
+          ProviderType.Existence => VisitExistence((ExistenceProvider) cp),
+          ProviderType.PredicateJoin => VisitPredicateJoin((PredicateJoinProvider) cp),
+          ProviderType.Intersect => VisitIntersect((IntersectProvider) cp),
+          ProviderType.Except => VisitExcept((ExceptProvider) cp),
+          ProviderType.Concat => VisitConcat((ConcatProvider) cp),
+          ProviderType.Union => VisitUnion((UnionProvider) cp),
+          ProviderType.Lock => VisitLock((LockProvider) cp),
+          ProviderType.Include => VisitInclude((IncludeProvider) cp),
+          ProviderType.FreeText => VisitFreeText((FreeTextProvider) cp),
+          ProviderType.ContainsTable => VisitContainsTable((ContainsTableProvider) cp),
+          ProviderType.Void => throw new NotSupportedException(Strings.ExProcessingOfVoidProviderIsNotSupported),
+          _ => throw new ArgumentOutOfRangeException()
+        };
 
     /// <summary>
     /// Visits <see cref="PredicateJoinProvider"/>.
     /// </summary>
     /// <param name="provider">Predicate join provider.</param>
-    protected abstract Provider VisitPredicateJoin(PredicateJoinProvider provider);
+    protected abstract CompilableProvider VisitPredicateJoin(PredicateJoinProvider provider);
 
     /// <summary>
     /// Visits <see cref="ExistenceProvider"/>.
     /// </summary>
     /// <param name="provider">Existence provider.</param>
-    protected abstract Provider VisitExistence(ExistenceProvider provider);
+    protected abstract CompilableProvider VisitExistence(ExistenceProvider provider);
 
     /// <summary>
     /// Visits <see cref="ApplyProvider"/>.
     /// </summary>
     /// <param name="provider">Apply provider.</param>
-    protected abstract Provider VisitApply(ApplyProvider provider);
+    protected abstract CompilableProvider VisitApply(ApplyProvider provider);
 
     /// <summary>
     /// Visits <see cref="RowNumberProvider"/>.
     /// </summary>
     /// <param name="provider">Row number provider.</param>
-    protected abstract Provider VisitRowNumber(RowNumberProvider provider);
+    protected abstract CompilableProvider VisitRowNumber(RowNumberProvider provider);
 
     /// <summary>
     /// Visits <see cref="TakeProvider"/>.
     /// </summary>
     /// <param name="provider">Take provider.</param>
-    protected abstract Provider VisitTake(TakeProvider provider);
+    protected abstract CompilableProvider VisitTake(TakeProvider provider);
 
     /// <summary>
     /// Visits <see cref="SkipProvider"/>.
     /// </summary>
     /// <param name="provider">Skip provider.</param>
-    protected abstract Provider VisitSkip(SkipProvider provider);
+    protected abstract CompilableProvider VisitSkip(SkipProvider provider);
 
     /// <summary>
     /// Visits <see cref="PagingProvider"/>.
     /// </summary>
     /// <param name="provider">Paging provider.</param>
-    protected abstract Provider VisitPaging(PagingProvider provider);
+    protected abstract CompilableProvider VisitPaging(PagingProvider provider);
 
     /// <summary>
     /// Visits <see cref="SelectProvider"/>.
     /// </summary>
     /// <param name="provider">Select provider.</param>
-    protected abstract Provider VisitSelect(SelectProvider provider);
+    protected abstract CompilableProvider VisitSelect(SelectProvider provider);
 
     /// <summary>
     /// Visits <see cref="TagProvider"/>.
@@ -175,123 +114,123 @@ namespace Xtensive.Orm.Rse.Providers
     /// Visits <see cref="SeekProvider"/>.
     /// </summary>
     /// <param name="provider">Seek provider.</param>
-    protected abstract Provider VisitSeek(SeekProvider provider);
+    protected abstract CompilableProvider VisitSeek(SeekProvider provider);
 
     /// <summary>
     /// Visits <see cref="RawProvider"/>.
     /// </summary>
     /// <param name="provider">Raw provider.</param>
-    protected abstract Provider VisitRaw(RawProvider provider);
+    protected abstract CompilableProvider VisitRaw(RawProvider provider);
 
     /// <summary>
     /// Visits <see cref="SortProvider"/>.
     /// </summary>
     /// <param name="provider">Sort provider.</param>
-    protected abstract Provider VisitSort(SortProvider provider);
+    protected abstract CompilableProvider VisitSort(SortProvider provider);
 
     /// <summary>
     /// Visits <see cref="JoinProvider"/>.
     /// </summary>
     /// <param name="provider">Join provider.</param>
-    protected abstract Provider VisitJoin(JoinProvider provider);
+    protected abstract CompilableProvider VisitJoin(JoinProvider provider);
 
     /// <summary>
     /// Visits <see cref="FilterProvider"/>.
     /// </summary>
     /// <param name="provider">Filter provider.</param>
-    protected abstract Provider VisitFilter(FilterProvider provider);
+    protected abstract CompilableProvider VisitFilter(FilterProvider provider);
 
     /// <summary>
     /// Visits <see cref="DistinctProvider"/>.
     /// </summary>
     /// <param name="provider">Distinct provider.</param>
-    protected abstract Provider VisitDistinct(DistinctProvider provider);
+    protected abstract CompilableProvider VisitDistinct(DistinctProvider provider);
 
     /// <summary>
     /// Visits <see cref="CalculateProvider"/>.
     /// </summary>
     /// <param name="provider">Calculate provider.</param>
-    protected abstract Provider VisitCalculate(CalculateProvider provider);
+    protected abstract CompilableProvider VisitCalculate(CalculateProvider provider);
 
     /// <summary>
     /// Visits <see cref="AliasProvider"/>.
     /// </summary>
     /// <param name="provider">Alias provider.</param>
-    protected abstract Provider VisitAlias(AliasProvider provider);
+    protected abstract CompilableProvider VisitAlias(AliasProvider provider);
 
     /// <summary>
     /// Visits <see cref="AggregateProvider"/>.
     /// </summary>
     /// <param name="provider">Aggregate provider.</param>
     /// <returns></returns>
-    protected abstract Provider VisitAggregate(AggregateProvider provider);
+    protected abstract CompilableProvider VisitAggregate(AggregateProvider provider);
 
     /// <summary>
     /// Visits <see cref="StoreProvider"/>.
     /// </summary>
     /// <param name="provider">Store provider.</param>
-    protected abstract Provider VisitStore(StoreProvider provider);
+    protected abstract CompilableProvider VisitStore(StoreProvider provider);
 
     /// <summary>
     /// Visits <see cref="IndexProvider"/>.
     /// </summary>
     /// <param name="provider">Index provider.</param>
-    protected abstract Provider VisitIndex(IndexProvider provider);
+    protected abstract CompilableProvider VisitIndex(IndexProvider provider);
 
     /// <summary>
     /// Visits the <see cref="IntersectProvider"/>.
     /// </summary>
     /// <param name="provider">Intersect provider.</param>
     /// <returns></returns>
-    protected abstract Provider VisitIntersect(IntersectProvider provider);
+    protected abstract CompilableProvider VisitIntersect(IntersectProvider provider);
 
     /// <summary>
     /// Visits the <see cref="ExceptProvider"/>.
     /// </summary>
     /// <param name="provider">Except provider.</param>
     /// <returns></returns>
-    protected abstract Provider VisitExcept(ExceptProvider provider);
+    protected abstract CompilableProvider VisitExcept(ExceptProvider provider);
 
     /// <summary>
     /// Visits the <see cref="ConcatProvider"/>.
     /// </summary>
     /// <param name="provider">Concat provider.</param>
     /// <returns></returns>
-    protected abstract Provider VisitConcat(ConcatProvider provider);
+    protected abstract CompilableProvider VisitConcat(ConcatProvider provider);
 
     /// <summary>
     /// Visits the <see cref="UnionProvider"/>.
     /// </summary>
     /// <param name="provider">Union provider.</param>
     /// <returns></returns>
-    protected abstract Provider VisitUnion(UnionProvider provider);
+    protected abstract CompilableProvider VisitUnion(UnionProvider provider);
 
     /// <summary>
     /// Visits the <see cref="LockProvider"/>.
     /// </summary>
     /// <param name="provider">Lock provider.</param>
     /// <returns></returns>
-    protected abstract Provider VisitLock(LockProvider provider);
+    protected abstract CompilableProvider VisitLock(LockProvider provider);
 
     /// <summary>
     /// Visits the <see cref="IncludeProvider"/>.
     /// </summary>
     /// <param name="provider">Include provider.</param>
     /// <returns></returns>
-    protected abstract Provider VisitInclude(IncludeProvider provider);
+    protected abstract CompilableProvider VisitInclude(IncludeProvider provider);
 
     /// <summary>
     /// Visits the <see cref="FreeTextProvider"/>.
     /// </summary>
     /// <param name="provider">FreeText provider.</param>
     /// <returns></returns>
-    protected abstract Provider VisitFreeText(FreeTextProvider provider);
+    protected abstract CompilableProvider VisitFreeText(FreeTextProvider provider);
 
     /// <summary>
-    /// Visits the <see cref="FreeTextProvider"/>.
+    /// Visits the <see cref="ContainsTableProvider"/>.
     /// </summary>
     /// <param name="provider">SearchCondition provider.</param>
     /// <returns></returns>
-    protected abstract Provider VisitContainsTable(ContainsTableProvider provider);
+    protected abstract CompilableProvider VisitContainsTable(ContainsTableProvider provider);
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
@@ -35,7 +35,7 @@ namespace Xtensive.Orm.Rse.Transformation
 
     #region Visit methods
 
-    protected override CompilableProvider VisitInclude(IncludeProvider provider)
+    protected override IncludeProvider VisitInclude(IncludeProvider provider)
     {
       var sourceLength = provider.Source.Header.Length;
       mappings[provider.Source] = Merge(mappings[provider].Where(i => i < sourceLength), provider.FilteredColumns);
@@ -51,7 +51,7 @@ namespace Xtensive.Orm.Rse.Transformation
         provider.FilterDataSource, provider.ResultColumnName, filteredColumns);
     }
 
-    protected override CompilableProvider VisitSelect(SelectProvider provider)
+    protected override SelectProvider VisitSelect(SelectProvider provider)
     {
       var requiredColumns = mappings[provider];
       var remappedColumns = requiredColumns
@@ -82,7 +82,7 @@ namespace Xtensive.Orm.Rse.Transformation
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitFreeText(FreeTextProvider provider)
+    protected override FreeTextProvider VisitFreeText(FreeTextProvider provider)
     {
       mappings[provider] = CollectionUtils.RangeToList(0, provider.Header.Length);
       return provider;
@@ -94,19 +94,19 @@ namespace Xtensive.Orm.Rse.Transformation
       return provider;
     }
 
-    protected override CompilableProvider VisitIndex(IndexProvider provider)
+    protected override IndexProvider VisitIndex(IndexProvider provider)
     {
       mappings[provider] = CollectionUtils.RangeToList(0, provider.Header.Length);
       return provider;
     }
 
-    protected override CompilableProvider VisitSeek(SeekProvider provider)
+    protected override SeekProvider VisitSeek(SeekProvider provider)
     {
       mappings[provider] = CollectionUtils.RangeToList(0, provider.Header.Length);
       return provider;
     }
 
-    protected override CompilableProvider VisitFilter(FilterProvider provider)
+    protected override FilterProvider VisitFilter(FilterProvider provider)
     {
       mappings[provider.Source] = Merge(mappings[provider], mappingsGatherer.Gather(provider.Predicate));
       var newSourceProvider = VisitCompilable(provider.Source);
@@ -118,7 +118,7 @@ namespace Xtensive.Orm.Rse.Transformation
         : new FilterProvider(newSourceProvider, (Expression<Func<Tuple, bool>>) predicate);
     }
 
-    protected override CompilableProvider VisitJoin(JoinProvider provider)
+    protected override JoinProvider VisitJoin(JoinProvider provider)
     {
       // split
 
@@ -146,7 +146,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return new JoinProvider(newLeftProvider, newRightProvider, provider.JoinType, newIndexes.ToArray());
     }
 
-    protected override CompilableProvider VisitPredicateJoin(PredicateJoinProvider provider)
+    protected override PredicateJoinProvider VisitPredicateJoin(PredicateJoinProvider provider)
     {
       SplitMappings(provider, out var leftMapping, out var rightMapping);
 
@@ -167,7 +167,7 @@ namespace Xtensive.Orm.Rse.Transformation
         : new PredicateJoinProvider(newLeftProvider, newRightProvider, (Expression<Func<Tuple, Tuple, bool>>) predicate, provider.JoinType);
     }
 
-    protected override CompilableProvider VisitSort(SortProvider provider)
+    protected override SortProvider VisitSort(SortProvider provider)
     {
       mappings[provider.Source] = Merge(mappings[provider], provider.Order.Keys);
       var source = VisitCompilable(provider.Source);
@@ -186,7 +186,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return source == provider.Source ? provider : new SortProvider(source, order);
     }
 
-    protected override CompilableProvider VisitApply(ApplyProvider provider)
+    protected override ApplyProvider VisitApply(ApplyProvider provider)
     {
       // split
 
@@ -233,7 +233,7 @@ namespace Xtensive.Orm.Rse.Transformation
         : new ApplyProvider(applyParameter, newLeftProvider, newRightProvider, provider.IsInlined, provider.SequenceType, provider.ApplyType);
     }
 
-    protected override CompilableProvider VisitAggregate(AggregateProvider provider)
+    protected override AggregateProvider VisitAggregate(AggregateProvider provider)
     {
       var map = provider.AggregateColumns
         .Select(c => c.SourceIndex)
@@ -309,7 +309,7 @@ namespace Xtensive.Orm.Rse.Transformation
         : new CalculateProvider(newSourceProvider, descriptors.ToArray());
     }
 
-    protected override CompilableProvider VisitRowNumber(RowNumberProvider provider)
+    protected override RowNumberProvider VisitRowNumber(RowNumberProvider provider)
     {
       var sourceLength = provider.Source.Header.Length;
       mappings[provider.Source] = mappings[provider].Where(i => i < sourceLength).ToList();

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyProviderCorrectorRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyProviderCorrectorRewriter.cs
@@ -188,7 +188,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return newProvider;
     }
 
-    protected override CompilableProvider VisitSelect(SelectProvider provider)
+    protected override SelectProvider VisitSelect(SelectProvider provider)
     {
       var source = VisitCompilable(provider.Source);
       var newProvider = provider;
@@ -199,7 +199,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return newProvider;
     }
 
-    protected override CompilableProvider VisitJoin(JoinProvider provider)
+    protected override JoinProvider VisitJoin(JoinProvider provider)
     {
       CompilableProvider left;
       CompilableProvider right;
@@ -213,7 +213,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return provider;
     }
 
-    protected override CompilableProvider VisitPredicateJoin(PredicateJoinProvider provider)
+    protected override PredicateJoinProvider VisitPredicateJoin(PredicateJoinProvider provider)
     {
       CompilableProvider left;
       CompilableProvider right;
@@ -227,7 +227,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return provider;
     }
 
-    protected override CompilableProvider VisitIntersect(IntersectProvider provider)
+    protected override IntersectProvider VisitIntersect(IntersectProvider provider)
     {
       CompilableProvider left;
       CompilableProvider right;
@@ -237,7 +237,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return provider;
     }
 
-    protected override CompilableProvider VisitExcept(ExceptProvider provider)
+    protected override ExceptProvider VisitExcept(ExceptProvider provider)
     {
       CompilableProvider left;
       CompilableProvider right;
@@ -257,7 +257,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return provider;
     }
 
-    protected override CompilableProvider VisitUnion(UnionProvider provider)
+    protected override UnionProvider VisitUnion(UnionProvider provider)
     {
       CompilableProvider left;
       CompilableProvider right;
@@ -286,7 +286,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return calculateProviderCollector.TryAdd(newProvider) ? source : newProvider;
     }
 
-    protected override CompilableProvider VisitTake(TakeProvider provider)
+    protected override TakeProvider VisitTake(TakeProvider provider)
     {
       var source = VisitCompilable(provider.Source);
       EnsureAbsenceOfApplyProviderRequiringConversion();
@@ -295,7 +295,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return provider;
     }
 
-    protected override CompilableProvider VisitSkip(SkipProvider provider)
+    protected override SkipProvider VisitSkip(SkipProvider provider)
     {
       var source = VisitCompilable(provider.Source);
       EnsureAbsenceOfApplyProviderRequiringConversion();

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/RedundantColumnRemover.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/RedundantColumnRemover.cs
@@ -36,7 +36,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return new Pair<CompilableProvider, List<int>>(selectProvider, requestedMapping);
     }
 
-    protected override CompilableProvider VisitRaw(RawProvider provider)
+    protected override RawProvider VisitRaw(RawProvider provider)
     {
       var mapping = mappings[provider];
       if (mapping.SequenceEqual(Enumerable.Range(0, provider.Header.Length)))


### PR DESCRIPTION
- Descendant classes of ```CompilableProviderVisitor``` use covariant returns where it is possible.
- Changes signature of ```CompilableProviderVisitor.expressionTranslator``` to not allow having ```Provider``` as incoming parameter and cause issues.