### PR TITLE
Optimization: Replace `CounterIncrementer` & `PositionUpdater` array indexing by direct reference from Accessor

### DIFF
--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
@@ -120,26 +120,22 @@ namespace Xtensive.Tuples.Packed
 
       CounterIncrementer = Rank switch {
         0 => (ref Counters counters) => counters.Val001Counter++,
-        1 => (ref Counters counters) => throw new NotSupportedException(),
-        2 => (ref Counters counters) => throw new NotSupportedException(),
         3 => (ref Counters counters) => counters.Val008Counter++,
         4 => (ref Counters counters) => counters.Val016Counter++,
         5 => (ref Counters counters) => counters.Val032Counter++,
         6 => (ref Counters counters) => counters.Val064Counter++,
         7 => (ref Counters counters) => counters.Val128Counter++,
-        _ => null
+        _ => (ref Counters counters) => throw new NotSupportedException(),
       };
 
       PositionUpdater = Rank switch {
         0 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val001Counter),
-        1 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => throw new NotSupportedException(),
-        2 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => throw new NotSupportedException(),
         3 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val008Counter),
         4 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val016Counter),
         5 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val032Counter),
         6 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val064Counter),
         7 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val128Counter),
-        _ => null
+        _ => (ref PackedFieldDescriptor descriptor, ref Counters counters) => throw new NotSupportedException()
       };
     }
   }

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
@@ -40,6 +40,9 @@ namespace Xtensive.Tuples.Packed
     protected readonly long ValueBitMask;
     public readonly byte Index;
 
+    public TupleLayout.CounterIncrementer CounterIncrementer;
+    public TupleLayout.PositionUpdater PositionUpdater;
+
     public void SetValue<T>(PackedTuple tuple, PackedFieldDescriptor descriptor, bool isNullable, T value)
     {
       if ((isNullable ? NullableSetter : Setter) is SetValueDelegate<T> setter) {

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
@@ -118,31 +118,29 @@ namespace Xtensive.Tuples.Packed
       // 1000_0000 << 1 = 0000_0000
       ValueBitMask = (1L << (ValueBitCount - 1) << 1) - 1;
 
-      if (Rank != -1) {
-        CounterIncrementer = Rank switch {
-          0 => (ref Counters counters) => counters.Val001Counter++,
-          1 => (ref Counters counters) => throw new NotSupportedException(),
-          2 => (ref Counters counters) => throw new NotSupportedException(),
-          3 => (ref Counters counters) => counters.Val008Counter++,
-          4 => (ref Counters counters) => counters.Val016Counter++,
-          5 => (ref Counters counters) => counters.Val032Counter++,
-          6 => (ref Counters counters) => counters.Val064Counter++,
-          7 => (ref Counters counters) => counters.Val128Counter++,
-          _ => null
-        };
+      CounterIncrementer = Rank switch {
+        0 => (ref Counters counters) => counters.Val001Counter++,
+        1 => (ref Counters counters) => throw new NotSupportedException(),
+        2 => (ref Counters counters) => throw new NotSupportedException(),
+        3 => (ref Counters counters) => counters.Val008Counter++,
+        4 => (ref Counters counters) => counters.Val016Counter++,
+        5 => (ref Counters counters) => counters.Val032Counter++,
+        6 => (ref Counters counters) => counters.Val064Counter++,
+        7 => (ref Counters counters) => counters.Val128Counter++,
+        _ => null
+      };
 
-        PositionUpdater = Rank switch {
-          0 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val001Counter),
-          1 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => throw new NotSupportedException(),
-          2 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => throw new NotSupportedException(),
-          3 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val008Counter),
-          4 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val016Counter),
-          5 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val032Counter),
-          6 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val064Counter),
-          7 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val128Counter),
-          _ => null
-        };
-      }
+      PositionUpdater = Rank switch {
+        0 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val001Counter),
+        1 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => throw new NotSupportedException(),
+        2 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => throw new NotSupportedException(),
+        3 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val008Counter),
+        4 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val016Counter),
+        5 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val032Counter),
+        6 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val064Counter),
+        7 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val128Counter),
+        _ => null
+      };
     }
   }
 

--- a/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
@@ -226,13 +226,6 @@ namespace Xtensive.Tuples.Packed
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void UpdateDescriptorPosition(ref PackedFieldDescriptor descriptor, ref int bitCounter, int valueBitCount)
-    {
-      descriptor.DataPosition = bitCounter;
-      bitCounter += valueBitCount;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void ConfigureFieldPhase1(ref PackedFieldDescriptor descriptor, ref Counters counters,
       Type[] fieldTypes, int fieldIndex)
     {
@@ -248,37 +241,6 @@ namespace Xtensive.Tuples.Packed
 
       descriptor.AccessorIndex = ObjectAccessor.Index;
       descriptor.DataPosition = counters.ObjectCounter++;
-    }
-
-    static TupleLayout()
-    {
-      var incrementerByRank = new CounterIncrementer[] {
-        (ref Counters counters) => counters.Val001Counter++,
-        (ref Counters counters) => throw new NotSupportedException(),
-        (ref Counters counters) => throw new NotSupportedException(),
-        (ref Counters counters) => counters.Val008Counter++,
-        (ref Counters counters) => counters.Val016Counter++,
-        (ref Counters counters) => counters.Val032Counter++,
-        (ref Counters counters) => counters.Val064Counter++,
-        (ref Counters counters) => counters.Val128Counter++
-      };
-
-      foreach (var accessor in PackedFieldAccessor.All) {
-        accessor.CounterIncrementer = incrementerByRank[accessor.Rank];
-
-        int valueBitCount = accessor.ValueBitCount;
-        accessor.PositionUpdater = accessor.Rank switch {
-          0 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val001Counter, valueBitCount),
-          1 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => throw new NotSupportedException(),
-          2 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => throw new NotSupportedException(),
-          3 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val008Counter, valueBitCount),
-          4 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val016Counter, valueBitCount),
-          5 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val032Counter, valueBitCount),
-          6 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val064Counter, valueBitCount),
-          7 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val128Counter, valueBitCount),
-          _ => null
-        };
-      }
     }
   }
 }


### PR DESCRIPTION
This link is computed statically

Also:
* Optimize `TupleLayout.UpdateDescriptorPosition()` to have  direct access to Accessor's `valueBitCount`