### PR TITLE
Optimization: Replace indexing in `FieldAccessor[]` by direct reference `Field.Accessor`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Internals/FieldAccessorProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/FieldAccessorProvider.cs
@@ -17,7 +17,6 @@ namespace Xtensive.Orm.Internals
 {
   internal sealed class FieldAccessorProvider
   {
-    private readonly FieldAccessor[] fieldAccessors;
     private static readonly Type EntityFieldAccessorType = typeof(EntityFieldAccessor<>);
     private static readonly Type EntitySetFieldAccessorType = typeof(EntitySetFieldAccessor<>);
     private static readonly Type StructureFieldAccessorType = typeof(StructureFieldAccessor<>);
@@ -25,9 +24,7 @@ namespace Xtensive.Orm.Internals
     private static readonly Type KeyFieldAccessorType = typeof(KeyFieldAccessor<>);
     private static readonly Type DefaultFieldAccessorType = typeof(DefaultFieldAccessor<>);
 
-    public FieldAccessor GetFieldAccessor(FieldInfo field) => fieldAccessors[field.FieldId];
-
-    private static FieldAccessor CreateFieldAccessor(FieldInfo field)
+    internal static FieldAccessor CreateFieldAccessor(FieldInfo field)
     {
       if (field.IsEntity) {
         return CreateFieldAccessor(EntityFieldAccessorType, field);
@@ -61,20 +58,6 @@ namespace Xtensive.Orm.Internals
           null, Array.Empty<object>(), null);
       accessor.Field = field;
       return accessor;
-    }
-
-
-    // Constructors
-
-    public FieldAccessorProvider(TypeInfo typeInfo)
-    {
-      var fields = typeInfo.Fields;
-      fieldAccessors = new FieldAccessor[fields.Count == 0 ? 0 : (fields.Max(field => field.FieldId) + 1)];
-      foreach (var field in fields) {
-        if (field.FieldId != FieldInfo.NoFieldId) {
-          fieldAccessors[field.FieldId] = CreateFieldAccessor(field);
-        }
-      }
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
@@ -12,6 +12,7 @@ using System.Diagnostics;
 using System.Reflection;
 using Xtensive.Collections;
 using Xtensive.Core;
+using Xtensive.Orm.Internals;
 using Xtensive.Orm.Validation;
 using Xtensive.Reflection;
 using Xtensive.Sorting;
@@ -79,6 +80,8 @@ namespace Xtensive.Orm.Model
         fieldId = value;
       }
     }
+
+    internal FieldAccessor Accessor { get; set; }
 
     /// <summary>
     /// Gets a value indicating whether this property is system.

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
@@ -540,8 +540,6 @@ namespace Xtensive.Orm.Model
     /// </summary>
     public bool HasValidators { get; private set; }
 
-    internal FieldAccessorProvider Accessors { get; private set; }
-
     /// <summary>
     /// Creates the tuple prototype with specified <paramref name="primaryKey"/>.
     /// </summary>
@@ -790,8 +788,11 @@ namespace Xtensive.Orm.Model
       isLeaf = GetIsLeaf();
       key = GetKey();
 
-      if (IsEntity || IsStructure)
-        Accessors = new FieldAccessorProvider(this);
+      if (IsEntity || IsStructure) {
+        foreach (var field in Fields.Where(f => f.FieldId != FieldInfo.NoFieldId)) {
+          field.Accessor = FieldAccessorProvider.CreateFieldAccessor(field);
+        }
+      }
 
       if (!recursive)
         return;

--- a/Orm/Xtensive.Orm/Orm/Persistent.cs
+++ b/Orm/Xtensive.Orm/Orm/Persistent.cs
@@ -781,14 +781,12 @@ namespace Xtensive.Orm
       return Session.Domain.Model.Types[GetType()];
     }
 
-    internal FieldAccessor GetNormalizedFieldAccessor(FieldInfo field) =>
-      field.ReflectedType.Accessors.GetFieldAccessor(field);
+    internal FieldAccessor GetNormalizedFieldAccessor(FieldInfo field) => field.Accessor;
 
     internal FieldAccessor GetFieldAccessor(FieldInfo field) =>
       GetNormalizedFieldAccessor(field.ReflectedType.IsInterface ? TypeInfo.FieldMap[field] : field);
 
-    private FieldAccessor<T> GetNormalizedFieldAccessor<T>(FieldInfo field) =>
-      (FieldAccessor<T>) field.ReflectedType.Accessors.GetFieldAccessor(field);
+    private FieldAccessor<T> GetNormalizedFieldAccessor<T>(FieldInfo field) => (FieldAccessor<T>) field.Accessor;
 
     internal FieldAccessor<T> GetFieldAccessor<T>(FieldInfo field) =>
       GetNormalizedFieldAccessor<T>(field.ReflectedType.IsInterface ? TypeInfo.FieldMap[field] : field);


### PR DESCRIPTION
This indexing was invoked on every field access