### PR TITLE
Optimization: Refactor common code in `IMappedExpression.Remap()` implementation

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnExpression.cs
@@ -11,12 +11,11 @@ using Xtensive.Core;
 
 namespace Xtensive.Orm.Linq.Expressions
 {
-  internal class ColumnExpression : ParameterizedExpression,
-    IMappedExpression
+  internal class ColumnExpression : ParameterizedExpression
   {
     internal readonly Segment<ColNum> Mapping;
 
-    public Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
+    public override ColumnExpression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;
@@ -24,7 +23,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return new ColumnExpression(Type, newMapping, OuterParameter, DefaultIfEmpty);
     }
 
-    public Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override ColumnExpression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;
@@ -37,12 +36,12 @@ namespace Xtensive.Orm.Linq.Expressions
       return BindParameter(parameter, new Dictionary<Expression, Expression>());
     }
 
-    public Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
+    public override ColumnExpression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
       return new ColumnExpression(Type, Mapping, parameter, DefaultIfEmpty);
     }
 
-    public Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
+    public override Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
     {
       return new ColumnExpression(Type, Mapping, null, DefaultIfEmpty);
     }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
@@ -18,8 +18,7 @@ using System.Linq;
 namespace Xtensive.Orm.Linq
 {
   [Serializable]
-  internal class ConstructorExpression : ParameterizedExpression,
-    IMappedExpression
+  internal class ConstructorExpression : ParameterizedExpression
   {
     public Dictionary<MemberInfo, Expression> Bindings { get; }
 
@@ -29,7 +28,7 @@ namespace Xtensive.Orm.Linq
 
     public IReadOnlyList<Expression> ConstructorArguments { get; }
 
-    public Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
       Func<Expression, Expression> genericBinder =
         e => GenericExpressionVisitor<IMappedExpression>.Process(e, mapped => mapped.BindParameter(parameter, processedExpressions));
@@ -41,7 +40,7 @@ namespace Xtensive.Orm.Linq
         ConstructorArguments.Select(genericBinder).ToList());
     }
 
-    public Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
+    public override Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
     {
       Func<Expression, Expression> genericRemover =
         e => GenericExpressionVisitor<IMappedExpression>.Process(e, mapped => mapped.RemoveOuterParameter(processedExpressions));
@@ -54,7 +53,7 @@ namespace Xtensive.Orm.Linq
       return result;
     }
 
-    public Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
       Func<IMappedExpression, Expression> remapper = delegate(IMappedExpression mapped) {
         var parametrizedExpression = mapped as ParameterizedExpression;
@@ -75,7 +74,7 @@ namespace Xtensive.Orm.Linq
       return result;
     }
 
