### PR TITLE
Deprecate `.IsNullOrEmpty()` extension

### DIFF
--- a/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
@@ -37,7 +37,7 @@ namespace Xtensive.Core
     /// <param name="items">Items to check.</param>
     /// <returns><see langword="True"/> if collection is definitely <see langword="null"/> or empty;
     /// otherwise, <see langword="false"/>.</returns>
-    [Obsolete]
+    [Obsolete("Don't use Xtensive.Core for 'collection is empty' checking")]
     public static bool IsNullOrEmpty<TItem>(this IEnumerable<TItem> items)
     {
       if (items==null)

--- a/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
@@ -52,9 +52,6 @@ namespace Xtensive.Core
       return count.Value==0;
     }
 
-    [Obsolete("Use string.IsNullOrEmpty(s) instead")]
-    public static bool IsNullOrEmpty(this string s) => string.IsNullOrEmpty(s);
-
     /// <summary>
     /// Gets the count of items (as <see cref="long"/>) of <see cref="IEnumerable{T}"/>, if it is actually
     /// <see cref="ICollection{T}"/> or <see cref="IQueryable{T}"/>.

--- a/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
@@ -37,6 +37,7 @@ namespace Xtensive.Core
     /// <param name="items">Items to check.</param>
     /// <returns><see langword="True"/> if collection is definitely <see langword="null"/> or empty;
     /// otherwise, <see langword="false"/>.</returns>
+    [Obsolete]
     public static bool IsNullOrEmpty<TItem>(this IEnumerable<TItem> items)
     {
       if (items==null)
@@ -50,6 +51,9 @@ namespace Xtensive.Core
           return !e.MoveNext();
       return count.Value==0;
     }
+
+    [Obsolete("Use string.IsNullOrEmpty() instead")]
+    public static bool IsNullOrEmpty(this string s) => string.IsNullOrEmpty(s);
 
     /// <summary>
     /// Gets the count of items (as <see cref="long"/>) of <see cref="IEnumerable{T}"/>, if it is actually

--- a/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
@@ -52,7 +52,7 @@ namespace Xtensive.Core
       return count.Value==0;
     }
 
-    [Obsolete("Use string.IsNullOrEmpty() instead")]
+    [Obsolete("Use string.IsNullOrEmpty(s) instead")]
     public static bool IsNullOrEmpty(this string s) => string.IsNullOrEmpty(s);
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Core/Extensions/ListExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/ListExtensions.cs
@@ -25,6 +25,7 @@ namespace Xtensive.Core
     /// <param name="item">An item to be looked for.</param>
     /// <returns>A zero based index of the specified <paramref name="item"/> if found;
     /// otherwise <c>-1</c>.</returns>
+    [Obsolete("Don't use Xtensive.Core for IndexOf()")]
     public static int IndexOf<T>(this IReadOnlyList<T> list, T item)
     {
       var comparer = EqualityComparer<T>.Default;


### PR DESCRIPTION
This is a preparation to make this extension `internal`  to avoid using it from ST App.

ST App has its own version of `.IsNullOrEmpty()` and should not use DO for string/collection checking for emptiness


This PR is not intended to be merged into Upstream DO repo
