### PR TITLE
Optimize `Tuple.GetValue<T>()`

### DIFF
--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
@@ -50,8 +50,7 @@ namespace Xtensive.Tuples.Packed
 
     public T GetValue<T>(PackedTuple tuple, in PackedFieldDescriptor descriptor, bool isNullable, out TupleFieldState fieldState)
     {
-      var getter = (isNullable ? NullableGetter : Getter) as GetValueDelegate<T>;
-      if (getter != null) {
+      if ((isNullable ? NullableGetter : Getter) is GetValueDelegate<T> getter) {
         return getter.Invoke(tuple, descriptor, out fieldState);
       }
       var targetType = typeof(T);

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
@@ -95,6 +95,13 @@ namespace Xtensive.Tuples.Packed
       return descriptor.GetAccessor().GetUntypedValue(this, descriptor, out fieldState);
     }
 
+    public override T GetValue<T>(int fieldIndex, out TupleFieldState fieldState)
+    {
+      var isNullable = null == default(T); // Is nullable value type or class
+      ref readonly var descriptor = ref PackedDescriptor.FieldDescriptors[fieldIndex];
+      return descriptor.GetAccessor().GetValue<T>(this, descriptor, isNullable, out fieldState);
+    }
+
     public override void SetValue(int fieldIndex, object fieldValue)
     {
       ref readonly var descriptor = ref PackedDescriptor.FieldDescriptors[fieldIndex];

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
@@ -108,6 +108,13 @@ namespace Xtensive.Tuples.Packed
       descriptor.GetAccessor().SetUntypedValue(this, descriptor, fieldValue);
     }
 
+    public override void SetValue<T>(int fieldIndex, T fieldValue)
+    {
+      var isNullable = null==default(T); // Is nullable value type or class
+      ref readonly var descriptor = ref PackedDescriptor.FieldDescriptors[fieldIndex];
+      descriptor.GetAccessor().SetValue(this, descriptor, isNullable, fieldValue);
+    }
+
     public void SetFieldState(in PackedFieldDescriptor d, TupleFieldState fieldState)
     {
       var bits = (long) fieldState;

--- a/Orm/Xtensive.Orm/Tuples/Tuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Tuple.cs
@@ -106,19 +106,11 @@ namespace Xtensive.Tuples
     /// <param name="fieldState">Field state associated with the field.</param>
     /// <returns>Field value, if it is available; otherwise, <see langword="default(T)"/>.</returns>
     /// <typeparam name="T">The type of value to get.</typeparam>
-    public T GetValue<T>(int fieldIndex, out TupleFieldState fieldState)
+    public virtual T GetValue<T>(int fieldIndex, out TupleFieldState fieldState)
     {
-      var isNullable = null==default(T); // Is nullable value type or class
-
-      if (this is PackedTuple packedTuple) {
-        ref readonly var descriptor = ref packedTuple.PackedDescriptor.FieldDescriptors[fieldIndex];
-        return descriptor.GetAccessor().GetValue<T>(packedTuple, descriptor, isNullable, out fieldState);
-      }
-
       var mappedContainer = GetMappedContainer(fieldIndex, false);
       if (mappedContainer.First is PackedTuple mappedTuple) {
-        ref readonly var descriptor = ref mappedTuple.PackedDescriptor.FieldDescriptors[mappedContainer.Second];
-        return descriptor.GetAccessor().GetValue<T>(mappedTuple, descriptor, isNullable, out fieldState);
+        return mappedTuple.GetValue<T>(mappedContainer.Second, out fieldState);
       }
 
       var value = GetValue(fieldIndex, out fieldState);

--- a/Orm/Xtensive.Orm/Tuples/Tuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Tuple.cs
@@ -173,20 +173,11 @@ namespace Xtensive.Tuples
     /// <typeparam name="T">The type of value to set.</typeparam>
     /// <exception cref="InvalidCastException">Type of stored value and <typeparamref name="T"/>
     /// are incompatible.</exception>
-    public void SetValue<T>(int fieldIndex, T fieldValue)
+    public virtual void SetValue<T>(int fieldIndex, T fieldValue)
     {
-      var isNullable = null==default(T); // Is nullable value type or class
-
-      if (this is PackedTuple packedTuple) {
-        ref readonly var descriptor = ref packedTuple.PackedDescriptor.FieldDescriptors[fieldIndex];
-        descriptor.GetAccessor().SetValue(packedTuple, descriptor, isNullable, fieldValue);
-        return;
-      }
-
       var mappedContainer = GetMappedContainer(fieldIndex, true);
       if (mappedContainer.First is PackedTuple mappedTuple) {
-        ref readonly var descriptor = ref mappedTuple.PackedDescriptor.FieldDescriptors[mappedContainer.Second];
-        descriptor.GetAccessor().SetValue(mappedTuple, descriptor, isNullable, fieldValue);
+        mappedTuple.SetValue(mappedContainer.Second, fieldValue);
         return;
       }
 


### PR DESCRIPTION
Use virtual function dispatching instead of explicit type checking