-    public Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
       Func<IMappedExpression, Expression> remapper = delegate(IMappedExpression mapped) {
         var parametrizedExpression = mapped as ParameterizedExpression;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityExpression.cs
@@ -12,8 +12,7 @@ using Xtensive.Orm.Model;
 
 namespace Xtensive.Orm.Linq.Expressions
 {
-  internal class EntityExpression : ParameterizedExpression,
-    IEntityExpression
+  internal class EntityExpression : ParameterizedExpression, IEntityExpression
   {
     private List<PersistentFieldExpression> fields;
 
@@ -34,41 +33,31 @@ namespace Xtensive.Orm.Linq.Expressions
 
     public bool IsNullable { get; set; }
 
-    public Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
+    public override EntityExpression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
-      if (!CanRemap) {
-        return this;
-      }
-
-      if (processedExpressions.TryGetValue(this, out var value)) {
+      if (TryProcessed<EntityExpression>(processedExpressions, out var value))
         return value;
-      }
 
-      var keyExpression = (KeyExpression) Key.Remap(offset, processedExpressions);
+      var keyExpression = Key.Remap(offset, processedExpressions);
       var result = new EntityExpression(PersistentType, keyExpression, OuterParameter, DefaultIfEmpty);
       processedExpressions.Add(this, result);
       result.IsNullable = IsNullable;
       var processedFields = new List<PersistentFieldExpression>(fields.Count);
       foreach (var field in fields) {
         // Do not convert to LINQ. We want to avoid a closure creation here.
-        processedFields.Add((PersistentFieldExpression) field.Remap(offset, processedExpressions));
+        processedFields.Add(field.Remap(offset, processedExpressions));
       }
 
       result.Fields = processedFields;
       return result;
     }
 
-    public Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override EntityExpression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
-      if (!CanRemap) {
-        return this;
-      }
-
-      if (processedExpressions.TryGetValue(this, out var value)) {
+      if (TryProcessed<EntityExpression>(processedExpressions, out var value))
         return value;
-      }
 
-      var keyExpression = (KeyExpression) Key.Remap(map, processedExpressions);
+      var keyExpression = Key.Remap(map, processedExpressions);
       if (keyExpression == null) {
         return null;
       }
@@ -91,7 +80,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
       if (processedExpressions.TryGetValue(this, out var value)) {
         return value;
@@ -111,7 +100,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
+    public override Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
     {
       if (processedExpressions.TryGetValue(this, out var value)) {
         return value;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityFieldExpression.cs
@@ -30,25 +30,20 @@ namespace Xtensive.Orm.Linq.Expressions
       Entity.IsNullable = IsNullable;
     }
 
-    public override Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
+    public override EntityFieldExpression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
-      if (!CanRemap) {
-        return this;
-      }
-
-      if (processedExpressions.TryGetValue(this, out var result)) {
-        return result;
-      }
+      if (TryProcessed<EntityFieldExpression>(processedExpressions, out var value))
+        return value;
 
       var newFields = new List<PersistentFieldExpression>(fields.Count);
       foreach (var field in fields) {
         // Do not convert to LINQ. We want to avoid a closure creation here.
-        newFields.Add((PersistentFieldExpression) field.Remap(offset, processedExpressions));
+        newFields.Add(field.Remap(offset, processedExpressions));
       }
 
-      var keyExpression = (KeyExpression) Key.Remap(offset, processedExpressions);
-      var entity = (EntityExpression) Entity?.Remap(offset, processedExpressions);
-      result = new EntityFieldExpression(
+      var keyExpression = Key.Remap(offset, processedExpressions);
+      var entity = Entity?.Remap(offset, processedExpressions);
+      var result = new EntityFieldExpression(
         PersistentType, Field, newFields, keyExpression.Mapping, keyExpression, entity, OuterParameter, DefaultIfEmpty);
       if (Owner == null) {
         return result;
@@ -59,15 +54,10 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override EntityFieldExpression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
-      if (!CanRemap) {
-        return this;
-      }
-
-      if (processedExpressions.TryGetValue(this, out var result)) {
-        return result;
-      }
+      if (TryProcessed<EntityFieldExpression>(processedExpressions, out var value))
+        return value;
 
       var newFields = new List<PersistentFieldExpression>(fields.Count);
       using (new SkipOwnerCheckScope()) {
@@ -87,13 +77,13 @@ namespace Xtensive.Orm.Linq.Expressions
         return null;
       }
 
-      var keyExpression = (KeyExpression) Key.Remap(map, processedExpressions);
+      var keyExpression = Key.Remap(map, processedExpressions);
       EntityExpression entity;
       using (new SkipOwnerCheckScope()) {
-        entity = (EntityExpression) Entity?.Remap(map, processedExpressions);
+        entity = Entity?.Remap(map, processedExpressions);
       }
 
-      result = new EntityFieldExpression(
+      var result = new EntityFieldExpression(
         PersistentType, Field, newFields, keyExpression.Mapping, keyExpression, entity, OuterParameter, DefaultIfEmpty);
       if (Owner == null) {
         return result;
@@ -104,11 +94,11 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression BindParameter(
+    public override EntityFieldExpression BindParameter(
       ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
-      if (processedExpressions.TryGetValue(this, out var result)) {
-        return result;
+      if (processedExpressions.TryGetValue(this, out var r)) {
+        return (EntityFieldExpression)r;
       }
 
       var newFields = new List<PersistentFieldExpression>(fields.Count);
@@ -118,7 +108,7 @@ namespace Xtensive.Orm.Linq.Expressions
       }
       var keyExpression = (KeyExpression) Key.BindParameter(parameter, processedExpressions);
       var entity = (EntityExpression) Entity?.BindParameter(parameter, processedExpressions);
-      result = new EntityFieldExpression(
+      var result = new EntityFieldExpression(
         PersistentType, Field, newFields, Mapping, keyExpression, entity, parameter, DefaultIfEmpty);
       if (Owner == null) {
         return result;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntitySetExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntitySetExpression.cs
@@ -44,15 +44,14 @@ namespace Xtensive.Orm.Linq.Expressions
       throw Exceptions.InternalError(Strings.ExUnableToRemoveOwnerFromEntitySetExpression, OrmLog.Instance);
     }
 
-    public override Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
+    public override FieldExpression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;
 
-      Expression result;
-      if (processedExpressions.TryGetValue(this, out result))
-        return result;
-      result = new EntitySetExpression(Field, null, DefaultIfEmpty);
+      if (processedExpressions.TryGetValue(this, out var r))
+        return (FieldExpression)r;
+      var result = new EntitySetExpression(Field, null, DefaultIfEmpty);
       if (base.Owner==null)
         return result;
       processedExpressions.Add(this, result);
@@ -60,15 +59,14 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override EntitySetExpression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;
 
-      Expression result;
-      if (processedExpressions.TryGetValue(this, out result))
-        return result;
-      result = new EntitySetExpression(Field, null, DefaultIfEmpty);
+      if (processedExpressions.TryGetValue(this, out var r))
+        return (EntitySetExpression)r;
+      var result = new EntitySetExpression(Field, null, DefaultIfEmpty);
       if (base.Owner==null)
         return result;
       processedExpressions.Add(this, result);
@@ -76,12 +74,11 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
+    public override EntitySetExpression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
-      Expression result;
-      if (processedExpressions.TryGetValue(this, out result))
-        return result;
-      result = new EntitySetExpression(Field, parameter, DefaultIfEmpty);
+      if (processedExpressions.TryGetValue(this, out var r))
+        return (EntitySetExpression)r;
+      var result = new EntitySetExpression(Field, parameter, DefaultIfEmpty);
       if (base.Owner==null)
         return result;
       processedExpressions.Add(this, result);

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
@@ -30,18 +30,13 @@ namespace Xtensive.Orm.Linq.Expressions
       }
     }
 
-    public override Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
+    public override FieldExpression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
-      if (!CanRemap) {
-        return this;
-      }
-
-      if (processedExpressions.TryGetValue(this, out var result)) {
-        return result;
-      }
+      if (TryProcessed<FieldExpression>(processedExpressions, out var value))
+        return value;
 
       var newMapping = new Segment<ColNum>((ColNum)(Mapping.Offset + offset), Mapping.Length);
-      result = new FieldExpression(ExtendedExpressionType.Field, Field, newMapping, OuterParameter, DefaultIfEmpty);
+      var result = new FieldExpression(ExtendedExpressionType.Field, Field, newMapping, OuterParameter, DefaultIfEmpty);
       if (owner == null) {
         return result;
       }
@@ -51,15 +46,10 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override FieldExpression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
-      if (!CanRemap) {
-        return this;
-      }
-
-      if (processedExpressions.TryGetValue(this, out var result)) {
-        return result;
-      }
+      if (TryProcessed<FieldExpression>(processedExpressions, out var value))
+        return value;
 
       var offset = (ColNum)map.IndexOf(Mapping.Offset);
       if (offset < 0) {
@@ -75,7 +65,7 @@ namespace Xtensive.Orm.Linq.Expressions
         return null;
       }
       var newMapping = new Segment<ColNum>(offset, Mapping.Length);
-      result = new FieldExpression(ExtendedExpressionType.Field, Field, newMapping, OuterParameter, DefaultIfEmpty);
+      var result = new FieldExpression(ExtendedExpressionType.Field, Field, newMapping, OuterParameter, DefaultIfEmpty);
       if (owner == null) {
         return result;
       }
@@ -85,13 +75,13 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
+    public override FieldExpression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
-      if (processedExpressions.TryGetValue(this, out var result)) {
-        return result;
+      if (processedExpressions.TryGetValue(this, out var r)) {
+        return (FieldExpression)r;
       }
 
-      result = new FieldExpression(ExtendedExpressionType.Field, Field, Mapping, parameter, DefaultIfEmpty);
+      var result = new FieldExpression(ExtendedExpressionType.Field, Field, Mapping, parameter, DefaultIfEmpty);
       if (owner == null) {
         return result;
       }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/FullTextExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/FullTextExpression.cs
@@ -15,8 +15,7 @@ using Xtensive.Reflection;
 namespace Xtensive.Orm.Linq.Expressions
 {
   [Serializable]
-  internal class FullTextExpression : ParameterizedExpression,
-    IMappedExpression
+  internal class FullTextExpression : ParameterizedExpression
   {
     public FullTextIndexInfo FullTextIndex { get; private set; }
 
@@ -24,7 +23,7 @@ namespace Xtensive.Orm.Linq.Expressions
 
     public EntityExpression EntityExpression { get; private set; }
 
-    public Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
       Expression result;
       if (processedExpressions.TryGetValue(this, out result))
@@ -35,7 +34,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return new FullTextExpression(FullTextIndex, entityExpression, rankExpression, parameter);
     }
 
-    public Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
+    public override Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
     {
       Expression result;
       if (processedExpressions.TryGetValue(this, out result))
@@ -46,7 +45,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return new FullTextExpression(FullTextIndex, entityExpression, rankExpression, null);
     }
 
-    public Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;
@@ -55,12 +54,12 @@ namespace Xtensive.Orm.Linq.Expressions
       if (processedExpressions.TryGetValue(this, out result))
         return result;
 
-      var remappedEntityExpression = (EntityExpression) EntityExpression.Remap(offset, processedExpressions);
-      var remappedRankExpression = (ColumnExpression) RankExpression.Remap(offset, processedExpressions);
+      var remappedEntityExpression = EntityExpression.Remap(offset, processedExpressions);
+      var remappedRankExpression = RankExpression.Remap(offset, processedExpressions);
       return new FullTextExpression(FullTextIndex, remappedEntityExpression, remappedRankExpression, OuterParameter);
     }
 
-    public Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;
@@ -69,8 +68,8 @@ namespace Xtensive.Orm.Linq.Expressions
       if (processedExpressions.TryGetValue(this, out result))
         return result;
 
-      var remappedEntityExpression = (EntityExpression) EntityExpression.Remap(map, processedExpressions);
-      var remappedRankExpression = (ColumnExpression) RankExpression.Remap(map, processedExpressions);
+      var remappedEntityExpression = EntityExpression.Remap(map, processedExpressions);
+      var remappedRankExpression = RankExpression.Remap(map, processedExpressions);
       return new FullTextExpression(FullTextIndex, remappedEntityExpression, remappedRankExpression, OuterParameter);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/GroupingExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/GroupingExpression.cs
@@ -70,16 +70,16 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override GroupingExpression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
-      var remappedSubquery = (SubQueryExpression) base.Remap(map, processedExpressions);
+      var remappedSubquery = base.Remap(map, processedExpressions);
       var remappedKeyExpression = GenericExpressionVisitor<IMappedExpression>.Process(KeyExpression, mapped => mapped.Remap(map, processedExpressions));
       return new GroupingExpression(remappedSubquery.Type, remappedSubquery.OuterParameter, DefaultIfEmpty, remappedSubquery.ProjectionExpression, remappedSubquery.ApplyParameter, remappedKeyExpression, SelectManyInfo);
     }
 
-    public override Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
+    public override GroupingExpression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
-      var remappedSubquery = (SubQueryExpression) base.Remap(offset, processedExpressions);
+      var remappedSubquery = base.Remap(offset, processedExpressions);
       var remappedKeyExpression = GenericExpressionVisitor<IMappedExpression>.Process(KeyExpression, mapped => mapped.Remap(offset, processedExpressions));
       return new GroupingExpression(remappedSubquery.Type, remappedSubquery.OuterParameter, DefaultIfEmpty, remappedSubquery.ProjectionExpression, remappedSubquery.ApplyParameter, remappedKeyExpression, SelectManyInfo);
     }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/LocalCollectionExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/LocalCollectionExpression.cs
@@ -15,8 +15,7 @@ using Xtensive.Core;
 namespace Xtensive.Orm.Linq.Expressions
 {
   [Serializable]
-  internal class LocalCollectionExpression : ParameterizedExpression,
-    IMappedExpression
+  internal class LocalCollectionExpression : ParameterizedExpression
   {
     // just to have good error
     private readonly string expressionAsString;
@@ -32,11 +31,9 @@ namespace Xtensive.Orm.Linq.Expressions
           : ((LocalCollectionExpression) field.Value).Columns.Cast<IMappedExpression>())
         .Cast<ColumnExpression>();
 
-    public Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
+    public override LocalCollectionExpression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
-      if (!CanRemap)
-        return this;
-      if (processedExpressions.TryGetValue(this, out var value))
+      if (TryProcessed<LocalCollectionExpression>(processedExpressions, out var value))
         return value;
 
       var result = new LocalCollectionExpression(Type, MemberInfo, expressionAsString);
@@ -45,11 +42,9 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
-      if (!CanRemap)
-        return this;
-      if (processedExpressions.TryGetValue(this, out var value))
+      if (TryProcessed<LocalCollectionExpression>(processedExpressions, out var value))
         return value;
 
       var result = new LocalCollectionExpression(Type, MemberInfo, expressionAsString);
@@ -58,7 +53,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
       if (processedExpressions.TryGetValue(this, out var value))
         return value;
@@ -69,7 +64,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
+    public override Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
     {
       if (processedExpressions.TryGetValue(this, out var value))
         return value;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ParameterizedExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ParameterizedExpression.cs
@@ -5,11 +5,12 @@
 // Created:    2009.05.18
 
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace Xtensive.Orm.Linq.Expressions
 {
-  internal abstract class ParameterizedExpression : ExtendedExpression
+  internal abstract class ParameterizedExpression : ExtendedExpression, IMappedExpression
   {
     public ParameterExpression OuterParameter { get; private set; }
     public bool DefaultIfEmpty { get; set; }
@@ -33,6 +34,27 @@ namespace Xtensive.Orm.Linq.Expressions
           : OuterParameter==context.SubqueryParameterExpression;
       }
     }
+
+    protected bool TryProcessed<T>(Dictionary<Expression, Expression> processedExpressions, out T result) where T : ParameterizedExpression
+    {
+      if (!CanRemap) {
+        result = (T)this;
+        return true;
+      }
+
+      if (processedExpressions.TryGetValue(this, out var value)) {
+        result = (T)value;
+        return true;
+      }
+
+      result = null;
+      return false;
+    }
+
+    public abstract Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions);
+    public abstract Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions);
+    public abstract Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions);
+    public abstract Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/PersistentFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/PersistentFieldExpression.cs
@@ -12,17 +12,13 @@ using Xtensive.Core;
 
 namespace Xtensive.Orm.Linq.Expressions
 {
-  internal abstract class PersistentFieldExpression : ParameterizedExpression,
-    IMappedExpression
+  internal abstract class PersistentFieldExpression : ParameterizedExpression
   {
     internal Segment<ColNum> Mapping;
 
     public string Name { get; private set; }
     public PropertyInfo UnderlyingProperty { get; private set; }
-    public abstract Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions);
-    public abstract Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions);
-    public abstract Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions);
-    public abstract Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions);
+    public override PersistentFieldExpression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions) => throw new NotImplementedException();
 
     public override string ToString()
     {

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureExpression.cs
@@ -13,8 +13,7 @@ using System.Linq;
 
 namespace Xtensive.Orm.Linq.Expressions
 {
-  internal sealed class StructureExpression : ParameterizedExpression,
-    IPersistentExpression
+  internal sealed class StructureExpression : ParameterizedExpression, IPersistentExpression
   {
     private List<PersistentFieldExpression> fields;
     private bool isNullable;
@@ -35,15 +34,10 @@ namespace Xtensive.Orm.Linq.Expressions
       }
     }
 
-    public Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
-      if (!CanRemap) {
-        return this;
-      }
-
-      if (processedExpressions.TryGetValue(this, out var value)) {
+      if (TryProcessed<StructureExpression>(processedExpressions, out var value))
         return value;
-      }
 
       var mapping = new Segment<ColNum>((ColNum) (Mapping.Offset + offset), Mapping.Length);
       var result = new StructureExpression(PersistentType, mapping);
@@ -51,7 +45,7 @@ namespace Xtensive.Orm.Linq.Expressions
       var processedFields = new List<PersistentFieldExpression>(fields.Count);
       foreach (var field in fields) {
         // Do not convert to LINQ. We intentionally avoiding closure creation here
-        processedFields.Add((PersistentFieldExpression) field.Remap(offset, processedExpressions));
+        processedFields.Add(field.Remap(offset, processedExpressions));
       }
 
       result.Fields = processedFields;
@@ -60,15 +54,10 @@ namespace Xtensive.Orm.Linq.Expressions
     }
 
     
-    public Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
-      if (!CanRemap) {
-        return this;
-      }
-
-      if (processedExpressions.TryGetValue(this, out var value)) {
+      if (TryProcessed<StructureExpression>(processedExpressions, out var value))
         return value;
-      }
 
       var result = new StructureExpression(PersistentType, default);
       processedExpressions.Add(this, result);
@@ -99,7 +88,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
       if (processedExpressions.TryGetValue(this, out var value)) {
         return value;
@@ -117,7 +106,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
+    public override Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
     {
       if (processedExpressions.TryGetValue(this, out var value)) {
         return value;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureFieldExpression.cs
@@ -32,15 +32,10 @@ namespace Xtensive.Orm.Linq.Expressions
       }
     }
 
-    public override Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
+    public override StructureFieldExpression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
-      if (!CanRemap) {
-        return this;
-      }
-
-      if (processedExpressions.TryGetValue(this, out var value)) {
+      if (TryProcessed<StructureFieldExpression>(processedExpressions, out var value))
         return value;
-      }
 
       var newMapping = new Segment<ColNum>((ColNum) (Mapping.Offset + offset), Mapping.Length);
       var result = new StructureFieldExpression(PersistentType, Field, newMapping, OuterParameter, DefaultIfEmpty);
@@ -48,7 +43,7 @@ namespace Xtensive.Orm.Linq.Expressions
       var processedFields = new List<PersistentFieldExpression>(fields.Count);
       foreach (var field in fields) {
         // Do not convert to LINQ. We want to avoid a closure creation here.
-        processedFields.Add((PersistentFieldExpression) field.Remap(offset, processedExpressions));
+        processedFields.Add(field.Remap(offset, processedExpressions));
       }
 
       if (Owner == null) {
@@ -61,15 +56,10 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override StructureFieldExpression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
-      if (!CanRemap) {
-        return this;
-      }
-
-      if (processedExpressions.TryGetValue(this, out var value)) {
+      if (TryProcessed<StructureFieldExpression>(processedExpressions, out var value))
         return value;
-      }
 
       var result = new StructureFieldExpression(PersistentType, Field, default, OuterParameter, DefaultIfEmpty);
       processedExpressions.Add(this, result);
@@ -105,10 +95,10 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
+    public override StructureFieldExpression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
       if (processedExpressions.TryGetValue(this, out var value)) {
-        return value;
+        return (StructureFieldExpression)value;
       }
 
       var result = new StructureFieldExpression(PersistentType, Field, Mapping, OuterParameter, DefaultIfEmpty);

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/SubQueryExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/SubQueryExpression.cs
@@ -16,24 +16,23 @@ using Xtensive.Collections;
 namespace Xtensive.Orm.Linq.Expressions
 {
   [Serializable]
-  internal class SubQueryExpression : ParameterizedExpression,
-    IMappedExpression
+  internal class SubQueryExpression : ParameterizedExpression
   {
     public ProjectionExpression ProjectionExpression { get; }
 
     public ApplyParameter ApplyParameter { get; }
 
-    public virtual Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
       return this;
     }
 
-    public virtual Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
+    public override Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
     {
       return this;
     }
 
-    public virtual Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
+    public override SubQueryExpression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
     {
       // Don't check CanRemap - Remap always.
 
@@ -67,7 +66,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public virtual Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override SubQueryExpression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
     {
       // Don't check CanRemap - Remap always.
 


### PR DESCRIPTION
Also:
* use covariant return types to avoid unnecessary casting