### PR TITLE
Optimization: Don't pass not-readonly `PackedFieldDescriptor` with `in` specifier

### DIFF
--- a/Orm/Xtensive.Orm/Tuples/AccessorDelegates.cs
+++ b/Orm/Xtensive.Orm/Tuples/AccessorDelegates.cs
@@ -16,7 +16,7 @@ namespace Xtensive.Tuples
   /// <param name="descriptor">Field descriptor.</param>
   /// <param name="fieldState">State of a field.</param>
   /// <returns></returns>
-  internal delegate TValue GetValueDelegate<TValue>(PackedTuple tuple, in PackedFieldDescriptor descriptor, out TupleFieldState fieldState);
+  internal delegate TValue GetValueDelegate<TValue>(PackedTuple tuple, PackedFieldDescriptor descriptor, out TupleFieldState fieldState);
 
   /// <summary>
   /// Incapsulates <see cref="Tuple.SetValue{T}"/> method.
@@ -25,5 +25,5 @@ namespace Xtensive.Tuples
   /// <param name="tuple">Tuple to use.</param>
   /// <param name="descriptor">Field descriptor.</param>
   /// <param name="value">A value.</param>
-  internal delegate void SetValueDelegate<TValue>(PackedTuple tuple, in PackedFieldDescriptor descriptor, TValue value);
+  internal delegate void SetValueDelegate<TValue>(PackedTuple tuple, PackedFieldDescriptor descriptor, TValue value);
 }

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
@@ -40,7 +40,7 @@ namespace Xtensive.Tuples.Packed
     protected readonly long ValueBitMask;
     public readonly byte Index;
 
-    public void SetValue<T>(PackedTuple tuple, in PackedFieldDescriptor descriptor, bool isNullable, T value)
+    public void SetValue<T>(PackedTuple tuple, PackedFieldDescriptor descriptor, bool isNullable, T value)
     {
       if ((isNullable ? NullableSetter : Setter) is SetValueDelegate<T> setter) {
         setter.Invoke(tuple, descriptor, value);
@@ -50,10 +50,10 @@ namespace Xtensive.Tuples.Packed
       }
     }
 
-    public virtual void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+    public virtual void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, MapperReader mr) =>
       throw new NotSupportedException($"{this} does not support reading from DbDataReader");
 
-    public T GetValue<T>(PackedTuple tuple, in PackedFieldDescriptor descriptor, bool isNullable, out TupleFieldState fieldState)
+    public T GetValue<T>(PackedTuple tuple, PackedFieldDescriptor descriptor, bool isNullable, out TupleFieldState fieldState)
     {
       if ((isNullable ? NullableGetter : Getter) is GetValueDelegate<T> getter) {
         return getter.Invoke(tuple, descriptor, out fieldState);
@@ -70,17 +70,17 @@ namespace Xtensive.Tuples.Packed
       return (T) GetUntypedValue(tuple, descriptor, out fieldState);
     }
 
-    public abstract object GetUntypedValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, out TupleFieldState fieldState);
+    public abstract object GetUntypedValue(PackedTuple tuple, PackedFieldDescriptor descriptor, out TupleFieldState fieldState);
 
-    public abstract void SetUntypedValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, object value);
+    public abstract void SetUntypedValue(PackedTuple tuple, PackedFieldDescriptor descriptor, object value);
 
-    public abstract void CopyValue(PackedTuple source, in PackedFieldDescriptor sourceDescriptor,
-      PackedTuple target, in PackedFieldDescriptor targetDescriptor);
+    public abstract void CopyValue(PackedTuple source, PackedFieldDescriptor sourceDescriptor,
+      PackedTuple target, PackedFieldDescriptor targetDescriptor);
 
-    public abstract bool ValueEquals(PackedTuple left, in PackedFieldDescriptor leftDescriptor,
-      PackedTuple right, in PackedFieldDescriptor rightDescriptor);
+    public abstract bool ValueEquals(PackedTuple left, PackedFieldDescriptor leftDescriptor,
+      PackedTuple right, PackedFieldDescriptor rightDescriptor);
 
