### PR TITLE
Optimize IDisposable implementations

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchManagerBasicTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchManagerBasicTest.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using NUnit.Framework;
 using Xtensive.Core;
@@ -930,13 +931,14 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
     [Test]
     public void ReferenceToSessionIsNotPreservedInCacheTest()
     {
-      // Use separate method for session related processing
+      // Use separate method with [MethodImpl(MethodImplOptions.NoInlining)] attribute for session related processing
       // to make sure we don't hold session reference somewhere on stack
       OpenSessionsAndRunPrefetches();
       TestHelper.CollectGarbage(true);
       Assert.That(instanceCount, Is.EqualTo(0));
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private void OpenSessionsAndRunPrefetches()
     {
       instanceCount = Iterations;

--- a/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchManagerBasicTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchManagerBasicTest.cs
@@ -33,10 +33,7 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
 
     public class MemoryLeakTester
     {
-      ~MemoryLeakTester()
-      {
-        instanceCount--;
-      }
+      ~MemoryLeakTester() => Interlocked.Decrement(ref instanceCount);
     }
 
     #endregion

--- a/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchManagerBasicTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchManagerBasicTest.cs
@@ -27,6 +27,7 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
   [TestFixture]
   public class PrefetchManagerBasicTest : PrefetchManagerTestBase
   {
+    private const int Iterations = 10;
     private volatile static int instanceCount;
 
     #region Nested class
@@ -938,8 +939,8 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
 
     private void OpenSessionsAndRunPrefetches()
     {
-      instanceCount = 10;
-      for (int i = 0; i < instanceCount; i++) {
+      instanceCount = Iterations;
+      for (int i = 0; i < Iterations; i++) {
         using (var session = Domain.OpenSession())
         using (var t = session.OpenTransaction()) {
           session.Extensions.Set(new MemoryLeakTester());

--- a/Orm/Xtensive.Orm/Collections/BindingCollection.cs
+++ b/Orm/Xtensive.Orm/Collections/BindingCollection.cs
@@ -112,9 +112,7 @@ namespace Xtensive.Collections
     public virtual void PermanentAdd(TKey key, TValue value)
     {
       bindings[key] = value;
-      if (!permanentBindings.Contains(key)) {
-        permanentBindings.Add(key);
-      }
+      permanentBindings.Add(key);
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Collections/Graphs/Graph.cs
+++ b/Orm/Xtensive.Orm/Collections/Graphs/Graph.cs
@@ -56,9 +56,8 @@ namespace Xtensive.Collections.Graphs
       foreach (var rNode in copy.Nodes) {
         var node = rNode.Value;
         foreach (var edge in node.Edges) {
-          if (!processedEdges.Contains(edge)) {
+          if (processedEdges.Add(edge)) {
             var rEdge = new Edge<TEdge>(nodeMap[edge.Source], nodeMap[edge.Target], (TEdge) edge);
-            processedEdges.Add(edge);
           }
         }
       }

--- a/Orm/Xtensive.Orm/Orm/Entity.cs
+++ b/Orm/Xtensive.Orm/Orm/Entity.cs
@@ -138,8 +138,7 @@ namespace Xtensive.Orm
         List<PrefetchFieldDescriptor> columnsToPrefetch = null;
         foreach (var columnInfo in versionColumns) {
           if (!tuple.GetFieldState(columnInfo.Field.MappingInfo.Offset).IsAvailable()) {
-            if (columnsToPrefetch==null)
-              columnsToPrefetch = new List<PrefetchFieldDescriptor>();
+            columnsToPrefetch ??= new List<PrefetchFieldDescriptor>(1);
             columnsToPrefetch.Add(new PrefetchFieldDescriptor(columnInfo.Field));
           }
         }

--- a/Orm/Xtensive.Orm/Orm/Model/FullTextIndexInfoCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FullTextIndexInfoCollection.cs
@@ -54,8 +54,7 @@ namespace Xtensive.Orm.Model
     public void Add(TypeInfo typeInfo, FullTextIndexInfo fullTextIndexInfo)
     {
       EnsureNotLocked();
-      if (!container.Contains(fullTextIndexInfo))
-        container.Add(fullTextIndexInfo);
+      container.Add(fullTextIndexInfo);
       indexMap.Add(typeInfo, fullTextIndexInfo);
     }
 

--- a/Orm/Xtensive.Orm/Orm/OperationLog.cs
+++ b/Orm/Xtensive.Orm/Orm/OperationLog.cs
@@ -61,7 +61,7 @@ namespace Xtensive.Orm
       KeyMapping keyMapping;
 
       using (session.Activate()) {
-        using (isSystemOperationLog ? session.OpenSystemLogicOnlyRegion() : null) 
+        using (isSystemOperationLog ? (IDisposable) session.OpenSystemLogicOnlyRegion() : null)
         using (var tx = session.OpenTransaction(TransactionOpenMode.New)) {
 
           foreach (var operation in operations)

--- a/Orm/Xtensive.Orm/Orm/Services/DirectSessionAccessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Services/DirectSessionAccessor.cs
@@ -28,10 +28,7 @@ namespace Xtensive.Orm.Services
     /// disposal will restore previous state of
     /// <see cref="Session.IsSystemLogicOnly"/> property.
     /// </returns>
-    public IDisposable OpenSystemLogicOnlyRegion()
-    {
-      return Session.OpenSystemLogicOnlyRegion();
-    }
+    public Session.SystemLogicOnlyRegionScope OpenSystemLogicOnlyRegion() => Session.OpenSystemLogicOnlyRegion();
 
     /// <summary>
     /// Changes the value of <see cref="Session.Handler"/>.

--- a/Orm/Xtensive.Orm/Orm/Session.Persist.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.Persist.cs
@@ -18,6 +18,8 @@ namespace Xtensive.Orm
 {
   public partial class Session
   {
+    private static readonly IDisposable EmptyDisposable = new Disposable(b => { return; });
+
     private bool disableAutoSaveChanges;
     private KeyRemapper remapper;
     private bool persistingIsFailed;
@@ -245,9 +247,9 @@ namespace Xtensive.Orm
       ArgumentValidator.EnsureArgumentNotNull(target, "target");
       var targetEntity = (Entity) target;
       targetEntity.EnsureNotRemoved();
-      if (!Configuration.Supports(SessionOptions.AutoSaveChanges))
-        return new Disposable(b => {return;}); // No need to pin in this case
-      return pinner.RegisterRoot(targetEntity.State);
+      return Configuration.Supports(SessionOptions.AutoSaveChanges)
+        ? pinner.RegisterRoot(targetEntity.State)
+        : EmptyDisposable; // No need to pin in this case
     }
 
     /// <summary>
@@ -260,8 +262,9 @@ namespace Xtensive.Orm
     /// </summary>
     public IDisposable DisableSaveChanges()
     {
-      if (!Configuration.Supports(SessionOptions.AutoSaveChanges))
-        return new Disposable(b => { return; }); // No need to pin in this case
+      if (!Configuration.Supports(SessionOptions.AutoSaveChanges)) {
+        return EmptyDisposable; // No need to pin in this case
+      }
       if (disableAutoSaveChanges)
         return null;
 

--- a/Orm/Xtensive.Orm/Orm/Session.SystemLogic.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.SystemLogic.cs
@@ -11,17 +11,26 @@ namespace Xtensive.Orm
 {
   public partial class Session
   {
+    public readonly struct SystemLogicOnlyRegionScope : IDisposable
+    {
+      private readonly Session session;
+      private readonly bool prevIsSystemLogicOnly;
+
+      public SystemLogicOnlyRegionScope(Session session)
+      {
+        this.session = session;
+        prevIsSystemLogicOnly = session.IsSystemLogicOnly;
+        session.IsSystemLogicOnly = true;
+      }
+
+      public void Dispose() => session.IsSystemLogicOnly = prevIsSystemLogicOnly;
+    }
+
     /// <summary>
     /// Gets a value indicating whether only a system logic is enabled.
     /// </summary>
     internal bool IsSystemLogicOnly { get; set; }
 
-    internal IDisposable OpenSystemLogicOnlyRegion()
-    {
-      var result = new Disposable<Session, bool>(this, IsSystemLogicOnly,
-        (disposing, session, previousState) => session.IsSystemLogicOnly = previousState);
-      IsSystemLogicOnly = true;
-      return result;
-    }
+    internal SystemLogicOnlyRegionScope OpenSystemLogicOnlyRegion() => new(this);
   }
 }


### PR DESCRIPTION
* Make frequently invoked methods  `OpenSystemLogicOnlyRegion()`, `EnableSystemOperationRegistration()`, `DisableSystemOperationRegistration()` alloc-less  (there were 2 allocations: for `Disposable<>` & closure)
* Optimize `RegisterRoot()`
* Use static `EmptyDisposable` where possible
* Refactor `if (!hashSet.Contains(x)) hashSet.Add(x);` pattern into `hashSet.Add(x)` to avoid double search
* Fix `PrefetchManagerBasicTest`: prohibit JIT to inline the function