### PR TITLE
`RecordsetEnumerating` / `RecordsetEnumerated` Session events

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Providers/EnumerationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/EnumerationContext.cs
@@ -19,11 +19,9 @@ namespace Xtensive.Orm.Providers
   /// </summary>
   public sealed class EnumerationContext : Rse.Providers.EnumerationContext
   {
-    private class EnumerationFinalizer : ICompletableScope
+    private class EnumerationFinalizer(Queue<Action> finalizationQueue, TransactionScope transactionScope, SessionEventAccessor events)
+      : ICompletableScope
     {
-      private readonly Queue<Action> finalizationQueue;
-      private readonly TransactionScope transactionScope;
-
       public void Complete()
       {
         if (IsCompleted)
@@ -36,16 +34,11 @@ namespace Xtensive.Orm.Providers
 
       public void Dispose()
       {
-        while (finalizationQueue.TryDequeue(out var materializeSelf)) {
+        while (finalizationQueue?.TryDequeue(out var materializeSelf) == true) {
           materializeSelf.Invoke();
         }
-        transactionScope.DisposeSafely();
-      }
-
-      public EnumerationFinalizer(Queue<Action> finalizationQueue, TransactionScope transactionScope)
-      {
-        this.finalizationQueue = finalizationQueue;
-        this.transactionScope = transactionScope;
+        transactionScope?.Dispose();
+        events.NotifyRecordsetEnumerated();
       }
     }
 
@@ -56,7 +49,7 @@ namespace Xtensive.Orm.Providers
     /// Gets the session handler.
     /// </summary>
     /// <value>The session handler.</value>
-    public Session Session { get; private set; }
+    public Session Session { get; }
 
     /// <inheritdoc/>
     protected override EnumerationContextOptions Options { get { return options; } }
@@ -71,9 +64,10 @@ namespace Xtensive.Orm.Providers
       var tx = Session.OpenAutoTransaction();
       if (!Session.Configuration.Supports(SessionOptions.NonTransactionalReads))
         Session.DemandTransaction();
-      if (MaterializationContext!=null && MaterializationContext.MaterializationQueue!=null)
-        return new EnumerationFinalizer(MaterializationContext.MaterializationQueue, tx);
-      return tx;
+      var events = Session.Events;
+      return events.NotifyRecordsetEnumerating() || MaterializationContext?.MaterializationQueue != null
+        ? new EnumerationFinalizer(MaterializationContext?.MaterializationQueue, tx, events)
+        : tx;
     }
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/SessionEventAccessor.cs
+++ b/Orm/Xtensive.Orm/Orm/SessionEventAccessor.cs
@@ -244,6 +244,16 @@ namespace Xtensive.Orm
     /// </summary>
     public event EventHandler<TransactionEventArgs> TransactionRollbacked;
 
+    /// <summary>
+    /// Occurs when Recordset enumeration begins
+    /// </summary>
+    public event EventHandler RecordsetEnumerating;
+
+    /// <summary>
+    /// Occurs when Recordset enumeration ends
+    /// </summary>
+    public event EventHandler RecordsetEnumerated;
+
     #endregion
 
     #region NotifyXxx methods
@@ -495,6 +505,21 @@ namespace Xtensive.Orm
     {
       if (TransactionRollbacked!=null && AreNotificationsEnabled())
         TransactionRollbacked(this, new TransactionEventArgs(transaction));
+    }
+
+    internal bool NotifyRecordsetEnumerating()
+    {
+      if (RecordsetEnumerating != null && AreNotificationsEnabled()) {
+        RecordsetEnumerating(this, EventArgs.Empty);
+        return true;
+      }
+      return false;
+    }
+
+    internal void NotifyRecordsetEnumerated()
+    {
+      if (RecordsetEnumerated != null && AreNotificationsEnabled())
+        RecordsetEnumerated(this, EventArgs.Empty);
     }
 
     #endregion

--- a/Orm/Xtensive.Orm/Orm/SessionEventAccessor.cs
+++ b/Orm/Xtensive.Orm/Orm/SessionEventAccessor.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using Xtensive.Core;
 using Xtensive.Orm.Model;
+using Xtensive.Orm.Providers;
 
 namespace Xtensive.Orm
 {
@@ -247,12 +248,12 @@ namespace Xtensive.Orm
     /// <summary>
     /// Occurs when Recordset enumeration begins
     /// </summary>
-    public event EventHandler RecordsetEnumerating;
+    public event EventHandler<EnumerationContext> RecordsetEnumerating;
 
     /// <summary>
     /// Occurs when Recordset enumeration ends
     /// </summary>
-    public event EventHandler RecordsetEnumerated;
+    public event EventHandler<EnumerationContext> RecordsetEnumerated;
 
     #endregion
 
@@ -507,19 +508,19 @@ namespace Xtensive.Orm
         TransactionRollbacked(this, new TransactionEventArgs(transaction));
     }
 
-    internal bool NotifyRecordsetEnumerating()
+    internal bool NotifyRecordsetEnumerating(EnumerationContext context)
     {
       if (RecordsetEnumerating != null && AreNotificationsEnabled()) {
-        RecordsetEnumerating(this, EventArgs.Empty);
+        RecordsetEnumerating(this, context);
         return true;
       }
       return false;
     }
 
-    internal void NotifyRecordsetEnumerated()
+    internal void NotifyRecordsetEnumerated(EnumerationContext context)
     {
       if (RecordsetEnumerated != null && AreNotificationsEnabled())
-        RecordsetEnumerated(this, EventArgs.Empty);
+        RecordsetEnumerated(this, context);
     }
 
     #endregion


### PR DESCRIPTION
The event have `EnumerationContext` argument to distinguish interleaving enumerations

Also:
* Fix compilation warnings in `DataReader`

ETW/LTTng provider would be more complicated