### PR TITLE
UpgradeDomain: Move `Rollback()` into `Commit()` method. Else it will fail

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
@@ -234,14 +234,14 @@ namespace Xtensive.Orm.Providers
       }
     }
 
-    public void CommitTransaction(Session session, SqlConnection connection)
+    public void CommitTransaction(Session session, SqlConnection connection, bool rollbackOnFail = false)
     {
       if (isLoggingEnabled) {
         SqlLog.Info(nameof(Strings.LogSessionXCommitTransaction), session.ToStringSafely());
       }
 
       try {
-        connection.Commit();
+        connection.Commit(rollbackOnFail);
       }
       catch (Exception exception) {
         throw ExceptionBuilder.BuildException(exception);
@@ -249,14 +249,14 @@ namespace Xtensive.Orm.Providers
     }
 
     public async ValueTask CommitTransactionAsync(
-      Session session, SqlConnection connection, CancellationToken token = default)
+      Session session, SqlConnection connection, bool rollbackOnFail = false, CancellationToken token = default)
     {
       if (isLoggingEnabled) {
         SqlLog.Info(nameof(Strings.LogSessionXCommitTransaction), session.ToStringSafely());
       }
 
       try {
-        await connection.CommitAsync(token).ConfigureAwaitFalse();
+        await connection.CommitAsync(rollbackOnFail, token).ConfigureAwaitFalse();
       }
       catch (Exception exception) {
         throw ExceptionBuilder.BuildException(exception);

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SchemaUpgrader.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SchemaUpgrader.cs
@@ -91,7 +91,7 @@ namespace Xtensive.Orm.Upgrade
 
     private async Task ExecuteNonTransactionallyAsync(IEnumerable<string> batch, CancellationToken token)
     {
-      await driver.CommitTransactionAsync(null, connection, token).ConfigureAwaitFalse();
+      await driver.CommitTransactionAsync(null, connection, false, token).ConfigureAwaitFalse();
       await executor.ExecuteManyAsync(batch, token).ConfigureAwaitFalse();
       await driver.BeginTransactionAsync(null, connection, null, token).ConfigureAwaitFalse();
     }

--- a/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
@@ -159,7 +159,7 @@ namespace Xtensive.Orm.Upgrade
     {
       var connection = context.Services.Connection;
       if (connection.ActiveTransaction is not null) {
-        context.Services.StorageDriver.CommitTransaction(null, connection);
+        context.Services.StorageDriver.CommitTransaction(null, connection, true);
       }
     }
 
@@ -167,7 +167,7 @@ namespace Xtensive.Orm.Upgrade
     {
       var connection = context.Services.Connection;
       if (connection.ActiveTransaction is not null) {
-        await context.Services.StorageDriver.CommitTransactionAsync(null, connection, token);
+        await context.Services.StorageDriver.CommitTransactionAsync(null, connection, true, token);
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
@@ -176,18 +176,8 @@ namespace Xtensive.Orm.Upgrade
     private async ValueTask CompleteUpgradeTransactionAsync(CancellationToken token)
     {
       var connection = context.Services.Connection;
-      var driver = context.Services.StorageDriver;
-
-      if (connection.ActiveTransaction == null) {
-        return;
-      }
-
-      try {
-        await driver.CommitTransactionAsync(null, connection, token);
-      }
-      catch {
-        await driver.RollbackTransactionAsync(null, connection, token);
-        throw;
+      if (connection.ActiveTransaction is not null) {
+        await context.Services.StorageDriver.CommitTransactionAsync(null, connection, token);
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
@@ -158,18 +158,8 @@ namespace Xtensive.Orm.Upgrade
     private void CompleteUpgradeTransaction()
     {
       var connection = context.Services.Connection;
-      var driver = context.Services.StorageDriver;
-
-      if (connection.ActiveTransaction == null) {
-        return;
-      }
-
-      try {
-        driver.CommitTransaction(null, connection);
-      }
-      catch {
-        driver.RollbackTransaction(null, connection);
-        throw;
+      if (connection.ActiveTransaction is not null) {
+        context.Services.StorageDriver.CommitTransaction(null, connection);
       }
     }
 

--- a/Orm/Xtensive.Orm/Sql/SqlConnection.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlConnection.cs
@@ -373,13 +373,17 @@ namespace Xtensive.Sql
     /// <summary>
     /// Commits the current transaction.
     /// </summary>
-    public virtual void Commit()
+    public virtual void Commit(bool rollbackOnFail = false)
     {
       EnsureIsNotDisposed();
       EnsureTransactionIsActive();
 
       try {
         ActiveTransaction.Commit();
+      }
+      catch when (rollbackOnFail) {
+        ActiveTransaction.Rollback();
+        throw;
       }
       finally {
         ActiveTransaction.Dispose();
@@ -392,12 +396,16 @@ namespace Xtensive.Sql
     /// </summary>
     /// <remarks> Multiple active operations are not supported. Use <see langword="await"/>
     /// to ensure that all asynchronous operations have completed.</remarks>
-    public virtual async Task CommitAsync(CancellationToken token = default)
+    public virtual async Task CommitAsync(bool rollbackOnFail = false, CancellationToken token = default)
     {
       EnsureIsNotDisposed();
       EnsureTransactionIsActive();
       try {
         await ActiveTransaction.CommitAsync(token).ConfigureAwaitFalse();
+      }
+      catch when (rollbackOnFail) {
+        await ActiveTransaction.RollbackAsync(token).ConfigureAwaitFalse();;
+        throw;
       }
       finally {
         await ActiveTransaction.DisposeAsync().ConfigureAwaitFalse();

--- a/Orm/Xtensive.Orm/Sql/SqlConnection.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlConnection.cs
@@ -404,7 +404,7 @@ namespace Xtensive.Sql
         await ActiveTransaction.CommitAsync(token).ConfigureAwaitFalse();
       }
       catch when (rollbackOnFail) {
-        await ActiveTransaction.RollbackAsync(token).ConfigureAwaitFalse();;
+        await ActiveTransaction.RollbackAsync(token).ConfigureAwaitFalse();
         throw;
       }
       finally {


### PR DESCRIPTION
Commit always clears transaction in its `finally`: https://github.com/DataObjects-NET/dataobjects-net/blob/master/Orm/Xtensive.Orm/Sql/SqlConnection.cs#L404

but `Rollback()` requires active transaction and fails.
We get nested exception like

```
Original message 'Transaction should be active'
--------Inner Exception:--------
[InvalidOperationException] Transaction should be active

at Xtensive.Orm.Providers.StorageDriver.RollbackTransactionAsync(Session session, SqlConnection connection, CancellationToken token)    at Xtensive.Orm.Upgrade.UpgradingDomainBuilder.CompleteUpgradeTransactionAsync(CancellationToken token)    at Xtensive.Orm.Upgrade.UpgradingDomainBuilder.RunAsync(CancellationToken token)
--



```