### PR TITLE
Optimization: `SchemaMapping` class to decrease `sizeof(SchemaMappedNode)`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Building/Builders/ModelBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/ModelBuilder.cs
@@ -379,8 +379,7 @@ namespace Xtensive.Orm.Building.Builders
         underlyingTypeDef.Name = association.Name;
         underlyingTypeDef.MappingName = context.NameBuilder.BuildAuxiliaryTypeMappingName(association);
         // Copy mapping information from master type
-        underlyingTypeDef.MappingSchema = association.OwnerType.MappingSchema;
-        underlyingTypeDef.MappingDatabase = association.OwnerType.MappingDatabase;
+        underlyingTypeDef.SchemaMapping = association.OwnerType.SchemaMapping;
 
         // HierarchyRootAttribute is not inherited so we must take it from the generic type definition or generic instance type
         var hra = WellKnownOrmTypes.EntitySetItemOfT1T2

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/SchemaMapping.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/SchemaMapping.cs
@@ -1,0 +1,15 @@
+using BitFaster.Caching.Lru;
+
+namespace Xtensive.Orm.Building.Builders
+{
+  public class SchemaMapping
+  {
+      private static readonly FastConcurrentLru<(string, string), SchemaMapping> cache = new(20_000);
+
+      public string Database { get; private init; }
+      public string Schema { get; private init; }
+
+      public static SchemaMapping Get(string database, string schema) =>
+        cache.GetOrAdd((database, schema), static p => new SchemaMapping { Database = p.Item1, Schema = p.Item2 });
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingBuilder.cs
@@ -57,21 +57,8 @@ namespace Xtensive.Orm.Building.Builders
       }
     }
 
-    private struct MappingResult
-    {
-      public readonly string MappingDatabase;
-      public readonly string MappingSchema;
-
-      public MappingResult(string mappingDatabase, string mappingSchema)
-      {
-        MappingDatabase = mappingDatabase;
-        MappingSchema = mappingSchema;
-      }
-    }
-
     private readonly BuildingContext context;
-    private readonly Dictionary<MappingRequest, MappingResult> mappingCache
-      = new Dictionary<MappingRequest,MappingResult>();
+    private readonly Dictionary<MappingRequest, SchemaMapping> mappingCache = new();
 
     private readonly bool verbose;
     private readonly List<MappingRule> mappingRules;
@@ -105,12 +92,11 @@ namespace Xtensive.Orm.Building.Builders
             BuildLog.Info(nameof(Strings.LogReusingCachedMappingInformationForX), underlyingType.GetShortName());
           }
         }
-        type.MappingDatabase = result.MappingDatabase;
-        type.MappingSchema = result.MappingSchema;
+        type.SchemaMapping = result;
       }
     }
 
-    private MappingResult Process(Type type)
+    private SchemaMapping Process(Type type)
     {
       var rule = mappingRules.First(r => RuleMatch(r, type));
 
@@ -121,7 +107,7 @@ namespace Xtensive.Orm.Building.Builders
         BuildLog.Info(nameof(Strings.ApplyingRuleXToY), rule, type.GetShortName());
       }
 
-      return new MappingResult(resultDatabase, resultSchema);
+      return SchemaMapping.Get(resultDatabase, resultSchema);
     }
 
     private static bool RuleMatch(MappingRule rule, Type type)

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/TypeBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/TypeBuilder.cs
@@ -48,8 +48,7 @@ namespace Xtensive.Orm.Building.Builders
           UnderlyingType = typeDef.UnderlyingType,
           Name = typeDef.Name,
           MappingName = typeDef.MappingName,
-          MappingDatabase = typeDef.MappingDatabase,
-          MappingSchema = typeDef.MappingSchema,
+          SchemaMapping = SchemaMapping.Get(typeDef.MappingDatabase, typeDef.MappingSchema),
           HasVersionRoots = TypeHelper.GetInterfacesUnordered(typeDef.UnderlyingType)
             .Any(static type => type == typeof(IHasVersionRoots)),
           Validators = validators.AsReadOnly(),