-    public abstract int GetValueHashCode(PackedTuple tuple, in PackedFieldDescriptor descriptor);
+    public abstract int GetValueHashCode(PackedTuple tuple, PackedFieldDescriptor descriptor);
 
     protected PackedFieldAccessor(int rank, byte index)
     {
@@ -109,35 +109,35 @@ namespace Xtensive.Tuples.Packed
 
   internal sealed class ObjectFieldAccessor : PackedFieldAccessor
   {
-    public override object GetUntypedValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, out TupleFieldState fieldState)
+    public override object GetUntypedValue(PackedTuple tuple, PackedFieldDescriptor descriptor, out TupleFieldState fieldState)
     {
       var state = tuple.GetFieldState(descriptor);
       fieldState = state;
       return state == TupleFieldState.Available ? tuple.Objects[descriptor.GetObjectIndex()] : null;
     }
 
-    public override void SetUntypedValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, object value)
+    public override void SetUntypedValue(PackedTuple tuple, PackedFieldDescriptor descriptor, object value)
     {
       tuple.Objects[descriptor.GetObjectIndex()] = value;
       tuple.SetFieldState(descriptor, value != null ? TupleFieldState.Available : (TupleFieldState.Available | TupleFieldState.Null));
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+    public override void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, MapperReader mr) =>
       SetUntypedValue(tuple, descriptor, mr.Reader(mr.DbDataReader, mr.FieldIndex));
 
-    public override void CopyValue(PackedTuple source, in PackedFieldDescriptor sourceDescriptor,
-      PackedTuple target, in PackedFieldDescriptor targetDescriptor)
+    public override void CopyValue(PackedTuple source, PackedFieldDescriptor sourceDescriptor,
+      PackedTuple target, PackedFieldDescriptor targetDescriptor)
     {
       target.Objects[targetDescriptor.GetObjectIndex()] = source.Objects[sourceDescriptor.GetObjectIndex()];
     }
 
-    public override bool ValueEquals(PackedTuple left, in PackedFieldDescriptor leftDescriptor,
-      PackedTuple right, in PackedFieldDescriptor rightDescriptor)
+    public override bool ValueEquals(PackedTuple left, PackedFieldDescriptor leftDescriptor,
+      PackedTuple right, PackedFieldDescriptor rightDescriptor)
     {
       return Equals(left.Objects[leftDescriptor.GetObjectIndex()], right.Objects[rightDescriptor.GetObjectIndex()]);
     }
 
-    public override int GetValueHashCode(PackedTuple tuple, in PackedFieldDescriptor descriptor)
+    public override int GetValueHashCode(PackedTuple tuple, PackedFieldDescriptor descriptor)
     {
       return tuple.Objects[descriptor.GetObjectIndex()]?.GetHashCode() ?? 0;
     }
@@ -173,13 +173,13 @@ namespace Xtensive.Tuples.Packed
 
     protected virtual T Decode(long[] values, int offset) => throw new NotSupportedException();
 
-    public override object GetUntypedValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, out TupleFieldState fieldState)
+    public override object GetUntypedValue(PackedTuple tuple, PackedFieldDescriptor descriptor, out TupleFieldState fieldState)
     {
       fieldState = tuple.GetFieldState(descriptor);
       return fieldState == TupleFieldState.Available ? (object) Load(tuple, descriptor) : null;
     }
 
-    public override void SetUntypedValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, object value)
+    public override void SetUntypedValue(PackedTuple tuple, PackedFieldDescriptor descriptor, object value)
     {
       if (value != null) {
         Store(tuple, descriptor, (T) value);
@@ -190,39 +190,39 @@ namespace Xtensive.Tuples.Packed
       }
     }
 
-    public override void CopyValue(PackedTuple source, in PackedFieldDescriptor sourceDescriptor,
-      PackedTuple target, in PackedFieldDescriptor targetDescriptor)
+    public override void CopyValue(PackedTuple source, PackedFieldDescriptor sourceDescriptor,
+      PackedTuple target, PackedFieldDescriptor targetDescriptor)
     {
       Store(target, targetDescriptor, Load(source, sourceDescriptor));
     }
 
-    public override bool ValueEquals(PackedTuple left, in PackedFieldDescriptor leftDescriptor, PackedTuple right, in PackedFieldDescriptor rightDescriptor) =>
+    public override bool ValueEquals(PackedTuple left, PackedFieldDescriptor leftDescriptor, PackedTuple right, PackedFieldDescriptor rightDescriptor) =>
       Load(left, leftDescriptor).Equals(Load(right, rightDescriptor));
 
-    public override int GetValueHashCode(PackedTuple tuple, in PackedFieldDescriptor descriptor)
+    public override int GetValueHashCode(PackedTuple tuple, PackedFieldDescriptor descriptor)
     {
       return Load(tuple, descriptor).GetHashCode();
     }
 
-    private T GetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, out TupleFieldState fieldState)
+    private T GetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, out TupleFieldState fieldState)
     {
       fieldState = tuple.GetFieldState(descriptor);
       return fieldState == TupleFieldState.Available ? Load(tuple, descriptor) : DefaultValue;
     }
 
