### PR TITLE
Generalize column management to use `ColNum` alias, which can be `short` or `int` (for backward compatibility)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -51,7 +51,7 @@
     <!-- hard binding to net8, no property and env variable allowed-->
     <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
-  
+
   <!-- Debug-NET7, Release-NET7 are mostly for development convenience -->
   <PropertyGroup Condition = "$(Configuration.Contains('NET7')) == 'true'">
     <!-- hard binding to net7, no property and env variable allowed-->
@@ -86,7 +86,7 @@
   <PropertyGroup>
     <NoLogo>true</NoLogo>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <SolutionDir Condition="$(SolutionDir) == ''">$([MSBuild]::EnsureTrailingSlash(
       $([MSBuild]::GetDirectoryNameOfFileAbove('$(MSBuildThisFileDirectory)', 'Orm.sln'))))</SolutionDir>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
@@ -131,6 +131,8 @@
       <PackagePath>.</PackagePath>
       <Pack>true</Pack>
     </None>
+
+    <Using Include="System.Int16" Alias="ColNum" />
   </ItemGroup>
 
   <Import Condition="Exists('User.Directory.Build.props')" Project="User.Directory.Build.props" />

--- a/Orm/Xtensive.Orm.Tests.Core/Collections/CollectionUtilsTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Collections/CollectionUtilsTest.cs
@@ -26,8 +26,8 @@ namespace Xtensive.Orm.Tests.Core.Collections
     [Test]
     public void RangeToListTest()
     {
-      Assert.That(CollectionUtils.RangeToList(1, 10).SequenceEqual(Enumerable.Range(1, 10)));
-      Assert.That(CollectionUtils.RangeToList(-1, 10).SequenceEqual(Enumerable.Range(-1, 10)));
+      Assert.That(CollectionUtils.RangeToList(1, 10).SequenceEqual(Enumerable.Range(1, 10).Select(i => (ColNum)i)));
+      Assert.That(CollectionUtils.RangeToList(-1, 10).SequenceEqual(Enumerable.Range(-1, 10).Select(i => (ColNum) i)));
       _ = Assert.Throws<ArgumentOutOfRangeException>(() => CollectionUtils.RangeToList(1, -10));
     }
 