@@ -591,8 +590,7 @@ namespace Xtensive.Orm.Building.Builders
       var sequence = new SequenceInfo(generatorName) {
         Seed = seed + cacheSize, // Preallocate keys for the first access
         Increment = cacheSize,
-        MappingDatabase = hierarchyDef.Root.MappingDatabase,
-        MappingSchema = context.Configuration.DefaultSchema,
+        SchemaMapping = SchemaMapping.Get(hierarchyDef.Root.MappingDatabase, context.Configuration.DefaultSchema),
         MappingName = context.NameBuilder.BuildSequenceName(key),
       };
 

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/TypeBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/TypeBuilder.cs
@@ -48,7 +48,7 @@ namespace Xtensive.Orm.Building.Builders
           UnderlyingType = typeDef.UnderlyingType,
           Name = typeDef.Name,
           MappingName = typeDef.MappingName,
-          SchemaMapping = SchemaMapping.Get(typeDef.MappingDatabase, typeDef.MappingSchema),
+          SchemaMapping = typeDef.SchemaMapping,
           HasVersionRoots = TypeHelper.GetInterfacesUnordered(typeDef.UnderlyingType)
             .Any(static type => type == typeof(IHasVersionRoots)),
           Validators = validators.AsReadOnly(),

--- a/Orm/Xtensive.Orm/Orm/Building/FixupActionProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/FixupActionProcessor.cs
@@ -127,8 +127,7 @@ namespace Xtensive.Orm.Building
         // Copy schema/database from first generic argument
         var originatingType = instanceType.GetGenericArguments()[0];
         var originatingEntity = context.ModelDef.Types[originatingType];
-        typeDef.MappingDatabase = originatingEntity.MappingDatabase;
-        typeDef.MappingSchema = originatingEntity.MappingSchema;
+        typeDef.SchemaMapping = originatingEntity.SchemaMapping;
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Model/SchemaMappedNode.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/SchemaMappedNode.cs
@@ -32,12 +32,12 @@ namespace Xtensive.Orm.Model
     /// <summary>
     /// Gets or sets database this node is mapped to.
     /// </summary>
-    public string MappingDatabase => SchemaMapping.Database;
+    public string MappingDatabase => SchemaMapping?.Database;
 
     /// <summary>
     /// Gets or sets schema this node is mapped to.
     /// </summary>
-    public string MappingSchema => SchemaMapping.Schema;
+    public string MappingSchema => SchemaMapping?.Schema;
 
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/Model/SchemaMappedNode.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/SchemaMappedNode.cs
@@ -6,6 +6,7 @@
 
 using System;
 using Xtensive.Core;
+using Xtensive.Orm.Building.Builders;
 
 namespace Xtensive.Orm.Model
 {
@@ -15,34 +16,28 @@ namespace Xtensive.Orm.Model
   [Serializable]
   public abstract class SchemaMappedNode : MappedNode
   {
-    private string mappingDatabase;
-    private string mappingSchema;
+    private SchemaMapping schemaMapping;
+
+    /// <summary>
+    /// Gets or sets database/schema this node is mapped to.
+    /// </summary>
+    public SchemaMapping SchemaMapping {
+      get => schemaMapping;
+      set {
+        EnsureNotLocked();
+        schemaMapping = value;
+      }
+    }
 
     /// <summary>
     /// Gets or sets database this node is mapped to.
     /// </summary>
-    public string MappingDatabase
-    {
-      get { return mappingDatabase; }
-      set
-      {
-        EnsureNotLocked();
-        mappingDatabase = value;
-      }
-    }
+    public string MappingDatabase => SchemaMapping.Database;
 
     /// <summary>
     /// Gets or sets schema this node is mapped to.
     /// </summary>
-    public string MappingSchema
-    {
-      get { return mappingSchema; }
-      set
-      {
-        EnsureNotLocked();
-        mappingSchema = value;
-      }
-    }
+    public string MappingSchema => SchemaMapping.Schema;
 
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
@@ -696,8 +696,7 @@ namespace Xtensive.Orm.Model
         // MappingSchema is not important: it's copied for consistency.
         var firstImplementor = DirectImplementors.FirstOrDefault();
         if (firstImplementor != null) {
-          MappingDatabase = firstImplementor.MappingDatabase;
-          MappingSchema = firstImplementor.MappingSchema;
+          SchemaMapping = firstImplementor.SchemaMapping;
         }
       }
 


### PR DESCRIPTION
Cached shared pairs `(Database, Schema)` is more efficient than storing two string fields in every `SchemaMappedNode` instance

Cache capacity == `20_000` is ~ number of our tenants

P.S.
The optimization is insignificant, because number of `TypeInfo : SchemaMapping` is low (1,500)