### PR TITLE
Fix ambiguity of IEnumerable/IAsyncEnumerable for DelayedQuery

### DIFF
--- a/Orm/Xtensive.Orm.Manual/Prefetch/PrefetchTest.cs
+++ b/Orm/Xtensive.Orm.Manual/Prefetch/PrefetchTest.cs
@@ -379,6 +379,17 @@ namespace Xtensive.Orm.Manual.Prefetch
       }
     }
 
+    [Test]
+    public async Task DelayedQueryAmbiguityTest()
+    {
+      await using (var session = await Domain.OpenSessionAsync())// no session activation!
+      using (var transactionScope = session.OpenTransaction()) {
+        var people = session.Query.CreateDelayedQuery(q => q.All<Person>());
+        _ = people.Select(o => o).Count();
+        transactionScope.Complete();
+      }
+    }
+
     private class QueryCounterSessionHandlerMoq : ChainingSessionHandler
     {
       private volatile int syncCounter;

--- a/Orm/Xtensive.Orm.Manual/Xtensive.Orm.Manual.csproj
+++ b/Orm/Xtensive.Orm.Manual/Xtensive.Orm.Manual.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="EntitySets\DatabaseSchema.gif" />

--- a/Orm/Xtensive.Orm/Orm/DelayedQuery{T}.cs
+++ b/Orm/Xtensive.Orm/Orm/DelayedQuery{T}.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Xtensive.Core;
@@ -20,7 +21,7 @@ namespace Xtensive.Orm
   /// </summary>
   /// <typeparam name="TElement">The type of the element in a resulting sequence.</typeparam>
   [Serializable]
-  public sealed class DelayedQuery<TElement> : DelayedQuery, IEnumerable<TElement>, IAsyncEnumerable<TElement>
+  public sealed class DelayedQuery<TElement> : DelayedQuery, IEnumerable<TElement>
   {
     /// <inheritdoc/>
     public IEnumerator<TElement> GetEnumerator() => Materialize<TElement>().GetEnumerator();
@@ -28,11 +29,9 @@ namespace Xtensive.Orm
     /// <inheritdoc/>
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-    /// <inheritdoc/>
-    async IAsyncEnumerator<TElement> IAsyncEnumerable<TElement>.GetAsyncEnumerator(CancellationToken token)
+    public async IAsyncEnumerable<TElement> AsAsyncEnumerable([EnumeratorCancellation]CancellationToken token)
     {
-      var elements = await ExecuteAsync(token).ConfigureAwaitFalse();
-      foreach (var element in elements) {
+      foreach (var element in await ExecuteAsync(token).ConfigureAwaitFalse()) {
         yield return element;
       }
     }
@@ -53,6 +52,5 @@ namespace Xtensive.Orm
     internal DelayedQuery(Session session, TranslatedQuery translatedQuery, ParameterContext parameterContext)
       : base(session, translatedQuery, parameterContext)
     { }
-
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchQueryAsyncEnumerable.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchQueryAsyncEnumerable.cs
@@ -63,7 +63,9 @@ namespace Xtensive.Orm.Internals.Prefetch
         currentTaskCount = sessionHandler.PrefetchTaskExecutionCount;
       }
 
-      if (source is IAsyncEnumerable<TItem> asyncItemSource) {
+      var asyncItemSource = (source as DelayedQuery<TItem>)?.AsAsyncEnumerable(token)
+        ?? source as IAsyncEnumerable<TItem>;
+      if (asyncItemSource is not null) {
         await foreach (var item in asyncItemSource.WithCancellation(token).ConfigureAwaitFalse()) {
           await foreach (var p in ProcessItem(item).WithCancellation(token).ConfigureAwaitFalse()) {
             yield return p;

--- a/Version.props
+++ b/Version.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.2.0.112</DoVersion>
+    <DoVersion>7.2.0.113</DoVersion>
     <DoVersionSuffix>servicetitan</DoVersionSuffix>
 </PropertyGroup>
 


### PR DESCRIPTION
Follow up of https://github.com/servicetitan/dataobjects-net/pull/170

See the build ambiguity of `.Select()`
https://teamcity.st.dev/buildConfiguration/Services_ServiceTitan_DockerImageBuildAndPublishDevelopment/4042188?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildProblemsSection=true&expandBuildChangesSection=true