### PR TITLE
ARCH-6225: Optimize `ModelMapping` memory consumption

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Model/TypeIdRegistry.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeIdRegistry.cs
@@ -120,7 +120,7 @@ namespace Xtensive.Orm.Model
       EnsureNotLocked();
 
       if (mapping is null) {
-        if (typeId <= UInt16.MaxValue && type.SharedId <= UInt16.MaxValue) {
+        if ((uint)typeId <= UInt16.MaxValue && type.SharedId <= UInt16.MaxValue) {
           sharedIdToTypeId ??= new UInt16[1];
           typeIdToSharedId ??= new UInt16[1];
           Array.Resize(ref sharedIdToTypeId, Math.Max(type.SharedId + 10, Math.Max(sharedIdToTypeInfo.Count, sharedIdToTypeId.Length)));

--- a/Orm/Xtensive.Orm/Orm/Model/TypeIdRegistry.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeIdRegistry.cs
@@ -123,9 +123,9 @@ namespace Xtensive.Orm.Model
         if (typeId <= UInt16.MaxValue && type.SharedId <= UInt16.MaxValue) {
           sharedIdToTypeId ??= new UInt16[1];
           typeIdToSharedId ??= new UInt16[1];
-          Array.Resize(ref sharedIdToTypeId, Math.Max(type.SharedId + 1, Math.Max(sharedIdToTypeInfo.Count, sharedIdToTypeId.Length)));
+          Array.Resize(ref sharedIdToTypeId, Math.Max(type.SharedId + 10, Math.Max(sharedIdToTypeInfo.Count, sharedIdToTypeId.Length)));
           sharedIdToTypeId[type.SharedId] = (UInt16)typeId;
-          Array.Resize(ref typeIdToSharedId, Math.Max(typeIdToSharedId.Length, typeId + 1));
+          Array.Resize(ref typeIdToSharedId, Math.Max(typeIdToSharedId.Length, typeId + 10));
           typeIdToSharedId[typeId] = (UInt16) type.SharedId;
           return;
         }

--- a/Orm/Xtensive.Orm/Orm/Providers/ModelMapping.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/ModelMapping.cs
@@ -60,7 +60,7 @@ namespace Xtensive.Orm.Providers
     public void Register(TypeInfo typeInfo, Table table)
     {
       EnsureNotLocked();
-      Array.Resize(ref tableMap, Math.Max(tableMap.Length, typeInfo.SharedId + 1));
+      Array.Resize(ref tableMap, Math.Max(tableMap.Length, typeInfo.SharedId + 10));
       tableMap[typeInfo.SharedId] = table;
     }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/ModelMapping.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/ModelMapping.cs
@@ -4,6 +4,7 @@
 // Created by: Dmitri Maximov
 // Created:    2008.09.23
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xtensive.Core;
@@ -18,8 +19,8 @@ namespace Xtensive.Orm.Providers
   /// </summary>
   public sealed class ModelMapping : LockableBase
   {
-    private readonly Dictionary<TypeInfo, Table> tableMap = new Dictionary<TypeInfo, Table>();
-    private readonly Dictionary<SequenceInfo, SchemaNode> sequenceMap = new Dictionary<SequenceInfo, SchemaNode>();
+    private Table[] tableMap = new Table[1];      // Indexed by TypeInfo.SharedId
+    private readonly Dictionary<SequenceInfo, SchemaNode> sequenceMap = new();
 
     private string temporaryTableDatabase;
     private string temporaryTableSchema;
@@ -27,9 +28,8 @@ namespace Xtensive.Orm.Providers
 
     public string TemporaryTableDatabase
     {
-      get { return temporaryTableDatabase; }
-      set
-      {
+      get => temporaryTableDatabase;
+      set {
         EnsureNotLocked();
         temporaryTableDatabase = value;
       }
@@ -37,9 +37,8 @@ namespace Xtensive.Orm.Providers
 
     public string TemporaryTableSchema
     {
-      get { return temporaryTableSchema; }
-      set
-      {
+      get => temporaryTableSchema;
+      set {
         EnsureNotLocked();
         temporaryTableSchema = value;
       }
@@ -47,38 +46,22 @@ namespace Xtensive.Orm.Providers
 
     public string TemporaryTableCollation
     {
-      get { return temporaryTableCollation; }
-      set
-      {
+      get => temporaryTableCollation;
+      set {
         EnsureNotLocked();
         temporaryTableCollation = value;
       }
     }
 
-    public Table this[TypeInfo typeInfo]
-    {
-      get
-      {
-        Table result;
-        tableMap.TryGetValue(typeInfo, out result);
-        return result;
-      }
-    }
+    public Table this[TypeInfo typeInfo] => typeInfo.SharedId < tableMap.Length ? tableMap[typeInfo.SharedId] : null;
 
-    public SchemaNode this[SequenceInfo sequenceInfo]
-    {
-      get
-      {
-        SchemaNode result;
-        sequenceMap.TryGetValue(sequenceInfo, out result);
-        return result;
-      }
-    }
+    public SchemaNode this[SequenceInfo sequenceInfo] => sequenceMap.GetValueOrDefault(sequenceInfo);
 
     public void Register(TypeInfo typeInfo, Table table)
     {
       EnsureNotLocked();
-      tableMap[typeInfo] = table;
+      Array.Resize(ref tableMap, Math.Max(tableMap.Length, typeInfo.SharedId + 1));
+      tableMap[typeInfo.SharedId] = table;
     }
 
     public void Register(SequenceInfo sequenceInfo, SchemaNode sequence)
@@ -87,15 +70,7 @@ namespace Xtensive.Orm.Providers
       sequenceMap[sequenceInfo] = sequence;
     }
 
-    internal IList<SchemaNode> GetAllSchemaNodes()
-    {
-      return tableMap.Values.Union(sequenceMap.Values).ToList();
-    }
-
-    // Constructors
-
-    internal ModelMapping()
-    {
-    }
+    internal IEnumerable<SchemaNode> GetAllSchemaNodes() =>
+      tableMap.Where(static o => o != null).Union(sequenceMap.Values);
   }
 }


### PR DESCRIPTION
This is followup of   https://github.com/servicetitan/dataobjects-net/pull/151

With big number of nodes we have huge RAM consumption in `ModelMapping` class

|objects|bytes|class|
|-------|-------|----|
|18,750|413,982,672|Dictionary<Xtensive.Orm.Model.TypeInfo, Xtensive.Sql.Model.Table>+Entry[]|

We can represent this mapping as Table[] array.

Then our RAM consumption will be `1100*8*18750` ~=  165M.
2.5 times less, saving 248MB