### PR TITLE
Optimization: Get rid of `ref readonly var descriptor`

### DIFF
--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
@@ -48,7 +48,7 @@ namespace Xtensive.Tuples.Packed
       var fieldDescriptors = PackedDescriptor.FieldDescriptors;
       var count = Count;
       for (int i = 0; i < count; i++) {
-        ref readonly var descriptor = ref fieldDescriptors[i];
+        var descriptor = fieldDescriptors[i];
         var thisState = GetFieldState(descriptor);
         var otherState = packedOther.GetFieldState(descriptor);
         if (thisState != otherState) {
@@ -69,7 +69,7 @@ namespace Xtensive.Tuples.Packed
       var fieldDescriptors = PackedDescriptor.FieldDescriptors;
       int result = 0;
       for (int i = 0; i < count; i++) {
-        ref readonly var descriptor = ref fieldDescriptors[i];
+        var descriptor = fieldDescriptors[i];
         var state = GetFieldState(descriptor);
         var fieldHash = state == TupleFieldState.Available
           ? descriptor.Accessor.GetValueHashCode(this, descriptor)
@@ -93,27 +93,27 @@ namespace Xtensive.Tuples.Packed
 
     public override object GetValue(int fieldIndex, out TupleFieldState fieldState)
     {
-      ref readonly var descriptor = ref PackedDescriptor.FieldDescriptors[fieldIndex];
+      var descriptor = PackedDescriptor.FieldDescriptors[fieldIndex];
       return descriptor.Accessor.GetUntypedValue(this, descriptor, out fieldState);
     }
 
     public override T GetValue<T>(int fieldIndex, out TupleFieldState fieldState)
     {
       var isNullable = null == default(T); // Is nullable value type or class
-      ref readonly var descriptor = ref PackedDescriptor.FieldDescriptors[fieldIndex];
+      var descriptor = PackedDescriptor.FieldDescriptors[fieldIndex];
       return descriptor.Accessor.GetValue<T>(this, descriptor, isNullable, out fieldState);
     }
 
     public override void SetValue(int fieldIndex, object fieldValue)
     {
-      ref readonly var descriptor = ref PackedDescriptor.FieldDescriptors[fieldIndex];
+      var descriptor = PackedDescriptor.FieldDescriptors[fieldIndex];
       descriptor.Accessor.SetUntypedValue(this, descriptor, fieldValue);
     }
 
     public override void SetValue<T>(int fieldIndex, T fieldValue)
     {
       var isNullable = null==default(T); // Is nullable value type or class
-      ref readonly var descriptor = ref PackedDescriptor.FieldDescriptors[fieldIndex];
+      var descriptor = PackedDescriptor.FieldDescriptors[fieldIndex];
       descriptor.Accessor.SetValue(this, descriptor, isNullable, fieldValue);
     }
 
@@ -123,7 +123,7 @@ namespace Xtensive.Tuples.Packed
         SetValue(mr.FieldIndex, null);
       }
       else {
-        ref readonly var descriptor = ref PackedDescriptor.FieldDescriptors[mr.FieldIndex];
+        var descriptor = PackedDescriptor.FieldDescriptors[mr.FieldIndex];
         descriptor.Accessor.SetValue(this, descriptor, mr);
       }
     }

--- a/Orm/Xtensive.Orm/Tuples/TupleExtensions.cs
+++ b/Orm/Xtensive.Orm/Tuples/TupleExtensions.cs
@@ -431,8 +431,8 @@ namespace Xtensive.Tuples
 
     private static void CopyPackedValue(PackedTuple source, int sourceIndex, PackedTuple target, int targetIndex)
     {
-      ref readonly var sourceDescriptor = ref source.PackedDescriptor.FieldDescriptors[sourceIndex];
-      ref readonly var targetDescriptor = ref target.PackedDescriptor.FieldDescriptors[targetIndex];
+      var sourceDescriptor = source.PackedDescriptor.FieldDescriptors[sourceIndex];
+      var targetDescriptor = target.PackedDescriptor.FieldDescriptors[targetIndex];
 
       var fieldState = source.GetFieldState(sourceDescriptor);
       if (!fieldState.IsAvailable()) {


### PR DESCRIPTION
Descriptors are 64-bit structs and can be returned in CPU Registers
No need to access them by reference