--- a/Orm/Xtensive.Orm.Tests.Core/Tuples/Transform/MapTransformTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Tuples/Transform/MapTransformTest.cs
@@ -17,7 +17,7 @@ namespace Xtensive.Orm.Tests.Core.Tuples.Transform
     public void MainTest()
     {
       Xtensive.Tuples.Tuple source = Tuple.Create(1);
-      MapTransform transform = new MapTransform(true, TupleDescriptor.Create<byte, int, string>(), new[] {-1, 0});
+      MapTransform transform = new MapTransform(true, TupleDescriptor.Create<byte, int, string>(), new ColNum[] {-1, 0});
       Xtensive.Tuples.Tuple result = transform.Apply(TupleTransformType.TransformedTuple, source);
       Assert.AreEqual(TupleFieldState.Default, result.GetFieldState(0));
       Assert.AreEqual(TupleFieldState.Available, result.GetFieldState(1));

--- a/Orm/Xtensive.Orm.Tests.Core/Tuples/Transform/MergeTransformTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Tuples/Transform/MergeTransformTest.cs
@@ -120,7 +120,7 @@ namespace Xtensive.Orm.Tests.Core.Tuples.Transform
       AdvancedComparerStruct<Xtensive.Tuples.Tuple> comparer = AdvancedComparerStruct<Xtensive.Tuples.Tuple>.Default;
       Xtensive.Tuples.Tuple t   = Xtensive.Tuples.Tuple.Create(1);
       CombineTransform mt = new CombineTransform(false, t.Descriptor, t.Descriptor, t.Descriptor, t.Descriptor);
-      SegmentTransform st = new SegmentTransform(false, mt.Descriptor, new Segment<int>(1,2));
+      SegmentTransform st = new SegmentTransform(false, mt.Descriptor, new Segment<ColNum>(1,2));
       Xtensive.Tuples.Tuple wt1 = st.Apply(TupleTransformType.TransformedTuple, mt.Apply(TupleTransformType.TransformedTuple, t, t, t, t));
       Xtensive.Tuples.Tuple wt2 = st.Apply(TupleTransformType.TransformedTuple, mt.Apply(TupleTransformType.TransformedTuple, t, t, t, t));
       Xtensive.Tuples.Tuple ct1 = st.Apply(TupleTransformType.Tuple, mt.Apply(TupleTransformType.Tuple, t, t, t, t));

--- a/Orm/Xtensive.Orm.Tests.Core/Tuples/Transform/SegmentTransformTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Tuples/Transform/SegmentTransformTest.cs
@@ -26,8 +26,8 @@ namespace Xtensive.Orm.Tests.Core.Tuples.Transform
       Xtensive.Tuples.Tuple t  = Xtensive.Tuples.Tuple.Create(1, "2", 3, 4.0);
       TestLog.Info("Original: {0}", t);
 
-      SegmentTransform st   = new SegmentTransform(false, t.Descriptor, new Segment<int>(1,2));
-      SegmentTransform stro = new SegmentTransform(true,  t.Descriptor, new Segment<int>(1,2));
+      SegmentTransform st   = new SegmentTransform(false, t.Descriptor, new Segment<ColNum>(1,2));
+      SegmentTransform stro = new SegmentTransform(true,  t.Descriptor, new Segment<ColNum>(1,2));
 
       Xtensive.Tuples.Tuple wt1 = st.Apply(TupleTransformType.TransformedTuple, t);
       TestLog.Info("Wrapper:  {0}", wt1);
@@ -65,7 +65,7 @@ namespace Xtensive.Orm.Tests.Core.Tuples.Transform
     {
       AdvancedComparerStruct<Xtensive.Tuples.Tuple> comparer = AdvancedComparerStruct<Xtensive.Tuples.Tuple>.Default;
       Xtensive.Tuples.Tuple t   = Xtensive.Tuples.Tuple.Create(1, 2, 3, 4);
-      SegmentTransform st = new SegmentTransform(false, t.Descriptor, new Segment<int>(1,2));
+      SegmentTransform st = new SegmentTransform(false, t.Descriptor, new Segment<ColNum>(1,2));
       Xtensive.Tuples.Tuple wt1 = st.Apply(TupleTransformType.TransformedTuple, t);
       Xtensive.Tuples.Tuple wt2 = st.Apply(TupleTransformType.TransformedTuple, t);
       Xtensive.Tuples.Tuple ct1 = st.Apply(TupleTransformType.Tuple, t);

--- a/Orm/Xtensive.Orm.Tests/Rse/HeaderParseTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Rse/HeaderParseTest.cs
@@ -54,7 +54,7 @@ namespace Xtensive.Orm.Tests.Rse
           ResetState(state);
 
           // Select Id, TypeId, Title
-          CompilableProvider rsTitle = rsMain.Select(new[] { 0, 1, 2 });
+          CompilableProvider rsTitle = rsMain.Select(new ColNum[] { 0, 1, 2 });
           UpdateCache(session, rsTitle.GetRecordSetReader(session, parameterContext));
           state = Session.Current.EntityStateCache[key, true];
           Assert.IsNotNull(state);
@@ -63,7 +63,7 @@ namespace Xtensive.Orm.Tests.Rse
           ResetState(state);
 
           // Select Id, TypeId, Text
-          CompilableProvider rsText = rsMain.Select(new[] { 0, 1, 3 });
+          CompilableProvider rsText = rsMain.Select(new ColNum[] { 0, 1, 3 });
           UpdateCache(session, rsText.GetRecordSetReader(session, parameterContext));
           state = Session.Current.EntityStateCache[key, true];
           Assert.IsNotNull(state);
@@ -72,7 +72,7 @@ namespace Xtensive.Orm.Tests.Rse
           ResetState(state);
 
           // Select a.Id, a.TypeId, a.Title, b.Id, b.TypeId, b.Text
-          CompilableProvider rsJoin = rsTitle.Alias("a").Join(rsText.Alias("b"), new Pair<int>(0, 0), new Pair<int>(1, 1));
+          CompilableProvider rsJoin = rsTitle.Alias("a").Join(rsText.Alias("b"), new Pair<ColNum>(0, 0), new Pair<ColNum>(1, 1));
           UpdateCache(session, rsJoin.GetRecordSetReader(session, parameterContext));
           state = Session.Current.EntityStateCache[key, true];
           Assert.IsNotNull(state);

--- a/Orm/Xtensive.Orm.Tests/Rse/IncludeProviderTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Rse/IncludeProviderTest.cs
@@ -26,7 +26,7 @@ namespace Xtensive.Orm.Tests.Rse
       var ids = tracks.Select(supplier => (Tuple)Tuple.Create(supplier.TrackId));
 
       var trackRs = Domain.Model.Types[typeof (Track)].Indexes.PrimaryIndex.GetQuery();
-      var inRs = trackRs.Include(context => ids, "columnName", new[] {0});
+      var inRs = trackRs.Include(context => ids, "columnName", new ColNum[] { 0 });
       var inIndex = inRs.Header.Columns.Count-1;
       var whereRs = inRs.Filter(tuple => tuple.GetValueOrDefault<bool>(inIndex));
       var parameterContext = new ParameterContext();

--- a/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchManagerBasicTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchManagerBasicTest.cs
@@ -373,7 +373,7 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
         var parameterContext = new ParameterContext();
         var orderPrimaryIndex = OrderType.Indexes.PrimaryIndex;
         var selectedColumns = orderPrimaryIndex.ColumnIndexMap.System
-          .Concat(EmployeeField.Columns.Select(column => orderPrimaryIndex.Columns.IndexOf(column))).ToArray();
+          .Concat(EmployeeField.Columns.Select(column => (ColNum) orderPrimaryIndex.Columns.IndexOf(column))).ToArray();
         var orderQuery = OrderType.Indexes.PrimaryIndex.GetQuery()
           .Filter(t => t.GetValue<int>(0)==orderKey.Value.GetValue<int>(0)).Select(selectedColumns);
         orderQuery.GetRecordSetReader(session, parameterContext).ToEntities(0).Single();

--- a/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/CharSupportTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/CharSupportTest.cs
@@ -66,7 +66,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
         var rs = GetRseQuery<MyEntity>();
         var parameterContext = new ParameterContext();
         var result = rs
-          .Select(new[] { rs.Header.IndexOf(charColumn) })
+          .Select(new ColNum[] { (ColNum) rs.Header.IndexOf(charColumn) })
           .GetRecordSetReader(Session.Current, parameterContext)
           .ToEnumerable()
           .Select(i => i.GetValueOrDefault<char>(0))
@@ -88,7 +88,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
         var rs = GetRseQuery<MyEntity>();
         var parameterContext = new ParameterContext();
         var result = rs
-          .Select(new[] { rs.Header.IndexOf(charColumn) })
+          .Select(new ColNum[] { (ColNum) rs.Header.IndexOf(charColumn) })
           .Filter(t => t.GetValueOrDefault<char>(0) == y)
           .GetRecordSetReader(Session.Current, parameterContext)
           .ToEnumerable()
@@ -108,7 +108,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
         var rs = GetRseQuery<MyEntity>();
         var parameterContext = new ParameterContext();
         var result = rs
-          .Select(new[] { rs.Header.IndexOf(charColumn) })
+          .Select(new ColNum[] { (ColNum) rs.Header.IndexOf(charColumn) })
           .Filter(t => t.GetValueOrDefault<char>(0)=='Y')
           .GetRecordSetReader(Session.Current, parameterContext)
           .ToEnumerable()

--- a/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/TotalBatchingTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/TotalBatchingTest.cs
@@ -93,7 +93,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
     {
       for (int i = 0; i < amount; i++) {
         var rs = Domain.Model.Types[typeof (X)].Indexes.PrimaryIndex.GetQuery()
-          .Aggregate(System.Array.Empty<int>(),
+          .Aggregate(System.Array.Empty<ColNum>(),
             new AggregateColumnDescriptor("_count_", 0, AggregateType.Count));
         var compiledProvider = session.Compile(rs);
         var task = new QueryTask(compiledProvider, session.GetLifetimeToken(), null);

--- a/Orm/Xtensive.Orm/Collections/CollectionUtils.cs
+++ b/Orm/Xtensive.Orm/Collections/CollectionUtils.cs
@@ -41,11 +41,11 @@ namespace Xtensive.Collections
     /// <exception cref="T:System.ArgumentOutOfRangeException">
     /// <paramref name="count"/> is less than 0.-or-
     /// <paramref name="start"/> + <paramref name="count"/> -1 is larger than <see cref="F:System.Int32.MaxValue"/>.</exception>
-    public static List<int> RangeToList(int start, int count)
+    public static List<ColNum> RangeToList(ColNum start, ColNum count)
     {
       ArgumentValidator.EnsureArgumentIsGreaterThanOrEqual(count, 0, "count");
-      var result = new List<int>(count);
-      result.AddRange(Enumerable.Range(start, count));
+      var result = new List<ColNum>(count);
+      result.AddRange(Enumerable.Range(start, count).Select(i => (ColNum) i));
       return result;
     }
 

--- a/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
@@ -403,8 +403,8 @@ namespace Xtensive.Core
     public static IEnumerable<int> GetItems(this in Segment<int> segment) =>
       Enumerable.Range(segment.Offset, segment.Length);
 
-    public static IEnumerable<ColNum> GetItems(this in Segment<ColNum> segment) =>
-      Enumerable.Range(segment.Offset, segment.Length).Select(i => (ColNum) i);
+    public static IEnumerable<short> GetItems(this in Segment<short> segment) =>
+      Enumerable.Range(segment.Offset, segment.Length).Select(i => (short) i);
 
     /// <summary>
     /// Splits the specified <see cref="IEnumerable{T}"/> into batches.

--- a/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
@@ -403,8 +403,8 @@ namespace Xtensive.Core
     public static IEnumerable<int> GetItems(this in Segment<int> segment) =>
       Enumerable.Range(segment.Offset, segment.Length);
 
-    public static IEnumerable<short> GetItems(this in Segment<short> segment) =>
-      Enumerable.Range(segment.Offset, segment.Length).Select(i => (short)i);
+    public static IEnumerable<ColNum> GetItems(this in Segment<ColNum> segment) =>
+      Enumerable.Range(segment.Offset, segment.Length).Select(i => (ColNum) i);
 
     /// <summary>
     /// Splits the specified <see cref="IEnumerable{T}"/> into batches.

--- a/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
@@ -400,10 +400,11 @@ namespace Xtensive.Core
     /// Gets the items from the segment.
     /// </summary>
     /// <param name="segment">The segment.</param>
-    public static IEnumerable<int> GetItems(this in Segment<int> segment)
-    {
-      return Enumerable.Range(segment.Offset, segment.Length);
-    }
+    public static IEnumerable<int> GetItems(this in Segment<int> segment) =>
+      Enumerable.Range(segment.Offset, segment.Length);
+
+    public static IEnumerable<short> GetItems(this in Segment<short> segment) =>
+      Enumerable.Range(segment.Offset, segment.Length).Select(i => (short)i);
 
     /// <summary>
     /// Splits the specified <see cref="IEnumerable{T}"/> into batches.

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
@@ -804,15 +804,16 @@ namespace Xtensive.Orm.Building.Builders
     {
       var reflectedType = index.ReflectedType;
       var keyColumns = index.IsPrimary
-        ? Enumerable.Range(0, index.KeyColumns.Count).ToList(index.KeyColumns.Count)
+        ? Enumerable.Range(0, index.KeyColumns.Count).Select(i => (short)i).ToList(index.KeyColumns.Count)
         : index.KeyColumns
             .Select(static pair => pair.Key)
             .Concat(index.ValueColumns)
-            .Select(static (c, i) => (c, i))
+            .Select(static (c, i) => (c, (short)i))
             .Where(static arg => arg.c.IsPrimaryKey)
-            .Select(static arg => arg.i)
+            .Select(static arg => arg.Item2)
             .ToList();
-      var columns = Enumerable.Range(0, index.KeyColumns.Count + index.ValueColumns.Count).ToList(index.KeyColumns.Count + index.ValueColumns.Count);
+      var columns = Enumerable.Range(0, index.KeyColumns.Count + index.ValueColumns.Count).ToList(index.KeyColumns.Count + index.ValueColumns.Count)
+        .Select(i => (short)i);
       return new ColumnGroup(reflectedType, keyColumns, columns);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
@@ -804,7 +804,7 @@ namespace Xtensive.Orm.Building.Builders
     {
       var reflectedType = index.ReflectedType;
       var keyColumns = index.IsPrimary
-        ? Enumerable.Range(0, index.KeyColumns.Count).Select(i => (short)i).ToList(index.KeyColumns.Count)
+        ? Enumerable.Range(0, index.KeyColumns.Count).Select(i => (ColNum) i).ToList(index.KeyColumns.Count)
         : index.KeyColumns
             .Select(static pair => pair.Key)
             .Concat(index.ValueColumns)

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
@@ -808,12 +808,12 @@ namespace Xtensive.Orm.Building.Builders
         : index.KeyColumns
             .Select(static pair => pair.Key)
             .Concat(index.ValueColumns)
-            .Select(static (c, i) => (c, (short)i))
+            .Select(static (c, i) => (c, i: (ColNum)i))
             .Where(static arg => arg.c.IsPrimaryKey)
-            .Select(static arg => arg.Item2)
+            .Select(static arg => arg.i)
             .ToList();
       var columns = Enumerable.Range(0, index.KeyColumns.Count + index.ValueColumns.Count).ToList(index.KeyColumns.Count + index.ValueColumns.Count)
-        .Select(i => (short)i);
+        .Select(i => (ColNum) i);
       return new ColumnGroup(reflectedType, keyColumns, columns);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Entity.cs
+++ b/Orm/Xtensive.Orm/Orm/Entity.cs
@@ -70,7 +70,7 @@ namespace Xtensive.Orm
       session.Compile(t.typeInfo.Indexes.PrimaryIndex.GetQuery()
         .Seek(context => context.GetValue(keyParameter))
         .Lock(() => t.lockMode, () => t.lockBehavior)
-        .Select(Array.Empty<short>()));
+        .Select(Array.Empty<ColNum>()));
 
     private static readonly Parameter<Tuple> keyParameter = new Parameter<Tuple>(WellKnown.KeyFieldName);
     private readonly bool changeVersionOnSetAttempt;

--- a/Orm/Xtensive.Orm/Orm/Entity.cs
+++ b/Orm/Xtensive.Orm/Orm/Entity.cs
@@ -70,7 +70,7 @@ namespace Xtensive.Orm
       session.Compile(t.typeInfo.Indexes.PrimaryIndex.GetQuery()
         .Seek(context => context.GetValue(keyParameter))
         .Lock(() => t.lockMode, () => t.lockBehavior)
-        .Select(Array.Empty<int>()));
+        .Select(Array.Empty<short>()));
 
     private static readonly Parameter<Tuple> keyParameter = new Parameter<Tuple>(WellKnown.KeyFieldName);
     private readonly bool changeVersionOnSetAttempt;

--- a/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
+++ b/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
@@ -940,7 +940,7 @@ namespace Xtensive.Orm
             .Where(ci => ci.IsPrimaryKey)
             .Select(ci => ci.Field.MappingInfo.Offset)
             .ToList()
-        : Enumerable.Range(0, targetDescriptor.Count).ToList();
+        : Enumerable.Range(0, targetDescriptor.Count).Select(i => (ColNum)i).ToList();
 
       var keyFieldCount = ownerDescriptor.Count + itemColumnOffsets.Count;
       var keyFieldTypes = ownerDescriptor
@@ -949,8 +949,8 @@ namespace Xtensive.Orm
       var keyDescriptor = TupleDescriptor.Create(keyFieldTypes);
 
       var map = Enumerable.Range(0, ownerDescriptor.Count)
-        .Select(i => new Pair<int, int>(0, i))
-        .Concat(itemColumnOffsets.Select(i => new Pair<int, int>(1, i)))
+        .Select(i => new Pair<ColNum, ColNum>(0, (ColNum) i))
+        .Concat(itemColumnOffsets.Select(i => new Pair<ColNum, ColNum>(1, i)))
         .ToArray(keyFieldCount);
       var seekTransform = new MapTransform(true, keyDescriptor, map);
 

--- a/Orm/Xtensive.Orm/Orm/Internals/EntityDataReader.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/EntityDataReader.cs
@@ -22,10 +22,10 @@ namespace Xtensive.Orm.Internals
     private readonly struct RecordPartMapping
     {
       public int TypeIdColumnIndex { get; }
-      public IReadOnlyList<Pair<int>> Columns { get; }
+      public IReadOnlyList<Pair<ColNum>> Columns { get; }
       public TypeInfo ApproximateType { get; }
 
-      public RecordPartMapping(int typeIdColumnIndex, IReadOnlyList<Pair<int>> columns, TypeInfo approximateType)
+      public RecordPartMapping(int typeIdColumnIndex, IReadOnlyList<Pair<ColNum>> columns, TypeInfo approximateType)
       {
         TypeIdColumnIndex = typeIdColumnIndex;
         Columns = columns;
@@ -60,7 +60,7 @@ namespace Xtensive.Orm.Internals
         for (int i = 0; i < recordPartCount; i++) {
           var columnGroup = columnGroups[i];
           var approximateType = columnGroup.TypeInfoRef.Resolve(model);
-          var columnMapping = new List<Pair<int>>(columnGroup.Columns.Count);
+          var columnMapping = new List<Pair<ColNum>>(columnGroup.Columns.Count);
           var typeIdColumnIndex = -1;
           foreach (var columnIndex in columnGroup.Columns) {
             var column = (MappedColumn) columns[columnIndex];
@@ -70,7 +70,7 @@ namespace Xtensive.Orm.Internals
               if (columnInfo.Name == typeIdColumnName) {
                 typeIdColumnIndex = column.Index;
               }
-              columnMapping.Add(new Pair<int>(targetColumnIndex, columnIndex));
+              columnMapping.Add(new Pair<ColNum>(targetColumnIndex, columnIndex));
             }
           }
           mappings[i] = new RecordPartMapping(typeIdColumnIndex, columnMapping, approximateType);

--- a/Orm/Xtensive.Orm/Orm/Internals/GenericKeyFactory.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/GenericKeyFactory.cs
@@ -16,14 +16,14 @@ namespace Xtensive.Orm.Internals
   {
     public readonly Type Type;
     public readonly Func<string, TypeInfo, Tuple, TypeReferenceAccuracy, Key> DefaultConstructor;
-    public readonly Func<string, TypeInfo, Tuple, TypeReferenceAccuracy, IReadOnlyList<int>, Key> KeyIndexBasedConstructor;
+    public readonly Func<string, TypeInfo, Tuple, TypeReferenceAccuracy, IReadOnlyList<ColNum>, Key> KeyIndexBasedConstructor;
 
 
     // Constructors
 
     public GenericKeyFactory(Type type,
       Func<string, TypeInfo, Tuple, TypeReferenceAccuracy, Key> defaultConstructor,
-      Func<string, TypeInfo, Tuple, TypeReferenceAccuracy, IReadOnlyList<int>, Key> keyIndexBasedConstructor)
+      Func<string, TypeInfo, Tuple, TypeReferenceAccuracy, IReadOnlyList<ColNum>, Key> keyIndexBasedConstructor)
     {
       Type = type;
       DefaultConstructor = defaultConstructor;

--- a/Orm/Xtensive.Orm/Orm/Internals/KeyFactory.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/KeyFactory.cs
@@ -35,7 +35,7 @@ namespace Xtensive.Orm.Internals
     }
 
     public static Key Materialize(Domain domain, string nodeId,
-      TypeInfo type, Tuple value, TypeReferenceAccuracy accuracy, bool canCache, IReadOnlyList<int> keyIndexes)
+      TypeInfo type, Tuple value, TypeReferenceAccuracy accuracy, bool canCache, IReadOnlyList<ColNum> keyIndexes)
     {
       var hierarchy = type.Hierarchy;
       var keyInfo = type.Key;
@@ -131,7 +131,7 @@ namespace Xtensive.Orm.Internals
       return true;
     }
 
-    public static bool IsValidKeyTuple(Tuple tuple, IReadOnlyList<int> keyIndexes)
+    public static bool IsValidKeyTuple(Tuple tuple, IReadOnlyList<ColNum> keyIndexes)
     {
       if (keyIndexes==null)
         return IsValidKeyTuple(tuple);
@@ -142,7 +142,7 @@ namespace Xtensive.Orm.Internals
       return true;
     }
 
-    private static Key CreateGenericKey(Domain domain, string nodeId, TypeInfo type, TypeReferenceAccuracy accuracy, Tuple tuple, IReadOnlyList<int> keyIndexes)
+    private static Key CreateGenericKey(Domain domain, string nodeId, TypeInfo type, TypeReferenceAccuracy accuracy, Tuple tuple, IReadOnlyList<ColNum> keyIndexes)
     {
       var keyTypeInfo = domain.GenericKeyFactories.GetOrAdd(type, BuildGenericKeyFactory);
       if (keyIndexes==null)
@@ -158,7 +158,7 @@ namespace Xtensive.Orm.Internals
       keyType = keyType.MakeGenericType(descriptor.ToArray(descriptor.Count));
       var defaultConstructor = DelegateHelper.CreateDelegate<Func<string, TypeInfo, Tuple, TypeReferenceAccuracy, Key>>(
         null, keyType, "Create", Array.Empty<Type>());
-      var keyIndexBasedConstructor = DelegateHelper.CreateDelegate<Func<string, TypeInfo, Tuple, TypeReferenceAccuracy, IReadOnlyList<int>, Key>>(
+      var keyIndexBasedConstructor = DelegateHelper.CreateDelegate<Func<string, TypeInfo, Tuple, TypeReferenceAccuracy, IReadOnlyList<ColNum>, Key>>(
         null, keyType, "Create", Array.Empty<Type>());
       return new GenericKeyFactory(keyType, defaultConstructor, keyIndexBasedConstructor);
     }

--- a/Orm/Xtensive.Orm/Orm/Internals/Key{T1,T2,T3,T4}.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Key{T1,T2,T3,T4}.cs
@@ -63,7 +63,7 @@ namespace Xtensive.Orm.Internals
     }
 
     [UsedImplicitly]
-    public static Key Create(string nodeId, TypeInfo type, Tuple tuple, TypeReferenceAccuracy accuracy, IReadOnlyList<int> keyIndexes)
+    public static Key Create(string nodeId, TypeInfo type, Tuple tuple, TypeReferenceAccuracy accuracy, IReadOnlyList<ColNum> keyIndexes)
     {
       return new Key<T1, T2, T3, T4>(nodeId, type, accuracy,
         tuple.GetValueOrDefault<T1>(keyIndexes[0]),

--- a/Orm/Xtensive.Orm/Orm/Internals/Key{T1,T2,T3}.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Key{T1,T2,T3}.cs
@@ -57,7 +57,7 @@ namespace Xtensive.Orm.Internals
     }
 
     [UsedImplicitly]
-    public static Key Create(string nodeId, TypeInfo type, Tuple tuple, TypeReferenceAccuracy accuracy, IReadOnlyList<int> keyIndexes)
+    public static Key Create(string nodeId, TypeInfo type, Tuple tuple, TypeReferenceAccuracy accuracy, IReadOnlyList<ColNum> keyIndexes)
     {
       return new Key<T1, T2, T3>(nodeId, type, accuracy,
         tuple.GetValueOrDefault<T1>(keyIndexes[0]),

--- a/Orm/Xtensive.Orm/Orm/Internals/Key{T1,T2}.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Key{T1,T2}.cs
@@ -49,7 +49,7 @@ namespace Xtensive.Orm.Internals
     }
 
     [UsedImplicitly]
-    public static Key Create(string nodeId, TypeInfo type, Tuple tuple, TypeReferenceAccuracy accuracy, IReadOnlyList<int> keyIndexes)
+    public static Key Create(string nodeId, TypeInfo type, Tuple tuple, TypeReferenceAccuracy accuracy, IReadOnlyList<ColNum> keyIndexes)
     {
       return new Key<T1, T2>(nodeId, type, accuracy,
         tuple.GetValueOrDefault<T1>(keyIndexes[0]),

--- a/Orm/Xtensive.Orm/Orm/Internals/Key{T}.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Key{T}.cs
@@ -44,7 +44,7 @@ namespace Xtensive.Orm.Internals
     }
 
     [UsedImplicitly]
-    public static Key Create(string nodeId, TypeInfo type, Tuple tuple, TypeReferenceAccuracy accuracy, IReadOnlyList<int> keyIndexes)
+    public static Key Create(string nodeId, TypeInfo type, Tuple tuple, TypeReferenceAccuracy accuracy, IReadOnlyList<ColNum> keyIndexes)
     {
       return new Key<T>(nodeId, type, accuracy, tuple.GetValueOrDefault<T>(keyIndexes[0]));
     }

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityContainer.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityContainer.cs
@@ -18,7 +18,7 @@ namespace Xtensive.Orm.Internals.Prefetch
   {
     private static readonly Parameter<Tuple> seekParameter = new Parameter<Tuple>(WellKnown.KeyFieldName);
 
-    private SortedDictionary<int, ColumnInfo> columns;
+    private SortedDictionary<ColNum, ColumnInfo> columns;
 
     protected readonly PrefetchManager Manager;
 
@@ -30,19 +30,19 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     public EntityGroupTask Task { get; protected set; }
 
-    protected IReadOnlyList<int> ColumnIndexesToBeLoaded { get; set; }
+    protected IReadOnlyList<ColNum> ColumnIndexesToBeLoaded { get; set; }
 
     public abstract EntityGroupTask GetTask();
 
     public void AddColumns(IEnumerable<ColumnInfo> candidateColumns)
     {
-      columns ??= new SortedDictionary<int, ColumnInfo>();
+      columns ??= new SortedDictionary<ColNum, ColumnInfo>();
       if (PrefetchHelper.AddColumns(candidateColumns, columns, Type))
         ColumnIndexesToBeLoaded = null;
     }
 
-    public void SetColumnCollections(SortedDictionary<int, ColumnInfo> forcedColumns,
-      IReadOnlyList<int> forcedColumnsToBeLoaded)
+    public void SetColumnCollections(SortedDictionary<ColNum, ColumnInfo> forcedColumns,
+      IReadOnlyList<ColNum> forcedColumnsToBeLoaded)
     {
       if (columns != null)
         throw new InvalidOperationException();
@@ -59,7 +59,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       var tuple = state == null ? null : state.Tuple;
       if (tuple == null && ColumnIndexesToBeLoaded != null)
         return true;
-      List<int> columnIndexesToBeLoaded = null;
+      List<ColNum> columnIndexesToBeLoaded = null;
       var needToFetchSystemColumns = false;
       foreach (var pair in columns) {
         if (tuple == null || !tuple.GetFieldState(pair.Key).IsAvailable())
@@ -76,9 +76,9 @@ namespace Xtensive.Orm.Internals.Prefetch
       return ColumnIndexesToBeLoaded != null;
     }
 
-    private List<int> CreateColumnIndexCollection()
+    private List<ColNum> CreateColumnIndexCollection()
     {
-      var result = new List<int>(columns.Count);
+      var result = new List<ColNum>(columns.Count);
       result.AddRange(Type.Indexes.PrimaryIndex.ColumnIndexMap.System);
       return result;
     }

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityGroupTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityGroupTask.cs
@@ -17,28 +17,12 @@ namespace Xtensive.Orm.Internals.Prefetch
 {
   internal readonly struct RecordSetCacheKey : IEquatable<RecordSetCacheKey>
   {
-    public readonly int[] ColumnIndexes;
+    public readonly IReadOnlyList<int> ColumnIndexes;
     public readonly TypeInfo Type;
     private readonly int cachedHashCode;
 
-    public bool Equals(RecordSetCacheKey other)
-    {
-      if (!Type.Equals(other.Type)) {
-        return false;
-      }
-
-      if (ColumnIndexes.Length != other.ColumnIndexes.Length) {
-        return false;
-      }
-
-      for (var i = ColumnIndexes.Length - 1; i >= 0; i--) {
-        if (ColumnIndexes[i] != other.ColumnIndexes[i]) {
-          return false;
-        }
-      }
-
-      return true;
-    }
+    public bool Equals(RecordSetCacheKey other) =>
+      Type.Equals(other.Type) && ColumnIndexes.SequenceEqual(other.ColumnIndexes);
 
     public override bool Equals(object obj) =>
       obj is RecordSetCacheKey other && Equals(other);
@@ -48,7 +32,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     // Constructors
 
-    public RecordSetCacheKey(int[] columnIndexes, TypeInfo type, int cachedHashCode)
+    public RecordSetCacheKey(IReadOnlyList<int> columnIndexes, TypeInfo type, int cachedHashCode)
     {
       ColumnIndexes = columnIndexes;
       Type = type;
@@ -201,11 +185,11 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     // Constructors
 
-    public EntityGroupTask(TypeInfo type, int[] columnIndexes, PrefetchManager manager)
+    public EntityGroupTask(TypeInfo type, IReadOnlyList<int> columnIndexes, PrefetchManager manager)
     {
       ArgumentValidator.EnsureArgumentNotNull(type, nameof(type));
       ArgumentValidator.EnsureArgumentNotNull(columnIndexes, nameof(columnIndexes));
-      ArgumentValidator.EnsureArgumentIsGreaterThan(columnIndexes.Length, 0, "columnIndexes.Length");
+      ArgumentValidator.EnsureArgumentIsGreaterThan(columnIndexes.Count, 0, "columnIndexes.Length");
       ArgumentValidator.EnsureArgumentNotNull(manager, nameof(manager));
 
       this.type = type;

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityGroupTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntityGroupTask.cs
@@ -17,7 +17,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 {
   internal readonly struct RecordSetCacheKey : IEquatable<RecordSetCacheKey>
   {
-    public readonly IReadOnlyList<int> ColumnIndexes;
+    public readonly IReadOnlyList<ColNum> ColumnIndexes;
     public readonly TypeInfo Type;
     private readonly int cachedHashCode;
 
@@ -32,7 +32,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     // Constructors
 
-    public RecordSetCacheKey(IReadOnlyList<int> columnIndexes, TypeInfo type, int cachedHashCode)
+    public RecordSetCacheKey(IReadOnlyList<ColNum> columnIndexes, TypeInfo type, int cachedHashCode)
     {
       ColumnIndexes = columnIndexes;
       Type = type;
@@ -51,8 +51,8 @@ namespace Xtensive.Orm.Internals.Prefetch
       var selectedColumnIndexes = cachingKey.ColumnIndexes;
       var primaryIndex = cachingKey.Type.Indexes.PrimaryIndex;
       var keyColumnsCount = primaryIndex.KeyColumns.Count;
-      var keyColumnIndexes = new int[keyColumnsCount];
-      foreach (var index in Enumerable.Range(0, keyColumnsCount)) {
+      var keyColumnIndexes = new ColNum[keyColumnsCount];
+      foreach (var index in Enumerable.Range(0, keyColumnsCount).Select(i => (ColNum) i)) {
         keyColumnIndexes[index] = index;
       }
 
@@ -185,7 +185,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     // Constructors
 
-    public EntityGroupTask(TypeInfo type, IReadOnlyList<int> columnIndexes, PrefetchManager manager)
+    public EntityGroupTask(TypeInfo type, IReadOnlyList<ColNum> columnIndexes, PrefetchManager manager)
     {
       ArgumentValidator.EnsureArgumentNotNull(type, nameof(type));
       ArgumentValidator.EnsureArgumentNotNull(columnIndexes, nameof(columnIndexes));

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntitySetTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntitySetTask.cs
@@ -222,7 +222,7 @@ namespace Xtensive.Orm.Internals.Prefetch
     }
 
     private static void AddResultColumnIndexes(ICollection<ColNum> indexes, IndexInfo index,
-      short columnIndexOffset)
+      ColNum columnIndexOffset)
     {
       for (ColNum i = 0; i < index.Columns.Count; i++) {
         var column = index.Columns[i];

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/GraphContainer.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/GraphContainer.cs
@@ -52,7 +52,7 @@ namespace Xtensive.Orm.Internals.Prefetch
     }
 
     public void CreateRootEntityContainer(
-      SortedDictionary<int, ColumnInfo> forcedColumns, IReadOnlyList<int> forcedColumnsToBeLoaded)
+      SortedDictionary<ColNum, ColumnInfo> forcedColumns, IReadOnlyList<ColNum> forcedColumnsToBeLoaded)
     {
       RootEntityContainer = new RootEntityContainer(Key, Type, exactType, Manager);
       RootEntityContainer.SetColumnCollections(forcedColumns, forcedColumnsToBeLoaded);

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/GraphContainer.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/GraphContainer.cs
@@ -52,7 +52,7 @@ namespace Xtensive.Orm.Internals.Prefetch
     }
 
     public void CreateRootEntityContainer(
-      SortedDictionary<int, ColumnInfo> forcedColumns, List<int> forcedColumnsToBeLoaded)
+      SortedDictionary<int, ColumnInfo> forcedColumns, IReadOnlyList<int> forcedColumnsToBeLoaded)
     {
       RootEntityContainer = new RootEntityContainer(Key, Type, exactType, Manager);
       RootEntityContainer.SetColumnCollections(forcedColumns, forcedColumnsToBeLoaded);

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchHelper.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchHelper.cs
@@ -49,16 +49,16 @@ namespace Xtensive.Orm.Internals.Prefetch
       return true;
     }
 
-    public static SortedDictionary<int, ColumnInfo> GetColumns(IEnumerable<ColumnInfo> candidateColumns,
+    public static SortedDictionary<ColNum, ColumnInfo> GetColumns(IEnumerable<ColumnInfo> candidateColumns,
       TypeInfo type)
     {
-      var columns = new SortedDictionary<int, ColumnInfo>();
+      var columns = new SortedDictionary<ColNum, ColumnInfo>();
       AddColumns(candidateColumns, columns, type);
       return columns;
     }
 
     public static bool AddColumns(IEnumerable<ColumnInfo> candidateColumns,
-      SortedDictionary<int, ColumnInfo> columns, TypeInfo type)
+      SortedDictionary<ColNum, ColumnInfo> columns, TypeInfo type)
     {
       var result = false;
       var typeIsInterface = type.IsInterface;
@@ -68,20 +68,17 @@ namespace Xtensive.Orm.Internals.Prefetch
         result = true;
         var columnField = column.Field;
         var columnIsInterface = columnField.DeclaringType.IsInterface;
-        if (typeIsInterface == columnIsInterface)
-          columns[typeFields[columnField.Name].MappingInfo.Offset] = column;
-        else if (columnIsInterface)
-          columns[typeFieldMap[columnField].MappingInfo.Offset] = column;
-        else
-          throw new InvalidOperationException();
+        var fieldInfo = typeIsInterface == columnIsInterface ? typeFields[columnField.Name]
+          : columnIsInterface ? typeFieldMap[columnField] : throw new InvalidOperationException();
+        columns[(short) fieldInfo.MappingInfo.Offset] = column;          
       }
       return result;
     }
 
-    public static List<int> GetColumnsToBeLoaded(SortedDictionary<int, ColumnInfo> userColumnIndexes,
+    public static List<ColNum> GetColumnsToBeLoaded(SortedDictionary<ColNum, ColumnInfo> userColumnIndexes,
       TypeInfo type)
     {
-      var result = new List<int>(userColumnIndexes.Count);
+      var result = new List<ColNum>(userColumnIndexes.Count);
       result.AddRange(type.Indexes.PrimaryIndex.ColumnIndexMap.System);
       result.AddRange(userColumnIndexes.Where(pair => !pair.Value.IsPrimaryKey
         && !pair.Value.IsSystem).Select(pair => pair.Key));

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchHelper.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchHelper.cs
@@ -70,7 +70,7 @@ namespace Xtensive.Orm.Internals.Prefetch
         var columnIsInterface = columnField.DeclaringType.IsInterface;
         var fieldInfo = typeIsInterface == columnIsInterface ? typeFields[columnField.Name]
           : columnIsInterface ? typeFieldMap[columnField] : throw new InvalidOperationException();
-        columns[(short) fieldInfo.MappingInfo.Offset] = column;          
+        columns[fieldInfo.MappingInfo.Offset] = column;
       }
       return result;
     }

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchManager.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchManager.cs
@@ -53,15 +53,15 @@ namespace Xtensive.Orm.Internals.Prefetch
     {
       public readonly RootContainerCacheKey Key;
 
-      public readonly SortedDictionary<int, ColumnInfo> Columns;
+      public readonly SortedDictionary<ColNum, ColumnInfo> Columns;
 
-      public readonly IReadOnlyList<int> ColumnsToBeLoaded;
+      public readonly IReadOnlyList<ColNum> ColumnsToBeLoaded;
 
 
       // Constructors
 
-      public RootContainerCacheEntry(in RootContainerCacheKey key, SortedDictionary<int, ColumnInfo> columns,
-        IReadOnlyList<int> columnsToBeLoaded)
+      public RootContainerCacheEntry(in RootContainerCacheKey key, SortedDictionary<ColNum, ColumnInfo> columns,
+        IReadOnlyList<ColNum> columnsToBeLoaded)
       {
         Key = key;
         Columns = columns;
@@ -252,8 +252,8 @@ namespace Xtensive.Orm.Internals.Prefetch
     }
 
     public void GetCachedColumnIndexes(TypeInfo type,
-      IEnumerable<PrefetchFieldDescriptor> descriptors, out SortedDictionary<int, ColumnInfo> columns,
-      out IReadOnlyList<int> columnsToBeLoaded)
+      IEnumerable<PrefetchFieldDescriptor> descriptors, out SortedDictionary<ColNum, ColumnInfo> columns,
+      out IReadOnlyList<ColNum> columnsToBeLoaded)
     {
       var cacheKey = new RootContainerCacheKey(type, descriptors);
       var cacheEntry = columnsCache[cacheKey, true];

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchManager.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchManager.cs
@@ -55,13 +55,13 @@ namespace Xtensive.Orm.Internals.Prefetch
 
       public readonly SortedDictionary<int, ColumnInfo> Columns;
 
-      public readonly List<int> ColumnsToBeLoaded;
+      public readonly IReadOnlyList<int> ColumnsToBeLoaded;
 
 
       // Constructors
 
       public RootContainerCacheEntry(in RootContainerCacheKey key, SortedDictionary<int, ColumnInfo> columns,
-        List<int> columnsToBeLoaded)
+        IReadOnlyList<int> columnsToBeLoaded)
       {
         Key = key;
         Columns = columns;
@@ -253,7 +253,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     public void GetCachedColumnIndexes(TypeInfo type,
       IEnumerable<PrefetchFieldDescriptor> descriptors, out SortedDictionary<int, ColumnInfo> columns,
-      out List<int> columnsToBeLoaded)
+      out IReadOnlyList<int> columnsToBeLoaded)
     {
       var cacheKey = new RootContainerCacheKey(type, descriptors);
       var cacheEntry = columnsCache[cacheKey, true];

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/ReferencedEntityContainer.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/ReferencedEntityContainer.cs
@@ -100,7 +100,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       FillColumnCollection();
       if (!SelectColumnsToBeLoaded())
         return null;
-      Task = new EntityGroupTask(Type, ColumnIndexesToBeLoaded.ToArray(), Manager);
+      Task = new EntityGroupTask(Type, ColumnIndexesToBeLoaded, Manager);
       return Task;
     }
 
@@ -109,8 +109,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       var descriptors = PrefetchHelper
         .GetCachedDescriptorsForFieldsLoadedByDefault(Manager.Owner.Session.Domain, Type);
       SortedDictionary<int, ColumnInfo> columns;
-      List<int> columnsToBeLoaded;
-      Manager.GetCachedColumnIndexes(Type, descriptors, out columns, out columnsToBeLoaded);
+      Manager.GetCachedColumnIndexes(Type, descriptors, out columns, out var columnsToBeLoaded);
       SetColumnCollections(columns, columnsToBeLoaded);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/ReferencedEntityContainer.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/ReferencedEntityContainer.cs
@@ -108,7 +108,7 @@ namespace Xtensive.Orm.Internals.Prefetch
     {
       var descriptors = PrefetchHelper
         .GetCachedDescriptorsForFieldsLoadedByDefault(Manager.Owner.Session.Domain, Type);
-      SortedDictionary<int, ColumnInfo> columns;
+      SortedDictionary<ColNum, ColumnInfo> columns;
       Manager.GetCachedColumnIndexes(Type, descriptors, out columns, out var columnsToBeLoaded);
       SetColumnCollections(columns, columnsToBeLoaded);
     }

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/RootEntityContainer.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/RootEntityContainer.cs
@@ -21,7 +21,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       if (Task == null) {
         if (!SelectColumnsToBeLoaded())
           return null;
-        Task = new EntityGroupTask(Type, ColumnIndexesToBeLoaded.ToArray(), Manager);
+        Task = new EntityGroupTask(Type, ColumnIndexesToBeLoaded, Manager);
       }
       return Task;
     }

--- a/Orm/Xtensive.Orm/Orm/Internals/TupleExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/TupleExtensions.cs
@@ -33,7 +33,7 @@ namespace Xtensive.Orm.Internals
       return false;
     }
 
-    public static bool ContainsEmptyValues(this Tuple target, in Segment<int> segment)
+    public static bool ContainsEmptyValues(this Tuple target, in Segment<ColNum> segment)
     {
       for (int i = segment.Offset; i < segment.EndOffset; i++) {
         var state = target.GetFieldState(i);
@@ -43,7 +43,7 @@ namespace Xtensive.Orm.Internals
       return false;
     }
 
-    public static bool ContainsNonEmptyValues(this Tuple target, in Segment<int> segment)
+    public static bool ContainsNonEmptyValues(this Tuple target, in Segment<ColNum> segment)
     {
       for (int i = segment.Offset; i < segment.EndOffset; i++) {
         var state = target.GetFieldState(i);
@@ -53,7 +53,7 @@ namespace Xtensive.Orm.Internals
       return false;
     }
 
-    public static bool AreAllColumnsAvalilable(this Tuple target, in Segment<int> segment)
+    public static bool AreAllColumnsAvalilable(this Tuple target, in Segment<ColNum> segment)
     {
       for (int i = segment.Offset; i < segment.EndOffset; i++) {
         var state = target.GetFieldState(i);
@@ -63,7 +63,7 @@ namespace Xtensive.Orm.Internals
       return true;
     }
 
-    public static bool IsAtLeastOneColumAvailable(this Tuple target, in Segment<int> segment)
+    public static bool IsAtLeastOneColumAvailable(this Tuple target, in Segment<ColNum> segment)
     {
       for (int i = segment.Offset; i < segment.EndOffset; i++) {
         var state = target.GetFieldState(i);

--- a/Orm/Xtensive.Orm/Orm/Internals/TypeMapping.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/TypeMapping.cs
@@ -14,13 +14,13 @@ namespace Xtensive.Orm.Internals
   {
     public readonly TypeInfo Type;
     public readonly MapTransform KeyTransform;
-    public readonly IReadOnlyList<int> KeyIndexes;
+    public readonly IReadOnlyList<ColNum> KeyIndexes;
     public readonly MapTransform Transform;
 
 
     // Constructors
 
-    public TypeMapping(TypeInfo type, MapTransform keyTransform, MapTransform transform, IReadOnlyList<int> keyIndexes)
+    public TypeMapping(TypeInfo type, MapTransform keyTransform, MapTransform transform, IReadOnlyList<ColNum> keyIndexes)
     {
       Type = type;
       KeyTransform = keyTransform;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnExpression.cs
@@ -28,7 +28,7 @@ namespace Xtensive.Orm.Linq.Expressions
     {
       if (!CanRemap)
         return this;
-      var newMapping = new Segment<ColNum>((short)map.IndexOf(Mapping.Offset), 1);
+      var newMapping = new Segment<ColNum>((ColNum) map.IndexOf(Mapping.Offset), 1);
       return new ColumnExpression(Type, newMapping, OuterParameter, DefaultIfEmpty);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnExpression.cs
@@ -14,21 +14,21 @@ namespace Xtensive.Orm.Linq.Expressions
   internal class ColumnExpression : ParameterizedExpression,
     IMappedExpression
   {
-    internal readonly Segment<int> Mapping;
+    internal readonly Segment<ColNum> Mapping;
 
-    public Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions)
+    public Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;
-      var newMapping = new Segment<int>(Mapping.Offset + offset, 1);
+      var newMapping = new Segment<ColNum>((ColNum) (Mapping.Offset + offset), 1);
       return new ColumnExpression(Type, newMapping, OuterParameter, DefaultIfEmpty);
     }
 
-    public Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
+    public Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;
-      var newMapping = new Segment<int>(map.IndexOf(Mapping.Offset), 1);
+      var newMapping = new Segment<ColNum>((short)map.IndexOf(Mapping.Offset), 1);
       return new ColumnExpression(Type, newMapping, OuterParameter, DefaultIfEmpty);
     }
 
@@ -47,9 +47,9 @@ namespace Xtensive.Orm.Linq.Expressions
       return new ColumnExpression(Type, Mapping, null, DefaultIfEmpty);
     }
 
-    public static ColumnExpression Create(Type type, int columnIndex)
+    public static ColumnExpression Create(Type type, ColNum columnIndex)
     {
-      var mapping = new Segment<int>(columnIndex, 1);
+      var mapping = new Segment<ColNum>(columnIndex, 1);
       return new ColumnExpression(type, mapping, null, false);
     }
 
@@ -63,7 +63,7 @@ namespace Xtensive.Orm.Linq.Expressions
 
     protected ColumnExpression(
       Type type,
-      in Segment<int> mapping,
+      in Segment<ColNum> mapping,
       ParameterExpression parameterExpression,
       bool defaultIfEmpty)
       : base(ExtendedExpressionType.Column, type, parameterExpression, defaultIfEmpty)

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
@@ -54,7 +54,7 @@ namespace Xtensive.Orm.Linq
       return result;
     }
 
-    public Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions)
+    public Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
       Func<IMappedExpression, Expression> remapper = delegate(IMappedExpression mapped) {
         var parametrizedExpression = mapped as ParameterizedExpression;
@@ -75,7 +75,7 @@ namespace Xtensive.Orm.Linq
       return result;
     }
 
-    public Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
+    public Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
       Func<IMappedExpression, Expression> remapper = delegate(IMappedExpression mapped) {
         var parametrizedExpression = mapped as ParameterizedExpression;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityExpression.cs
@@ -34,7 +34,7 @@ namespace Xtensive.Orm.Linq.Expressions
 
     public bool IsNullable { get; set; }
 
-    public Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions)
+    public Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap) {
         return this;
@@ -58,7 +58,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
+    public Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap) {
         return this;
@@ -131,7 +131,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public static void Fill(EntityExpression entityExpression, int offset)
+    public static void Fill(EntityExpression entityExpression, ColNum offset)
     {
       using (new RemapScope()) {
         _ = entityExpression.Remap(offset, new Dictionary<Expression, Expression>());
@@ -147,7 +147,7 @@ namespace Xtensive.Orm.Linq.Expressions
       }
     }
 
-    public static EntityExpression Create(TypeInfo typeInfo, int offset, bool keyFieldsOnly)
+    public static EntityExpression Create(TypeInfo typeInfo, ColNum offset, bool keyFieldsOnly)
     {
       if (!typeInfo.IsEntity && !typeInfo.IsInterface) {
         throw new ArgumentException(
@@ -178,7 +178,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public static EntityExpression Create(EntityFieldExpression entityFieldExpression, int offset)
+    public static EntityExpression Create(EntityFieldExpression entityFieldExpression, ColNum offset)
     {
       var typeInfo = entityFieldExpression.PersistentType;
       var keyExpression = KeyExpression.Create(typeInfo, offset);
@@ -197,7 +197,7 @@ namespace Xtensive.Orm.Linq.Expressions
           entityFieldExpression.OuterParameter, new Dictionary<Expression, Expression>());
     }
 
-    private static PersistentFieldExpression BuildNestedFieldExpression(FieldInfo nestedField, int offset)
+    private static PersistentFieldExpression BuildNestedFieldExpression(FieldInfo nestedField, ColNum offset)
     {
       if (nestedField.IsPrimitive) {
         return FieldExpression.CreateField(nestedField, offset);

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityFieldExpression.cs
@@ -24,13 +24,13 @@ namespace Xtensive.Orm.Linq.Expressions
 
     public bool IsNullable => (Owner != null && Owner.IsNullable) || Field.IsNullable;
 
-    public void RegisterEntityExpression(int offset)
+    public void RegisterEntityExpression(ColNum offset)
     {
       Entity = EntityExpression.Create(this, offset);
       Entity.IsNullable = IsNullable;
     }
 
-    public override Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap) {
         return this;
@@ -59,7 +59,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap) {
         return this;
@@ -156,7 +156,7 @@ namespace Xtensive.Orm.Linq.Expressions
     public override FieldExpression RemoveOwner() =>
       new EntityFieldExpression(PersistentType, Field, Fields, Mapping, Key, Entity, OuterParameter, DefaultIfEmpty);
 
-    public static EntityFieldExpression CreateEntityField(FieldInfo entityField, int offset)
+    public static EntityFieldExpression CreateEntityField(FieldInfo entityField, ColNum offset)
     {
       if (!entityField.IsEntity) {
         throw new ArgumentException(string.Format(Strings.ExFieldXIsNotEntity, entityField.Name), nameof(entityField));
@@ -166,19 +166,19 @@ namespace Xtensive.Orm.Linq.Expressions
       var persistentType = entityField.ReflectedType.Model.Types[entityType];
 
       var mappingInfo = entityField.MappingInfo;
-      var mapping = new Segment<int>(mappingInfo.Offset + offset, mappingInfo.Length);
+      var mapping = new Segment<ColNum>((ColNum) (mappingInfo.Offset + offset), mappingInfo.Length);
       var keyFields = persistentType.Key.Fields;
-      var keyExpression = KeyExpression.Create(persistentType, offset + mappingInfo.Offset);
+      var keyExpression = KeyExpression.Create(persistentType, (ColNum) (offset + mappingInfo.Offset));
       var fields = new List<PersistentFieldExpression>(keyFields.Count + 1) { keyExpression };
       foreach (var field in keyFields) {
         // Do not convert to LINQ. We want to avoid a closure creation here.
-        fields.Add(BuildNestedFieldExpression(field, offset + mappingInfo.Offset));
+        fields.Add(BuildNestedFieldExpression(field, (ColNum) (offset + mappingInfo.Offset)));
       }
 
       return new EntityFieldExpression(persistentType, entityField, fields, mapping, keyExpression, null, null, false);
     }
 
-    private static PersistentFieldExpression BuildNestedFieldExpression(FieldInfo nestedField, int offset)
+    private static PersistentFieldExpression BuildNestedFieldExpression(FieldInfo nestedField, ColNum offset)
     {
       if (nestedField.IsPrimitive) {
         return CreateField(nestedField, offset);
@@ -198,7 +198,7 @@ namespace Xtensive.Orm.Linq.Expressions
       TypeInfo persistentType,
       FieldInfo field,
       List<PersistentFieldExpression> fields,
-      in Segment<int> mapping,
+      in Segment<ColNum> mapping,
       KeyExpression key,
       EntityExpression entity,
       ParameterExpression parameterExpression,

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntitySetExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntitySetExpression.cs
@@ -44,7 +44,7 @@ namespace Xtensive.Orm.Linq.Expressions
       throw Exceptions.InternalError(Strings.ExUnableToRemoveOwnerFromEntitySetExpression, OrmLog.Instance);
     }
 
-    public override Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;
@@ -60,7 +60,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;
@@ -119,7 +119,7 @@ namespace Xtensive.Orm.Linq.Expressions
       FieldInfo field,
       ParameterExpression parameterExpression,
       bool defaultIfEmpty)
-      : base(ExtendedExpressionType.EntitySet, field, default(Segment<int>), parameterExpression, defaultIfEmpty)
+      : base(ExtendedExpressionType.EntitySet, field, default(Segment<ColNum>), parameterExpression, defaultIfEmpty)
     {
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
@@ -30,7 +30,7 @@ namespace Xtensive.Orm.Linq.Expressions
       }
     }
 
-    public override Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap) {
         return this;
@@ -40,7 +40,7 @@ namespace Xtensive.Orm.Linq.Expressions
         return result;
       }
 
-      var newMapping = new Segment<int>(Mapping.Offset + offset, Mapping.Length);
+      var newMapping = new Segment<ColNum>((ColNum)(Mapping.Offset + offset), Mapping.Length);
       result = new FieldExpression(ExtendedExpressionType.Field, Field, newMapping, OuterParameter, DefaultIfEmpty);
       if (owner == null) {
         return result;
@@ -51,7 +51,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap) {
         return this;
@@ -61,7 +61,7 @@ namespace Xtensive.Orm.Linq.Expressions
         return result;
       }
 
-      var offset = map.IndexOf(Mapping.Offset);
+      var offset = (ColNum)map.IndexOf(Mapping.Offset);
       if (offset < 0) {
         if (owner == null && !SkipOwnerCheckScope.IsActive) {
           throw new InvalidOperationException(Strings.ExUnableToRemapFieldExpression);
@@ -74,7 +74,7 @@ namespace Xtensive.Orm.Linq.Expressions
 
         return null;
       }
-      var newMapping = new Segment<int>(offset, Mapping.Length);
+      var newMapping = new Segment<ColNum>(offset, Mapping.Length);
       result = new FieldExpression(ExtendedExpressionType.Field, Field, newMapping, OuterParameter, DefaultIfEmpty);
       if (owner == null) {
         return result;
@@ -127,7 +127,7 @@ namespace Xtensive.Orm.Linq.Expressions
       }
 
       var mappingInfo = field.MappingInfo;
-      var mapping = new Segment<int>(mappingInfo.Offset + offset, mappingInfo.Length);
+      var mapping = new Segment<ColNum>((ColNum)(mappingInfo.Offset + offset), mappingInfo.Length);
       return new FieldExpression(ExtendedExpressionType.Field, field, mapping, null, false);
     }
 
@@ -136,7 +136,7 @@ namespace Xtensive.Orm.Linq.Expressions
     protected FieldExpression(
       ExtendedExpressionType expressionType,
       FieldInfo field,
-      in Segment<int> mapping,
+      in Segment<ColNum> mapping,
       ParameterExpression parameterExpression,
       bool defaultIfEmpty)
       : base(expressionType, field.Name, field.ValueType, mapping, field.UnderlyingProperty, parameterExpression, defaultIfEmpty)

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/FullTextExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/FullTextExpression.cs
@@ -46,7 +46,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return new FullTextExpression(FullTextIndex, entityExpression, rankExpression, null);
     }
 
-    public Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions)
+    public Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;
@@ -60,7 +60,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return new FullTextExpression(FullTextIndex, remappedEntityExpression, remappedRankExpression, OuterParameter);
     }
 
-    public Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
+    public Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/GroupingExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/GroupingExpression.cs
@@ -70,14 +70,14 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
       var remappedSubquery = (SubQueryExpression) base.Remap(map, processedExpressions);
       var remappedKeyExpression = GenericExpressionVisitor<IMappedExpression>.Process(KeyExpression, mapped => mapped.Remap(map, processedExpressions));
       return new GroupingExpression(remappedSubquery.Type, remappedSubquery.OuterParameter, DefaultIfEmpty, remappedSubquery.ProjectionExpression, remappedSubquery.ApplyParameter, remappedKeyExpression, SelectManyInfo);
     }
 
-    public override Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
       var remappedSubquery = (SubQueryExpression) base.Remap(offset, processedExpressions);
       var remappedKeyExpression = GenericExpressionVisitor<IMappedExpression>.Process(KeyExpression, mapped => mapped.Remap(offset, processedExpressions));

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Interfaces/IMappedExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Interfaces/IMappedExpression.cs
@@ -14,7 +14,7 @@ namespace Xtensive.Orm.Linq.Expressions
   {
     Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions);
     Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions);
-    Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions);
-    Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions);
+    Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions);
+    Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions);
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
@@ -44,7 +44,7 @@ namespace Xtensive.Orm.Linq.Expressions
       }
     }
 
-    public IEnumerable<short> GetColumns(ColumnExtractionModes columnExtractionModes) =>
+    public IEnumerable<ColNum> GetColumns(ColumnExtractionModes columnExtractionModes) =>
       ColumnGatherer.GetColumns(Item, columnExtractionModes);
 
     public List<Pair<ColNum, Expression>> GetColumnsAndExpressions(ColumnExtractionModes columnExtractionModes) =>

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
@@ -44,13 +44,13 @@ namespace Xtensive.Orm.Linq.Expressions
       }
     }
 
-    public IEnumerable<int> GetColumns(ColumnExtractionModes columnExtractionModes) =>
+    public IEnumerable<short> GetColumns(ColumnExtractionModes columnExtractionModes) =>
       ColumnGatherer.GetColumns(Item, columnExtractionModes);
 
-    public List<Pair<int, Expression>> GetColumnsAndExpressions(ColumnExtractionModes columnExtractionModes) =>
+    public List<Pair<ColNum, Expression>> GetColumnsAndExpressions(ColumnExtractionModes columnExtractionModes) =>
       ColumnGatherer.GetColumnsAndExpressions(Item, columnExtractionModes);
 
-    public ItemProjectorExpression Remap(CompilableProvider dataSource, int offset)
+    public ItemProjectorExpression Remap(CompilableProvider dataSource, ColNum offset)
     {
       if (offset == 0) {
         return new ItemProjectorExpression(Item, dataSource, Context, AggregateType);
@@ -61,7 +61,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return new ItemProjectorExpression(item, dataSource, Context, AggregateType);
     }
 
-    public ItemProjectorExpression Remap(CompilableProvider dataSource, IReadOnlyList<int> columnMap)
+    public ItemProjectorExpression Remap(CompilableProvider dataSource, IReadOnlyList<ColNum> columnMap)
     {
       var item = GenericExpressionVisitor<IMappedExpression>
         .Process(Item, mapped => mapped.Remap(columnMap, new Dictionary<Expression, Expression>()));
@@ -139,10 +139,10 @@ namespace Xtensive.Orm.Linq.Expressions
           var joinedIndex = typeInfo.Indexes.PrimaryIndex;
           var joinedRs = joinedIndex.GetQuery().Alias(Context.GetNextAlias());
           var keySegment = entityExpression.Key.Mapping;
-          var keyPairs = new Pair<int>[keySegment.Length];
-          var rightIndex = 0;
+          var keyPairs = new Pair<ColNum>[keySegment.Length];
+          ColNum rightIndex = 0;
           foreach (var leftIndex in keySegment.GetItems()) {
-            keyPairs[rightIndex] = new Pair<int>(leftIndex, rightIndex);
+            keyPairs[rightIndex] = new Pair<ColNum>(leftIndex, rightIndex);
             rightIndex++;
           }
           var offset = dataSource.Header.Length;
@@ -163,10 +163,10 @@ namespace Xtensive.Orm.Linq.Expressions
           var joinedIndex = typeInfo.Indexes.PrimaryIndex;
           var joinedRs = joinedIndex.GetQuery().Alias(Context.GetNextAlias());
           var keySegment = entityFieldExpression.Mapping;
-          var keyPairs = new Pair<int>[keySegment.Length];
-          var rightIndex = 0;
+          var keyPairs = new Pair<ColNum>[keySegment.Length];
+          ColNum rightIndex = 0;
           foreach (var leftIndex in keySegment.GetItems()) {
-            keyPairs[rightIndex] = new Pair<int>(leftIndex, rightIndex);
+            keyPairs[rightIndex] = new Pair<ColNum>(leftIndex, rightIndex);
             rightIndex++;
           }
           var offset = dataSource.Header.Length;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/KeyExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/KeyExpression.cs
@@ -20,7 +20,7 @@ namespace Xtensive.Orm.Linq.Expressions
     public TypeInfo EntityType { get; }
     public IReadOnlyList<FieldExpression> KeyFields { get; }
 
-    public override Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap) {
         return this;
@@ -33,9 +33,9 @@ namespace Xtensive.Orm.Linq.Expressions
 
     // Having this code as a separate method helps to avoid closure allocation during Remap call
     // in case processedExpressions dictionary already contains a result.
-    private Expression RemapWithNoCheck(int offset, Dictionary<Expression, Expression> processedExpressions)
+    private Expression RemapWithNoCheck(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
-      var newMapping = new Segment<int>(Mapping.Offset + offset, Mapping.Length);
+      var newMapping = new Segment<ColNum>((ColNum)(Mapping.Offset + offset), Mapping.Length);
 
       FieldExpression Remap(FieldExpression f) => (FieldExpression) f.Remap(offset, processedExpressions);
 
@@ -46,7 +46,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap) {
         return this;
@@ -56,7 +56,7 @@ namespace Xtensive.Orm.Linq.Expressions
         return value;
       }
 
-      var segment = new Segment<int>(map.IndexOf(Mapping.Offset), Mapping.Length);
+      var segment = new Segment<ColNum>((ColNum)map.IndexOf(Mapping.Offset), Mapping.Length);
       var fields = new FieldExpression[KeyFields.Count];
       using (new SkipOwnerCheckScope()) {
         for (var index = 0; index < fields.Length; index++) {
@@ -126,9 +126,9 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public static KeyExpression Create(TypeInfo entityType, int offset)
+    public static KeyExpression Create(TypeInfo entityType, ColNum offset)
     {
-      var mapping = new Segment<int>(offset, entityType.Key.TupleDescriptor.Count);
+      var mapping = new Segment<ColNum>(offset, entityType.Key.TupleDescriptor.Count);
 
       FieldExpression CreateField(ColumnInfo c) => FieldExpression.CreateField(c.Field, offset);
 
@@ -148,7 +148,7 @@ namespace Xtensive.Orm.Linq.Expressions
     private KeyExpression(
       TypeInfo entityType, 
       IReadOnlyList<FieldExpression> keyFields,
-      in Segment<int> segment,
+      in Segment<ColNum> segment,
       PropertyInfo underlyingProperty, 
       ParameterExpression parameterExpression, 
       bool defaultIfEmpty)

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/LocalCollectionExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/LocalCollectionExpression.cs
@@ -32,7 +32,7 @@ namespace Xtensive.Orm.Linq.Expressions
           : ((LocalCollectionExpression) field.Value).Columns.Cast<IMappedExpression>())
         .Cast<ColumnExpression>();
 
-    public Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions)
+    public Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;
@@ -45,7 +45,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
+    public Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/PersistentFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/PersistentFieldExpression.cs
@@ -15,14 +15,14 @@ namespace Xtensive.Orm.Linq.Expressions
   internal abstract class PersistentFieldExpression : ParameterizedExpression,
     IMappedExpression
   {
-    internal Segment<int> Mapping;
+    internal Segment<ColNum> Mapping;
 
     public string Name { get; private set; }
     public PropertyInfo UnderlyingProperty { get; private set; }
     public abstract Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions);
     public abstract Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions);
-    public abstract Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions);
-    public abstract Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions);
+    public abstract Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions);
+    public abstract Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions);
 
     public override string ToString()
     {
@@ -36,7 +36,7 @@ namespace Xtensive.Orm.Linq.Expressions
       ExtendedExpressionType expressionType, 
       string name, 
       Type type, 
-      in Segment<int> segment,
+      in Segment<ColNum> segment,
       PropertyInfo underlyingProperty,
       ParameterExpression parameterExpression,
       bool defaultIfEmpty)

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureExpression.cs
@@ -19,7 +19,7 @@ namespace Xtensive.Orm.Linq.Expressions
     private List<PersistentFieldExpression> fields;
     private bool isNullable;
 
-    internal Segment<int> Mapping;
+    internal Segment<ColNum> Mapping;
     public TypeInfo PersistentType { get; }
 
     public bool IsNullable => isNullable;
@@ -35,7 +35,7 @@ namespace Xtensive.Orm.Linq.Expressions
       }
     }
 
-    public Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions)
+    public Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap) {
         return this;
@@ -45,7 +45,7 @@ namespace Xtensive.Orm.Linq.Expressions
         return value;
       }
 
-      var mapping = new Segment<int>(Mapping.Offset + offset, Mapping.Length);
+      var mapping = new Segment<ColNum>((ColNum) (Mapping.Offset + offset), Mapping.Length);
       var result = new StructureExpression(PersistentType, mapping);
       processedExpressions.Add(this, result);
       var processedFields = new List<PersistentFieldExpression>(fields.Count);
@@ -60,7 +60,7 @@ namespace Xtensive.Orm.Linq.Expressions
     }
 
     
