### PR TITLE
Optimization: Don't pass not-readonly `PackedFieldDescriptor` with `in` specifier (`in this` case)

### DIFF
--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldDescriptiorExtensions.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldDescriptiorExtensions.cs
@@ -2,6 +2,8 @@
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
+using System.Runtime.CompilerServices;
+
 namespace Xtensive.Tuples.Packed
 {
   internal static class PackedFieldDescriptorExtensions
@@ -9,12 +11,25 @@ namespace Xtensive.Tuples.Packed
     private const int OffsetBitCount = 6;
     private const int OffsetMask = (1 << OffsetBitCount) - 1;
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static PackedFieldAccessor GetAccessor(this PackedFieldDescriptor descriptor) => PackedFieldAccessor.All[descriptor.AccessorIndex];
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsObjectField(this PackedFieldDescriptor descriptor) => descriptor.GetAccessor().Rank < 0;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int GetObjectIndex(this PackedFieldDescriptor descriptor) => descriptor.DataPosition;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int GetValueIndex(this PackedFieldDescriptor descriptor) => descriptor.DataPosition >> OffsetBitCount;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int GetValueBitOffset(this PackedFieldDescriptor descriptor) => descriptor.DataPosition & OffsetMask;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int GetStateIndex(this PackedFieldDescriptor descriptor) => descriptor.StatePosition >> OffsetBitCount;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int GetStateBitOffset(this PackedFieldDescriptor descriptor) => descriptor.StatePosition & OffsetMask;
   }
 }

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldDescriptiorExtensions.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldDescriptiorExtensions.cs
@@ -9,12 +9,12 @@ namespace Xtensive.Tuples.Packed
     private const int OffsetBitCount = 6;
     private const int OffsetMask = (1 << OffsetBitCount) - 1;
 
-    public static PackedFieldAccessor GetAccessor(in this PackedFieldDescriptor descriptor) => PackedFieldAccessor.All[descriptor.AccessorIndex];
-    public static bool IsObjectField(in this PackedFieldDescriptor descriptor) => descriptor.GetAccessor().Rank < 0;
-    public static int GetObjectIndex(in this PackedFieldDescriptor descriptor) => descriptor.DataPosition;
-    public static int GetValueIndex(in this PackedFieldDescriptor descriptor) => descriptor.DataPosition >> OffsetBitCount;
-    public static int GetValueBitOffset(in this PackedFieldDescriptor descriptor) => descriptor.DataPosition & OffsetMask;
-    public static int GetStateIndex(in this PackedFieldDescriptor descriptor) => descriptor.StatePosition >> OffsetBitCount;
-    public static int GetStateBitOffset(in this PackedFieldDescriptor descriptor) => descriptor.StatePosition & OffsetMask;
+    public static PackedFieldAccessor GetAccessor(this PackedFieldDescriptor descriptor) => PackedFieldAccessor.All[descriptor.AccessorIndex];
+    public static bool IsObjectField(this PackedFieldDescriptor descriptor) => descriptor.GetAccessor().Rank < 0;
+    public static int GetObjectIndex(this PackedFieldDescriptor descriptor) => descriptor.DataPosition;
+    public static int GetValueIndex(this PackedFieldDescriptor descriptor) => descriptor.DataPosition >> OffsetBitCount;
+    public static int GetValueBitOffset(this PackedFieldDescriptor descriptor) => descriptor.DataPosition & OffsetMask;
+    public static int GetStateIndex(this PackedFieldDescriptor descriptor) => descriptor.StatePosition >> OffsetBitCount;
+    public static int GetStateBitOffset(this PackedFieldDescriptor descriptor) => descriptor.StatePosition & OffsetMask;
   }
 }


### PR DESCRIPTION
Follow up of https://github.com/servicetitan/dataobjects-net/pull/197

Also:
* Add `[MethodImpl(MethodImplOptions.AggressiveInlining)]` attribute