### PR TITLE
Avoid boxing of value-type field values during reading

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 
 [*]
 charset = utf-8
-max_line_length = 120
+max_line_length = 140
 
 # Markdown Files
 [*.md]

--- a/Orm/Xtensive.Orm.Firebird/Sql.Drivers.Firebird/v2_5/TypeMapper.cs
+++ b/Orm/Xtensive.Orm.Firebird/Sql.Drivers.Firebird/v2_5/TypeMapper.cs
@@ -59,21 +59,21 @@ namespace Xtensive.Sql.Drivers.Firebird.v2_5
       return base.MapShort(length, precision, scale);
     }
 
-    public override object ReadGuid(DbDataReader reader, int index)
+    public override Guid ReadGuid(DbDataReader reader, int index)
     {
       string s = reader.GetString(index);
       if (string.IsNullOrEmpty(s))
-        return null;
+        return default;
       return SqlHelper.GuidFromString(s);
     }
 
-    public override object ReadChar(DbDataReader reader, int index)
+    public override char ReadChar(DbDataReader reader, int index)
     {
       char c = (char) base.ReadChar(reader, index);
       if (char.IsControl(c) || char.IsPunctuation(c))
         return c;
       if (char.IsWhiteSpace(c))
-        return null;
+        return '\0';
       return c;
     }
 
@@ -88,7 +88,7 @@ namespace Xtensive.Sql.Drivers.Firebird.v2_5
       parameter.Value = _char==default(char) ? string.Empty : _char.ToString();
     }
 