-    private T? GetNullableValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, out TupleFieldState fieldState)
+    private T? GetNullableValue(PackedTuple tuple, PackedFieldDescriptor descriptor, out TupleFieldState fieldState)
     {
       fieldState = tuple.GetFieldState(descriptor);
       return fieldState == TupleFieldState.Available ? Load(tuple, descriptor) : NullValue;
     }
 
-    protected void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, T value)
+    protected void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, T value)
     {
       Store(tuple, descriptor, value);
       tuple.SetFieldState(descriptor, TupleFieldState.Available);
     }
 
-    private void SetNullableValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, T? value)
+    private void SetNullableValue(PackedTuple tuple, PackedFieldDescriptor descriptor, T? value)
     {
       if (value != null) {
         Store(tuple, descriptor, value.Value);
@@ -233,7 +233,7 @@ namespace Xtensive.Tuples.Packed
       }
     }
 
-    private void Store(PackedTuple tuple, in PackedFieldDescriptor d, T value)
+    private void Store(PackedTuple tuple, PackedFieldDescriptor d, T value)
     {
       var valueIndex = d.GetValueIndex();
       if (Rank > 6) {
@@ -248,7 +248,7 @@ namespace Xtensive.Tuples.Packed
       block = (block & ~mask) | ((encoded << valueBitOffset) & mask);
     }
 
-    private T Load(PackedTuple tuple, in PackedFieldDescriptor d)
+    private T Load(PackedTuple tuple, PackedFieldDescriptor d)
     {
       var valueIndex = d.GetValueIndex();
       if (Rank > 6) {
@@ -283,7 +283,7 @@ namespace Xtensive.Tuples.Packed
       return value != 0;
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+    public override void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, MapperReader mr) =>
       SetValue(tuple, descriptor, mr.Mapper.ReadBoolean(mr.DbDataReader, mr.FieldIndex));
 
     public BooleanFieldAccessor()
@@ -309,7 +309,7 @@ namespace Xtensive.Tuples.Packed
       }
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+    public override void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, MapperReader mr) =>
       SetValue(tuple, descriptor, mr.Mapper.ReadFloat(mr.DbDataReader, mr.FieldIndex));
 
     public FloatFieldAccessor()
@@ -330,7 +330,7 @@ namespace Xtensive.Tuples.Packed
       return BitConverter.Int64BitsToDouble(value);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+    public override void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, MapperReader mr) =>
       SetValue(tuple, descriptor, mr.Mapper.ReadDouble(mr.DbDataReader, mr.FieldIndex));
 
     public DoubleFieldAccessor()
@@ -351,7 +351,7 @@ namespace Xtensive.Tuples.Packed
       return TimeSpan.FromTicks(value);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+    public override void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, MapperReader mr) =>
       SetValue(tuple, descriptor, mr.Mapper.ReadTimeSpan(mr.DbDataReader, mr.FieldIndex));
 
     public TimeSpanFieldAccessor()
@@ -372,7 +372,7 @@ namespace Xtensive.Tuples.Packed
       return DateTime.FromBinary(value);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+    public override void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, MapperReader mr) =>
       SetValue(tuple, descriptor, mr.Mapper.ReadDateTime(mr.DbDataReader, mr.FieldIndex));
 
     public DateTimeFieldAccessor()
@@ -393,7 +393,7 @@ namespace Xtensive.Tuples.Packed
       return unchecked((byte) value);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+    public override void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, MapperReader mr) =>
       SetValue(tuple, descriptor, mr.Mapper.ReadByte(mr.DbDataReader, mr.FieldIndex));
 
     public ByteFieldAccessor()
@@ -414,7 +414,7 @@ namespace Xtensive.Tuples.Packed
       return unchecked((sbyte) value);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+    public override void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, MapperReader mr) =>
       SetValue(tuple, descriptor, mr.Mapper.ReadSByte(mr.DbDataReader, mr.FieldIndex));
 
     public SByteFieldAccessor()
@@ -435,7 +435,7 @@ namespace Xtensive.Tuples.Packed
       return unchecked((short) value);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+    public override void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, MapperReader mr) =>
       SetValue(tuple, descriptor, mr.Mapper.ReadShort(mr.DbDataReader, mr.FieldIndex));
 
     public ShortFieldAccessor()
@@ -456,7 +456,7 @@ namespace Xtensive.Tuples.Packed
       return unchecked((ushort) value);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+    public override void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, MapperReader mr) =>
       SetValue(tuple, descriptor, mr.Mapper.ReadUShort(mr.DbDataReader, mr.FieldIndex));
 
     public UShortFieldAccessor()
