### PR TITLE
Deprecate `TableMappingAttribute`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Attributes/TableMappingAttribute.cs
+++ b/Orm/Xtensive.Orm/Orm/Attributes/TableMappingAttribute.cs
@@ -12,7 +12,7 @@ namespace Xtensive.Orm
   /// <summary>
   /// Table mapping attribute.
   /// </summary>
-  [Obsolete("Deprecated due to Model Upgrade problems. Create new Entity class instead and copy data to it by Upgrade Handler or Content Upgrade")]
+  [Obsolete("Deprecated due to problems with Model Upgrade. Create new Entity class instead and copy data to it by Upgrade Handler or Content Upgrade")]
   [Serializable]
   [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Property,
     AllowMultiple = false, Inherited = false)]

--- a/Orm/Xtensive.Orm/Orm/Attributes/TableMappingAttribute.cs
+++ b/Orm/Xtensive.Orm/Orm/Attributes/TableMappingAttribute.cs
@@ -12,17 +12,18 @@ namespace Xtensive.Orm
   /// <summary>
   /// Table mapping attribute.
   /// </summary>
+  [Obsolete("Deprecated due to Model Upgrade problems. Create new Entity class instead and copy data to it by Upgrade Handler or Content Upgrade")]
   [Serializable]
-  [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Property, 
+  [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Property,
     AllowMultiple = false, Inherited = false)]
   public sealed class TableMappingAttribute : StorageAttribute
   {
     /// <summary>
-    /// Gets the base part of the field's related column name 
+    /// Gets the base part of the field's related column name
     /// or the base part of the class' related table name.
     /// </summary>
     /// <remarks>
-    /// You can use the following characters in <see cref="Name"/>s: [_A-Za-z0-9-.]. 
+    /// You can use the following characters in <see cref="Name"/>s: [_A-Za-z0-9-.].
     /// <see cref="Name"/> can't be an empty string or <see langword="null"/>.
     /// </remarks>
     public string Name { get; private set; }


### PR DESCRIPTION
Very often we have problems with incorrect usage of this attribute during Model Upgrades.
See discussions:
* https://servicetitan.slack.com/archives/CAXMG2939/p1691103672617859
* https://servicetitan.slack.com/archives/GD2910GBS/p1632402570258000
* https://servicetitan.slack.com/archives/D43MJL9EF/p1628634932004100

If it is absolutely necessary to have another  entity class name, it seems better to copy data in Upgrade Handler