-    public override object ReadString(DbDataReader reader, int index)
+    public override string ReadString(DbDataReader reader, int index)
     {
       string s = (string) base.ReadString(reader, index);
       if (s!=null)

--- a/Orm/Xtensive.Orm.Firebird/Sql.Drivers.Firebird/v4_0/TypeMapper.cs
+++ b/Orm/Xtensive.Orm.Firebird/Sql.Drivers.Firebird/v4_0/TypeMapper.cs
@@ -29,7 +29,7 @@ namespace Xtensive.Sql.Drivers.Firebird.v4_0
     private static readonly BigInteger MaxDoubleAsBigInteger = new(double.MaxValue);
     private static readonly BigInteger MinDoubleAsBigInteger = new(double.MinValue);
 
-    public override object ReadInt(DbDataReader reader, int index)
+    public override int ReadInt(DbDataReader reader, int index)
     {
       var typeOfValue = reader.GetFieldType(index);
       if (typeOfValue == BigIntegerType) {
@@ -41,7 +41,7 @@ namespace Xtensive.Sql.Drivers.Firebird.v4_0
       return base.ReadInt(reader, index);
     }
 
-    public override object ReadUInt(DbDataReader reader, int index)
+    public override uint ReadUInt(DbDataReader reader, int index)
     {
       var typeOfValue = reader.GetFieldType(index);
       if (typeOfValue == BigIntegerType) {
@@ -53,7 +53,7 @@ namespace Xtensive.Sql.Drivers.Firebird.v4_0
       return base.ReadUInt(reader, index);
     }
 
-    public override object ReadLong(DbDataReader reader, int index)
+    public override long ReadLong(DbDataReader reader, int index)
     {
       var typeOfValue = reader.GetFieldType(index);
       if(typeOfValue == BigIntegerType) {
@@ -65,7 +65,7 @@ namespace Xtensive.Sql.Drivers.Firebird.v4_0
       return base.ReadLong(reader, index);
     }
 
-    public override object ReadULong(DbDataReader reader, int index)
+    public override ulong ReadULong(DbDataReader reader, int index)
     {
       var typeOfValue = reader.GetFieldType(index);
       if (typeOfValue == BigIntegerType) {
@@ -77,7 +77,7 @@ namespace Xtensive.Sql.Drivers.Firebird.v4_0
       return base.ReadULong(reader, index);
     }
 
-    public override object ReadDouble(DbDataReader reader, int index)
+    public override double ReadDouble(DbDataReader reader, int index)
     {
       var typeOfValue = reader.GetFieldType(index);
       if (typeOfValue == BigIntegerType) {

--- a/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/v5_0/TypeMapper.cs
+++ b/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/v5_0/TypeMapper.cs
@@ -112,13 +112,13 @@ namespace Xtensive.Sql.Drivers.MySql.v5_0
     }
 
     /// <inheritdoc/>
-    public override object ReadByte(DbDataReader reader, int index)
+    public override byte ReadByte(DbDataReader reader, int index)
     {
       return Convert.ToByte(reader[index]);
     }
 
     /// <inheritdoc/>
-    public override object ReadGuid(DbDataReader reader, int index)
+    public override Guid ReadGuid(DbDataReader reader, int index)
     {
       return SqlHelper.GuidFromString(reader.GetString(index));
     }

--- a/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/v09/Driver.cs
+++ b/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/v09/Driver.cs
@@ -40,7 +40,7 @@ namespace Xtensive.Sql.Drivers.Oracle.v09
     protected override void RegisterCustomMappings(TypeMappingRegistryBuilder builder)
     {
       builder.Add(typeof (DateTimeOffset),
-        builder.Mapper.ReadDateTimeOffset,
+        builder.Mapper.ReadBoxedDateTimeOffset,
         builder.Mapper.BindDateTimeOffset,
         builder.Mapper.MapDateTimeOffset);
     }

--- a/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/v09/TypeMapper.cs
+++ b/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/v09/TypeMapper.cs
@@ -138,89 +138,89 @@ namespace Xtensive.Sql.Drivers.Oracle.v09
       nativeParameter.Value = value ?? DBNull.Value;
     }
 
-    public override object ReadBoolean(DbDataReader reader, int index)
+    public override bool ReadBoolean(DbDataReader reader, int index)
     {
       //return reader.GetDecimal(index)!=0.0m;
       return Math.Abs(ReadDecimalSafely(reader, index, BooleanPrecision, 0)) > 0.3m;
     }
 
-    public override object ReadByte(DbDataReader reader, int index)
+    public override byte ReadByte(DbDataReader reader, int index)
     {
       //return (byte) reader.GetDecimal(index);
       return (byte) ReadDecimalSafely(reader, index, BytePrecision, 0);
     }
 
-    public override object ReadSByte(DbDataReader reader, int index)
+    public override sbyte ReadSByte(DbDataReader reader, int index)
     {
       //return (sbyte) reader.GetDecimal(index);
       return (sbyte) ReadDecimalSafely(reader, index, BytePrecision, 0);
     }
 
-    public override object ReadShort(DbDataReader reader, int index)
+    public override short ReadShort(DbDataReader reader, int index)
     {
       //return (short) reader.GetDecimal(index);
       return (short) ReadDecimalSafely(reader, index, ShortPrecision, 0);
     }
 
-    public override object ReadUShort(DbDataReader reader, int index)
+    public override ushort ReadUShort(DbDataReader reader, int index)
     {
       //return (ushort) reader.GetDecimal(index);
       return (ushort) ReadDecimalSafely(reader, index, ShortPrecision, 0);
     }
 
-    public override object ReadInt(DbDataReader reader, int index)
+    public override int ReadInt(DbDataReader reader, int index)
     {
       //return (int) reader.GetDecimal(index);
       return (int) ReadDecimalSafely(reader, index, IntPrecision, 0);
     }
 
-    public override object ReadUInt(DbDataReader reader, int index)
+    public override uint ReadUInt(DbDataReader reader, int index)
     {
       //return (uint) reader.GetDecimal(index);
       return (uint) ReadDecimalSafely(reader, index, IntPrecision, 0);
     }
 
-    public override object ReadLong(DbDataReader reader, int index)
+    public override long ReadLong(DbDataReader reader, int index)
     {
       //return (long) reader.GetDecimal(index);
       return (long) ReadDecimalSafely(reader, index, LongPrecision, 0);
     }
 
-    public override object ReadULong(DbDataReader reader, int index)
+    public override ulong ReadULong(DbDataReader reader, int index)
     {
       //return (ulong) reader.GetDecimal(index);
       return (ulong) ReadDecimalSafely(reader, index, LongPrecision, 0);
     }
 
-    public override object ReadDecimal(DbDataReader reader, int index)
+    public override decimal ReadDecimal(DbDataReader reader, int index)
     {
       return ReadDecimalSafely(reader, index, MaxDecimalPrecision.Value, MaxDecimalPrecision.Value / 2);
     }
 
-    public override object ReadFloat(DbDataReader reader, int index)
+    public override float ReadFloat(DbDataReader reader, int index)
     {
       return Convert.ToSingle(reader[index]);
     }
 
-    public override object ReadDouble(DbDataReader reader, int index)
+    public override double ReadDouble(DbDataReader reader, int index)
     {
       return Convert.ToDouble(reader[index]);
     }
 
-    public override object ReadDateTimeOffset(DbDataReader reader, int index)
+    public override DateTimeOffset ReadDateTimeOffset(DbDataReader reader, int index)
     {
       var nativeReader = (OracleDataReader) reader;
       var timeStampTZ = nativeReader.GetOracleTimeStampTZ(index);
       return new DateTimeOffset(timeStampTZ.Value, timeStampTZ.GetTimeZoneOffset());
     }
 
-    public override object ReadTimeSpan(DbDataReader reader, int index)
+    public override TimeSpan ReadTimeSpan(DbDataReader reader, int index)
     {
       var nativeReader = (OracleDataReader) reader;
       return (TimeSpan) nativeReader.GetOracleIntervalDS(index);
     }
     
-    public override object ReadGuid(DbDataReader reader, int index)
+    public override Guid ReadGuid(DbDataReader reader, int index)
     {
       return SqlHelper.GuidFromString(reader.GetString(index));
     }

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Driver.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Driver.cs
@@ -33,7 +33,7 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
       builder.Add(new PolygonMapper());
       builder.Add(new CircleMapper());
       builder.Add(WellKnownTypes.DateTimeOffsetType,
-        builder.Mapper.ReadDateTimeOffset,
+        builder.Mapper.ReadBoxedDateTimeOffset,
         builder.Mapper.BindDateTimeOffset,
         builder.Mapper.MapDateTimeOffset);
     }

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/TypeMapper.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/TypeMapper.cs
@@ -167,31 +167,31 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
       return new SqlValueType(SqlType.Interval);
     }
 
-    public override object ReadByte(DbDataReader reader, int index)
+    public override byte ReadByte(DbDataReader reader, int index)
     {
       return Convert.ToByte(reader[index]);
     }
 
-    public override object ReadGuid(DbDataReader reader, int index)
+    public override Guid ReadGuid(DbDataReader reader, int index)
     {
       return SqlHelper.GuidFromString(reader.GetString(index));
     }
 
     [SecuritySafeCritical]
-    public override object ReadTimeSpan(DbDataReader reader, int index)
+    public override TimeSpan ReadTimeSpan(DbDataReader reader, int index)
     {
       var nativeReader = (NpgsqlDataReader) reader;
       return (TimeSpan) nativeReader.GetInterval(index);
     }
 
-    public override object ReadDecimal(DbDataReader reader, int index)
+    public override decimal ReadDecimal(DbDataReader reader, int index)
     {
       var nativeReader = (NpgsqlDataReader) reader;
       return nativeReader.GetDecimal(index);
     }
 
     [SecuritySafeCritical]
-    public override object ReadDateTimeOffset(DbDataReader reader, int index)
+    public override DateTimeOffset ReadDateTimeOffset(DbDataReader reader, int index)
     {
       var nativeReader = (NpgsqlDataReader) reader;
       var value = nativeReader.GetFieldValue<DateTimeOffset>(index);

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_3/TypeMapper.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_3/TypeMapper.cs
@@ -18,7 +18,7 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_3
       parameter.Value = value ?? DBNull.Value;
     }
 
-    public override object ReadGuid(DbDataReader reader, int index) => reader.GetGuid(index);
+    public override Guid ReadGuid(DbDataReader reader, int index) => reader.GetGuid(index);
 
     public override SqlValueType MapGuid(int? length, int? precision, int? scale) => new SqlValueType(SqlType.Guid);
 

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v09/Driver.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v09/Driver.cs
@@ -39,7 +39,7 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
     protected override void RegisterCustomMappings(TypeMappingRegistryBuilder builder)
     {
       builder.Add(typeof (DateTimeOffset),
-        builder.Mapper.ReadDateTimeOffset,
+        builder.Mapper.ReadBoxedDateTimeOffset,
         builder.Mapper.BindDateTimeOffset,
         builder.Mapper.MapDateTimeOffset);
     }

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v09/TypeMapper.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v09/TypeMapper.cs
@@ -112,7 +112,7 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
       return new SqlValueType(SqlType.Decimal, 20, 0);
     }
 
-    public override object ReadDecimal(DbDataReader reader, int index)
+    public override decimal ReadDecimal(DbDataReader reader, int index)
     {
       var nativeReader = (SqlDataReader) reader;
       var sqlDecimal = nativeReader.GetSqlDecimal(index);
@@ -125,15 +125,13 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
       return InternalHelpers.TruncateToNetDecimal(sqlDecimal);
     }
 
-    public override object ReadDateTimeOffset(DbDataReader reader, int index)
-    {
-      return ((SqlDataReader) reader).GetDateTimeOffset(index);
-    }
+    public override DateTimeOffset ReadDateTimeOffset(DbDataReader reader, int index) =>
+      ((SqlDataReader) reader).GetDateTimeOffset(index);
 
-    public override object ReadDateOnly(DbDataReader reader, int index) =>
+    public override DateOnly ReadDateOnly(DbDataReader reader, int index) =>
       reader.GetFieldValue<DateOnly>(index);
 
-    public override object ReadTimeOnly(DbDataReader reader, int index) =>
+    public override TimeOnly ReadTimeOnly(DbDataReader reader, int index) =>
       reader.GetFieldValue<TimeOnly>(index);
 
     public override void Initialize()

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/TypeMapper.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/TypeMapper.cs
@@ -18,7 +18,7 @@ namespace Xtensive.Sql.Drivers.SqlServer.v10
       parameter.Value = value ?? DBNull.Value;
     }
 
-    public override object ReadDateTime(DbDataReader reader, int index)
+    public override DateTime ReadDateTime(DbDataReader reader, int index)
     {
       string type = reader.GetDataTypeName(index);
       if (type=="time") {

--- a/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/v3/Driver.cs
+++ b/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/v3/Driver.cs
@@ -40,7 +40,7 @@ namespace Xtensive.Sql.Drivers.Sqlite.v3
     protected override void RegisterCustomMappings(TypeMappingRegistryBuilder builder)
     {
       builder.Add(typeof (DateTimeOffset),
-        builder.Mapper.ReadDateTimeOffset,
+        builder.Mapper.ReadBoxedDateTimeOffset,
         builder.Mapper.BindDateTimeOffset,
         builder.Mapper.MapDateTimeOffset);
     }

--- a/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/v3/TypeMapper.cs
+++ b/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/v3/TypeMapper.cs
@@ -26,25 +26,25 @@ namespace Xtensive.Sql.Drivers.Sqlite.v3
     private const string DateFormat = "yyyy-MM-dd";
     private const string TimeFormat = "HH:mm:ss.fffffff";
 
-    public override object ReadBoolean(DbDataReader reader, int index)
+    public override bool ReadBoolean(DbDataReader reader, int index)
     {
       var value = reader.GetDecimal(index);
       return SQLiteConvert.ToBoolean(value);
     }
 
-    public override object ReadDateOnly(DbDataReader reader, int index)
+    public override DateOnly ReadDateOnly(DbDataReader reader, int index)
     {
       var value = reader.GetString(index);
       return DateOnly.ParseExact(value, DateFormat, CultureInfo.InvariantCulture);
     }
 
-    public override object ReadTimeOnly(DbDataReader reader, int index)
+    public override TimeOnly ReadTimeOnly(DbDataReader reader, int index)
     {
       var value = reader.GetString(index);
       return TimeOnly.ParseExact(value, TimeFormat, CultureInfo.InvariantCulture);
     }
 
-    public override object ReadDateTimeOffset(DbDataReader reader, int index)
+    public override DateTimeOffset ReadDateTimeOffset(DbDataReader reader, int index)
     {
       var value = reader.GetString(index);
       return DateTimeOffset.ParseExact(value, DateTimeOffsetFormat, CultureInfo.InvariantCulture);

--- a/Orm/Xtensive.Orm/Orm/Providers/DbDataReaderAccessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/DbDataReaderAccessor.cs
@@ -4,6 +4,7 @@
 // Created by: Dmitri Maximov
 // Created:    2008.09.30
 
+using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
@@ -19,6 +20,7 @@ namespace Xtensive.Orm.Providers
   public sealed class DbDataReaderAccessor
   {
     private readonly TypeMapper mapper;
+    private readonly Func<DbDataReader, int, object>[] readers;
 
     public TupleDescriptor Descriptor { get; private set; }
 
@@ -26,17 +28,18 @@ namespace Xtensive.Orm.Providers
     {
       var target = Tuple.Create(Descriptor);
       for (int i = 0, n = Descriptor.Count; i < n; ++i) {
-        target.SetValueFromDataReader(i, source, mapper);
+        target.SetValueFromDataReader(new(mapper, readers[i], source, i));
       }
       return target;
     }
 
     // Constructors
 
-    internal DbDataReaderAccessor(in TupleDescriptor descriptor, TypeMapper mapper)
+    internal DbDataReaderAccessor(in TupleDescriptor descriptor, TypeMapper mapper, Func<DbDataReader, int, object>[] readers)
     {
       Descriptor = descriptor;
       this.mapper = mapper;
+      this.readers = readers;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/DbDataReaderAccessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/DbDataReaderAccessor.cs
@@ -18,28 +18,25 @@ namespace Xtensive.Orm.Providers
   /// </summary>
   public sealed class DbDataReaderAccessor
   {
-    private readonly TypeMapping[] mappings;
+    private readonly TypeMapper mapper;
 
     public TupleDescriptor Descriptor { get; private set; }
 
     public Tuple Read(DbDataReader source)
     {
       var target = Tuple.Create(Descriptor);
-      for (int i = 0; i < mappings.Length; i++) {
-        var value = !source.IsDBNull(i)
-          ? mappings[i].ReadValue(source, i)
-          : null;
-        target.SetValue(i, value);
+      for (int i = 0, n = Descriptor.Count; i < n; ++i) {
+        target.SetValueFromDataReader(i, source, mapper);
       }
       return target;
     }
 
     // Constructors
 
-    internal DbDataReaderAccessor(in TupleDescriptor descriptor, IEnumerable<TypeMapping> mappings)
+    internal DbDataReaderAccessor(in TupleDescriptor descriptor, TypeMapper mapper)
     {
       Descriptor = descriptor;
-      this.mappings = mappings.ToArray();
+      this.mapper = mapper;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
@@ -94,7 +95,11 @@ namespace Xtensive.Orm.Providers
 
     public DbDataReaderAccessor GetDataReaderAccessor(in TupleDescriptor descriptor)
     {
-      return new DbDataReaderAccessor(descriptor, allMappings.Mapper);
+      var readers = new Func<DbDataReader, int, object>[descriptor.Count];
+      for (int i = 0, n = descriptor.Count; i < n; ++i) {
+        readers[i] = GetTypeMapping(descriptor[i]).ValueReader;
+      }
+      return new DbDataReaderAccessor(descriptor, allMappings.Mapper, readers);
     }
 
     public StorageDriver CreateNew(Domain domain)

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
@@ -94,7 +94,7 @@ namespace Xtensive.Orm.Providers
 
     public DbDataReaderAccessor GetDataReaderAccessor(in TupleDescriptor descriptor)
     {
-      return new DbDataReaderAccessor(descriptor, descriptor.Select(GetTypeMapping));
+      return new DbDataReaderAccessor(descriptor, allMappings.Mapper);
     }
 
     public StorageDriver CreateNew(Domain domain)

--- a/Orm/Xtensive.Orm/Sql/SqlDriver.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlDriver.cs
@@ -405,26 +405,26 @@ namespace Xtensive.Sql
     {
       var mapper = builder.Mapper;
 
-      builder.Add(WellKnownTypes.Bool, mapper.ReadBoolean, mapper.BindBoolean, mapper.MapBoolean);
-      builder.Add(WellKnownTypes.Char, mapper.ReadChar, mapper.BindChar, mapper.MapChar);
+      builder.Add(WellKnownTypes.Bool, mapper.ReadBoxedBoolean, mapper.BindBoolean, mapper.MapBoolean);
+      builder.Add(WellKnownTypes.Char, mapper.ReadBoxedChar, mapper.BindChar, mapper.MapChar);
       builder.Add(WellKnownTypes.String, mapper.ReadString, mapper.BindString, mapper.MapString);
-      builder.Add(WellKnownTypes.Byte, mapper.ReadByte, mapper.BindByte, mapper.MapByte);
-      builder.Add(WellKnownTypes.SByte, mapper.ReadSByte, mapper.BindSByte, mapper.MapSByte);
-      builder.Add(WellKnownTypes.Int16, mapper.ReadShort, mapper.BindShort, mapper.MapShort);
-      builder.Add(WellKnownTypes.UInt16, mapper.ReadUShort, mapper.BindUShort, mapper.MapUShort);
-      builder.Add(WellKnownTypes.Int32, mapper.ReadInt, mapper.BindInt, mapper.MapInt);
-      builder.Add(WellKnownTypes.UInt32, mapper.ReadUInt, mapper.BindUInt, mapper.MapUInt);
-      builder.Add(WellKnownTypes.Int64, mapper.ReadLong, mapper.BindLong, mapper.MapLong);
-      builder.Add(WellKnownTypes.UInt64, mapper.ReadULong, mapper.BindULong, mapper.MapULong);
-      builder.Add(WellKnownTypes.Single, mapper.ReadFloat, mapper.BindFloat, mapper.MapFloat);
-      builder.Add(WellKnownTypes.Double, mapper.ReadDouble, mapper.BindDouble, mapper.MapDouble);
-      builder.Add(WellKnownTypes.Decimal, mapper.ReadDecimal, mapper.BindDecimal, mapper.MapDecimal);
-      builder.Add(WellKnownTypes.DateTime, mapper.ReadDateTime, mapper.BindDateTime, mapper.MapDateTime);
-      builder.Add(WellKnownTypes.TimeSpan, mapper.ReadTimeSpan, mapper.BindTimeSpan, mapper.MapTimeSpan);
-      builder.Add(WellKnownTypes.Guid, mapper.ReadGuid, mapper.BindGuid, mapper.MapGuid);
+      builder.Add(WellKnownTypes.Byte, mapper.ReadBoxedByte, mapper.BindByte, mapper.MapByte);
+      builder.Add(WellKnownTypes.SByte, mapper.ReadBoxedSByte, mapper.BindSByte, mapper.MapSByte);
+      builder.Add(WellKnownTypes.Int16, mapper.ReadBoxedShort, mapper.BindShort, mapper.MapShort);
+      builder.Add(WellKnownTypes.UInt16, mapper.ReadBoxedUShort, mapper.BindUShort, mapper.MapUShort);
+      builder.Add(WellKnownTypes.Int32, mapper.ReadBoxedInt, mapper.BindInt, mapper.MapInt);
+      builder.Add(WellKnownTypes.UInt32, mapper.ReadBoxedUInt, mapper.BindUInt, mapper.MapUInt);
+      builder.Add(WellKnownTypes.Int64, mapper.ReadBoxedLong, mapper.BindLong, mapper.MapLong);
+      builder.Add(WellKnownTypes.UInt64, mapper.ReadBoxedULong, mapper.BindULong, mapper.MapULong);
+      builder.Add(WellKnownTypes.Single, mapper.ReadBoxedFloat, mapper.BindFloat, mapper.MapFloat);
+      builder.Add(WellKnownTypes.Double, mapper.ReadBoxedDouble, mapper.BindDouble, mapper.MapDouble);
+      builder.Add(WellKnownTypes.Decimal, mapper.ReadBoxedDecimal, mapper.BindDecimal, mapper.MapDecimal);
+      builder.Add(WellKnownTypes.DateTime, mapper.ReadBoxedDateTime, mapper.BindDateTime, mapper.MapDateTime);
+      builder.Add(WellKnownTypes.TimeSpan, mapper.ReadBoxedTimeSpan, mapper.BindTimeSpan, mapper.MapTimeSpan);
+      builder.Add(WellKnownTypes.Guid, mapper.ReadBoxedGuid, mapper.BindGuid, mapper.MapGuid);
       builder.Add(WellKnownTypes.ByteArray, mapper.ReadByteArray, mapper.BindByteArray, mapper.MapByteArray);
-      builder.Add(WellKnownTypes.DateOnly, mapper.ReadDateOnly, mapper.BindDateOnly, mapper.MapDateOnly);
-      builder.Add(WellKnownTypes.TimeOnly, mapper.ReadTimeOnly, mapper.BindTimeOnly, mapper.MapTimeOnly);
+      builder.Add(WellKnownTypes.DateOnly, mapper.ReadBoxedDateOnly, mapper.BindDateOnly, mapper.MapDateOnly);
+      builder.Add(WellKnownTypes.TimeOnly, mapper.ReadBoxedTimeOnly, mapper.BindTimeOnly, mapper.MapTimeOnly);
     }
 
     private static void RegisterStandardReverseMappings(TypeMappingRegistryBuilder builder)

--- a/Orm/Xtensive.Orm/Sql/ValueTypeMapping/TypeMapper.cs
+++ b/Orm/Xtensive.Orm/Sql/ValueTypeMapping/TypeMapper.cs
@@ -376,4 +376,11 @@ namespace Xtensive.Sql
       Driver = driver;
     }
   }
+
+  public readonly record struct MapperReader(
+    TypeMapper Mapper,
+    Func<DbDataReader, int, object> Reader,
+    DbDataReader DbDataReader,
+    int FieldIndex
+  );
 }

--- a/Orm/Xtensive.Orm/Sql/ValueTypeMapping/TypeMapper.cs
+++ b/Orm/Xtensive.Orm/Sql/ValueTypeMapping/TypeMapper.cs
@@ -177,61 +177,60 @@ namespace Xtensive.Sql
 
     #region ReadXxx methods
 
-    public virtual object ReadBoolean(DbDataReader reader, int index) =>
-      reader.GetBoolean(index);
+    public virtual bool ReadBoolean(DbDataReader reader, int index) => reader.GetBoolean(index);
+    public object ReadBoxedBoolean(DbDataReader reader, int index) => ReadBoolean(reader, index);
 
-    public virtual object ReadChar(DbDataReader reader, int index) =>
-      reader.GetString(index).SingleOrDefault();
+    public virtual char ReadChar(DbDataReader reader, int index) => reader.GetString(index).SingleOrDefault();
+    public object ReadBoxedChar(DbDataReader reader, int index) => ReadChar(reader, index);
 
-    public virtual object ReadString(DbDataReader reader, int index) =>
-      reader.GetString(index);
+    public virtual string ReadString(DbDataReader reader, int index) => reader.GetString(index);
 
-    public virtual object ReadByte(DbDataReader reader, int index) =>
-      reader.GetByte(index);
+    public virtual byte ReadByte(DbDataReader reader, int index) => reader.GetByte(index);
+    public object ReadBoxedByte(DbDataReader reader, int index) => ReadByte(reader, index);
 
-    public virtual object ReadSByte(DbDataReader reader, int index) =>
-      Convert.ToSByte(reader[index]);
+    public virtual sbyte ReadSByte(DbDataReader reader, int index) => Convert.ToSByte(reader[index]);
+    public object ReadBoxedSByte(DbDataReader reader, int index) => ReadSByte(reader, index);
 
-    public virtual object ReadShort(DbDataReader reader, int index) =>
-      reader.GetInt16(index);
+    public virtual short ReadShort(DbDataReader reader, int index) => reader.GetInt16(index);
+    public object ReadBoxedShort(DbDataReader reader, int index) => ReadShort(reader, index);
 
-    public virtual object ReadUShort(DbDataReader reader, int index) =>
-      Convert.ToUInt16(reader[index]);
+    public virtual ushort ReadUShort(DbDataReader reader, int index) => Convert.ToUInt16(reader[index]);
+    public object ReadBoxedUShort(DbDataReader reader, int index) => ReadUShort(reader, index);
 
-    public virtual object ReadInt(DbDataReader reader, int index) =>
-      reader.GetInt32(index);
+    public virtual int ReadInt(DbDataReader reader, int index) => reader.GetInt32(index);
+    public object ReadBoxedInt(DbDataReader reader, int index) => ReadInt(reader, index);
 
-    public virtual object ReadUInt(DbDataReader reader, int index) =>
-      Convert.ToUInt32(reader[index]);
+    public virtual uint ReadUInt(DbDataReader reader, int index) => Convert.ToUInt32(reader[index]);
+    public object ReadBoxedUInt(DbDataReader reader, int index) => ReadUInt(reader, index);
 
-    public virtual object ReadLong(DbDataReader reader, int index) =>
-      reader.GetInt64(index);
+    public virtual long ReadLong(DbDataReader reader, int index) => reader.GetInt64(index);
+    public object ReadBoxedLong(DbDataReader reader, int index) => ReadLong(reader, index);
 
-    public virtual object ReadULong(DbDataReader reader, int index) =>
-      Convert.ToUInt64(reader[index]);
+    public virtual ulong ReadULong(DbDataReader reader, int index) => Convert.ToUInt64(reader[index]);
+    public object ReadBoxedULong(DbDataReader reader, int index) => ReadULong(reader, index);
 
-    public virtual object ReadFloat(DbDataReader reader, int index) =>
-      reader.GetFloat(index);
+    public virtual float ReadFloat(DbDataReader reader, int index) => reader.GetFloat(index);
+    public object ReadBoxedFloat(DbDataReader reader, int index) => ReadFloat(reader, index);
 
-    public virtual object ReadDouble(DbDataReader reader, int index) =>
-      reader.GetDouble(index);
+    public virtual double ReadDouble(DbDataReader reader, int index) => reader.GetDouble(index);
+    public object ReadBoxedDouble(DbDataReader reader, int index) => ReadDouble(reader, index);
 
-    public virtual object ReadDecimal(DbDataReader reader, int index) =>
-      reader.GetDecimal(index);
+    public virtual decimal ReadDecimal(DbDataReader reader, int index) => reader.GetDecimal(index);
+    public object ReadBoxedDecimal(DbDataReader reader, int index) => ReadDecimal(reader, index);
 
-    public virtual object ReadDateTime(DbDataReader reader, int index) =>
-      reader.GetDateTime(index);
+    public virtual DateTime ReadDateTime(DbDataReader reader, int index) => reader.GetDateTime(index);
+    public object ReadBoxedDateTime(DbDataReader reader, int index) => ReadDateTime(reader, index);
 
-    public virtual object ReadDateOnly(DbDataReader reader, int index) =>
-        DateOnly.FromDateTime(reader.GetFieldValue<DateTime>(index));
+    public virtual DateOnly ReadDateOnly(DbDataReader reader, int index) => DateOnly.FromDateTime(reader.GetFieldValue<DateTime>(index));
+    public object ReadBoxedDateOnly(DbDataReader reader, int index) => ReadDateOnly(reader, index);
 
-    public virtual object ReadTimeOnly(DbDataReader reader, int index) =>
-      TimeOnly.FromTimeSpan(reader.GetFieldValue<TimeSpan>(index));
+    public virtual TimeOnly ReadTimeOnly(DbDataReader reader, int index) => TimeOnly.FromTimeSpan(reader.GetFieldValue<TimeSpan>(index));
+    public object ReadBoxedTimeOnly(DbDataReader reader, int index) => ReadTimeOnly(reader, index);
 
-    public virtual object ReadDateTimeOffset(DbDataReader reader, int index) =>
-      (DateTimeOffset) reader.GetValue(index);
+    public virtual DateTimeOffset ReadDateTimeOffset(DbDataReader reader, int index) => (DateTimeOffset) reader.GetValue(index);
+    public object ReadBoxedDateTimeOffset(DbDataReader reader, int index) => ReadDateTimeOffset(reader, index);
 
-    public virtual object ReadTimeSpan(DbDataReader reader, int index)
+    public virtual TimeSpan ReadTimeSpan(DbDataReader reader, int index)
     {
       long value;
       try {
@@ -242,17 +241,17 @@ namespace Xtensive.Sql
       }
       return TimeSpan.FromTicks(value / 100);
     }
+    public object ReadBoxedTimeSpan(DbDataReader reader, int index) => ReadTimeSpan(reader, index);
 
-    public virtual object ReadGuid(DbDataReader reader, int index) =>
-      reader.GetGuid(index);
+    public virtual Guid ReadGuid(DbDataReader reader, int index) => reader.GetGuid(index);
+    public object ReadBoxedGuid(DbDataReader reader, int index) => ReadGuid(reader, index);
 
-    public virtual object ReadByteArray(DbDataReader reader, int index)
-    {
-      var value = reader[index];
-      if (value == null || value is byte[])
-        return value;
-
-      throw new NotSupportedException("There is no support of SqlGeometry, SqlGeography, or other complex SQL types to the moment");
+    public virtual byte[] ReadByteArray(DbDataReader reader, int index) =>
+      reader[index] switch {
+        null => null,
+        byte[] bytes => bytes,
+        _ => throw new NotSupportedException("There is no support of SqlGeometry, SqlGeography, or other complex SQL types to the moment")
+      };
       // As far as SqlGeometry and SqlGeography have no support in .Net 5
       // we don't need to provide a functionality reading those data as byte arrays
 
@@ -260,7 +259,6 @@ namespace Xtensive.Sql
       // var stream = new MemoryStream();
       // formatter.Serialize(stream, value);
       // return stream.ToArray();
-    }
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Sql/ValueTypeMapping/TypeMapping.cs
+++ b/Orm/Xtensive.Orm/Sql/ValueTypeMapping/TypeMapping.cs
@@ -14,7 +14,7 @@ namespace Xtensive.Sql
   /// </summary>
   public sealed class TypeMapping
   {
-    private readonly Func<DbDataReader, int, object> valueReader;
+    public Func<DbDataReader, int, object> ValueReader { get; }
     private readonly Action<DbParameter, object> valueBinder;
     private readonly Func<int?, int?, int?, SqlValueType> mapper;
 
@@ -23,7 +23,7 @@ namespace Xtensive.Sql
 
     public object ReadValue(DbDataReader reader, int index)
     {
-      return valueReader.Invoke(reader, index);
+      return ValueReader.Invoke(reader, index);
     }
 
     public void BindValue(DbParameter parameter, object value)
@@ -52,7 +52,7 @@ namespace Xtensive.Sql
     {
       Type = type;
 
-      this.valueReader = valueReader;
+      ValueReader = valueReader;
       this.valueBinder = valueBinder;
       this.mapper = mapper;
 

--- a/Orm/Xtensive.Orm/Sql/ValueTypeMapping/TypeMappingRegistry.cs
+++ b/Orm/Xtensive.Orm/Sql/ValueTypeMapping/TypeMappingRegistry.cs
@@ -19,6 +19,7 @@ namespace Xtensive.Sql
   {
     public IReadOnlyDictionary<Type, TypeMapping> Mappings { get; private set; }
     public IReadOnlyDictionary<SqlType, Type> ReverseMappings { get; private set; }
+    public TypeMapper Mapper { get; }
 
     public TypeMapping this[Type type] { get { return GetMapping(type); } }
     
@@ -57,10 +58,11 @@ namespace Xtensive.Sql
 
     // Constructors
 
-    public TypeMappingRegistry(IEnumerable<TypeMapping> mappings, IEnumerable<KeyValuePair<SqlType, Type>> reverseMappings)
+    public TypeMappingRegistry(IEnumerable<TypeMapping> mappings, IEnumerable<KeyValuePair<SqlType, Type>> reverseMappings, TypeMapper mapper)
     {
       Mappings = new ReadOnlyDictionary<Type, TypeMapping>(mappings.ToDictionary(m => m.Type));
       ReverseMappings = new ReadOnlyDictionary<SqlType, Type>(reverseMappings.ToDictionary(r => r.Key, r => r.Value));
+      Mapper = mapper;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Sql/ValueTypeMapping/TypeMappingRegistryBuilder.cs
+++ b/Orm/Xtensive.Orm/Sql/ValueTypeMapping/TypeMappingRegistryBuilder.cs
@@ -49,7 +49,7 @@ namespace Xtensive.Sql
 
     public TypeMappingRegistry Build()
     {
-      return new TypeMappingRegistry(mappings, reverseMappings);
+      return new TypeMappingRegistry(mappings, reverseMappings, Mapper);
     }
 
     // Constructors

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
@@ -50,7 +50,7 @@ namespace Xtensive.Tuples.Packed
       }
     }
 
-    public virtual void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
+    public virtual void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
       throw new NotSupportedException($"{this} does not support reading from DbDataReader");
 
     public T GetValue<T>(PackedTuple tuple, in PackedFieldDescriptor descriptor, bool isNullable, out TupleFieldState fieldState)
@@ -121,6 +121,9 @@ namespace Xtensive.Tuples.Packed
       tuple.Objects[descriptor.GetObjectIndex()] = value;
       tuple.SetFieldState(descriptor, value != null ? TupleFieldState.Available : (TupleFieldState.Available | TupleFieldState.Null));
     }
+
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+      SetUntypedValue(tuple, descriptor, mr.Reader(mr.DbDataReader, mr.FieldIndex));
 
     public override void CopyValue(PackedTuple source, in PackedFieldDescriptor sourceDescriptor,
       PackedTuple target, in PackedFieldDescriptor targetDescriptor)
@@ -280,8 +283,8 @@ namespace Xtensive.Tuples.Packed
       return value != 0;
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
-      SetValue(tuple, descriptor, mapper.ReadBoolean(reader, fieldIndex));
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+      SetValue(tuple, descriptor, mr.Mapper.ReadBoolean(mr.DbDataReader, mr.FieldIndex));
 
     public BooleanFieldAccessor()
       : base(1, 2)
@@ -306,8 +309,8 @@ namespace Xtensive.Tuples.Packed
       }
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
-      SetValue(tuple, descriptor, mapper.ReadFloat(reader, fieldIndex));
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+      SetValue(tuple, descriptor, mr.Mapper.ReadFloat(mr.DbDataReader, mr.FieldIndex));
 
     public FloatFieldAccessor()
       : base(sizeof(float) * 8, 3)
@@ -327,8 +330,8 @@ namespace Xtensive.Tuples.Packed
       return BitConverter.Int64BitsToDouble(value);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
-      SetValue(tuple, descriptor, mapper.ReadDouble(reader, fieldIndex));
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+      SetValue(tuple, descriptor, mr.Mapper.ReadDouble(mr.DbDataReader, mr.FieldIndex));
 
     public DoubleFieldAccessor()
       : base(sizeof(double) * 8, 4)
@@ -348,8 +351,8 @@ namespace Xtensive.Tuples.Packed
       return TimeSpan.FromTicks(value);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
-      SetValue(tuple, descriptor, mapper.ReadTimeSpan(reader, fieldIndex));
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+      SetValue(tuple, descriptor, mr.Mapper.ReadTimeSpan(mr.DbDataReader, mr.FieldIndex));
 
     public TimeSpanFieldAccessor()
       : base(sizeof(long) * 8, 5)
@@ -369,8 +372,8 @@ namespace Xtensive.Tuples.Packed
       return DateTime.FromBinary(value);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
-      SetValue(tuple, descriptor, mapper.ReadDateTime(reader, fieldIndex));
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+      SetValue(tuple, descriptor, mr.Mapper.ReadDateTime(mr.DbDataReader, mr.FieldIndex));
 
     public DateTimeFieldAccessor()
       : base(sizeof(long) * 8, 6)
@@ -390,8 +393,8 @@ namespace Xtensive.Tuples.Packed
       return unchecked((byte) value);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
-      SetValue(tuple, descriptor, mapper.ReadByte(reader, fieldIndex));
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+      SetValue(tuple, descriptor, mr.Mapper.ReadByte(mr.DbDataReader, mr.FieldIndex));
 
     public ByteFieldAccessor()
       : base(sizeof(byte) * 8, 7)
@@ -411,8 +414,8 @@ namespace Xtensive.Tuples.Packed
       return unchecked((sbyte) value);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
-      SetValue(tuple, descriptor, mapper.ReadSByte(reader, fieldIndex));
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+      SetValue(tuple, descriptor, mr.Mapper.ReadSByte(mr.DbDataReader, mr.FieldIndex));
 
     public SByteFieldAccessor()
       : base(sizeof(sbyte) * 8, 8)
@@ -432,8 +435,8 @@ namespace Xtensive.Tuples.Packed
       return unchecked((short) value);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
-      SetValue(tuple, descriptor, mapper.ReadShort(reader, fieldIndex));
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+      SetValue(tuple, descriptor, mr.Mapper.ReadShort(mr.DbDataReader, mr.FieldIndex));
 
     public ShortFieldAccessor()
       : base(sizeof(short) * 8, 9)
@@ -453,8 +456,8 @@ namespace Xtensive.Tuples.Packed
       return unchecked((ushort) value);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
-      SetValue(tuple, descriptor, mapper.ReadUShort(reader, fieldIndex));
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+      SetValue(tuple, descriptor, mr.Mapper.ReadUShort(mr.DbDataReader, mr.FieldIndex));
 
     public UShortFieldAccessor()
       : base(sizeof(ushort) * 8, 10)
@@ -474,8 +477,8 @@ namespace Xtensive.Tuples.Packed
       return unchecked((int) value);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
-      SetValue(tuple, descriptor, mapper.ReadInt(reader, fieldIndex));
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+      SetValue(tuple, descriptor, mr.Mapper.ReadInt(mr.DbDataReader, mr.FieldIndex));
 
     public IntFieldAccessor()
       : base(sizeof(int) * 8, 11)
@@ -495,8 +498,8 @@ namespace Xtensive.Tuples.Packed
       return unchecked((uint) value);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
-      SetValue(tuple, descriptor, mapper.ReadUInt(reader, fieldIndex));
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+      SetValue(tuple, descriptor, mr.Mapper.ReadUInt(mr.DbDataReader, mr.FieldIndex));
 
     public UIntFieldAccessor()
       : base(sizeof(uint) * 8, 12)
@@ -516,8 +519,8 @@ namespace Xtensive.Tuples.Packed
       return value;
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
-      SetValue(tuple, descriptor, mapper.ReadLong(reader, fieldIndex));
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+      SetValue(tuple, descriptor, mr.Mapper.ReadLong(mr.DbDataReader, mr.FieldIndex));
 
     public LongFieldAccessor()
       : base(sizeof(long) * 8, 13)
@@ -537,8 +540,8 @@ namespace Xtensive.Tuples.Packed
       return unchecked((ulong) value);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
-      SetValue(tuple, descriptor, mapper.ReadULong(reader, fieldIndex));
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+      SetValue(tuple, descriptor, mr.Mapper.ReadULong(mr.DbDataReader, mr.FieldIndex));
 
     public ULongFieldAccessor()
       : base(sizeof(ulong) * 8, 14)
@@ -569,8 +572,8 @@ namespace Xtensive.Tuples.Packed
       return sizeof(Guid);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
-      SetValue(tuple, descriptor, mapper.ReadGuid(reader, fieldIndex));
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+      SetValue(tuple, descriptor, mr.Mapper.ReadGuid(mr.DbDataReader, mr.FieldIndex));
 
     public GuidFieldAccessor()
       : base(GetSize() * 8, 15)
@@ -596,8 +599,8 @@ namespace Xtensive.Tuples.Packed
       }
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
-      SetValue(tuple, descriptor, mapper.ReadDecimal(reader, fieldIndex));
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+      SetValue(tuple, descriptor, mr.Mapper.ReadDecimal(mr.DbDataReader, mr.FieldIndex));
 
     public DecimalFieldAccessor()
       : base(sizeof(decimal) * 8, 16)
@@ -632,8 +635,8 @@ namespace Xtensive.Tuples.Packed
       return sizeof(long) * 2;
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
-      SetValue(tuple, descriptor, mapper.ReadDateTimeOffset(reader, fieldIndex));
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+      SetValue(tuple, descriptor, mr.Mapper.ReadDateTimeOffset(mr.DbDataReader, mr.FieldIndex));
 
     public DateTimeOffsetFieldAccessor()
        : base(GetSize() * 8, 17)
@@ -648,8 +651,8 @@ namespace Xtensive.Tuples.Packed
     protected override long Encode(DateOnly value) =>
       value.DayNumber;
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
-      SetValue(tuple, descriptor, mapper.ReadDateOnly(reader, fieldIndex));
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+      SetValue(tuple, descriptor, mr.Mapper.ReadDateOnly(mr.DbDataReader, mr.FieldIndex));
 
     public DateOnlyFieldAccessor()
        : base(sizeof(int) * 8, 18)
@@ -664,8 +667,8 @@ namespace Xtensive.Tuples.Packed
     protected override long Encode(TimeOnly value) =>
       value.Ticks;
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
-      SetValue(tuple, descriptor, mapper.ReadTimeOnly(reader, fieldIndex));
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+      SetValue(tuple, descriptor, mr.Mapper.ReadTimeOnly(mr.DbDataReader, mr.FieldIndex));
 
     public TimeOnlyFieldAccessor()
        : base(sizeof(long) * 8, 19)

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
@@ -6,6 +6,8 @@
 
 using System;
 using System.Numerics;
+using System.Data.Common;
+using Xtensive.Sql;
 
 namespace Xtensive.Tuples.Packed
 {
@@ -47,6 +49,9 @@ namespace Xtensive.Tuples.Packed
         SetUntypedValue(tuple, descriptor, value);
       }
     }
+
+    public virtual void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
+      throw new NotSupportedException($"{this} does not support reading from DbDataReader");
 
     public T GetValue<T>(PackedTuple tuple, in PackedFieldDescriptor descriptor, bool isNullable, out TupleFieldState fieldState)
     {
@@ -208,7 +213,7 @@ namespace Xtensive.Tuples.Packed
       return fieldState == TupleFieldState.Available ? Load(tuple, descriptor) : NullValue;
     }
 
-    private void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, T value)
+    protected void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, T value)
     {
       Store(tuple, descriptor, value);
       tuple.SetFieldState(descriptor, TupleFieldState.Available);
@@ -275,6 +280,9 @@ namespace Xtensive.Tuples.Packed
       return value != 0;
     }
 
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
+      SetValue(tuple, descriptor, mapper.ReadBoolean(reader, fieldIndex));
+
     public BooleanFieldAccessor()
       : base(1, 2)
     {
@@ -298,6 +306,9 @@ namespace Xtensive.Tuples.Packed
       }
     }
 
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
+      SetValue(tuple, descriptor, mapper.ReadFloat(reader, fieldIndex));
+
     public FloatFieldAccessor()
       : base(sizeof(float) * 8, 3)
     {
@@ -315,6 +326,9 @@ namespace Xtensive.Tuples.Packed
     {
       return BitConverter.Int64BitsToDouble(value);
     }
+
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
+      SetValue(tuple, descriptor, mapper.ReadDouble(reader, fieldIndex));
 
     public DoubleFieldAccessor()
       : base(sizeof(double) * 8, 4)
@@ -334,6 +348,9 @@ namespace Xtensive.Tuples.Packed
       return TimeSpan.FromTicks(value);
     }
 
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
+      SetValue(tuple, descriptor, mapper.ReadTimeSpan(reader, fieldIndex));
+
     public TimeSpanFieldAccessor()
       : base(sizeof(long) * 8, 5)
     {
@@ -351,6 +368,9 @@ namespace Xtensive.Tuples.Packed
     {
       return DateTime.FromBinary(value);
     }
+
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
+      SetValue(tuple, descriptor, mapper.ReadDateTime(reader, fieldIndex));
 
     public DateTimeFieldAccessor()
       : base(sizeof(long) * 8, 6)
@@ -370,6 +390,9 @@ namespace Xtensive.Tuples.Packed
       return unchecked((byte) value);
     }
 
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
+      SetValue(tuple, descriptor, mapper.ReadByte(reader, fieldIndex));
+
     public ByteFieldAccessor()
       : base(sizeof(byte) * 8, 7)
     {
@@ -387,6 +410,9 @@ namespace Xtensive.Tuples.Packed
     {
       return unchecked((sbyte) value);
     }
+
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
+      SetValue(tuple, descriptor, mapper.ReadSByte(reader, fieldIndex));
 
     public SByteFieldAccessor()
       : base(sizeof(sbyte) * 8, 8)
@@ -406,6 +432,9 @@ namespace Xtensive.Tuples.Packed
       return unchecked((short) value);
     }
 
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
+      SetValue(tuple, descriptor, mapper.ReadShort(reader, fieldIndex));
+
     public ShortFieldAccessor()
       : base(sizeof(short) * 8, 9)
     {
@@ -423,6 +452,9 @@ namespace Xtensive.Tuples.Packed
     {
       return unchecked((ushort) value);
     }
+
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
+      SetValue(tuple, descriptor, mapper.ReadUShort(reader, fieldIndex));
 
     public UShortFieldAccessor()
       : base(sizeof(ushort) * 8, 10)
@@ -442,6 +474,9 @@ namespace Xtensive.Tuples.Packed
       return unchecked((int) value);
     }
 
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
+      SetValue(tuple, descriptor, mapper.ReadInt(reader, fieldIndex));
+
     public IntFieldAccessor()
       : base(sizeof(int) * 8, 11)
     {
@@ -459,6 +494,9 @@ namespace Xtensive.Tuples.Packed
     {
       return unchecked((uint) value);
     }
+
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
+      SetValue(tuple, descriptor, mapper.ReadUInt(reader, fieldIndex));
 
     public UIntFieldAccessor()
       : base(sizeof(uint) * 8, 12)
@@ -478,6 +516,9 @@ namespace Xtensive.Tuples.Packed
       return value;
     }
 
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
+      SetValue(tuple, descriptor, mapper.ReadLong(reader, fieldIndex));
+
     public LongFieldAccessor()
       : base(sizeof(long) * 8, 13)
     {
@@ -495,6 +536,9 @@ namespace Xtensive.Tuples.Packed
     {
       return unchecked((ulong) value);
     }
+
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
+      SetValue(tuple, descriptor, mapper.ReadULong(reader, fieldIndex));
 
     public ULongFieldAccessor()
       : base(sizeof(ulong) * 8, 14)
@@ -525,6 +569,9 @@ namespace Xtensive.Tuples.Packed
       return sizeof(Guid);
     }
 
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
+      SetValue(tuple, descriptor, mapper.ReadGuid(reader, fieldIndex));
+
     public GuidFieldAccessor()
       : base(GetSize() * 8, 15)
     {
@@ -548,6 +595,10 @@ namespace Xtensive.Tuples.Packed
           *(decimal*) valuePtr = value;
       }
     }