@@ -477,7 +477,7 @@ namespace Xtensive.Tuples.Packed
       return unchecked((int) value);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+    public override void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, MapperReader mr) =>
       SetValue(tuple, descriptor, mr.Mapper.ReadInt(mr.DbDataReader, mr.FieldIndex));
 
     public IntFieldAccessor()
@@ -498,7 +498,7 @@ namespace Xtensive.Tuples.Packed
       return unchecked((uint) value);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+    public override void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, MapperReader mr) =>
       SetValue(tuple, descriptor, mr.Mapper.ReadUInt(mr.DbDataReader, mr.FieldIndex));
 
     public UIntFieldAccessor()
@@ -519,7 +519,7 @@ namespace Xtensive.Tuples.Packed
       return value;
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+    public override void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, MapperReader mr) =>
       SetValue(tuple, descriptor, mr.Mapper.ReadLong(mr.DbDataReader, mr.FieldIndex));
 
     public LongFieldAccessor()
@@ -540,7 +540,7 @@ namespace Xtensive.Tuples.Packed
       return unchecked((ulong) value);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+    public override void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, MapperReader mr) =>
       SetValue(tuple, descriptor, mr.Mapper.ReadULong(mr.DbDataReader, mr.FieldIndex));
 
     public ULongFieldAccessor()
@@ -572,7 +572,7 @@ namespace Xtensive.Tuples.Packed
       return sizeof(Guid);
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+    public override void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, MapperReader mr) =>
       SetValue(tuple, descriptor, mr.Mapper.ReadGuid(mr.DbDataReader, mr.FieldIndex));
 
     public GuidFieldAccessor()
@@ -599,7 +599,7 @@ namespace Xtensive.Tuples.Packed
       }
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+    public override void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, MapperReader mr) =>
       SetValue(tuple, descriptor, mr.Mapper.ReadDecimal(mr.DbDataReader, mr.FieldIndex));
 
     public DecimalFieldAccessor()
@@ -635,7 +635,7 @@ namespace Xtensive.Tuples.Packed
       return sizeof(long) * 2;
     }
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+    public override void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, MapperReader mr) =>
       SetValue(tuple, descriptor, mr.Mapper.ReadDateTimeOffset(mr.DbDataReader, mr.FieldIndex));
 
     public DateTimeOffsetFieldAccessor()
@@ -651,7 +651,7 @@ namespace Xtensive.Tuples.Packed
     protected override long Encode(DateOnly value) =>
       value.DayNumber;
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+    public override void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, MapperReader mr) =>
       SetValue(tuple, descriptor, mr.Mapper.ReadDateOnly(mr.DbDataReader, mr.FieldIndex));
 
     public DateOnlyFieldAccessor()
@@ -667,7 +667,7 @@ namespace Xtensive.Tuples.Packed
     protected override long Encode(TimeOnly value) =>
       value.Ticks;
 
-    public override void SetValue(PackedTuple tuple, in PackedFieldDescriptor descriptor, MapperReader mr) =>
+    public override void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, MapperReader mr) =>
       SetValue(tuple, descriptor, mr.Mapper.ReadTimeOnly(mr.DbDataReader, mr.FieldIndex));
 
     public TimeOnlyFieldAccessor()

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
@@ -128,7 +128,7 @@ namespace Xtensive.Tuples.Packed
       }
     }
 
-    public void SetFieldState(in PackedFieldDescriptor d, TupleFieldState fieldState)
+    public void SetFieldState(PackedFieldDescriptor d, TupleFieldState fieldState)
     {
       var bits = (long) fieldState;
       ref var block = ref Values[d.GetStateIndex()];
@@ -140,7 +140,7 @@ namespace Xtensive.Tuples.Packed
       }
     }
 
-    public TupleFieldState GetFieldState(in PackedFieldDescriptor d)
+    public TupleFieldState GetFieldState(PackedFieldDescriptor d)
     {
       int stateIndex = d.GetStateIndex(), stateBitOffset = d.GetStateBitOffset();
       return (TupleFieldState) ((Values[stateIndex] >> stateBitOffset) & 3);


### PR DESCRIPTION
See explanation at https://devblogs.microsoft.com/premier-developer/the-in-modifier-and-the-readonly-structs-in-c/

<b>you should never pass a non-readonly struct as in parameter</b>
||                 Method |      Mean |     Error |    StdDev | 
|----------------------- |----------:|----------:|----------:| 
|AggregatePassedByValue |  71.24 us | 0.3150 us | 0.2278 us | 
|    AggregatePassedByIn | 124.02 us | 3.2885 us | 9.6963 us |

And making this struct `readonly` requires more code rewriting