### PR TITLE
Optimization: avoid double-dereferencing the same `AccessorIndex`

### DIFF
--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
@@ -43,6 +43,12 @@ namespace Xtensive.Tuples.Packed
     protected readonly long ValueBitMask;
     public readonly byte Index;
 
+    public bool IsObjectAccessor
+    {
+      [MethodImpl(MethodImplOptions.AggressiveInlining)]
+      get => Rank < 0;
+    }
+
     public readonly CounterIncrementer CounterIncrementer;
     public readonly PositionUpdater PositionUpdater;
 
@@ -142,6 +148,8 @@ namespace Xtensive.Tuples.Packed
 
   internal sealed class ObjectFieldAccessor : PackedFieldAccessor
   {
+    public const int FixedIndex = 1;
+
     public override object GetUntypedValue(PackedTuple tuple, PackedFieldDescriptor descriptor, out TupleFieldState fieldState)
     {
       var state = tuple.GetFieldState(descriptor);
@@ -176,7 +184,7 @@ namespace Xtensive.Tuples.Packed
     }
 
     public ObjectFieldAccessor()
-      : base(-1, 1)
+      : base(-1, FixedIndex)
     { }
   }
 

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldDescriptor.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldDescriptor.cs
@@ -91,11 +91,5 @@ namespace Xtensive.Tuples.Packed
       [MethodImpl(MethodImplOptions.AggressiveInlining)]
       get => PackedFieldAccessor.All[AccessorIndex];
     }
-
-    internal bool IsObjectField
-    {
-      [MethodImpl(MethodImplOptions.AggressiveInlining)]
-      get => Accessor.Rank < 0;
-    }
   }
 }

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
@@ -135,7 +135,7 @@ namespace Xtensive.Tuples.Packed
       var stateBitOffset = d.StateBitOffset;
       block = (block & ~(3L << stateBitOffset)) | (bits << stateBitOffset);
 
-      if (fieldState != TupleFieldState.Available && d.IsObjectField) {
+      if (fieldState != TupleFieldState.Available && d.Accessor.IsObjectAccessor) {
         Objects[d.Index] = null;
       }
     }

--- a/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
@@ -132,7 +132,7 @@ namespace Xtensive.Tuples.Packed
         return;
       }
 
-      descriptor.AccessorIndex = ObjectAccessor.Index;
+      descriptor.AccessorIndex = ObjectFieldAccessor.FixedIndex;
       valuesLength = 1;
       objectsLength = 1;
     }
@@ -150,7 +150,7 @@ namespace Xtensive.Tuples.Packed
           valuesLength = 1;
           return;
         case 1: {
-          if (descriptor1.IsObjectField) {
+          if (descriptor1.Accessor.IsObjectAccessor) {
             descriptor2.DataPosition = Val064BitCount;
             val1BitCount = descriptor2.Accessor.ValueBitCount;
           }
@@ -216,8 +216,9 @@ namespace Xtensive.Tuples.Packed
 
       for (var fieldIndex = 0; fieldIndex < fieldCount; fieldIndex++) {
         ref var descriptor = ref fieldDescriptors[fieldIndex];
-        if (!descriptor.IsObjectField) {
-          descriptor.Accessor.PositionUpdater(ref descriptor, ref counters);
+        var accessor = descriptor.Accessor;
+        if (!accessor.IsObjectAccessor) {
+          accessor.PositionUpdater(ref descriptor, ref counters);
         }
       }
 
@@ -239,7 +240,7 @@ namespace Xtensive.Tuples.Packed
         return;
       }
 
-      descriptor.AccessorIndex = ObjectAccessor.Index;
+      descriptor.AccessorIndex = ObjectFieldAccessor.FixedIndex;
       descriptor.Index = counters.ObjectCounter++;
     }
   }

--- a/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
@@ -53,6 +53,8 @@ namespace Xtensive.Tuples.Packed
       private static readonly ValueFieldAccessor GuidAccessor = new GuidFieldAccessor();
       private static readonly ValueFieldAccessor DateTimeOffsetAccessor = new DateTimeOffsetFieldAccessor();
 
+      private static readonly ObjectFieldAccessor ObjectAccessor = new ObjectFieldAccessor();
+
       private static readonly int NullableTypeMetadataToken = WellKnownTypes.NullableOfT.MetadataToken;
 
       public static ValueFieldAccessor GetValue(Type probeType)
@@ -111,11 +113,9 @@ namespace Xtensive.Tuples.Packed
 
     internal delegate void PositionUpdater(ref PackedFieldDescriptor descriptor, ref Counters counters);
 
-    private static readonly ObjectFieldAccessor ObjectAccessor = new ObjectFieldAccessor();
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ConfigureFieldAccessor(ref PackedFieldDescriptor descriptor, Type fieldType) =>
-      descriptor.AccessorIndex = ((PackedFieldAccessor)ValueFieldAccessorResolver.GetValue(fieldType) ?? ObjectAccessor).Index;
+      descriptor.AccessorIndex = ((PackedFieldAccessor)ValueFieldAccessorResolver.GetValue(fieldType))?.Index ?? ObjectFieldAccessor.FixedIndex;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ConfigureLen1(ref Type fieldType, ref PackedFieldDescriptor descriptor, out int valuesLength,

--- a/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
@@ -150,13 +150,14 @@ namespace Xtensive.Tuples.Packed
           valuesLength = 1;
           return;
         case 1: {
-          if (descriptor1.Accessor.IsObjectAccessor) {
+          var accessor1 = descriptor1.Accessor;
+          if (accessor1.IsObjectAccessor) {
             descriptor2.DataPosition = Val064BitCount;
             val1BitCount = descriptor2.Accessor.ValueBitCount;
           }
           else {
             descriptor1.DataPosition = Val064BitCount;
-            val1BitCount = descriptor1.Accessor.ValueBitCount;
+            val1BitCount = accessor1.ValueBitCount;
           }
           valuesLength = (val1BitCount  + ((Val064BitCount * 2) - 1)) >> Val064Rank;
           return;


### PR DESCRIPTION
Also:
* Indrroduce constant `ObjectFieldAccessor.FixedIndex` == 1   instead of `ObjecctAccessor.Index` , because this index is hardcoded