+
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
+      SetValue(tuple, descriptor, mapper.ReadDecimal(reader, fieldIndex));
+
     public DecimalFieldAccessor()
       : base(sizeof(decimal) * 8, 16)
     {
@@ -581,6 +632,9 @@ namespace Xtensive.Tuples.Packed
       return sizeof(long) * 2;
     }
 
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
+      SetValue(tuple, descriptor, mapper.ReadDateTimeOffset(reader, fieldIndex));
+
     public DateTimeOffsetFieldAccessor()
        : base(GetSize() * 8, 17)
     { }
@@ -594,6 +648,9 @@ namespace Xtensive.Tuples.Packed
     protected override long Encode(DateOnly value) =>
       value.DayNumber;
 
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
+      SetValue(tuple, descriptor, mapper.ReadDateOnly(reader, fieldIndex));
+
     public DateOnlyFieldAccessor()
        : base(sizeof(int) * 8, 18)
     { }
@@ -606,6 +663,9 @@ namespace Xtensive.Tuples.Packed
 
     protected override long Encode(TimeOnly value) =>
       value.Ticks;
+
+    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, int fieldIndex, TypeMapper mapper, DbDataReader reader) =>
+      SetValue(tuple, descriptor, mapper.ReadTimeOnly(reader, fieldIndex));
 
     public TimeOnlyFieldAccessor()
        : base(sizeof(long) * 8, 19)

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
@@ -5,6 +5,8 @@
 // Created:    2012.12.29
 
 using System;
