### PR TITLE
Fallback `ToListAsync()` to `.ToList()` when `IAsyncEnumerable` is not available

### DIFF
--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
@@ -1459,6 +1459,9 @@ namespace Xtensive.Orm
     public static async Task<List<TSource>> ToListAsync<TSource>(this IQueryable<TSource> source,
       CancellationToken cancellationToken = default)
     {
+      if (source is not IAsyncEnumerable<TSource>) {
+        return source.ToList();
+      }
       var list = new List<TSource>();
       var asyncSource = source.AsAsyncEnumerable().WithCancellation(cancellationToken).ConfigureAwaitFalse();
       await foreach (var element in asyncSource) {


### PR DESCRIPTION
There are many non-Test cases where  `IAsyncEnumerable` is not implemented
For example: nested `.Select()` in DO LINQ expressions:
```
var poData = await Session.Query.All<PurchaseOrder>()
            .Where(po => po.Id == purchaseOrderId)
            .Select(
                po => new {
                    InvoiceId = po.Invoice != null ? (long?)po.Invoice.Id : null,
                    Items = po.Items.Where(i => i.Active).Select(i => i.Id)
                })
            .SingleAsync();
```

They will fail without this change