-    public Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
+    public Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap) {
         return this;
@@ -73,7 +73,7 @@ namespace Xtensive.Orm.Linq.Expressions
       var result = new StructureExpression(PersistentType, default);
       processedExpressions.Add(this, result);
       var processedFields = new List<PersistentFieldExpression>(fields.Count);
-      var offset = int.MaxValue;
+      var offset = ColNum.MaxValue;
       foreach (var field in fields) {
         var mappedField = (PersistentFieldExpression) field.Remap(map, processedExpressions);
         if (mappedField == null) {
@@ -93,7 +93,7 @@ namespace Xtensive.Orm.Linq.Expressions
         return null;
       }
 
-      result.Mapping = new Segment<int>(offset, processedFields.Count);
+      result.Mapping = new Segment<ColNum>(offset, (ColNum) processedFields.Count);
       result.Fields = processedFields;
       result.isNullable = isNullable;
       return result;
@@ -135,7 +135,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public static StructureExpression CreateLocalCollectionStructure(TypeInfo typeInfo, in Segment<int> mapping)
+    public static StructureExpression CreateLocalCollectionStructure(TypeInfo typeInfo, in Segment<ColNum> mapping)
     {
       if (!typeInfo.IsStructure) {
         throw new ArgumentException(string.Format(Strings.ExTypeXIsNotStructure, typeInfo.Name));
@@ -152,7 +152,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    private static PersistentFieldExpression BuildNestedFieldExpression(FieldInfo nestedField, int offset)
+    private static PersistentFieldExpression BuildNestedFieldExpression(FieldInfo nestedField, ColNum offset)
     {
       if (nestedField.IsPrimitive) {
         return FieldExpression.CreateField(nestedField, offset);
@@ -173,7 +173,7 @@ namespace Xtensive.Orm.Linq.Expressions
 
     private StructureExpression(
       TypeInfo persistentType, 
-      in Segment<int> mapping)
+      in Segment<ColNum> mapping)
       : base(ExtendedExpressionType.Structure, persistentType.UnderlyingType, null, false)
     {
       Mapping = mapping;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureFieldExpression.cs
@@ -32,7 +32,7 @@ namespace Xtensive.Orm.Linq.Expressions
       }
     }
 
-    public override Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap) {
         return this;
@@ -42,7 +42,7 @@ namespace Xtensive.Orm.Linq.Expressions
         return value;
       }
 
-      var newMapping = new Segment<int>(Mapping.Offset + offset, Mapping.Length);
+      var newMapping = new Segment<ColNum>((ColNum) (Mapping.Offset + offset), Mapping.Length);
       var result = new StructureFieldExpression(PersistentType, Field, newMapping, OuterParameter, DefaultIfEmpty);
       processedExpressions.Add(this, result);
       var processedFields = new List<PersistentFieldExpression>(fields.Count);
@@ -61,7 +61,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap) {
         return this;
@@ -73,7 +73,7 @@ namespace Xtensive.Orm.Linq.Expressions
 
       var result = new StructureFieldExpression(PersistentType, Field, default, OuterParameter, DefaultIfEmpty);
       processedExpressions.Add(this, result);
-      var offset = int.MaxValue;
+      var offset = ColNum.MaxValue;
       var processedFields = new List<PersistentFieldExpression>(fields.Count);
       foreach (var field in fields) {
         var mappedField = (PersistentFieldExpression) field.Remap(map, processedExpressions);
@@ -94,7 +94,7 @@ namespace Xtensive.Orm.Linq.Expressions
         return null;
       }
 
-      result.Mapping = new Segment<int>(offset, processedFields.Count);
+      result.Mapping = new Segment<ColNum>(offset, (ColNum) processedFields.Count);
       if (Owner == null) {
         result.fields = processedFields;
         return result;
@@ -169,7 +169,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public static StructureFieldExpression CreateStructure(FieldInfo structureField, int offset)
+    public static StructureFieldExpression CreateStructure(FieldInfo structureField, ColNum offset)
     {
       if (!structureField.IsStructure) {
         throw new ArgumentException(string.Format(Strings.ExFieldIsNotStructure, structureField.Name));
@@ -177,12 +177,12 @@ namespace Xtensive.Orm.Linq.Expressions
 
       var persistentType = structureField.ReflectedType.Model.Types[structureField.ValueType];
       var fieldMappingInfo = structureField.MappingInfo;
-      var mapping = new Segment<int>(offset + fieldMappingInfo.Offset, fieldMappingInfo.Length);
+      var mapping = new Segment<ColNum>((ColNum)(offset + fieldMappingInfo.Offset), fieldMappingInfo.Length);
       var result = new StructureFieldExpression(persistentType, structureField, mapping, null, false);
       var processedFields = new List<PersistentFieldExpression>(persistentType.Fields.Count);
       foreach (var field in persistentType.Fields) {
         // Do not convert to LINQ. We want to avoid a closure creation here.
-        processedFields.Add(BuildNestedFieldExpression(field, offset + fieldMappingInfo.Offset));
+        processedFields.Add(BuildNestedFieldExpression(field, (ColNum) (offset + fieldMappingInfo.Offset)));
       }
 
       result.Fields = processedFields;
@@ -190,7 +190,7 @@ namespace Xtensive.Orm.Linq.Expressions
     }
 
 // ReSharper disable RedundantNameQualifier
-    private static PersistentFieldExpression BuildNestedFieldExpression(FieldInfo nestedField, int offset)
+    private static PersistentFieldExpression BuildNestedFieldExpression(FieldInfo nestedField, ColNum offset)
     {
       if (nestedField.IsPrimitive) {
         return FieldExpression.CreateField(nestedField, offset);
@@ -214,7 +214,7 @@ namespace Xtensive.Orm.Linq.Expressions
     private StructureFieldExpression(
       TypeInfo persistentType, 
       FieldInfo structureField, 
-      in Segment<int> mapping,
+      in Segment<ColNum> mapping,
       ParameterExpression parameterExpression, 
       bool defaultIfEmpty)
       : base(ExtendedExpressionType.StructureField, structureField, mapping, parameterExpression, defaultIfEmpty)

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/SubQueryExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/SubQueryExpression.cs
@@ -33,7 +33,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return this;
     }
 
-    public virtual Expression Remap(int offset, Dictionary<Expression, Expression> processedExpressions)
+    public virtual Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
       // Don't check CanRemap - Remap always.
 
@@ -67,7 +67,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public virtual Expression Remap(IReadOnlyList<int> map, Dictionary<Expression, Expression> processedExpressions)
+    public virtual Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
       // Don't check CanRemap - Remap always.
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ApplyParameterAccessVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ApplyParameterAccessVisitor.cs
@@ -35,7 +35,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
         && memberExpression.Member==WellKnownMembers.ApplyParameterValue
         && memberExpression.Expression.NodeType==ExpressionType.Constant
         && ((ConstantExpression) memberExpression.Expression).Value==applyParameter) {
-        ColNum index = (ColNum) ((ConstantExpression) tupleAccess.Arguments[0]).Value;
+        ColNum index = (ColNum) (int) ((ConstantExpression) tupleAccess.Arguments[0]).Value;
         return processor.Invoke(mc, index);
       }
       return base.VisitMethodCall(mc);

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ApplyParameterAccessVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ApplyParameterAccessVisitor.cs
@@ -35,7 +35,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
         && memberExpression.Member==WellKnownMembers.ApplyParameterValue
         && memberExpression.Expression.NodeType==ExpressionType.Constant
         && ((ConstantExpression) memberExpression.Expression).Value==applyParameter) {
-        var index = (short) ((ConstantExpression) tupleAccess.Arguments[0]).Value;
+        ColNum index = (ColNum) ((ConstantExpression) tupleAccess.Arguments[0]).Value;
         return processor.Invoke(mc, index);
       }
       return base.VisitMethodCall(mc);

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ApplyParameterAccessVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ApplyParameterAccessVisitor.cs
@@ -18,7 +18,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
   internal class ApplyParameterAccessVisitor : ExpressionVisitor
   {
     private readonly ApplyParameter applyParameter;
-    private readonly Func<MethodCallExpression, short, Expression> processor;
+    private readonly Func<MethodCallExpression, ColNum, Expression> processor;
 
     protected override Expression VisitUnknown(Expression e)
     {
@@ -53,7 +53,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
     /// <summary>
     /// Initializes a new instance of this class.
     /// </summary>
-    public ApplyParameterAccessVisitor(ApplyParameter applyParameter, Func<MethodCallExpression, short, Expression> processor)
+    public ApplyParameterAccessVisitor(ApplyParameter applyParameter, Func<MethodCallExpression, ColNum, Expression> processor)
     {
       this.processor = processor;
       this.applyParameter = applyParameter;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ApplyParameterAccessVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ApplyParameterAccessVisitor.cs
@@ -18,7 +18,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
   internal class ApplyParameterAccessVisitor : ExpressionVisitor
   {
     private readonly ApplyParameter applyParameter;
-    private readonly Func<MethodCallExpression, int, Expression> processor;
+    private readonly Func<MethodCallExpression, short, Expression> processor;
 
     protected override Expression VisitUnknown(Expression e)
     {
@@ -35,7 +35,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
         && memberExpression.Member==WellKnownMembers.ApplyParameterValue
         && memberExpression.Expression.NodeType==ExpressionType.Constant
         && ((ConstantExpression) memberExpression.Expression).Value==applyParameter) {
-        var index = (int) ((ConstantExpression) tupleAccess.Arguments[0]).Value;
+        var index = (short) ((ConstantExpression) tupleAccess.Arguments[0]).Value;
         return processor.Invoke(mc, index);
       }
       return base.VisitMethodCall(mc);
@@ -53,7 +53,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
     /// <summary>
     /// Initializes a new instance of this class.
     /// </summary>
-    public ApplyParameterAccessVisitor(ApplyParameter applyParameter, Func<MethodCallExpression, int, Expression> processor)
+    public ApplyParameterAccessVisitor(ApplyParameter applyParameter, Func<MethodCallExpression, short, Expression> processor)
     {
       this.processor = processor;
       this.applyParameter = applyParameter;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ColumnGatherer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ColumnGatherer.cs
@@ -16,7 +16,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
   internal sealed class ColumnGatherer : PersistentExpressionVisitor
   {
     private readonly ColumnExtractionModes columnExtractionModes;
-    private readonly List<Pair<int, Expression>> columns = new List<Pair<int, Expression>>();
+    private readonly List<Pair<ColNum, Expression>> columns = new();
     private SubQueryExpression topSubquery;
 
     private bool TreatEntityAsKey
@@ -44,7 +44,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       get { return (columnExtractionModes & ColumnExtractionModes.OmitLazyLoad)!=ColumnExtractionModes.Default; }
     }
 
-    public static List<Pair<int, Expression>> GetColumnsAndExpressions(Expression expression, ColumnExtractionModes columnExtractionModes)
+    public static List<Pair<ColNum, Expression>> GetColumnsAndExpressions(Expression expression, ColumnExtractionModes columnExtractionModes)
     {
       var gatherer = new ColumnGatherer(columnExtractionModes);
       gatherer.Visit(expression);
@@ -57,7 +57,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       return ordered.ToList();
     }
     
-    public static IEnumerable<int> GetColumns(Expression expression, ColumnExtractionModes columnExtractionModes)
+    public static IEnumerable<short> GetColumns(Expression expression, ColumnExtractionModes columnExtractionModes)
     {
       var gatherer = new ColumnGatherer(columnExtractionModes);
       gatherer.Visit(expression);
@@ -166,7 +166,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
 
       Visit(subQueryExpression.ProjectionExpression.ItemProjector.Item);
       var visitor = new ApplyParameterAccessVisitor(topSubquery.ApplyParameter, (mc, index) => {
-        columns.Add(new Pair<int, Expression>(index, mc));
+        columns.Add(new Pair<short, Expression>(index, mc));
         return mc;
       });
       var providerVisitor = new CompilableProviderVisitor((provider, expression) => visitor.Visit(expression));
@@ -219,13 +219,13 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
             .Offset));
     }
 
-    private void AddColumns(ParameterizedExpression parameterizedExpression, IEnumerable<int> expressionColumns)
+    private void AddColumns(ParameterizedExpression parameterizedExpression, IEnumerable<ColNum> expressionColumns)
     {
       var isSubqueryParameter = topSubquery!=null && parameterizedExpression.OuterParameter==topSubquery.OuterParameter;
       var isNotParametrized = topSubquery==null && parameterizedExpression.OuterParameter==null;
 
       if (isSubqueryParameter || isNotParametrized)
-        columns.AddRange(expressionColumns.Select(i=>new Pair<int, Expression>(i, parameterizedExpression)));
+        columns.AddRange(expressionColumns.Select(i=>new Pair<ColNum, Expression>(i, parameterizedExpression)));
     }
 
     protected override Expression VisitFullTextExpression(FullTextExpression expression)

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ColumnGatherer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ColumnGatherer.cs
@@ -57,7 +57,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       return ordered.ToList();
     }
     
-    public static IEnumerable<short> GetColumns(Expression expression, ColumnExtractionModes columnExtractionModes)
+    public static IEnumerable<ColNum> GetColumns(Expression expression, ColumnExtractionModes columnExtractionModes)
     {
       var gatherer = new ColumnGatherer(columnExtractionModes);
       gatherer.Visit(expression);
@@ -166,7 +166,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
 
       Visit(subQueryExpression.ProjectionExpression.ItemProjector.Item);
       var visitor = new ApplyParameterAccessVisitor(topSubquery.ApplyParameter, (mc, index) => {
-        columns.Add(new Pair<short, Expression>(index, mc));
+        columns.Add(new Pair<ColNum, Expression>(index, mc));
         return mc;
       });
       var providerVisitor = new CompilableProviderVisitor((provider, expression) => visitor.Visit(expression));

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/IncludeFilterMappingGatherer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/IncludeFilterMappingGatherer.cs
@@ -18,11 +18,11 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
   {
     public sealed class MappingEntry
     {
-      public int ColumnIndex { get; private set; }
+      public ColNum ColumnIndex { get; }
 
-      public LambdaExpression CalculatedColumn { get; private set; }
+      public LambdaExpression CalculatedColumn { get; }
 
-      public MappingEntry(int columnIndex)
+      public MappingEntry(ColNum columnIndex)
       {
         ColumnIndex = columnIndex;
       }

--- a/Orm/Xtensive.Orm/Orm/Linq/ItemToTupleConverter{TItem}.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ItemToTupleConverter{TItem}.cs
@@ -135,7 +135,7 @@ namespace Xtensive.Orm.Linq
           var structure = (Structure) item;
           var typeInfo = structureExpression.PersistentType;
           var tupleDescriptor = typeInfo.TupleDescriptor;
-          var tupleSegment = new Segment<int>(0, tupleDescriptor.Count);
+          var tupleSegment = new Segment<ColNum>(0, tupleDescriptor.Count);
           var structureTuple = structure.Tuple.GetSegment(tupleSegment);
           structureTuple.CopyTo(tuple, 0, structureExpression.Mapping.Offset, structureTuple.Count);
           break;
@@ -157,7 +157,7 @@ namespace Xtensive.Orm.Linq
     }
 
     private LocalCollectionExpression BuildLocalCollectionExpression(Type type,
-      HashSet<Type> processedTypes, ref int columnIndex, MemberInfo parentMember, TupleTypeCollection types, Expression sourceExpression)
+      HashSet<Type> processedTypes, ref ColNum columnIndex, MemberInfo parentMember, TupleTypeCollection types, Expression sourceExpression)
     {
       if (type.IsAssignableFrom(WellKnownOrmTypes.Key))
         throw new InvalidOperationException(string.Format(Strings.ExUnableToStoreUntypedKeyToStorage, RefOfTType.GetShortName()));
@@ -192,7 +192,7 @@ namespace Xtensive.Orm.Linq
     }
 
 
-    private IMappedExpression BuildField(Type type, ref int index, TupleTypeCollection types)
+    private IMappedExpression BuildField(Type type, ref ColNum index, TupleTypeCollection types)
     {
 //      if (type.IsOfGenericType(typeof (Ref<>))) {
 //        var entityType = type.GetGenericType(typeof (Ref<>)).GetGenericArguments()[0];
@@ -217,7 +217,7 @@ namespace Xtensive.Orm.Linq
           entityExpression.IsNullable = true;
           expression = entityExpression;
         }
-        index += keyTupleDescriptor.Count;
+        index += (ColNum)keyTupleDescriptor.Count;
         types.AddRange(keyTupleDescriptor);
         return expression;
       }
@@ -225,9 +225,9 @@ namespace Xtensive.Orm.Linq
       if (type.IsSubclassOf(WellKnownOrmTypes.Structure)) {
         var typeInfo = model.Types[type];
         var tupleDescriptor = typeInfo.TupleDescriptor;
-        var tupleSegment = new Segment<int>(index, tupleDescriptor.Count);
+        var tupleSegment = new Segment<ColNum>(index, tupleDescriptor.Count);
         var structureExpression = StructureExpression.CreateLocalCollectionStructure(typeInfo, tupleSegment);
-        index += tupleDescriptor.Count;
+        index += (ColNum)tupleDescriptor.Count;
         types.AddRange(tupleDescriptor);
         return structureExpression;
       }
@@ -245,7 +245,7 @@ namespace Xtensive.Orm.Linq
     private void BuildConverter(Expression sourceExpression)
     {
       var itemType = isKeyConverter ? entityTypestoredInKey : typeof (TItem);
-      var index = 0;
+      ColNum index = 0;
       var types = new TupleTypeCollection();
       if (IsPersistableType(itemType)) {
         Expression = (Expression) BuildField(itemType, ref index, types);

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
@@ -359,7 +359,7 @@ namespace Xtensive.Orm.Linq.Materialization
         .OfType<FieldExpression>()
         .Where(f => f.ExtendedType==ExtendedExpressionType.Field)
         .OrderBy(f => f.Field.MappingInfo.Offset)
-        .Select(f => new Pair<int>(f.Field.MappingInfo.Offset, f.Mapping.Offset))
+        .Select(f => new Pair<ColNum>(f.Field.MappingInfo.Offset, f.Mapping.Offset))
         .Distinct()
         .ToArray();
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
@@ -245,7 +245,7 @@ namespace Xtensive.Orm.Linq.Materialization
           .OfType<FieldExpression>()
           .Where(f => f.ExtendedType==ExtendedExpressionType.Field)
           .OrderBy(f => f.Field.MappingInfo.Offset)
-          .Select(f => new Pair<int>(f.Field.MappingInfo.Offset, f.Mapping.Offset))
+          .Select(f => new Pair<ColNum>(f.Field.MappingInfo.Offset, f.Mapping.Offset))
           .Distinct()
           .ToArray();
 
@@ -294,7 +294,7 @@ namespace Xtensive.Orm.Linq.Materialization
         .OfType<FieldExpression>()
         .Where(f => f.ExtendedType==ExtendedExpressionType.Field)
         .OrderBy(f => f.Field.MappingInfo.Offset)
-        .Select(f => new Pair<int>(f.Field.MappingInfo.Offset, f.Mapping.Offset))
+        .Select(f => new Pair<ColNum>(f.Field.MappingInfo.Offset, f.Mapping.Offset))
         .Distinct()
         .ToArray();
 
@@ -537,14 +537,14 @@ namespace Xtensive.Orm.Linq.Materialization
       return TupleParameter;
     }
 
-    private static Tuple BuildPersistentTuple(Tuple tuple, Tuple tuplePrototype, int[] mapping)
+    private static Tuple BuildPersistentTuple(Tuple tuple, Tuple tuplePrototype, ColNum[] mapping)
     {
       var result = tuplePrototype.CreateNew();
       tuple.CopyTo(result, mapping);
       return result;
     }
 
-    private static Tuple GetTupleSegment(Tuple tuple, in Segment<int> segment) => tuple.GetSegment(segment).ToRegular();
+    private static Tuple GetTupleSegment(Tuple tuple, in Segment<ColNum> segment) => tuple.GetSegment(segment).ToRegular();
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ItemMaterializationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ItemMaterializationContext.cs
@@ -34,7 +34,7 @@ namespace Xtensive.Orm.Linq.Materialization
 
     public TypeInfo GetTypeInfo(int typeId) => typeId == TypeInfo.NoTypeId ? null : typeIdRegistry[typeId];
 
-    public Entity Materialize(int entityIndex, int typeIdIndex, TypeInfo type, Pair<int>[] entityColumns, Tuple tuple)
+    public Entity Materialize(int entityIndex, int typeIdIndex, TypeInfo type, Pair<ColNum>[] entityColumns, Tuple tuple)
     {
       var result = entities[entityIndex];
       if (result!=null)

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
@@ -58,7 +58,7 @@ namespace Xtensive.Orm.Linq.Materialization
     /// </summary>
     public Queue<Action> MaterializationQueue { get; set; }
 
-    public TypeMapping GetTypeMapping(int entityIndex, TypeInfo approximateType, int typeId, IReadOnlyList<Pair<int>> columns)
+    public TypeMapping GetTypeMapping(int entityIndex, TypeInfo approximateType, int typeId, IReadOnlyList<Pair<ColNum>> columns)
     {
       TypeMapping result;
       ref var cache = ref entityMappings[entityIndex];
@@ -78,20 +78,20 @@ namespace Xtensive.Orm.Linq.Materialization
       var typeColumnMap = columns;
       if (approximateType.IsInterface) {
         // fixup target index
-        var newColumns = new Pair<int>[columns.Count];
+        var newColumns = new Pair<ColNum>[columns.Count];
         for (int i = columns.Count; i-- > 0;) {
           var pair = columns[i];
           var approxTargetIndex = pair.First;
           var interfaceField = approximateType.Columns[approxTargetIndex].Field;
           var field = type.FieldMap[interfaceField];
           var targetIndex = field.MappingInfo.Offset;
-          newColumns[i] = new Pair<int>(targetIndex, pair.Second);
+          newColumns[i] = new Pair<ColNum>(targetIndex, pair.Second);
         }
         typeColumnMap = newColumns;
       }
 
-      ArraySegment<int> allIndexes = MaterializationHelper.CreateSingleSourceMap(descriptor.Count, typeColumnMap);
-      ArraySegment<int> keyIndexes = allIndexes.Slice(0, keyInfo.TupleDescriptor.Count);
+      ArraySegment<ColNum> allIndexes = MaterializationHelper.CreateSingleSourceMap(descriptor.Count, typeColumnMap);
+      ArraySegment<ColNum> keyIndexes = allIndexes.Slice(0, keyInfo.TupleDescriptor.Count);
 
       var transform    = new MapTransform(true, descriptor, allIndexes);
       var keyTransform = new MapTransform(true, keyInfo.TupleDescriptor, keyIndexes);

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationHelper.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationHelper.cs
@@ -60,7 +60,7 @@ namespace Xtensive.Orm.Linq.Materialization
 
     public static T GetDefault<T>() => default;
 
-    public static bool IsNull(Tuple tuple, int[] columns) =>
+    public static bool IsNull(Tuple tuple, ColNum[] columns) =>
       columns.All(column => tuple.GetFieldState(column).IsNull());
 
     public static object ThrowEmptySequenceException() =>

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationHelper.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationHelper.cs
@@ -43,9 +43,9 @@ namespace Xtensive.Orm.Linq.Materialization
     public static readonly MethodInfo PrefetchEntitySetMethodInfo = typeof(MaterializationHelper)
         .GetMethod(nameof(PrefetechEntitySet), BindingFlags.Public | BindingFlags.Static);
 
-    public static int[] CreateSingleSourceMap(int targetLength, IReadOnlyList<Pair<int>> remappedColumns)
+    public static ColNum[] CreateSingleSourceMap(int targetLength, IReadOnlyList<Pair<ColNum>> remappedColumns)
     {
-      var map = new int[targetLength];
+      var map = new ColNum[targetLength];
       Array.Fill(map, MapTransform.NoMapping);
 
       for (var i = 0; i < remappedColumns.Count; i++) {

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -592,7 +592,7 @@ namespace Xtensive.Orm.Linq
       else
         dataSource = new FreeTextProvider(fullTextIndex, compiledParameter, rankColumnAlias, fullFeatured);
 
-      rankExpression = ColumnExpression.Create(WellKnownTypes.Double, dataSource.Header.Columns.Count - 1);
+      rankExpression = ColumnExpression.Create(WellKnownTypes.Double, (ColNum) (dataSource.Header.Columns.Count - 1));
       freeTextExpression = new FullTextExpression(fullTextIndex, entityExpression, rankExpression, null);
       itemProjector = new ItemProjectorExpression(freeTextExpression, dataSource, context);
       return new ProjectionExpression(WellKnownInterfaces.QueryableOfT.CachedMakeGenericType(elementType), itemProjector, EmptyTupleParameterBindings);
@@ -657,7 +657,7 @@ namespace Xtensive.Orm.Linq
       else
         dataSource = new ContainsTableProvider(fullTextIndex, compiledParameter, rankColumnAlias, searchableColumns, fullFeatured);
 
-      rankExpression = ColumnExpression.Create(WellKnownTypes.Double, dataSource.Header.Columns.Count - 1);
+      rankExpression = ColumnExpression.Create(WellKnownTypes.Double, (ColNum) (dataSource.Header.Columns.Count - 1));
       freeTextExpression = new FullTextExpression(fullTextIndex, entityExpression, rankExpression, null);
       itemProjector = new ItemProjectorExpression(freeTextExpression, dataSource, context);
       return new ProjectionExpression(WellKnownInterfaces.QueryableOfT.CachedMakeGenericType(elementType), itemProjector, EmptyTupleParameterBindings);
@@ -973,7 +973,7 @@ namespace Xtensive.Orm.Linq
           return entityExpression.Fields.First(field => field.Name == evaluatedArgument);
         }
         if (typeInfo.IsStructure) {
-          var structureExpression = StructureExpression.CreateLocalCollectionStructure(typeInfo, new Segment<int>(0, typeInfo.TupleDescriptor.Count));
+          var structureExpression = StructureExpression.CreateLocalCollectionStructure(typeInfo, new Segment<ColNum>(0, typeInfo.TupleDescriptor.Count));
           return structureExpression.Fields.First(field => field.Name == evaluatedArgument);
         }
       }
@@ -1221,7 +1221,7 @@ namespace Xtensive.Orm.Linq
       var newResult = new ProjectionExpression(oldResult.Type, newItemProjector, oldResult.TupleParameterBindings);
       context.Bindings.ReplaceBound(sourceParameter, newResult);
 
-      var result = ColumnExpression.Create(originalColumnType, dataSource.Header.Length - 1);
+      var result = ColumnExpression.Create(originalColumnType, (ColNum) (dataSource.Header.Length - 1));
       ModifyStateAllowCalculableColumnCombine(true);
 
       return result;
@@ -1553,14 +1553,14 @@ namespace Xtensive.Orm.Linq
       // Replace original recordset. New recordset is left join with old recordset
       ProjectionExpression originalResultExpression = context.Bindings[parameter];
       var originalQuery = originalResultExpression.ItemProjector.DataSource;
-      int offset = originalQuery.Header.Columns.Count;
+      ColNum offset = originalQuery.Header.Columns.Count;
 
       // Join primary index of target type
       IndexInfo indexToJoin = targetTypeInfo.Indexes.PrimaryIndex;
       var queryToJoin = indexToJoin.GetQuery().Alias(context.GetNextAlias());
       var keySegment = entityExpression.Key.Mapping.GetItems();
       var keyPairs = keySegment
-        .Select((leftIndex, rightIndex) => new Pair<int>(leftIndex, rightIndex))
+        .Select((leftIndex, rightIndex) => new Pair<ColNum>(leftIndex, (ColNum)rightIndex))
         .ToArray();
 
       // Replace recordset.
@@ -1595,11 +1595,11 @@ namespace Xtensive.Orm.Linq
         return; // All fields are already joined
       IndexInfo joinedIndex = typeInfo.Indexes.PrimaryIndex;
       var joinedRs = joinedIndex.GetQuery().Alias(itemProjector.Context.GetNextAlias());
-      Segment<int> keySegment = entityExpression.Key.Mapping;
-      Pair<int>[] keyPairs = keySegment.GetItems()
-        .Select((leftIndex, rightIndex) => new Pair<int>(leftIndex, rightIndex))
+      Segment<ColNum> keySegment = entityExpression.Key.Mapping;
+      Pair<ColNum>[] keyPairs = keySegment.GetItems()
+        .Select((leftIndex, rightIndex) => new Pair<ColNum>(leftIndex, (ColNum)rightIndex))
         .ToArray();
-      int offset = itemProjector.DataSource.Header.Length;
+      ColNum offset = itemProjector.DataSource.Header.Length;
       var oldDataSource = itemProjector.DataSource;
       var newDataSource = entityExpression.IsNullable
         ? itemProjector.DataSource.LeftJoin(joinedRs, keyPairs)
@@ -1616,14 +1616,14 @@ namespace Xtensive.Orm.Linq
       TypeInfo typeInfo = entityFieldExpression.PersistentType;
       IndexInfo joinedIndex = typeInfo.Indexes.PrimaryIndex;
       var joinedRs = joinedIndex.GetQuery().Alias(context.GetNextAlias());
-      Segment<int> keySegment = entityFieldExpression.Mapping;
-      Pair<int>[] keyPairs = keySegment.GetItems()
-        .Select((leftIndex, rightIndex) => new Pair<int>(leftIndex, rightIndex))
+      Segment<ColNum> keySegment = entityFieldExpression.Mapping;
+      Pair<ColNum>[] keyPairs = keySegment.GetItems()
+        .Select((leftIndex, rightIndex) => new Pair<ColNum>(leftIndex, (ColNum)rightIndex))
         .ToArray();
       ItemProjectorExpression originalItemProjector = entityFieldExpression.OuterParameter == null
         ? context.Bindings[State.Parameters[0]].ItemProjector
         : context.Bindings[entityFieldExpression.OuterParameter].ItemProjector;
-      int offset = originalItemProjector.DataSource.Header.Length;
+      ColNum offset = originalItemProjector.DataSource.Header.Length;
       var oldDataSource = originalItemProjector.DataSource;
       bool shouldUseLeftJoin = false;
       var filterProvider = oldDataSource as FilterProvider;

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
@@ -186,7 +186,7 @@ namespace Xtensive.Orm.Linq
     {
       if (le.Parameters.Count == 2) {
         var indexDataSource = sequence.ItemProjector.DataSource.RowNumber(context.GetNextColumnAlias());
-        var columnExpression = ColumnExpression.Create(WellKnownTypes.Int64, indexDataSource.Header.Columns.Count - 1);
+        var columnExpression = ColumnExpression.Create(WellKnownTypes.Int64, (ColNum) (indexDataSource.Header.Columns.Count - 1));
         var indexExpression = Expression.Subtract(columnExpression, Expression.Constant(1L));
         var itemExpression = Expression.Convert(indexExpression, WellKnownTypes.Int32);
         var indexItemProjector = new ItemProjectorExpression(itemExpression, indexDataSource, context);

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -447,7 +447,7 @@ namespace Xtensive.Orm.Linq
       //        offset = recordSet.Header.Columns.Count;
       //        var keySegment = visitedSource.ItemProjector.GetColumns(ColumnExtractionModes.TreatEntityAsKey);
       //        var keyPairs = keySegment
-      //          .Select((leftIndex, rightIndex) => new Pair<int>(leftIndex, rightIndex))
+      //          .Select((leftIndex, rightIndex) => new Pair<ColNum>(leftIndex, rightIndex))
       //          .ToArray();
       //        recordSet = recordSet.Join(joinedRs, JoinAlgorithm.Default, keyPairs);
       //      }

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -370,8 +370,8 @@ namespace Xtensive.Orm.Linq
 
       var targetTypeInfo = context.Model.Types[targetType];
 
-      var currentIndex = 0;
-      var indexes = new List<int>(targetTypeInfo.Indexes.PrimaryIndex.Columns.Count);
+      short currentIndex = 0;
+      var indexes = new List<ColNum>(targetTypeInfo.Indexes.PrimaryIndex.Columns.Count);
       foreach (var indexColumn in targetTypeInfo.Indexes.PrimaryIndex.Columns) {
         if (targetTypeInfo.Columns.Contains(indexColumn)) {
           indexes.Add(currentIndex);
@@ -382,7 +382,7 @@ namespace Xtensive.Orm.Linq
       var recordSet = targetTypeInfo.Indexes.PrimaryIndex.GetQuery().Alias(context.GetNextAlias()).Select(indexes);
       var keySegment = visitedSource.ItemProjector.GetColumns(ColumnExtractionModes.TreatEntityAsKey);
       var keyPairs = keySegment
-        .Select((leftIndex, rightIndex) => new Pair<int>(leftIndex, rightIndex))
+        .Select((leftIndex, rightIndex) => new Pair<ColNum>(leftIndex, (ColNum)rightIndex))
         .ToArray();
 
       var dataSource = visitedSource.ItemProjector.DataSource;
@@ -413,8 +413,8 @@ namespace Xtensive.Orm.Linq
       var recordSet = projection.ItemProjector.DataSource;
       var targetTypeInfo = context.Model.Types[targetType];
       var sourceTypeInfo = context.Model.Types[sourceType];
-      var map = Enumerable.Repeat(-1, recordSet.Header.Columns.Count).ToArray();
-      var targetFieldIndex = 0;
+      var map = Enumerable.Repeat((ColNum)(-1), recordSet.Header.Columns.Count).ToArray();
+      ColNum targetFieldIndex = 0;
       var targetFields = targetTypeInfo.Fields.Where(f => f.IsPrimitive);
       foreach (var targetField in targetFields) {
         var sourceFieldInfo = targetType.IsInterface && sourceType.IsClass
@@ -834,7 +834,7 @@ namespace Xtensive.Orm.Linq
               }
             }
 
-            var resultColumn = ColumnExpression.Create(columnType, resultDataSource.Header.Length - 1);
+            var resultColumn = ColumnExpression.Create(columnType, (ColNum) (resultDataSource.Header.Length - 1));
             if (isSubqueryParameter) {
               resultColumn = (ColumnExpression) resultColumn.BindParameter(groupingParameter);
             }
@@ -883,7 +883,7 @@ namespace Xtensive.Orm.Linq
         if (aggregateDescriptor.SourceIndex >= source.Header.Length) {
           aggregateDescriptor = new AggregateColumnDescriptor(
             aggregateDescriptor.Name,
-            aggregateDescriptor.SourceIndex + leftCalculateProvider.CalculatedColumns.Length,
+            (ColNum) (aggregateDescriptor.SourceIndex + leftCalculateProvider.CalculatedColumns.Length),
             aggregateDescriptor.AggregateType);
         }
 
@@ -894,7 +894,7 @@ namespace Xtensive.Orm.Linq
       return null;
     }
 
-    private Pair<ProjectionExpression, int> VisitAggregateSource(Expression source, LambdaExpression aggregateParameter,
+    private Pair<ProjectionExpression, ColNum> VisitAggregateSource(Expression source, LambdaExpression aggregateParameter,
       AggregateType aggregateType, Expression visitedExpression)
     {
       // Process any selectors or filters specified via parameter to aggregating method.
@@ -905,15 +905,15 @@ namespace Xtensive.Orm.Linq
       // to which aggregate function should be applied.
 
       ProjectionExpression sourceProjection;
-      int aggregatedColumnIndex;
+      ColNum aggregatedColumnIndex;
 
       if (aggregateType == AggregateType.Count) {
         aggregatedColumnIndex = 0;
         sourceProjection = aggregateParameter != null ? VisitWhere(source, aggregateParameter) : VisitSequence(source);
-        return new Pair<ProjectionExpression, int>(sourceProjection, aggregatedColumnIndex);
+        return new Pair<ProjectionExpression, ColNum>(sourceProjection, aggregatedColumnIndex);
       }
 
-      List<int> columnList = null;
+      List<ColNum> columnList = null;
       sourceProjection = VisitSequence(source);
       if (aggregateParameter == null) {
         if (sourceProjection.ItemProjector.IsPrimitive) {
@@ -947,7 +947,7 @@ namespace Xtensive.Orm.Linq
       }
 
       aggregatedColumnIndex = columnList[0];
-      return new Pair<ProjectionExpression, int>(sourceProjection, aggregatedColumnIndex);
+      return new Pair<ProjectionExpression, ColNum>(sourceProjection, aggregatedColumnIndex);
     }
 
     private static void EnsureAggregateIsPossible(Type type, AggregateType aggregateType, Expression visitedExpression)
@@ -1162,7 +1162,7 @@ namespace Xtensive.Orm.Linq
         projection = VisitSequence(extractor.BaseExpression);
       }
 
-      var sortColumns = new DirectionCollection<int>();
+      var sortColumns = new DirectionCollection<ColNum>();
 
       foreach (var item in extractor.SortExpressions) {
         var sortExpression = item.Key;
@@ -1222,7 +1222,7 @@ namespace Xtensive.Orm.Linq
           innerColumnKeyExpression.EnsureKeyExpressionCompatible(outerColumnKeyExpression, expressionPart);
         }
 
-        var keyPairs = outerColumns.Zip(innerColumns, (o, i) => new Pair<int>(o.First, i.First)).ToArray();
+        var keyPairs = outerColumns.Zip(innerColumns, (o, i) => new Pair<ColNum>(o.First, i.First)).ToArray();
 
         var outer = context.Bindings[outerParameter];
         var inner = context.Bindings[innerParameter];
@@ -1540,7 +1540,7 @@ namespace Xtensive.Orm.Linq
           predicateLambda.Body, predicateLambda.Parameters[0], filteredTuple, filterColumnCount);
 
         // Mapping from filter data column to filtered column
-        var filteredColumns = new int[filterColumnCount];
+        var filteredColumns = new ColNum[filterColumnCount];
         for (var i = 0; i < filterColumnCount; i++) {
           var mapping = filteredColumnMappings[i];
           if (mapping.ColumnIndex >= 0) {
@@ -1656,7 +1656,7 @@ namespace Xtensive.Orm.Linq
       return new ProjectionExpression(outer.Type, itemProjector, tupleParameterBindings);
     }
 
-    private bool ShouldWrapDataSourceWithSelect(ItemProjectorExpression expression, IReadOnlyList<int> columns) =>
+    private bool ShouldWrapDataSourceWithSelect(ItemProjectorExpression expression, IReadOnlyList<ColNum> columns) =>
       expression.DataSource.Type != ProviderType.Select
       || expression.DataSource.Header.Length != columns.Count
       || columns.Select((c, i) => (c, i)).Any(x => x.c != x.i);
@@ -1799,7 +1799,7 @@ namespace Xtensive.Orm.Linq
       }
     }
 
-    private static ICollection<int> GetNullableGroupingExpressions(List<Pair<int, Expression>> keyFieldsRaw)
+    private static ICollection<int> GetNullableGroupingExpressions(List<Pair<ColNum, Expression>> keyFieldsRaw)
     {
       var nullableFields = new HashSet<int>();
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -370,7 +370,7 @@ namespace Xtensive.Orm.Linq
 
       var targetTypeInfo = context.Model.Types[targetType];
 
-      short currentIndex = 0;
+      ColNum currentIndex = 0;
       var indexes = new List<ColNum>(targetTypeInfo.Indexes.PrimaryIndex.Columns.Count);
       foreach (var indexColumn in targetTypeInfo.Indexes.PrimaryIndex.Columns) {
         if (targetTypeInfo.Columns.Contains(indexColumn)) {

--- a/Orm/Xtensive.Orm/Orm/Model/AssociationInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/AssociationInfo.cs
@@ -219,7 +219,7 @@ namespace Xtensive.Orm.Model
             UnderlyingIndex = Reversed.AuxiliaryType.Indexes.Where(indexInfo => indexInfo.IsSecondary).Skip(1).First();
 
           if (!OwnerType.IsInterface) {
-            var foreignKeySegment = new Segment<int>(OwnerType.Columns.Count(c => c.IsPrimaryKey), TargetType.Columns.Count(c => c.IsPrimaryKey));
+            var foreignKeySegment = new Segment<ColNum>((ColNum) OwnerType.Columns.Count(c => c.IsPrimaryKey), (ColNum) TargetType.Columns.Count(c => c.IsPrimaryKey));
             foreignKeyExtractor = new SegmentTransform(true, UnderlyingIndex.TupleDescriptor, foreignKeySegment);
           }
           break;

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnGroup.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnGroup.cs
@@ -28,12 +28,12 @@ namespace Xtensive.Orm.Model
     /// <summary>
     /// Gets the indexes of key columns.
     /// </summary>
-    public IReadOnlyList<short> Keys { get; }
+    public IReadOnlyList<ColNum> Keys { get; }
 
     /// <summary>
     /// Gets the indexes of all columns.
     /// </summary>
-    public IReadOnlyList<short> Columns { get; }
+    public IReadOnlyList<ColNum> Columns { get; }
 
 
     // Constructors
@@ -44,8 +44,8 @@ namespace Xtensive.Orm.Model
     /// <param name="type">The type.</param>
     /// <param name="keys">The keys.</param>
     /// <param name="columns">The columns.</param>
-    public ColumnGroup(TypeInfoRef type, IEnumerable<short> keys, IEnumerable<short> columns)
-      : this(type, new List<short>(keys), new List<short>(columns))
+    public ColumnGroup(TypeInfoRef type, IEnumerable<ColNum> keys, IEnumerable<short> columns)
+      : this(type, new List<ColNum>(keys), new List<ColNum>(columns))
     {
     }
 
@@ -55,7 +55,7 @@ namespace Xtensive.Orm.Model
     /// <param name="type">The type.</param>
     /// <param name="keys">The keys.</param>
     /// <param name="columns">The columns.</param>
-    public ColumnGroup(TypeInfoRef type, IReadOnlyList<short> keys, IReadOnlyList<short> columns)
+    public ColumnGroup(TypeInfoRef type, IReadOnlyList<ColNum> keys, IReadOnlyList<ColNum> columns)
     {
       TypeInfoRef = type;
       Keys = keys;

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnGroup.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnGroup.cs
@@ -44,7 +44,7 @@ namespace Xtensive.Orm.Model
     /// <param name="type">The type.</param>
     /// <param name="keys">The keys.</param>
     /// <param name="columns">The columns.</param>
-    public ColumnGroup(TypeInfoRef type, IEnumerable<ColNum> keys, IEnumerable<short> columns)
+    public ColumnGroup(TypeInfoRef type, IEnumerable<ColNum> keys, IEnumerable<ColNum> columns)
       : this(type, new List<ColNum>(keys), new List<ColNum>(columns))
     {
     }

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnGroup.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnGroup.cs
@@ -28,12 +28,12 @@ namespace Xtensive.Orm.Model
     /// <summary>
     /// Gets the indexes of key columns.
     /// </summary>
-    public IReadOnlyList<int> Keys { get; }
+    public IReadOnlyList<short> Keys { get; }
 
     /// <summary>
     /// Gets the indexes of all columns.
     /// </summary>
-    public IReadOnlyList<int> Columns { get; }
+    public IReadOnlyList<short> Columns { get; }
 
 
     // Constructors
@@ -44,8 +44,8 @@ namespace Xtensive.Orm.Model
     /// <param name="type">The type.</param>
     /// <param name="keys">The keys.</param>
     /// <param name="columns">The columns.</param>
-    public ColumnGroup(TypeInfoRef type, IEnumerable<int> keys, IEnumerable<int> columns)
-      : this(type, new List<int>(keys), new List<int>(columns))
+    public ColumnGroup(TypeInfoRef type, IEnumerable<short> keys, IEnumerable<short> columns)
+      : this(type, new List<short>(keys), new List<short>(columns))
     {
     }
 
@@ -55,7 +55,7 @@ namespace Xtensive.Orm.Model
     /// <param name="type">The type.</param>
     /// <param name="keys">The keys.</param>
     /// <param name="columns">The columns.</param>
-    public ColumnGroup(TypeInfoRef type, IReadOnlyList<int> keys, IReadOnlyList<int> columns)
+    public ColumnGroup(TypeInfoRef type, IReadOnlyList<short> keys, IReadOnlyList<short> columns)
     {
       TypeInfoRef = type;
       Keys = keys;

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnIndexMap.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnIndexMap.cs
@@ -20,17 +20,17 @@ namespace Xtensive.Orm.Model
     /// <summary>
     /// Gets or sets positions of system columns within <see cref="IndexInfo"/>.
     /// </summary>
-    public IReadOnlyList<int> System { get; }
+    public IReadOnlyList<ColNum> System { get; }
 
     /// <summary>
     /// Gets or sets positions of lazy load columns within <see cref="IndexInfo"/>.
     /// </summary>
-    public IReadOnlyList<int> LazyLoad { get; }
+    public IReadOnlyList<ColNum> LazyLoad { get; }
 
     /// <summary>
     /// Gets or sets positions of regular columns (not system and not lazy load) within <see cref="IndexInfo"/>.
     /// </summary>
-    public IReadOnlyList<int> Regular { get; }
+    public IReadOnlyList<ColNum> Regular { get; }
 
 
     // Constructors
@@ -41,7 +41,7 @@ namespace Xtensive.Orm.Model
     /// <param name="system">The system columns.</param>
     /// <param name="lazyLoad">The regular columns.</param>
     /// <param name="regular">The lazy load columns.</param>
-    public ColumnIndexMap(IReadOnlyList<int> system, IReadOnlyList<int> regular, IReadOnlyList<int> lazyLoad)
+    public ColumnIndexMap(IReadOnlyList<ColNum> system, IReadOnlyList<ColNum> regular, IReadOnlyList<ColNum> lazyLoad)
     {
       System = system;
       LazyLoad = lazyLoad;

--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
@@ -60,7 +60,7 @@ namespace Xtensive.Orm.Model
     private int fieldId;
     private int? cachedHashCode;
 
-    private Segment<int> mappingInfo;
+    private Segment<ColNum> mappingInfo;
 
     #region IsXxx properties
 
@@ -443,7 +443,7 @@ namespace Xtensive.Orm.Model
     /// <summary>
     /// Gets <see cref="MappingInfo"/> for current field.
     /// </summary>
-    public ref Segment<int> MappingInfo => ref mappingInfo;
+    public ref Segment<ColNum> MappingInfo => ref mappingInfo;
 
     /// <summary>
     /// Gets the underlying system property.
@@ -693,23 +693,23 @@ namespace Xtensive.Orm.Model
     {
       if (column != null) {
         if (reflectedType.IsStructure)
-          mappingInfo = new Segment<int>(reflectedType.Columns.IndexOf(column), 1);
+          mappingInfo = new Segment<ColNum>((ColNum) reflectedType.Columns.IndexOf(column), 1);
         else {
           var primaryIndex = reflectedType.Indexes.PrimaryIndex;
           var indexColumn = primaryIndex.Columns.Where(c => c.Name == column.Name).FirstOrDefault();
           if (indexColumn == null)
             throw new InvalidOperationException();
-          mappingInfo = new Segment<int>(primaryIndex.Columns.IndexOf(indexColumn), 1);
+          mappingInfo = new Segment<ColNum>((ColNum) primaryIndex.Columns.IndexOf(indexColumn), 1);
         }
       }
       else if (Fields.Count > 0) {
-        mappingInfo = new Segment<int>(
-          Fields[0].mappingInfo.Offset, Fields.Sum(f => f.IsPrimitive ? f.mappingInfo.Length : 0));
+        mappingInfo = new Segment<ColNum>(
+          Fields[0].mappingInfo.Offset, (ColNum)Fields.Sum(f => f.IsPrimitive ? f.mappingInfo.Length : 0));
       }
 
       if (IsEntity || IsStructure) {
         valueExtractor = new SegmentTransform(
-          false, reflectedType.TupleDescriptor, new Segment<int>(mappingInfo.Offset, mappingInfo.Length));
+          false, reflectedType.TupleDescriptor, new Segment<ColNum>(mappingInfo.Offset, mappingInfo.Length));
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Model/IndexInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/IndexInfo.cs
@@ -316,8 +316,8 @@ namespace Xtensive.Orm.Model
 
       ColumnIndexMap = new ColumnIndexMap(
         system,
-        (regular.Count == 0) ? Array.Empty<short>() : regular,
-        (lazy.Count == 0) ? Array.Empty<short>() : lazy);
+        (regular.Count == 0) ? Array.Empty<ColNum>() : regular,
+        (lazy.Count == 0) ? Array.Empty<ColNum>() : lazy);
     }
 
     /// <inheritdoc/>

--- a/Orm/Xtensive.Orm/Orm/Model/IndexInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/IndexInfo.cs
@@ -297,11 +297,11 @@ namespace Xtensive.Orm.Model
       }
 
       var keyColumnsCount = KeyColumns.Count;
-      var system = new List<int>(keyColumnsCount + 1);
-      var lazy = new List<int>();
-      var regular = new List<int>(Columns.Count - keyColumnsCount);
+      var system = new List<ColNum>(keyColumnsCount + 1);
+      var lazy = new List<ColNum>();
+      var regular = new List<ColNum>(Columns.Count - keyColumnsCount);
 
-      for (int i = 0, count = Columns.Count; i < count; i++) {
+      for (ColNum i = 0, count = (ColNum) Columns.Count; i < count; i++) {
         var item = Columns[i];
         if (item.IsPrimaryKey || item.IsSystem) {
           system.Add(i);
@@ -316,8 +316,8 @@ namespace Xtensive.Orm.Model
 
       ColumnIndexMap = new ColumnIndexMap(
         system,
-        (regular.Count == 0) ? Array.Empty<int>() : regular,
-        (lazy.Count == 0) ? Array.Empty<int>() : lazy);
+        (regular.Count == 0) ? Array.Empty<short>() : regular,
+        (lazy.Count == 0) ? Array.Empty<short>() : lazy);
     }
 
     /// <inheritdoc/>

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
@@ -848,7 +848,7 @@ namespace Xtensive.Orm.Model
     {
       // Building nullable map
       var nullabilityMap = new BitArray(TupleDescriptor.Count);
-      int i = 0;
+      ColNum i = 0;
       foreach (var column in Columns)
         nullabilityMap[i++] = column.IsNullable;
 
@@ -887,10 +887,10 @@ namespace Xtensive.Orm.Model
 
         // Building primary key injector
         var fieldCount = TupleDescriptor.Count;
-        var keyFieldCount = Key.TupleDescriptor.Count;
-        var keyFieldMap = new Pair<int, int>[fieldCount];
+        ColNum keyFieldCount = (ColNum) Key.TupleDescriptor.Count;
+        var keyFieldMap = new Pair<ColNum, ColNum>[fieldCount];
         for (i = 0; i < fieldCount; i++)
-          keyFieldMap[i] = new Pair<int, int>((i < keyFieldCount) ? 0 : 1, i);
+          keyFieldMap[i] = new Pair<ColNum, ColNum>((ColNum) ((i < keyFieldCount) ? 0 : 1), i);
         primaryKeyInjector = new MapTransform(false, TupleDescriptor, keyFieldMap);
       }
       TuplePrototype = IsEntity ? tuple.ToFastReadOnly() : tuple;

--- a/Orm/Xtensive.Orm/Orm/Providers/SessionHandler.References.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SessionHandler.References.cs
@@ -100,7 +100,7 @@ namespace Xtensive.Orm.Providers
           var index = association.OwnerType.Indexes.PrimaryIndex;
           var nonLazyColumnsSelector = index
             .Columns
-            .Select((column, i) => (Column: column, Index: (short)i))
+            .Select((column, i) => (Column: column, Index: (ColNum)i))
             .Where(a=>!a.Column.IsLazyLoad)
             .Select(a=>a.Index)
             .ToArray();
@@ -120,7 +120,7 @@ namespace Xtensive.Orm.Providers
             .Columns
             .Select((column, i) => (Column: column, Index: i))
             .Where(a=>!a.Column.IsLazyLoad)
-            .Select(a=>(short)(targetIndex.Columns.Count + a.Index))
+            .Select(a => (ColNum) (targetIndex.Columns.Count + a.Index))
             .ToArray();
           provider = targetIndex.GetQuery()
             .Filter(QueryHelper.BuildFilterLambda(0,

--- a/Orm/Xtensive.Orm/Orm/Providers/SessionHandler.References.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SessionHandler.References.cs
@@ -100,7 +100,7 @@ namespace Xtensive.Orm.Providers
           var index = association.OwnerType.Indexes.PrimaryIndex;
           var nonLazyColumnsSelector = index
             .Columns
-            .Select((column, i) => (Column: column, Index: i))
+            .Select((column, i) => (Column: column, Index: (short)i))
             .Where(a=>!a.Column.IsLazyLoad)
             .Select(a=>a.Index)
             .ToArray();
@@ -120,7 +120,7 @@ namespace Xtensive.Orm.Providers
             .Columns
             .Select((column, i) => (Column: column, Index: i))
             .Where(a=>!a.Column.IsLazyLoad)
-            .Select(a=>targetIndex.Columns.Count + a.Index)
+            .Select(a=>(short)(targetIndex.Columns.Count + a.Index))
             .ToArray();
           provider = targetIndex.GetQuery()
             .Filter(QueryHelper.BuildFilterLambda(0,
@@ -131,7 +131,7 @@ namespace Xtensive.Orm.Providers
               index.GetQuery(),
               association.Reversed.OwnerField.MappingInfo
                 .GetItems()
-                .Select((l,r) => new Pair<int>(l,r))
+                .Select((l,r) => new Pair<ColNum>(l, (ColNum) r))
                 .ToArray())
             .Select(nonLazyColumnsSelector);
           break;
@@ -150,7 +150,7 @@ namespace Xtensive.Orm.Providers
             .Columns
             .Select((column, i) => (Column: column, Index: i))
             .Where(a=>!a.Column.IsLazyLoad)
-            .Select(a=>targetIndex.Columns.Count + a.Index)
+            .Select(a => (ColNum) (targetIndex.Columns.Count + a.Index))
             .ToArray();
           var referencingField = association.IsMaster
             ? association.AuxiliaryType.Fields[WellKnown.SlaveFieldName]
@@ -168,7 +168,7 @@ namespace Xtensive.Orm.Providers
               index.GetQuery(),
               referencedField.MappingInfo
                 .GetItems()
-                .Select((l, r) => new Pair<int>(l, r))
+                .Select((l, r) => new Pair<ColNum>(l, (ColNum) r))
                 .ToArray())
             .Select(nonLazyColumnsSelector);
           break;

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Helpers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Helpers.cs
@@ -194,9 +194,9 @@ namespace Xtensive.Orm.Providers
         return false;
       }
 
-      var columnIndex = 0;
+      ColNum columnIndex = 0;
       var rowNumberIsUsed = false;
-      var calculatedColumnIndexes = new List<int>(8);
+      var calculatedColumnIndexes = new List<ColNum>(8);
       foreach (var column in sourceSelect.Columns) {
         if (IsCalculatedColumn(column)) {
           calculatedColumnIndexes.Add(columnIndex);
@@ -229,7 +229,7 @@ namespace Xtensive.Orm.Providers
         case ProviderType.Calculate: {
           var calculateProvider = (CalculateProvider) origin;
           var columnGatherer = new TupleAccessGatherer();
-          var usedColumnIndexes = new List<int>();
+          var usedColumnIndexes = new List<ColNum>();
           foreach (var column in calculateProvider.CalculatedColumns) {
             usedColumnIndexes.AddRange(
               columnGatherer.Gather(column.Expression.Body, column.Expression.Parameters[0]));

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Paging.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Paging.cs
@@ -86,7 +86,7 @@ namespace Xtensive.Orm.Providers
       query.OrderBy.Clear();
       if (provider.Source.Header.Order.Count > 0) {
         var columnExpressions = ExtractColumnExpressions(query);
-        foreach (KeyValuePair<int, Direction> pair in provider.Source.Header.Order) {
+        foreach (KeyValuePair<ColNum, Direction> pair in provider.Source.Header.Order) {
           query.OrderBy.Add(columnExpressions[pair.Key], pair.Value == Direction.Positive);
         }
       }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -298,7 +298,7 @@ namespace Xtensive.Orm.Providers
       var query = source.ShallowClone();
       var parameterBindings = new List<QueryParameterBinding>();
       var typeIdColumnName = Handlers.NameBuilder.TypeIdColumnName;
-      Func<KeyValuePair<int, Direction>, bool> filterNonTypeId =
+      Func<KeyValuePair<ColNum, Direction>, bool> filterNonTypeId =
         pair => ((MappedColumn) provider.Header.Columns[pair.Key]).ColumnInfoRef.ColumnName!=typeIdColumnName;
       var keyColumns = provider.Header.Order
         .Where(filterNonTypeId)
@@ -538,7 +538,7 @@ namespace Xtensive.Orm.Providers
     {
       var directionCollection = provider.Header.Order;
       if (directionCollection.Count == 0)
-        directionCollection = new DirectionCollection<int>(1);
+        directionCollection = new(1);
       var source = Compile(provider.Source);
 
       var query = ExtractSqlSelect(provider, source);

--- a/Orm/Xtensive.Orm/Orm/Rse/AggregateColumn.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/AggregateColumn.cs
@@ -24,7 +24,7 @@ namespace Xtensive.Orm.Rse
     /// <summary>
     /// Gets the source column index.
     /// </summary>
-    public int SourceIndex { get; private set; }
+    public ColNum SourceIndex { get; }
 
     /// <summary>
     /// Gets column descriptor.
@@ -39,7 +39,7 @@ namespace Xtensive.Orm.Rse
     }
 
     /// <inheritdoc/>
-    public override Column Clone(int newIndex)
+    public override Column Clone(ColNum newIndex)
     {
       return new AggregateColumn(this, newIndex);
     }
@@ -59,7 +59,7 @@ namespace Xtensive.Orm.Rse
     /// <param name="descriptor"><see cref="AggregateColumnDescriptor"/> property value.</param>
     /// <param name="index"><see cref="SourceIndex"/> property value.</param>
     /// <param name="type"><see cref="Column.Type"/> property value.</param>
-    public AggregateColumn(AggregateColumnDescriptor descriptor, int index, Type type)
+    public AggregateColumn(AggregateColumnDescriptor descriptor, ColNum index, Type type)
       : base(descriptor.Name, index, type, null)
     {
       AggregateType = descriptor.AggregateType;
@@ -76,7 +76,7 @@ namespace Xtensive.Orm.Rse
       SourceIndex = column.SourceIndex;
     }
 
-    private AggregateColumn(AggregateColumn column, int newIndex)
+    private AggregateColumn(AggregateColumn column, ColNum newIndex)
       : base(column.Name, newIndex, column.Type, column)
     {
       AggregateType = column.AggregateType;

--- a/Orm/Xtensive.Orm/Orm/Rse/AggregateColumnDescriptor.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/AggregateColumnDescriptor.cs
@@ -26,7 +26,7 @@ namespace Xtensive.Orm.Rse
     /// <summary>
     /// Gets the column index.
     /// </summary>
-    public int SourceIndex { get; private set; }
+    public ColNum SourceIndex { get; private set; }
 
     /// <summary>
     /// Gets the column type.
@@ -49,7 +49,7 @@ namespace Xtensive.Orm.Rse
     /// <param name="name"><see cref="Name"/> property value.</param>
     /// <param name="index"><see cref="SourceIndex"/> property value.</param>
     /// <param name="aggregateType">The <see cref="AggregateType"/> property value.</param>
-    public AggregateColumnDescriptor(string name, int index, AggregateType aggregateType)
+    public AggregateColumnDescriptor(string name, ColNum index, AggregateType aggregateType)
     {
       Name = name;
       SourceIndex = index;

--- a/Orm/Xtensive.Orm/Orm/Rse/CalculatedColumn.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/CalculatedColumn.cs
@@ -35,7 +35,7 @@ namespace Xtensive.Orm.Rse
     }
 
     /// <inheritdoc/>
-    public override Column Clone(int newIndex)
+    public override Column Clone(ColNum newIndex)
     {
       return new CalculatedColumn(this, newIndex);
     }
@@ -54,7 +54,7 @@ namespace Xtensive.Orm.Rse
     /// </summary>
     /// <param name="descriptor"><see cref="CalculatedColumnDescriptor"/> property value.</param>
     /// <param name="index"><see cref="Column.Index"/> property value.</param>
-    public CalculatedColumn(CalculatedColumnDescriptor descriptor, int index)
+    public CalculatedColumn(CalculatedColumnDescriptor descriptor, ColNum index)
       : base(descriptor.Name, index, descriptor.Type, null)
     {
       Expression = descriptor.Expression;
@@ -68,7 +68,7 @@ namespace Xtensive.Orm.Rse
       Expression = column.Expression;
     }
  
-    private CalculatedColumn(CalculatedColumn column, int newIndex)
+    private CalculatedColumn(CalculatedColumn column, ColNum newIndex)
       : base(column.Name, newIndex, column.Type, column)
     {
       Expression = column.Expression;

--- a/Orm/Xtensive.Orm/Orm/Rse/Column.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Column.cs
@@ -30,7 +30,7 @@ namespace Xtensive.Orm.Rse
     /// <summary>
     /// Gets the column index.
     /// </summary>
-    public int Index { get; private set; }
+    public ColNum Index { get; }
 
     /// <summary>
     /// Gets the column type.
@@ -100,7 +100,7 @@ namespace Xtensive.Orm.Rse
     /// </summary>
     /// <param name="newIndex">The new index value.</param>
     /// <returns>Clone of the column, but with another <see cref="Index"/>.</returns>
-    public abstract Column Clone(int newIndex);
+    public abstract Column Clone(ColNum newIndex);
 
     /// <summary>
     /// Creates clone of the column, but with another <see cref="Name"/>.
@@ -119,7 +119,7 @@ namespace Xtensive.Orm.Rse
     /// <param name="index"><see cref="Index"/> property value.</param>
     /// <param name="type"><see cref="Type"/> property value.</param>
     /// <param name="originalColumn">Original column.</param>
-    protected Column(string name, int index, Type type, Column originalColumn)
+    protected Column(string name, ColNum index, Type type, Column originalColumn)
     {
       Name = name;
       Index = index;

--- a/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
@@ -65,7 +65,9 @@ namespace Xtensive.Orm.Rse
     /// <summary>
     /// Gets the number of <see href="Column"/>s in the collection.
     /// </summary>
-    public int Count => columns.Count;
+    public ColNum Count => (ColNum)columns.Count;
+
+    int IReadOnlyCollection<Column>.Count => columns.Count;
 
     /// <summary>
     /// Gets a <see href="Column"/> instance by its index.

--- a/Orm/Xtensive.Orm/Orm/Rse/CompilableProviderExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/CompilableProviderExtensions.cs
@@ -98,7 +98,7 @@ namespace Xtensive.Orm.Rse
     }
 
     public static CompilableProvider Aggregate(this CompilableProvider recordQuery,
-      short[] groupIndexes, params AggregateColumnDescriptor[] descriptors)
+      ColNum[] groupIndexes, params AggregateColumnDescriptor[] descriptors)
     {
       return new AggregateProvider(recordQuery, groupIndexes, descriptors);
     }

--- a/Orm/Xtensive.Orm/Orm/Rse/CompilableProviderExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/CompilableProviderExtensions.cs
@@ -42,30 +42,30 @@ namespace Xtensive.Orm.Rse
     }
 
     public static CompilableProvider Join(this CompilableProvider left, CompilableProvider right,
-      params Pair<int>[] joinedColumnIndexes)
+      params Pair<ColNum>[] joinedColumnIndexes)
     {
       return new JoinProvider(left, right, JoinType.Inner, joinedColumnIndexes);
     }
 
     public static CompilableProvider Join(this CompilableProvider left, CompilableProvider right,
-      params int[] joinedColumnIndexes)
+      params ColNum[] joinedColumnIndexes)
     {
       return new JoinProvider(left, right, JoinType.Inner, joinedColumnIndexes);
     }
 
     public static CompilableProvider LeftJoin(this CompilableProvider left, CompilableProvider right,
-      params Pair<int>[] joinedColumnIndexes)
+      params Pair<ColNum>[] joinedColumnIndexes)
     {
       return new JoinProvider(left, right, JoinType.LeftOuter, joinedColumnIndexes);
     }
 
     public static CompilableProvider LeftJoin(this CompilableProvider left, CompilableProvider right,
-      params int[] joinedColumnIndexes)
+      params ColNum[] joinedColumnIndexes)
     {
       return new JoinProvider(left, right, JoinType.LeftOuter, joinedColumnIndexes);
     }
 
-    public static CompilableProvider OrderBy(this CompilableProvider source, DirectionCollection<int> columnIndexes)
+    public static CompilableProvider OrderBy(this CompilableProvider source, DirectionCollection<ColNum> columnIndexes)
     {
       return new SortProvider(source, columnIndexes);
     }
@@ -81,7 +81,7 @@ namespace Xtensive.Orm.Rse
       return new FilterProvider(source, predicate);
     }
 
-    public static CompilableProvider Select(this CompilableProvider source, IReadOnlyList<int> columnIndexes)
+    public static CompilableProvider Select(this CompilableProvider source, IReadOnlyList<ColNum> columnIndexes)
     {
       ArgumentValidator.EnsureArgumentNotNull(columnIndexes, "columnIndexes");
       return new SelectProvider(source, columnIndexes);
@@ -98,7 +98,7 @@ namespace Xtensive.Orm.Rse
     }
 
     public static CompilableProvider Aggregate(this CompilableProvider recordQuery,
-      int[] groupIndexes, params AggregateColumnDescriptor[] descriptors)
+      short[] groupIndexes, params AggregateColumnDescriptor[] descriptors)
     {
       return new AggregateProvider(recordQuery, groupIndexes, descriptors);
     }
@@ -157,7 +157,7 @@ namespace Xtensive.Orm.Rse
     }
 
     public static CompilableProvider Include(this CompilableProvider source,
-      Expression<Func<ParameterContext, IEnumerable<Tuple>>> filterDataSource, string resultColumnName, int[] filteredColumns)
+      Expression<Func<ParameterContext, IEnumerable<Tuple>>> filterDataSource, string resultColumnName, ColNum[] filteredColumns)
     {
       return new IncludeProvider(
         source, IncludeAlgorithm.Auto, false, filterDataSource, resultColumnName, filteredColumns);
@@ -165,14 +165,14 @@ namespace Xtensive.Orm.Rse
 
     public static CompilableProvider Include(this CompilableProvider source,
       IncludeAlgorithm algorithm, Expression<Func<ParameterContext, IEnumerable<Tuple>>> filterDataSource,
-      string resultColumnName, int[] filteredColumns)
+      string resultColumnName, ColNum[] filteredColumns)
     {
       return new IncludeProvider(source, algorithm, false, filterDataSource, resultColumnName, filteredColumns);
     }
 
     public static CompilableProvider Include(this CompilableProvider source,
       IncludeAlgorithm algorithm, bool isInlined, Expression<Func<ParameterContext, IEnumerable<Tuple>>> filterDataSource,
-      string resultColumnName, int[] filteredColumns)
+      string resultColumnName, ColNum[] filteredColumns)
     {
       return new IncludeProvider(source, algorithm, isInlined, filterDataSource, resultColumnName, filteredColumns);
     }

--- a/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
@@ -30,7 +30,7 @@ namespace Xtensive.Orm.Rse
     }
 
     /// <inheritdoc/>
-    public override Column Clone(int newIndex)
+    public override Column Clone(ColNum newIndex)
     {
       return new MappedColumn(ColumnInfoRef, Name, newIndex, Type);
     }
@@ -51,7 +51,7 @@ namespace Xtensive.Orm.Rse
     /// <param name="name"><see cref="Column.Name"/> property value.</param>
     /// <param name="index"><see cref="Column.Index"/> property value.</param>
     /// <param name="type"><see cref="Column.Type"/> property value.</param>
-    public MappedColumn(string name, int index, Type type)
+    public MappedColumn(string name, ColNum index, Type type)
       : this(default, name, index, type)
     {
     }
@@ -62,7 +62,7 @@ namespace Xtensive.Orm.Rse
     /// <param name="columnInfoRef"><see cref="ColumnInfoRef"/> property value.</param>
     /// <param name="index"><see cref="Column.Index"/> property value.</param>
     /// <param name="type"><see cref="Column.Type"/> property value.</param>
-    public MappedColumn(in ColumnInfoRef columnInfoRef, int index, Type type)
+    public MappedColumn(in ColumnInfoRef columnInfoRef, ColNum index, Type type)
       : this(columnInfoRef, columnInfoRef.ColumnName, index, type)
     {
     }
@@ -74,7 +74,7 @@ namespace Xtensive.Orm.Rse
     /// <param name="name"><see cref="Column.Name"/> property value.</param>
     /// <param name="index"><see cref="Column.Index"/> property value.</param>
     /// <param name="type"><see cref="Column.Type"/> property value.</param>
-    public MappedColumn(in ColumnInfoRef columnInfoRef, string name, int index, Type type)
+    public MappedColumn(in ColumnInfoRef columnInfoRef, string name, ColNum index, Type type)
       : base(name, index, type, null)
     {
       columnInfo = columnInfoRef;
@@ -90,7 +90,7 @@ namespace Xtensive.Orm.Rse
       columnInfo = column.ColumnInfoRef;
     }
 
-    private MappedColumn(MappedColumn column, int newIndex)
+    private MappedColumn(MappedColumn column, ColNum newIndex)
       : base(column.Name, newIndex, column.Type, column)
     {
       columnInfo = column.ColumnInfoRef;

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/AggregateProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/AggregateProvider.cs
@@ -199,7 +199,7 @@ namespace Xtensive.Orm.Rse.Providers
     public AggregateProvider(CompilableProvider source, short[] groupIndexes, params AggregateColumnDescriptor[] columnDescriptors)
       : base(ProviderType.Aggregate, source)
     {
-      groupIndexes = groupIndexes ?? Array.Empty<short>();
+      groupIndexes = groupIndexes ?? Array.Empty<ColNum>();
       var columns = new AggregateColumn[columnDescriptors.Length];
       for (int i = 0; i < columnDescriptors.Length; i++) {
         AggregateColumnDescriptor descriptor = columnDescriptors[i];

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/AggregateProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/AggregateProvider.cs
@@ -35,7 +35,7 @@ namespace Xtensive.Orm.Rse.Providers
     /// <summary>
     /// Gets column indexes to group by.
     /// </summary>
-    public int[] GroupColumnIndexes { get; private set; }
+    public short[] GroupColumnIndexes { get; private set; }
 
     /// <summary>
     /// Gets header resize transform.
@@ -74,7 +74,7 @@ namespace Xtensive.Orm.Rse.Providers
     {
       base.Initialize();
       var fieldTypes = new Type[GroupColumnIndexes.Length];
-      var columnIndexes = new int[GroupColumnIndexes.Length];
+      var columnIndexes = new ColNum[GroupColumnIndexes.Length];
       var i = 0;
       foreach (var index in GroupColumnIndexes) {
         fieldTypes[i] = Source.Header.Columns[index].Type;
@@ -196,15 +196,15 @@ namespace Xtensive.Orm.Rse.Providers
     /// <param name="source">The <see cref="UnaryProvider.Source"/> property value.</param>
     /// <param name="columnDescriptors">The descriptors of <see cref="AggregateColumns"/>.</param>
     /// <param name="groupIndexes">The column indexes to group by.</param>
-    public AggregateProvider(CompilableProvider source, int[] groupIndexes, params AggregateColumnDescriptor[] columnDescriptors)
+    public AggregateProvider(CompilableProvider source, short[] groupIndexes, params AggregateColumnDescriptor[] columnDescriptors)
       : base(ProviderType.Aggregate, source)
     {
-      groupIndexes = groupIndexes ?? Array.Empty<int>();
+      groupIndexes = groupIndexes ?? Array.Empty<short>();
       var columns = new AggregateColumn[columnDescriptors.Length];
       for (int i = 0; i < columnDescriptors.Length; i++) {
         AggregateColumnDescriptor descriptor = columnDescriptors[i];
         var type = GetAggregateColumnType(Source.Header.Columns[descriptor.SourceIndex].Type, descriptor.AggregateType);
-        columns[i] = new AggregateColumn(descriptor, groupIndexes.Length + i, type);
+        columns[i] = new AggregateColumn(descriptor, (ColNum)(groupIndexes.Length + i), type);
       }
       AggregateColumns = columns;
       GroupColumnIndexes = groupIndexes;

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/AggregateProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/AggregateProvider.cs
@@ -30,12 +30,12 @@ namespace Xtensive.Orm.Rse.Providers
     /// <summary>
     /// Gets the aggregate columns.
     /// </summary>
-    public AggregateColumn[] AggregateColumns { get; private set; }
+    public AggregateColumn[] AggregateColumns { get; }
 
     /// <summary>
     /// Gets column indexes to group by.
     /// </summary>
-    public short[] GroupColumnIndexes { get; private set; }
+    public ColNum[] GroupColumnIndexes { get; }
 
     /// <summary>
     /// Gets header resize transform.
@@ -196,7 +196,7 @@ namespace Xtensive.Orm.Rse.Providers
     /// <param name="source">The <see cref="UnaryProvider.Source"/> property value.</param>
     /// <param name="columnDescriptors">The descriptors of <see cref="AggregateColumns"/>.</param>
     /// <param name="groupIndexes">The column indexes to group by.</param>
-    public AggregateProvider(CompilableProvider source, short[] groupIndexes, params AggregateColumnDescriptor[] columnDescriptors)
+    public AggregateProvider(CompilableProvider source, ColNum[] groupIndexes, params AggregateColumnDescriptor[] columnDescriptors)
       : base(ProviderType.Aggregate, source)
     {
       groupIndexes = groupIndexes ?? Array.Empty<ColNum>();

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/CalculateProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/CalculateProvider.cs
@@ -51,8 +51,8 @@ namespace Xtensive.Orm.Rse.Providers
     protected override void Initialize()
     {
       base.Initialize();
-      var columnIndexes = new int[Header.Length];
-      for (int i = 0; i < columnIndexes.Length; i++)
+      var columnIndexes = new ColNum[Header.Length];
+      for (ColNum i = 0; i < columnIndexes.Length; i++)
         columnIndexes[i] = (i < Source.Header.Length) ? i : MapTransform.NoMapping;
       ResizeTransform = new MapTransform(false, Header.TupleDescriptor, columnIndexes);
     }
@@ -82,7 +82,7 @@ namespace Xtensive.Orm.Rse.Providers
       IsInlined = isInlined;
       var columns = new CalculatedColumn[columnDescriptors.Length];
       for (int i = 0; i < columnDescriptors.Length; i++) {
-        var col = new CalculatedColumn(columnDescriptors[i], Source.Header.Length + i);
+        var col = new CalculatedColumn(columnDescriptors[i], (ColNum) (Source.Header.Length + i));
         columns.SetValue(col, i);
       }
       CalculatedColumns = columns;

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ConcatProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ConcatProvider.cs
@@ -23,9 +23,9 @@ namespace Xtensive.Orm.Rse.Providers
     protected override RecordSetHeader BuildHeader()
     {
       EnsureConcatIsPossible();
-      var mappedColumnIndexes = new List<short>();
+      var mappedColumnIndexes = new List<ColNum>();
       var columns = new List<Column>();
-      for (short i = 0; i < Left.Header.Columns.Count; i++) {
+      for (ColNum i = 0; i < Left.Header.Columns.Count; i++) {
         var leftColumn = Left.Header.Columns[i];
         var rightColumn = Right.Header.Columns[i];
         if (leftColumn is MappedColumn leftMappedColumn && rightColumn is MappedColumn rightMappedColumn) {

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ConcatProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ConcatProvider.cs
@@ -23,9 +23,9 @@ namespace Xtensive.Orm.Rse.Providers
     protected override RecordSetHeader BuildHeader()
     {
       EnsureConcatIsPossible();
-      var mappedColumnIndexes = new List<int>();
+      var mappedColumnIndexes = new List<short>();
       var columns = new List<Column>();
-      for (int i = 0; i < Left.Header.Columns.Count; i++) {
+      for (short i = 0; i < Left.Header.Columns.Count; i++) {
         var leftColumn = Left.Header.Columns[i];
         var rightColumn = Right.Header.Columns[i];
         if (leftColumn is MappedColumn leftMappedColumn && rightColumn is MappedColumn rightMappedColumn) {

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ContainsTableProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ContainsTableProvider.cs
@@ -73,8 +73,8 @@ namespace Xtensive.Orm.Rse.Providers
           .ToArray(primaryIndexKeyColumns.Count + 1);
         var tupleDescriptor = TupleDescriptor.Create(fieldTypes);
         var columns = primaryIndexKeyColumns
-          .Select((c, i) => (Column) new MappedColumn("KEY", i, c.Key.ValueType))
-          .Append(new MappedColumn("RANK", tupleDescriptor.Count, WellKnownTypes.Double))
+          .Select((c, i) => (Column) new MappedColumn("KEY", (ColNum)i, c.Key.ValueType))
+          .Append(new MappedColumn("RANK", (ColNum)tupleDescriptor.Count, WellKnownTypes.Double))
           .ToArray(primaryIndexKeyColumns.Count + 1);;
         indexHeader = new RecordSetHeader(tupleDescriptor, columns);
       }

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/FreeTextProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/FreeTextProvider.cs
@@ -66,8 +66,8 @@ namespace Xtensive.Orm.Rse.Providers
           .ToArray(primaryIndexKeyColumns.Count + 1);
         var tupleDescriptor = TupleDescriptor.Create(fieldTypes);
         var columns = primaryIndexKeyColumns
-          .Select((c, i) => (Column) new MappedColumn("KEY", i, c.Key.ValueType))
-          .Append(new MappedColumn("RANK", tupleDescriptor.Count, WellKnownTypes.Double))
+          .Select((c, i) => (Column) new MappedColumn("KEY", (ColNum)i, c.Key.ValueType))
+          .Append(new MappedColumn("RANK", (ColNum)tupleDescriptor.Count, WellKnownTypes.Double))
           .ToArray(primaryIndexKeyColumns.Count + 1);
         indexHeader = new RecordSetHeader(tupleDescriptor, columns);
       }

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/IncludeProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/IncludeProvider.cs
@@ -46,7 +46,7 @@ namespace Xtensive.Orm.Rse.Providers
     /// <summary>
     /// Gets the filtered columns.
     /// </summary>
-    public IReadOnlyList<int> FilteredColumns { [DebuggerStepThrough] get; }
+    public IReadOnlyList<ColNum> FilteredColumns { [DebuggerStepThrough] get; }
 
     /// <summary>
     /// Gets filter data.
@@ -86,7 +86,7 @@ namespace Xtensive.Orm.Rse.Providers
     /// <param name="resultColumnName">A value for <see cref="ResultColumnName"/>.</param>
     /// <param name="filteredColumns">A value for <see cref="FilteredColumns"/>.</param>
     public IncludeProvider(CompilableProvider source, IncludeAlgorithm algorithm, bool isInlined,
-      Expression<Func<ParameterContext, IEnumerable<Tuple>>> filterDataSource, string resultColumnName, IReadOnlyList<int> filteredColumns)
+      Expression<Func<ParameterContext, IEnumerable<Tuple>>> filterDataSource, string resultColumnName, IReadOnlyList<ColNum> filteredColumns)
       : base(ProviderType.Include, source)
     {
       ArgumentValidator.EnsureArgumentNotNull(filterDataSource, "filterDataSource");
@@ -98,10 +98,10 @@ namespace Xtensive.Orm.Rse.Providers
       ResultColumnName = resultColumnName;
 
       switch (filteredColumns) {
-        case int[] columnArray:
+        case ColNum[] columnArray:
           FilteredColumns = Array.AsReadOnly(columnArray);
           break;
-        case List<int> columnList:
+        case List<ColNum> columnList:
           FilteredColumns = columnList.AsReadOnly();
           break;
         default:

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/JoinProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/JoinProvider.cs
@@ -31,7 +31,7 @@ namespace Xtensive.Orm.Rse.Providers
     /// <summary>
     /// Pairs of equal column indexes.
     /// </summary>
-    public Pair<int>[] EqualIndexes { get; private set; }
+    public Pair<ColNum>[] EqualIndexes { get; }
 
     /// <summary>
     /// Pairs of equal columns.
@@ -69,7 +69,7 @@ namespace Xtensive.Orm.Rse.Providers
     /// <param name="joinType">The join operation type.</param>
     /// <param name="equalIndexes">The <see cref="EqualIndexes"/> property value.</param>
     /// <exception cref="ArgumentException">Wrong arguments.</exception>
-    public JoinProvider(CompilableProvider left, CompilableProvider right, JoinType joinType, params Pair<int>[] equalIndexes)
+    public JoinProvider(CompilableProvider left, CompilableProvider right, JoinType joinType, params Pair<ColNum>[] equalIndexes)
       : base(ProviderType.Join, left, right)
     {
       if (equalIndexes==null || equalIndexes.Length==0)
@@ -88,15 +88,15 @@ namespace Xtensive.Orm.Rse.Providers
     /// <param name="joinType">The join operation type.</param>
     /// <param name="equalIndexes">Transformed to the <see cref="EqualIndexes"/> property value.</param>
     /// <exception cref="ArgumentException">Wrong arguments.</exception>
-    public JoinProvider(CompilableProvider left, CompilableProvider right, JoinType joinType, params int[] equalIndexes)
+    public JoinProvider(CompilableProvider left, CompilableProvider right, JoinType joinType, params ColNum[] equalIndexes)
       : base(ProviderType.Join, left, right)
     {
       if (equalIndexes==null || equalIndexes.Length<2)
         throw new ArgumentException(
           Strings.ExAtLeastOneColumnIndexPairMustBeSpecified, "equalIndexes");
-      var ei = new Pair<int>[equalIndexes.Length / 2];
+      var ei = new Pair<ColNum>[equalIndexes.Length / 2];
       for (int i = 0, j = 0; i < ei.Length; i++)
-        ei[i] = new Pair<int>(equalIndexes[j++], equalIndexes[j++]);
+        ei[i] = new Pair<ColNum>(equalIndexes[j++], equalIndexes[j++]);
       JoinType = joinType;
       EqualIndexes = ei;
       Initialize();

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/OrderProviderBase.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/OrderProviderBase.cs
@@ -28,7 +28,7 @@ namespace Xtensive.Orm.Rse.Providers
     /// <summary>
     /// Sort order of the index.
     /// </summary>
-    public DirectionCollection<short> Order { get; private set; }
+    public DirectionCollection<ColNum> Order { get; private set; }
 
     /// <summary>
     /// Gets the key extractor transform.

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/OrderProviderBase.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/OrderProviderBase.cs
@@ -28,7 +28,7 @@ namespace Xtensive.Orm.Rse.Providers
     /// <summary>
     /// Sort order of the index.
     /// </summary>
-    public DirectionCollection<int> Order { get; private set; }
+    public DirectionCollection<short> Order { get; private set; }
 
     /// <summary>
     /// Gets the key extractor transform.
@@ -75,7 +75,7 @@ namespace Xtensive.Orm.Rse.Providers
       }
 
       var fieldTypes = new Type[Order.Count];
-      var map = new int[Order.Count];
+      var map = new ColNum[Order.Count];
       for (var i = 0; i < Order.Count; i++) {
         var p = Order[i];
         fieldTypes[i] = Header.Columns[p.Key].Type;
@@ -94,7 +94,7 @@ namespace Xtensive.Orm.Rse.Providers
     /// <param name="providerType">Provider type.</param>
     /// <param name="source">The <see cref="UnaryProvider.Source"/> property value.</param>
     /// <param name="order">The <see cref="Order"/> property value.</param>
-    protected OrderProviderBase(ProviderType providerType, CompilableProvider source, DirectionCollection<int> order)
+    protected OrderProviderBase(ProviderType providerType, CompilableProvider source, DirectionCollection<ColNum> order)
       : base(providerType, source)
     {
       Order = order;

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/RowNumberProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/RowNumberProvider.cs
@@ -31,8 +31,8 @@ namespace Xtensive.Orm.Rse.Providers
     protected override void Initialize()
     {
       base.Initialize();
-      var columnIndexes = new int[Header.Length];
-      for (int i = 0; i < columnIndexes.Length; i++)
+      var columnIndexes = new ColNum[Header.Length];
+      for (ColNum i = 0; i < columnIndexes.Length; i++)
         columnIndexes[i] = (i < Source.Header.Length) ? i : MapTransform.NoMapping;
       ResizeTransform = new MapTransform(false, Header.TupleDescriptor, columnIndexes);
     }

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/SelectProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/SelectProvider.cs
@@ -21,7 +21,7 @@ namespace Xtensive.Orm.Rse.Providers
     /// <summary>
     /// Indexes of columns that should be selected from the <see cref="UnaryProvider.Source"/>.
     /// </summary>
-    public IReadOnlyList<int> ColumnIndexes { [DebuggerStepThrough] get; }
+    public IReadOnlyList<ColNum> ColumnIndexes { [DebuggerStepThrough] get; }
 
     /// <inheritdoc/>
     protected override RecordSetHeader BuildHeader()
@@ -41,7 +41,7 @@ namespace Xtensive.Orm.Rse.Providers
     /// <summary>
     ///   Initializes a new instance of this class.
     /// </summary>
-    public SelectProvider(CompilableProvider provider, IReadOnlyList<int> columnIndexes)
+    public SelectProvider(CompilableProvider provider, IReadOnlyList<ColNum> columnIndexes)
       : base(ProviderType.Select, provider)
     {
       ColumnIndexes = columnIndexes.AsSafeWrapper();

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/SortProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/SortProvider.cs
@@ -23,7 +23,7 @@ namespace Xtensive.Orm.Rse.Providers
     /// </summary>
     /// <param name="source">The <see cref="UnaryProvider.Source"/> property value.</param>
     /// <param name="order">The <see cref="OrderProviderBase.Order"/> property value.</param>
-    public SortProvider(CompilableProvider source, DirectionCollection<int> order)
+    public SortProvider(CompilableProvider source, DirectionCollection<ColNum> order)
       : base(ProviderType.Sort, source, order)
     {
       Initialize();

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/UnionProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/UnionProvider.cs
@@ -23,9 +23,9 @@ namespace Xtensive.Orm.Rse.Providers
     protected override RecordSetHeader BuildHeader()
     {
       EnsureUnionIsPossible();
-      var mappedColumnIndexes = new List<int>();
+      var mappedColumnIndexes = new List<short>();
       var columns = new List<Column>();
-      for (int i = 0; i < Left.Header.Columns.Count; i++) {
+      for (short i = 0; i < Left.Header.Columns.Count; i++) {
         var leftColumn = Left.Header.Columns[i];
         var rightColumn = Right.Header.Columns[i];
         if (leftColumn is MappedColumn && rightColumn is MappedColumn) {

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/UnionProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/UnionProvider.cs
@@ -23,9 +23,9 @@ namespace Xtensive.Orm.Rse.Providers
     protected override RecordSetHeader BuildHeader()
     {
       EnsureUnionIsPossible();
-      var mappedColumnIndexes = new List<short>();
+      var mappedColumnIndexes = new List<ColNum>();
       var columns = new List<Column>();
-      for (short i = 0; i < Left.Header.Columns.Count; i++) {
+      for (ColNum i = 0; i < Left.Header.Columns.Count; i++) {
         var leftColumn = Left.Header.Columns[i];
         var rightColumn = Right.Header.Columns[i];
         if (leftColumn is MappedColumn && rightColumn is MappedColumn) {

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProviderVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProviderVisitor.cs
@@ -60,7 +60,7 @@ namespace Xtensive.Orm.Rse.Providers
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
-      var columnIndexes = (int[])OnRecursionExit(provider);
+      var columnIndexes = (ColNum[])OnRecursionExit(provider);
       return source == provider.Source
         ? provider
         : new SelectProvider(source, columnIndexes ?? provider.ColumnIndexes);
@@ -111,7 +111,7 @@ namespace Xtensive.Orm.Rse.Providers
       var order = OnRecursionExit(provider);
       return source == provider.Source
         ? provider
-        : new SortProvider(source, (order == null) ? provider.Order : (DirectionCollection<int>)order);
+        : new SortProvider(source, (order == null) ? provider.Order : (DirectionCollection<ColNum>)order);
     }
 
     /// <inheritdoc/>
@@ -124,7 +124,7 @@ namespace Xtensive.Orm.Rse.Providers
       return left == provider.Left && right == provider.Right
         ? provider
         : new JoinProvider(left, right, provider.JoinType,
-            equalIndexes != null ? (Pair<int>[])equalIndexes : provider.EqualIndexes);
+            equalIndexes != null ? (Pair<ColNum>[])equalIndexes : provider.EqualIndexes);
     }
 
     /// <inheritdoc/>
@@ -200,7 +200,7 @@ namespace Xtensive.Orm.Rse.Providers
         acd.AddRange(provider.AggregateColumns.Select(ac => new AggregateColumnDescriptor(ac.Name, ac.SourceIndex, ac.AggregateType)));
         return new AggregateProvider(source, provider.GroupColumnIndexes, acd.ToArray());
       }
-      var result = (Pair<int[], AggregateColumnDescriptor[]>) resultParameters;
+      var result = (Pair<ColNum[], AggregateColumnDescriptor[]>) resultParameters;
       return new AggregateProvider(source, result.First, result.Second);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -147,13 +147,13 @@ namespace Xtensive.Orm.Rse
       var groups = new List<ColumnGroup>(columnGroupCount + joined.ColumnGroups.Count);
       groups.AddRange(ColumnGroups);
       foreach (var g in joined.ColumnGroups) {
-        var keys = new List<int>(g.Keys.Count);
+        var keys = new List<short>(g.Keys.Count);
         foreach (var i in g.Keys) {
-          keys.Add(columnCount + i);
+          keys.Add((short)(columnCount + i));
         }
-        var columns = new List<int>(g.Columns.Count);
+        var columns = new List<short>(g.Columns.Count);
         foreach (var i in g.Columns) {
-          columns.Add(columnCount + i);
+          columns.Add((short)(columnCount + i));
         }
         groups.Add(new ColumnGroup(g.TypeInfoRef, keys, columns));
       }
@@ -174,8 +174,8 @@ namespace Xtensive.Orm.Rse
     public RecordSetHeader Select(IEnumerable<int> selectedColumns)
     {
       var columns = new List<int>(selectedColumns);
-      var columnsMap = new List<int>(Enumerable.Repeat(-1, Columns.Count));
-      for (int newIndex = 0; newIndex < columns.Count; newIndex++) {
+      var columnsMap = new List<short>(Enumerable.Repeat((short)-1, Columns.Count));
+      for (short newIndex = 0; newIndex < columns.Count; newIndex++) {
         var oldIndex = columns[newIndex];
         columnsMap[oldIndex] = newIndex;
       }

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -30,9 +30,7 @@ namespace Xtensive.Orm.Rse
     /// <summary>
     /// Gets the length of this instance.
     /// </summary>
-    public int Length {
-      get { return Columns.Count; }
-    }
+    public ColNum Length => Columns.Count;
 
     /// <summary>
     /// Gets the <see cref="Provider"/> keys.
@@ -53,7 +51,7 @@ namespace Xtensive.Orm.Rse
     /// <summary>
     /// Gets the indexes of columns <see cref="Provider"/> is ordered by.
     /// </summary>
-    public DirectionCollection<int> Order { get; }
+    public DirectionCollection<ColNum> Order { get; }
 
     /// <summary>
     /// Gets the tuple descriptor describing
@@ -135,7 +133,7 @@ namespace Xtensive.Orm.Rse
       var newColumns = new List<Column>(columnCount + joined.Columns.Count);
       newColumns.AddRange(Columns);
       foreach (var c in joined.Columns) {
-        newColumns.Add(c.Clone(columnCount + c.Index));
+        newColumns.Add(c.Clone((ColNum) (columnCount + c.Index)));
       }
 
       var newFieldTypes = new Type[newColumns.Count];
@@ -147,13 +145,13 @@ namespace Xtensive.Orm.Rse
       var groups = new List<ColumnGroup>(columnGroupCount + joined.ColumnGroups.Count);
       groups.AddRange(ColumnGroups);
       foreach (var g in joined.ColumnGroups) {
-        var keys = new List<short>(g.Keys.Count);
+        var keys = new List<ColNum>(g.Keys.Count);
         foreach (var i in g.Keys) {
           keys.Add((short)(columnCount + i));
         }
-        var columns = new List<short>(g.Columns.Count);
+        var columns = new List<ColNum>(g.Columns.Count);
         foreach (var i in g.Columns) {
-          columns.Add((short)(columnCount + i));
+          columns.Add((ColNum) (columnCount + i));
         }
         groups.Add(new ColumnGroup(g.TypeInfoRef, keys, columns));
       }
@@ -171,10 +169,10 @@ namespace Xtensive.Orm.Rse
     /// </summary>
     /// <param name="selectedColumns">The indexes of columns to select.</param>
     /// <returns>A new header containing only specified columns.</returns>
-    public RecordSetHeader Select(IEnumerable<int> selectedColumns)
+    public RecordSetHeader Select(IEnumerable<short> selectedColumns)
     {
-      var columns = new List<int>(selectedColumns);
-      var columnsMap = new List<short>(Enumerable.Repeat((short)-1, Columns.Count));
+      var columns = new List<ColNum>(selectedColumns);
+      var columnsMap = new List<ColNum>(Enumerable.Repeat((ColNum)(-1), Columns.Count));
       for (short newIndex = 0; newIndex < columns.Count; newIndex++) {
         var oldIndex = columns[newIndex];
         columnsMap[oldIndex] = newIndex;
@@ -182,12 +180,12 @@ namespace Xtensive.Orm.Rse
 
       var fieldTypes = columns.Select(i => TupleDescriptor[i]).ToArray(columns.Count);
       var resultTupleDescriptor = Xtensive.Tuples.TupleDescriptor.Create(fieldTypes);
-      var resultOrder = new DirectionCollection<int>(
+      var resultOrder = new DirectionCollection<ColNum>(
         Order
-          .Select(o => new KeyValuePair<int, Direction>(columnsMap[o.Key], o.Value))
+          .Select(o => new KeyValuePair<ColNum, Direction>(columnsMap[o.Key], o.Value))
           .TakeWhile(o => o.Key >= 0));
 
-      var resultColumns = columns.Select((oldIndex, newIndex) => Columns[oldIndex].Clone(newIndex)).ToArray(columns.Count);
+      var resultColumns = columns.Select((oldIndex, newIndex) => Columns[oldIndex].Clone((ColNum)newIndex)).ToArray(columns.Count);
 
       var resultGroups = ColumnGroups
         .Where(g => g.Keys.All(k => columnsMap[k]>=0))
@@ -211,7 +209,7 @@ namespace Xtensive.Orm.Rse
     /// </summary>
     /// <param name="sortOrder">Order to sort this header in.</param>
     /// <returns>A new sorted header.</returns>
-    public RecordSetHeader Sort(DirectionCollection<int> sortOrder)
+    public RecordSetHeader Sort(DirectionCollection<ColNum> sortOrder)
     {
       return new RecordSetHeader(
         TupleDescriptor,
@@ -240,24 +238,24 @@ namespace Xtensive.Orm.Rse
       var resultFieldTypes = indexInfoColumns.Select(columnInfo => columnInfo.ValueType).ToArray(indexInfoColumns.Count);
       var resultTupleDescriptor = TupleDescriptor.Create(resultFieldTypes);
 
-      var keyOrder = new List<KeyValuePair<int, Direction>>(
-        indexInfoKeyColumns.Select((p, i) => new KeyValuePair<int, Direction>(i, p.Value)));
+      var keyOrder = new List<KeyValuePair<ColNum, Direction>>(
+        indexInfoKeyColumns.Select((p, i) => new KeyValuePair<ColNum, Direction>((ColNum) i, p.Value)));
       if (!indexInfo.IsPrimary) {
         var pkKeys = indexInfo.ReflectedType.Indexes.PrimaryIndex.KeyColumns;
         keyOrder.AddRange(
           indexInfo.ValueColumns
-            .Select((c, i) => new Pair<ColumnInfo, int>(c, i + indexInfoKeyColumns.Count))
+            .Select((c, i) => new Pair<ColumnInfo, ColNum>(c, (ColNum) (i + indexInfoKeyColumns.Count)))
             .Where(pair => pair.First.IsPrimaryKey)
-            .Select(pair => new KeyValuePair<int, Direction>(pair.Second, pkKeys[pair.First])));
+            .Select(pair => new KeyValuePair<ColNum, Direction>(pair.Second, pkKeys[pair.First])));
       }
-      var order = new DirectionCollection<int>(keyOrder);
+      var order = new DirectionCollection<ColNum>(keyOrder);
 
       var keyFieldTypes = indexInfoKeyColumns
         .Select(columnInfo => columnInfo.Key.ValueType)
         .ToArray(indexInfoKeyColumns.Count);
       var keyDescriptor = TupleDescriptor.Create(keyFieldTypes);
 
-      var resultColumns = indexInfoColumns.Select((c,i) => (Column) new MappedColumn(new ColumnInfoRef(c), i,c.ValueType)).ToArray(indexInfoColumns.Count);
+      var resultColumns = indexInfoColumns.Select((c,i) => (Column) new MappedColumn(new ColumnInfoRef(c), (ColNum)i, c.ValueType)).ToArray(indexInfoColumns.Count);
       var resultGroups = new[]{indexInfo.Group};
 
       return new RecordSetHeader(
@@ -314,7 +312,7 @@ namespace Xtensive.Orm.Rse
       TupleDescriptor tupleDescriptor,
       IReadOnlyList<Column> columns,
       TupleDescriptor orderKeyDescriptor,
-      DirectionCollection<int> order)
+      DirectionCollection<ColNum> order)
       : this(tupleDescriptor, columns, null, orderKeyDescriptor, order)
     {
     }
@@ -333,7 +331,7 @@ namespace Xtensive.Orm.Rse
       IReadOnlyList<Column> columns,
       IReadOnlyList<ColumnGroup> columnGroups,
       TupleDescriptor? orderKeyDescriptor,
-      DirectionCollection<int> order)
+      DirectionCollection<ColNum> order)
     {
       ArgumentValidator.EnsureArgumentNotNull(tupleDescriptor, "tupleDescriptor");
       ArgumentValidator.EnsureArgumentNotNull(columns, "columns");
@@ -351,7 +349,7 @@ namespace Xtensive.Orm.Rse
 
       orderTupleDescriptor = orderKeyDescriptor ?? TupleDescriptor.Empty;
       hasOrderTupleDescriptor = true;
-      Order = order ?? new DirectionCollection<int>();
+      Order = order ?? new DirectionCollection<ColNum>();
       Order.Lock(true);
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -147,7 +147,7 @@ namespace Xtensive.Orm.Rse
       foreach (var g in joined.ColumnGroups) {
         var keys = new List<ColNum>(g.Keys.Count);
         foreach (var i in g.Keys) {
-          keys.Add((short)(columnCount + i));
+          keys.Add((ColNum) (columnCount + i));
         }
         var columns = new List<ColNum>(g.Columns.Count);
         foreach (var i in g.Columns) {
@@ -173,7 +173,7 @@ namespace Xtensive.Orm.Rse
     {
       var columns = new List<ColNum>(selectedColumns);
       var columnsMap = new List<ColNum>(Enumerable.Repeat((ColNum)(-1), Columns.Count));
-      for (short newIndex = 0; newIndex < columns.Count; newIndex++) {
+      for (ColNum newIndex = 0; newIndex < columns.Count; newIndex++) {
         var oldIndex = columns[newIndex];
         columnsMap[oldIndex] = newIndex;
       }

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -169,7 +169,7 @@ namespace Xtensive.Orm.Rse
     /// </summary>
     /// <param name="selectedColumns">The indexes of columns to select.</param>
     /// <returns>A new header containing only specified columns.</returns>
-    public RecordSetHeader Select(IEnumerable<short> selectedColumns)
+    public RecordSetHeader Select(IEnumerable<ColNum> selectedColumns)
     {
       var columns = new List<ColNum>(selectedColumns);
       var columnsMap = new List<ColNum>(Enumerable.Repeat((ColNum)(-1), Columns.Count));

--- a/Orm/Xtensive.Orm/Orm/Rse/SystemColumn.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/SystemColumn.cs
@@ -16,7 +16,7 @@ namespace Xtensive.Orm.Rse
   public class SystemColumn : Column
   {
     /// <inheritdoc/>
-    public override Column Clone(int newIndex)
+    public override Column Clone(ColNum newIndex)
     {
       return new SystemColumn(this, newIndex);
     }
@@ -33,14 +33,14 @@ namespace Xtensive.Orm.Rse
     /// <param name="name"><see cref="Column.Name"/> property value.</param>
     /// <param name="index"><see cref="Column.Index"/> property value.</param>
     /// <param name="type"><see cref="Column.Type"/> property value.</param>
-    public SystemColumn(string name, int index, Type type)
+    public SystemColumn(string name, ColNum index, Type type)
       : base(name, index, type, null)
     {
     }
 
     #region Clone constructors
 
-    private SystemColumn(SystemColumn column, int newIndex)
+    private SystemColumn(SystemColumn column, ColNum newIndex)
       : base(column.Name, newIndex, column.Type, column)
     {
     }

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
@@ -65,7 +65,7 @@ namespace Xtensive.Orm.Rse.Transformation
       var indexColumns = new List<ColNum>(provider.ColumnIndexes.Count);
       var newMappings = new List<ColNum>(provider.ColumnIndexes.Count);
 
-      short currentItemIndex = 0;
+      ColNum currentItemIndex = 0;
       foreach(var item in provider.ColumnIndexes) {
         var indexInMap = (ColNum) sourceMap.IndexOf(item);
         if (indexInMap >= 0) {

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
@@ -457,7 +457,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return (leftMapping, rightMapping);
     }
 
-    private void RegisterOuterMapping(ApplyParameter parameter, short value)
+    private void RegisterOuterMapping(ApplyParameter parameter, ColNum value)
     {
       if (outerColumnUsages.TryGetValue(parameter, out var map) && !map.Contains(value)) {
         map.Add(value);

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyFilterRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyFilterRewriter.cs
@@ -37,7 +37,7 @@ namespace Xtensive.Orm.Rse.Transformation
         if (mc.GetApplyParameter() != null)
           return Expression.Call(LeftTupleParameter, mc.Method, mc.Arguments[0]);
         var name = sourceColumns.Single(column => column.Index == sourceIndex).Name;
-        var currentIndex = targetColumns[name].Index;
+        int currentIndex = targetColumns[name].Index;
         return Expression.Call(mc.Object, mc.Method, Expression.Constant(currentIndex));
       }
       return base.VisitMethodCall(mc);

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/CalculateProviderCollector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/CalculateProviderCollector.cs
@@ -81,7 +81,7 @@ namespace Xtensive.Orm.Rse.Transformation
       select parameter).Distinct().ToList();
     }
 
-    private bool TryAddCalculateFilter(FilterProvider filterProvider, List<int> tupleAccesses)
+    private bool TryAddCalculateFilter(FilterProvider filterProvider, List<ColNum> tupleAccesses)
     {
       var result = false;
       foreach (var key in owner.State.Predicates.Keys) {
@@ -98,7 +98,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return result;
     }
 
-    private static bool ContainsAccessToTupleField(IEnumerable<int> tupleAccesses,
+    private static bool ContainsAccessToTupleField(IEnumerable<ColNum> tupleAccesses,
       CalculateProvider calculateProvider, FilterProvider provider)
     {
       return tupleAccesses.Any(i => calculateProvider.Header.Columns.Contains(provider.Header.Columns[i]));

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/CalculateRelatedExpressionRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/CalculateRelatedExpressionRewriter.cs
@@ -47,7 +47,7 @@ namespace Xtensive.Orm.Rse.Transformation
         && mc.Object.Type == WellKnownOrmTypes.Tuple) {
         var sourceIndex = visited.GetTupleAccessArgument();
         var name = sourceColumns.Single(column => column.Index == sourceIndex).Name;
-        var currentIndex = targetColumns[name].Index;
+        int currentIndex = targetColumns[name].Index;
         return Expression.Call(visited.Object, visited.Method, Expression.Constant(currentIndex));
       }
       return visited;

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/OrderingRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/OrderingRewriter.cs
@@ -16,7 +16,7 @@ namespace Xtensive.Orm.Rse.Transformation
   internal sealed class OrderingRewriter : CompilableProviderVisitor
   {
     private readonly Func<CompilableProvider, ProviderOrderingDescriptor> descriptorResolver;
-    private DirectionCollection<short> sortOrder;
+    private DirectionCollection<ColNum> sortOrder;
     private ProviderOrderingDescriptor descriptor;
     private ProviderOrderingDescriptor consumerDescriptor;
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/OrderingRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/OrderingRewriter.cs
@@ -16,7 +16,7 @@ namespace Xtensive.Orm.Rse.Transformation
   internal sealed class OrderingRewriter : CompilableProviderVisitor
   {
     private readonly Func<CompilableProvider, ProviderOrderingDescriptor> descriptorResolver;
-    private DirectionCollection<int> sortOrder;
+    private DirectionCollection<short> sortOrder;
     private ProviderOrderingDescriptor descriptor;
     private ProviderOrderingDescriptor consumerDescriptor;
 
@@ -70,10 +70,10 @@ namespace Xtensive.Orm.Rse.Transformation
         result = new SelectProvider(source, provider.ColumnIndexes);
 
       if (sortOrder.Count > 0) {
-        var selectOrdering = new DirectionCollection<int>();
+        var selectOrdering = new DirectionCollection<ColNum>();
         var columnIndexes = result.ColumnIndexes;
         foreach (var pair in sortOrder) {
-          var columnIndex = columnIndexes.IndexOf(pair.Key);
+          var columnIndex = (ColNum)columnIndexes.IndexOf(pair.Key);
           if (columnIndex < 0) {
             if (selectOrdering.Count > 0)
               selectOrdering.Clear();
@@ -103,9 +103,9 @@ namespace Xtensive.Orm.Rse.Transformation
         result = new AggregateProvider(source, provider.GroupColumnIndexes, acds.ToArray());
       }
       if (sortOrder.Count > 0) {
-        var selectOrdering = new DirectionCollection<int>();
+        var selectOrdering = new DirectionCollection<ColNum>();
         foreach (var pair in sortOrder) {
-          var columnIndex = result.GroupColumnIndexes.IndexOf(pair.Key);
+          ColNum columnIndex = (ColNum)result.GroupColumnIndexes.IndexOf(pair.Key);
           if (columnIndex < 0) {
             if (selectOrdering.Count > 0)
               selectOrdering.Clear();
@@ -121,31 +121,31 @@ namespace Xtensive.Orm.Rse.Transformation
 
     protected override CompilableProvider VisitIndex(IndexProvider provider)
     {
-      sortOrder = new DirectionCollection<int>();
+      sortOrder = new();
       return provider;
     }
 
     protected override CompilableProvider VisitFreeText(FreeTextProvider provider)
     {
-      sortOrder = new DirectionCollection<int>();
+      sortOrder = new();
       return provider;
     }
 
     protected override CompilableProvider VisitContainsTable(ContainsTableProvider provider)
     {
-      sortOrder = new DirectionCollection<int>();
+      sortOrder = new();
       return provider;
     }
 
     protected override RawProvider VisitRaw(RawProvider provider)
     {
-      sortOrder = new DirectionCollection<int>();
+      sortOrder = new();
       return provider;
     }
 
     protected override CompilableProvider VisitStore(StoreProvider provider)
     {
-      sortOrder = new DirectionCollection<int>();
+      sortOrder = new();
       return provider;
     }
 
@@ -204,7 +204,7 @@ namespace Xtensive.Orm.Rse.Transformation
         if (descriptor.IsSorter)
           return result;
         if (descriptor.BreaksOrder) {
-          sortOrder = new DirectionCollection<int>();
+          sortOrder = new();
           return result;
         }
         if (consumerDescriptor.IsOrderSensitive && !descriptor.IsOrderSensitive)
@@ -213,13 +213,13 @@ namespace Xtensive.Orm.Rse.Transformation
       return result;
     }
 
-    private static DirectionCollection<int> ComputeBinaryOrder(BinaryProvider provider, DirectionCollection<int> leftOrder, DirectionCollection<int> rightOrder)
+    private static DirectionCollection<ColNum> ComputeBinaryOrder(BinaryProvider provider, DirectionCollection<ColNum> leftOrder, DirectionCollection<ColNum> rightOrder)
     {
       if (leftOrder.Count > 0)
-        return new DirectionCollection<int>(
+        return new DirectionCollection<ColNum>(
           leftOrder.Concat(
-            rightOrder.Select(p => new KeyValuePair<int, Direction>(p.Key + provider.Left.Header.Length, p.Value))));
-      return new DirectionCollection<int>();
+            rightOrder.Select(p => new KeyValuePair<ColNum, Direction>((ColNum) (p.Key + provider.Left.Header.Length), p.Value))));
+      return new();
     }
 
     #endregion
@@ -230,7 +230,7 @@ namespace Xtensive.Orm.Rse.Transformation
     {
       ArgumentValidator.EnsureArgumentNotNull(orderingDescriptorResolver, "orderingDescriptorResolver");
       descriptorResolver = orderingDescriptorResolver;
-      sortOrder = new DirectionCollection<int>();
+      sortOrder = new();
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/SkipTakeRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/SkipTakeRewriter.cs
@@ -55,7 +55,7 @@ namespace Xtensive.Orm.Rse.Transformation
         if (requiresRowNumber)
           visitedProvider = new SelectProvider(
             visitedProvider,
-            Enumerable.Range(0, visitedProvider.Header.Length - 1).ToArray());
+            Enumerable.Range(0, visitedProvider.Header.Length - 1).Select(i => (ColNum) i).ToArray());
 
         return visitedProvider;
       }

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/RedundantColumnRemover.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/RedundantColumnRemover.cs
@@ -27,7 +27,7 @@ namespace Xtensive.Orm.Rse.Transformation
         && methodInfo.GetParameters()[1].ParameterType.CachedGetGenericTypeDefinition() == WellKnownTypes.FuncOfTArgTResultType)
       .CachedMakeGenericMethod(WellKnownOrmTypes.Tuple, WellKnownOrmTypes.Tuple);
 
-    protected override (CompilableProvider, List<int>) OverrideRightApplySource(ApplyProvider applyProvider, CompilableProvider provider, List<int> requestedMapping)
+    protected override (CompilableProvider, List<ColNum>) OverrideRightApplySource(ApplyProvider applyProvider, CompilableProvider provider, List<ColNum> requestedMapping)
     {
       var currentMapping = mappings[applyProvider.Right];
       if (currentMapping.SequenceEqual(requestedMapping))
@@ -39,7 +39,7 @@ namespace Xtensive.Orm.Rse.Transformation
     protected override RawProvider VisitRaw(RawProvider provider)
     {
       var mapping = mappings[provider];
-      if (mapping.SequenceEqual(Enumerable.Range(0, provider.Header.Length)))
+      if (mapping.SequenceEqual(Enumerable.Range(0, provider.Header.Length).Select(i => (ColNum) i)))
         return provider;
       var mappingTransform = new MapTransform(true, provider.Header.TupleDescriptor, mapping.ToArray());
       var newExpression = RemapRawProviderSource(provider.Source, mappingTransform);

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/TupleAccessGatherer.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/TupleAccessGatherer.cs
@@ -18,8 +18,8 @@ namespace Xtensive.Orm.Rse.Transformation
   public class TupleAccessGatherer : ExpressionVisitor
   {
     private ParameterExpression tupleParameter;
-    protected readonly Action<ApplyParameter, int> registerOuterColumn;
-    protected List<int> mappings;
+    protected readonly Action<ApplyParameter, short> registerOuterColumn;
+    protected List<ColNum> mappings;
 
     /// <inheritdoc/>
     protected override Expression VisitUnknown(Expression e)
@@ -47,9 +47,9 @@ namespace Xtensive.Orm.Rse.Transformation
     /// </summary>
     /// <param name="expression">The predicate.</param>
     /// <returns>List containing all used columns (order and uniqueness are not guaranteed).</returns>
-    public virtual List<int> Gather(Expression expression)
+    public virtual List<ColNum> Gather(Expression expression)
     {
-      mappings = new List<int>();
+      mappings = new List<ColNum>();
       Visit(expression);
       var result = mappings;
       mappings = null;
@@ -62,7 +62,7 @@ namespace Xtensive.Orm.Rse.Transformation
     /// <param name="expression">The predicate.</param>
     /// <param name="parameter">The tuple parameter to be considered.</param>
     /// <returns>List containing all used columns (order and uniqueness are not guaranteed).</returns>
-    public List<int> Gather(Expression expression, ParameterExpression parameter)
+    public List<ColNum> Gather(Expression expression, ParameterExpression parameter)
     {
       ArgumentValidator.EnsureArgumentNotNull(expression, "expression");
       ArgumentValidator.EnsureArgumentNotNull(parameter, "parameter");
@@ -72,7 +72,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return result;
     }
 
-    private static void DefaultRegisterOuterColumn(ApplyParameter parameter, int columnIndex)
+    private static void DefaultRegisterOuterColumn(ApplyParameter parameter, short columnIndex)
     {
     }
 
@@ -90,7 +90,7 @@ namespace Xtensive.Orm.Rse.Transformation
     /// Initializes a new instance of this class.
     /// </summary>
     /// <param name="registerOuterColumn">A <see langword="delegate"/> invoked on each outer column usage.</param>
-    public TupleAccessGatherer(Action<ApplyParameter, int> registerOuterColumn)
+    public TupleAccessGatherer(Action<ApplyParameter, short> registerOuterColumn)
     {
       this.registerOuterColumn = registerOuterColumn ?? DefaultRegisterOuterColumn;
     }

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/TupleAccessGatherer.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/TupleAccessGatherer.cs
@@ -18,7 +18,7 @@ namespace Xtensive.Orm.Rse.Transformation
   public class TupleAccessGatherer : ExpressionVisitor
   {
     private ParameterExpression tupleParameter;
-    protected readonly Action<ApplyParameter, short> registerOuterColumn;
+    protected readonly Action<ApplyParameter, ColNum> registerOuterColumn;
     protected List<ColNum> mappings;
 
     /// <inheritdoc/>
@@ -72,7 +72,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return result;
     }
 
-    private static void DefaultRegisterOuterColumn(ApplyParameter parameter, short columnIndex)
+    private static void DefaultRegisterOuterColumn(ApplyParameter parameter, ColNum columnIndex)
     {
     }
 
@@ -90,7 +90,7 @@ namespace Xtensive.Orm.Rse.Transformation
     /// Initializes a new instance of this class.
     /// </summary>
     /// <param name="registerOuterColumn">A <see langword="delegate"/> invoked on each outer column usage.</param>
-    public TupleAccessGatherer(Action<ApplyParameter, short> registerOuterColumn)
+    public TupleAccessGatherer(Action<ApplyParameter, ColNum> registerOuterColumn)
     {
       this.registerOuterColumn = registerOuterColumn ?? DefaultRegisterOuterColumn;
     }

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/TupleAccessRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/TupleAccessRewriter.cs
@@ -19,11 +19,11 @@ namespace Xtensive.Orm.Rse.Transformation
   {
     private ParameterExpression tupleParameter;
     private bool ignoreMissing;
-    protected readonly Func<ApplyParameter, int, int> resolveOuterColumn;
-    protected readonly IList<int> mappings;
+    protected readonly Func<ApplyParameter, ColNum, ColNum> resolveOuterColumn;
+    protected readonly IList<ColNum> mappings;
 
 
-    public IList<int> Mappings
+    public IList<ColNum> Mappings
     {
       get { return mappings; }
     }
@@ -74,7 +74,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return Visit(expression);
     }
     
-    private static int DefaultResolveOuterColumn(ApplyParameter parameter, int columnIndex)
+    private static ColNum DefaultResolveOuterColumn(ApplyParameter parameter, ColNum columnIndex)
     {
       throw new NotSupportedException();
     }
@@ -89,7 +89,7 @@ namespace Xtensive.Orm.Rse.Transformation
     /// <param name="ignoreMissing">Indicates if the newly created <see cref="TupleAccessRewriter"/>
     /// should ignore rewriting accessors missing in the <paramref name="mappings"/> collection
     /// or not resolvable by <paramref name="resolveOuterColumn"/> delegate.</param>
-    public TupleAccessRewriter(IList<int> mappings, Func<ApplyParameter, int, int> resolveOuterColumn, bool ignoreMissing)
+    public TupleAccessRewriter(IList<ColNum> mappings, Func<ApplyParameter, ColNum, ColNum> resolveOuterColumn, bool ignoreMissing)
     {
       this.ignoreMissing = ignoreMissing;
       this.mappings = mappings;

--- a/Orm/Xtensive.Orm/Orm/Rse/TupleExpressionExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/TupleExpressionExtensions.cs
@@ -106,12 +106,12 @@ namespace Xtensive.Orm.Rse
     /// </summary>
     /// <param name="expression">An expression describing an access to tuple element.</param>
     /// <returns></returns>
-    public static int GetTupleAccessArgument(this Expression expression)
+    public static short GetTupleAccessArgument(this Expression expression)
     {
       var mc = expression.AsTupleAccess();
       if (mc==null)
         throw new ArgumentException(string.Format(Strings.ExParameterXIsNotATupleAccessExpression, "expression"));
-      return Evaluate<int>(mc.Arguments[0]);
+      return Evaluate<short>(mc.Arguments[0]);
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Rse/TupleExpressionExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/TupleExpressionExtensions.cs
@@ -111,7 +111,7 @@ namespace Xtensive.Orm.Rse
       var mc = expression.AsTupleAccess();
       if (mc==null)
         throw new ArgumentException(string.Format(Strings.ExParameterXIsNotATupleAccessExpression, "expression"));
-      return Evaluate<ColNum>(mc.Arguments[0]);
+      return (ColNum)Evaluate<int>(mc.Arguments[0]);
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Rse/TupleExpressionExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/TupleExpressionExtensions.cs
@@ -106,12 +106,12 @@ namespace Xtensive.Orm.Rse
     /// </summary>
     /// <param name="expression">An expression describing an access to tuple element.</param>
     /// <returns></returns>
-    public static short GetTupleAccessArgument(this Expression expression)
+    public static ColNum GetTupleAccessArgument(this Expression expression)
     {
       var mc = expression.AsTupleAccess();
       if (mc==null)
         throw new ArgumentException(string.Format(Strings.ExParameterXIsNotATupleAccessExpression, "expression"));
-      return Evaluate<short>(mc.Arguments[0]);
+      return Evaluate<ColNum>(mc.Arguments[0]);
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Tuples/Transform/CombineTransform.cs
+++ b/Orm/Xtensive.Orm/Tuples/Transform/CombineTransform.cs
@@ -63,14 +63,14 @@ namespace Xtensive.Tuples.Transform
     {
       int totalLength = sources.Sum(s => s.Count);
       var types = new Type[totalLength];
-      var map = new Pair<int, int>[totalLength];
+      var map = new Pair<ColNum, ColNum>[totalLength];
       int index = 0;
-      for (int i = 0; i<sources.Length; i++) {
+      for (ColNum i = 0; i<sources.Length; i++) {
         TupleDescriptor currentDescriptor = sources[i];
         int currentCount = currentDescriptor.Count;
-        for (int j = 0; j<currentCount; j++) {
+        for (ColNum j = 0; j<currentCount; j++) {
           types[index] = currentDescriptor[j];
-          map[index++] = new Pair<int, int>(i, j);
+          map[index++] = new Pair<ColNum, ColNum>(i, j);
         }
       }
       this.sources = sources;

--- a/Orm/Xtensive.Orm/Tuples/Transform/CutInTransform.cs
+++ b/Orm/Xtensive.Orm/Tuples/Transform/CutInTransform.cs
@@ -68,7 +68,7 @@ namespace Xtensive.Tuples.Transform
       this.index = index;
       int totalLength = sources.Sum(s => s.Count);
       Type[] types = new Type[totalLength];
-      Pair<int, int>[] map = new Pair<int, int>[totalLength];
+      Pair<ColNum, ColNum>[] map = new Pair<ColNum, ColNum>[totalLength];
       TupleDescriptor sourceDescriptor = sources[0];
       TupleDescriptor cutInDescriptor = sources[1];
       int sourceCount = sourceDescriptor.Count;
@@ -84,13 +84,13 @@ namespace Xtensive.Tuples.Transform
       }
       else if (index < 0 || index > sourceCount)
         throw new ArgumentOutOfRangeException("index");
-      for (int i = 0; i < sourceCount; i++)
+      for (ColNum i = 0; i < sourceCount; i++)
       {
         if ((i == index) && !isIndex) {
-          for (int j = 0; j < cutInCount; j++)
+          for (ColNum j = 0; j < cutInCount; j++)
           {
             types[ind] = cutInDescriptor[j];
-            map[ind++] = new Pair<int, int>(1, j);
+            map[ind++] = new Pair<ColNum, ColNum>(1, j);
           }
           if (!isEndOfTuple) {
             i--;
@@ -99,7 +99,7 @@ namespace Xtensive.Tuples.Transform
         }
         else {
           types[ind] = sourceDescriptor[i];
-          map[ind++] = new Pair<int, int>(0, i);
+          map[ind++] = new Pair<ColNum, ColNum>(0, i);
         }
       }
       this.sources = sources;

--- a/Orm/Xtensive.Orm/Tuples/Transform/CutOutTransform.cs
+++ b/Orm/Xtensive.Orm/Tuples/Transform/CutOutTransform.cs
@@ -19,12 +19,12 @@ namespace Xtensive.Tuples.Transform
   /// </summary>
   public sealed class CutOutTransform : MapTransform
   {
-    private Segment<int> segment;
+    private Segment<ColNum> segment;
 
     /// <summary>
     /// Gets the segment this transform cuts out.
     /// </summary>
-    public Segment<int> Segment
+    public Segment<ColNum> Segment
     {
       [DebuggerStepThrough]
       get { return segment; }
@@ -52,16 +52,16 @@ namespace Xtensive.Tuples.Transform
     /// <param name="isReadOnly"><see cref="MapTransform.IsReadOnly"/> property value.</param>
     /// <param name="sourceDescriptor">Source tuple descriptor.</param>
     /// <param name="segment">The segment to cut out.</param>
-    public CutOutTransform(bool isReadOnly, TupleDescriptor sourceDescriptor, in Segment<int> segment)
+    public CutOutTransform(bool isReadOnly, TupleDescriptor sourceDescriptor, in Segment<ColNum> segment)
       : base(isReadOnly)
     {
       this.segment = segment;
       Type[] fields = new Type[sourceDescriptor.Count - segment.Length];
-      int[] map = new int[sourceDescriptor.Count - segment.Length];
-      int j = segment.Offset;
+      ColNum[] map = new ColNum[sourceDescriptor.Count - segment.Length];
+      ColNum j = segment.Offset;
       bool flag = false;
       if (sourceDescriptor.Count >= j + segment.Length)
-      for (int i = 0; i < sourceDescriptor.Count - segment.Length; i++) {
+      for (ColNum i = 0; i < sourceDescriptor.Count - segment.Length; i++) {
         if ((i < j)) {
           fields[i] = sourceDescriptor[i];
           map[i] = i;

--- a/Orm/Xtensive.Orm/Tuples/Transform/Internals/MapTransformTuple3.cs
+++ b/Orm/Xtensive.Orm/Tuples/Transform/Internals/MapTransformTuple3.cs
@@ -48,7 +48,7 @@ namespace Xtensive.Tuples.Transform.Internals
     /// <inheritdoc/>
     public override object GetValue(int fieldIndex, out TupleFieldState fieldState)
     {
-      Pair<int, int> indexes = TypedTransform.map[fieldIndex];
+      Pair<ColNum, ColNum> indexes = TypedTransform.map[fieldIndex];
       return tuples[indexes.First].GetValue(indexes.Second, out fieldState);
     }
 
@@ -57,7 +57,7 @@ namespace Xtensive.Tuples.Transform.Internals
     {
       if (Transform.IsReadOnly)
         throw Exceptions.ObjectIsReadOnly(null);
-      Pair<int, int> indexes = TypedTransform.map[fieldIndex];
+      Pair<ColNum, ColNum> indexes = TypedTransform.map[fieldIndex];
       tuples[indexes.First].SetValue(indexes.Second, fieldValue);
     }
 

--- a/Orm/Xtensive.Orm/Tuples/Transform/MapTransform.cs
+++ b/Orm/Xtensive.Orm/Tuples/Transform/MapTransform.cs
@@ -25,13 +25,13 @@ namespace Xtensive.Tuples.Transform
   {
     private readonly bool isReadOnly;
     private int sourceCount;
-    internal IReadOnlyList<int> singleSourceMap;
-    internal Pair<int, int>[] map;
+    internal IReadOnlyList<ColNum> singleSourceMap;
+    internal Pair<ColNum, ColNum>[] map;
 
     /// <summary>
     /// Means that no mapping is available for the specified field index.
     /// </summary>
-    public const int NoMapping = int.MinValue;
+    public const ColNum NoMapping = ColNum.MinValue;
 
     /// <inheritdoc/>
     public override bool IsReadOnly {
@@ -51,7 +51,7 @@ namespace Xtensive.Tuples.Transform
     /// <summary>
     /// Gets or sets destination-to-source field map for the first source only.
     /// </summary>
-    public IReadOnlyList<int> SingleSourceMap {
+    public IReadOnlyList<ColNum> SingleSourceMap {
       [DebuggerStepThrough]
       get => singleSourceMap;
     }
@@ -59,22 +59,22 @@ namespace Xtensive.Tuples.Transform
     /// <summary>
     /// Gets or sets destination-to-source field map.
     /// </summary>
-    public IReadOnlyList<Pair<int, int>> Map
+    public IReadOnlyList<Pair<ColNum, ColNum>> Map
     {
       [DebuggerStepThrough]
       get { return Array.AsReadOnly(map); }
     }
 
-    protected void SetSingleSourceMap(IReadOnlyList<int> singleSourceMap)
+    protected void SetSingleSourceMap(IReadOnlyList<ColNum> singleSourceMap)
     {
       ArgumentValidator.EnsureArgumentNotNull(singleSourceMap, nameof(singleSourceMap));
-      var newMap = new Pair<int, int>[Descriptor.Count];
+      var newMap = new Pair<ColNum, ColNum>[Descriptor.Count];
       var index = 0;
       for (; index < newMap.Length && index < singleSourceMap.Count; index++) {
-        newMap[index] = new Pair<int, int>(0, singleSourceMap[index]);
+        newMap[index] = new Pair<ColNum, ColNum>(0, singleSourceMap[index]);
       }
       while (index < newMap.Length) {
-        newMap[index++] = new Pair<int, int>(0, NoMapping);
+        newMap[index++] = new Pair<ColNum, ColNum>(0, NoMapping);
       }
 
       map = newMap;
@@ -82,16 +82,16 @@ namespace Xtensive.Tuples.Transform
       sourceCount = 1;
     }
 
-    protected void SetMap(Pair<int, int>[] map)
+    protected void SetMap(Pair<short, short>[] map)
     {
       ArgumentValidator.EnsureArgumentNotNull(map, nameof(map));
-      int[] newFirstSourceMap = new int[map.Length];
+      ColNum[] newFirstSourceMap = new ColNum[map.Length];
       int index = 0;
       int newSourceCount = -1;
       foreach (var mappedTo in map) {
         if (mappedTo.First>newSourceCount)
           newSourceCount = mappedTo.First;
-        newFirstSourceMap[index++] = mappedTo.First==0 ? mappedTo.Second : -1;
+        newFirstSourceMap[index++] = mappedTo.First==0 ? mappedTo.Second : (ColNum) (-1);
       }
       newSourceCount++;
       this.map = map;
@@ -268,7 +268,7 @@ namespace Xtensive.Tuples.Transform
     /// <param name="isReadOnly"><see cref="IsReadOnly"/> property value.</param>
     /// <param name="descriptor">Initial <see cref="TupleTransformBase.Descriptor"/> property value.</param>
     /// <param name="map"><see cref="Map"/> property value.</param>
-    public MapTransform(bool isReadOnly, TupleDescriptor descriptor, Pair<int, int>[] map)
+    public MapTransform(bool isReadOnly, TupleDescriptor descriptor, Pair<ColNum, ColNum>[] map)
       : this(isReadOnly, descriptor)
     {
       SetMap(map);
@@ -280,7 +280,7 @@ namespace Xtensive.Tuples.Transform
     /// <param name="isReadOnly"><see cref="IsReadOnly"/> property value.</param>
     /// <param name="descriptor">Initial <see cref="TupleTransformBase.Descriptor"/> property value.</param>
     /// <param name="map"><see cref="SingleSourceMap"/> property value.</param>
-    public MapTransform(bool isReadOnly, TupleDescriptor descriptor, IReadOnlyList<int> map)
+    public MapTransform(bool isReadOnly, TupleDescriptor descriptor, IReadOnlyList<ColNum> map)
       : this(isReadOnly, descriptor)
     {
       SetSingleSourceMap(map);

--- a/Orm/Xtensive.Orm/Tuples/Transform/MapTransform.cs
+++ b/Orm/Xtensive.Orm/Tuples/Transform/MapTransform.cs
@@ -82,7 +82,7 @@ namespace Xtensive.Tuples.Transform
       sourceCount = 1;
     }
 
-    protected void SetMap(Pair<short, short>[] map)
+    protected void SetMap(Pair<ColNum, ColNum>[] map)
     {
       ArgumentValidator.EnsureArgumentNotNull(map, nameof(map));
       ColNum[] newFirstSourceMap = new ColNum[map.Length];

--- a/Orm/Xtensive.Orm/Tuples/Transform/SegmentTransform.cs
+++ b/Orm/Xtensive.Orm/Tuples/Transform/SegmentTransform.cs
@@ -18,12 +18,12 @@ namespace Xtensive.Tuples.Transform
   /// </summary>
   public sealed class SegmentTransform : MapTransform
   {
-    private Segment<int> segment;
+    private Segment<ColNum> segment;
 
     /// <summary>
     /// Gets the segment this transform extracts.
     /// </summary>
-    public Segment<int> Segment
+    public Segment<ColNum> Segment
     {
       [DebuggerStepThrough]
       get { return segment; }
@@ -51,13 +51,13 @@ namespace Xtensive.Tuples.Transform
     /// <param name="isReadOnly"><see cref="MapTransform.IsReadOnly"/> property value.</param>
     /// <param name="sourceDescriptor">Source tuple descriptor.</param>
     /// <param name="segment">The segment to extract.</param>
-    public SegmentTransform(bool isReadOnly, TupleDescriptor sourceDescriptor, in Segment<int> segment)
+    public SegmentTransform(bool isReadOnly, TupleDescriptor sourceDescriptor, in Segment<ColNum> segment)
       : base(isReadOnly)
     {
       this.segment = segment;
       Type[] fields = new Type[segment.Length];
-      int[] map = new int[segment.Length];
-      for (int i = 0, j = segment.Offset; i < segment.Length; i++, j++) {
+      ColNum[] map = new ColNum[segment.Length];
+      for (ColNum i = 0, j = segment.Offset; i < segment.Length; i++, j++) {
         fields[i] = sourceDescriptor[j];
         map[i] = j;
       }

--- a/Orm/Xtensive.Orm/Tuples/TupleDescriptor.cs
+++ b/Orm/Xtensive.Orm/Tuples/TupleDescriptor.cs
@@ -36,7 +36,7 @@ namespace Xtensive.Tuples
     [field: NonSerialized]
     private Type[] FieldTypes { get; }
 
-    private int FieldCount => FieldTypes.Length;
+    private ColNum FieldCount => (ColNum)FieldTypes.Length;
 
     /// <summary>
     /// Gets the empty tuple descriptor.
@@ -58,11 +58,13 @@ namespace Xtensive.Tuples
     }
 
     /// <inheritdoc/>
-    public int Count
+    public ColNum Count
     {
       [DebuggerStepThrough]
       get => FieldCount;
     }
+
+    int IReadOnlyCollection<Type>.Count => FieldCount;
 
     /// <inheritdoc/>
     public IEnumerator<Type> GetEnumerator()

--- a/Orm/Xtensive.Orm/Tuples/TupleExtensions.cs
+++ b/Orm/Xtensive.Orm/Tuples/TupleExtensions.cs
@@ -94,7 +94,7 @@ namespace Xtensive.Tuples
     /// <param name="target">Tuple that receives the data.</param>
     /// <param name="map">Target-to-source field index map.
     /// Negative value in this map means "skip this element".</param>
-    public static void CopyTo(this Tuple source, Tuple target, IReadOnlyList<int> map)
+    public static void CopyTo(this Tuple source, Tuple target, IReadOnlyList<ColNum> map)
     {
       if (source is PackedTuple packedSource && target is PackedTuple packedTarget) {
         CopyTupleWithMappingFast(packedSource, packedTarget, map);
@@ -113,7 +113,7 @@ namespace Xtensive.Tuples
     /// <param name="target">Tuple that receives the data.</param>
     /// <param name="map">Target-to-source field index map.
     /// Negative value in this map means "skip this element".</param>
-    public static void CopyTo(this Tuple[] sources, Tuple target, Pair<int, int>[] map)
+    public static void CopyTo(this Tuple[] sources, Tuple target, Pair<ColNum, ColNum>[] map)
     {
       var haveSlowSource = false;
       var packedSources = new PackedTuple[sources.Length];
@@ -145,7 +145,7 @@ namespace Xtensive.Tuples
     /// <param name="target">Tuple that receives the data.</param>
     /// <param name="map">Target-to-source field index map.
     /// Negative value in this map means "skip this element".</param>
-    public static void CopyTo(this FixedList3<Tuple> sources, Tuple target, Pair<int, int>[] map)
+    public static void CopyTo(this FixedList3<Tuple> sources, Tuple target, Pair<ColNum, ColNum>[] map)
     {
       var haveSlowSource = false;
       var packedSources = new FixedList3<PackedTuple>();
@@ -190,13 +190,13 @@ namespace Xtensive.Tuples
     /// <param name="tuple">The <see cref="Tuple"/> to get segment from.</param>
     /// <param name="segment">The <see cref="Segment{T}"/> to cut off.</param>
     /// <returns></returns>
-    public static Tuple GetSegment(this Tuple tuple, in Segment<int> segment)
+    public static Tuple GetSegment(this Tuple tuple, in Segment<ColNum> segment)
     {
       var length = segment.Length;
-      var map = new int[length];
+      var map = new ColNum[length];
       var fieldTypes = new Type[length];
       for (var index = 0; index < map.Length; index++) {
-        var sourceIndex = segment.Offset + index;
+        ColNum sourceIndex = (ColNum)(segment.Offset + index);
         map[index] = sourceIndex;
         fieldTypes[index] = tuple.Descriptor[sourceIndex];
       }
@@ -467,7 +467,7 @@ namespace Xtensive.Tuples
         CopyPackedValue(source, sourceStartIndex + i, target, targetStartIndex + i);
     }
 
-    private static void CopyTupleWithMappingSlow(Tuple source, Tuple target, IReadOnlyList<int> map)
+    private static void CopyTupleWithMappingSlow(Tuple source, Tuple target, IReadOnlyList<ColNum> map)
     {
       for (int targetIndex = 0, count = map.Count; targetIndex < count; targetIndex++) {
         var sourceIndex = map[targetIndex];
@@ -476,7 +476,7 @@ namespace Xtensive.Tuples
       }
     }
 
-    private static void CopyTupleWithMappingFast(PackedTuple source, PackedTuple target, IReadOnlyList<int> map)
+    private static void CopyTupleWithMappingFast(PackedTuple source, PackedTuple target, IReadOnlyList<ColNum> map)
     {
       for (int targetIndex = 0, count = map.Count; targetIndex < count; targetIndex++) {
         var sourceIndex = map[targetIndex];
@@ -485,7 +485,7 @@ namespace Xtensive.Tuples
       }
     }
 
-    private static void CopyTupleArrayWithMappingSlow(Tuple[] sources, Tuple target, Pair<int, int>[] map)
+    private static void CopyTupleArrayWithMappingSlow(Tuple[] sources, Tuple target, Pair<ColNum, ColNum>[] map)
     {
       for (int targetIndex = 0, length = map.Length; targetIndex < length; targetIndex++) {
         var sourceInfo = map[targetIndex];
@@ -496,7 +496,7 @@ namespace Xtensive.Tuples
       }
     }
 
-    private static void CopyTupleArrayWithMappingFast(PackedTuple[] sources, PackedTuple target, Pair<int, int>[] map)
+    private static void CopyTupleArrayWithMappingFast(PackedTuple[] sources, PackedTuple target, Pair<ColNum, ColNum>[] map)
     {
       for (int targetIndex = 0, length = map.Length; targetIndex < length; targetIndex++) {
         var sourceInfo = map[targetIndex];
@@ -507,7 +507,7 @@ namespace Xtensive.Tuples
       }
     }
 
-    private static void Copy3TuplesWithMappingSlow(FixedList3<Tuple> sources, Tuple target, Pair<int, int>[] map)
+    private static void Copy3TuplesWithMappingSlow(FixedList3<Tuple> sources, Tuple target, Pair<ColNum, ColNum>[] map)
     {
       for (int targetIndex = 0, length = map.Length; targetIndex < length; targetIndex++) {
         var sourceInfo = map[targetIndex];
@@ -518,7 +518,7 @@ namespace Xtensive.Tuples
       }
     }
 
-    private static void Copy3TuplesWithMappingFast(FixedList3<PackedTuple> sources, PackedTuple target, Pair<int, int>[] map)
+    private static void Copy3TuplesWithMappingFast(FixedList3<PackedTuple> sources, PackedTuple target, Pair<ColNum, ColNum>[] map)
     {
       for (int targetIndex = 0, length = map.Length; targetIndex < length; targetIndex++) {
         var sourceInfo = map[targetIndex];


### PR DESCRIPTION
Optimizations:
* Avoid unnecessary allocations
* Use `IReadOnlyList<>` instead of array for safety
* Use `short[]` instead of `int[]` for Column indexes. We have 16K limitation on number of columns anyway. No need reserve 4 bytes for column number.  This will save a few MB

Generalize `ColNum` type to be defined in `Directory.Build.props`, like
`<Using Include="System.Int16" Alias="ColNum" />`

We can return to the old behavior by single-line change:

`<Using Include="System.Int32" Alias="ColNum" />`