+using System.Data.Common;
+using Xtensive.Sql;
 
 namespace Xtensive.Tuples.Packed
 {
@@ -113,6 +115,17 @@ namespace Xtensive.Tuples.Packed
       var isNullable = null==default(T); // Is nullable value type or class
       ref readonly var descriptor = ref PackedDescriptor.FieldDescriptors[fieldIndex];
       descriptor.GetAccessor().SetValue(this, descriptor, isNullable, fieldValue);
+    }
+
+    public override void SetValueFromDataReader(int fieldIndex, DbDataReader reader, TypeMapper mapper)
+    {
+      if (reader.IsDBNull(fieldIndex)) {
+        SetValue(fieldIndex, null);
+      }
+      else {
+        ref readonly var descriptor = ref PackedDescriptor.FieldDescriptors[fieldIndex];
+        descriptor.GetAccessor().SetValue(this, descriptor, fieldIndex, mapper, reader);
+      }
     }
 
     public void SetFieldState(in PackedFieldDescriptor d, TupleFieldState fieldState)

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
@@ -117,14 +117,14 @@ namespace Xtensive.Tuples.Packed
       descriptor.GetAccessor().SetValue(this, descriptor, isNullable, fieldValue);
     }
 
-    public override void SetValueFromDataReader(int fieldIndex, DbDataReader reader, TypeMapper mapper)
+    public override void SetValueFromDataReader(in MapperReader mr)
     {
-      if (reader.IsDBNull(fieldIndex)) {
-        SetValue(fieldIndex, null);
+      if (mr.DbDataReader.IsDBNull(mr.FieldIndex)) {
+        SetValue(mr.FieldIndex, null);
       }
       else {
-        ref readonly var descriptor = ref PackedDescriptor.FieldDescriptors[fieldIndex];
-        descriptor.GetAccessor().SetValue(this, descriptor, fieldIndex, mapper, reader);
+        ref readonly var descriptor = ref PackedDescriptor.FieldDescriptors[mr.FieldIndex];
+        descriptor.GetAccessor().SetValue(this, descriptor, mr);
       }
     }
 

--- a/Orm/Xtensive.Orm/Tuples/RegularTuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/RegularTuple.cs
@@ -18,7 +18,7 @@ namespace Xtensive.Tuples
   [Serializable]
   public abstract class RegularTuple : Tuple
   {
-    public abstract void SetValueFromDataReader(int fieldIndex, DbDataReader reader, TypeMapper mapper);
+    public abstract void SetValueFromDataReader(in MapperReader mr);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Tuples/RegularTuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/RegularTuple.cs
@@ -5,7 +5,6 @@
 // Created:    2008.01.24
 
 using System;
-using System.Data.Common;
 using System.Runtime.Serialization;
 using Xtensive.Sql;
 

--- a/Orm/Xtensive.Orm/Tuples/RegularTuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/RegularTuple.cs
@@ -5,8 +5,9 @@
 // Created:    2008.01.24
 
 using System;
+using System.Data.Common;
 using System.Runtime.Serialization;
-
+using Xtensive.Sql;
 
 namespace Xtensive.Tuples
 {
@@ -17,6 +18,8 @@ namespace Xtensive.Tuples
   [Serializable]
   public abstract class RegularTuple : Tuple
   {
+    public abstract void SetValueFromDataReader(int fieldIndex, DbDataReader reader, TypeMapper mapper);
+
     // Constructors
 
     /// <summary>


### PR DESCRIPTION
Before this change every read value-type field was boxed and then unboxed to be written to `PackedTuple`
We can skip this intermediate boxing to save GC work
