### PR TITLE
Make `TupleDescriptor.FieldDescriptors` lazy-computed

### DIFF
--- a/Orm/Xtensive.Orm.Tests.Core/Tuples/TupleDescriptorTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Tuples/TupleDescriptorTest.cs
@@ -120,9 +120,7 @@ namespace Xtensive.Orm.Tests.Core.Tuples
     private TupleDescriptor TestDescriptor(TupleDescriptor theSame, Type[] types)
     {
       var d1 = TupleDescriptor.Create(types);
-      var fds1 = d1.FieldDescriptors;
       var d2 = TupleDescriptor.Create(types);
-      var fds2 = d2.FieldDescriptors;
       Assert.IsNotNull(d1);
       Assert.IsNotNull(d2);
       Assert.AreEqual(d1, d2);

--- a/Orm/Xtensive.Orm.Tests.Core/Tuples/TupleDescriptorTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Tuples/TupleDescriptorTest.cs
@@ -120,7 +120,9 @@ namespace Xtensive.Orm.Tests.Core.Tuples
     private TupleDescriptor TestDescriptor(TupleDescriptor theSame, Type[] types)
     {
       var d1 = TupleDescriptor.Create(types);
+      var fds1 = d1.FieldDescriptors;
       var d2 = TupleDescriptor.Create(types);
+      var fds2 = d2.FieldDescriptors;
       Assert.IsNotNull(d1);
       Assert.IsNotNull(d2);
       Assert.AreEqual(d1, d2);

--- a/Orm/Xtensive.Orm.Tests.Core/Tuples/TupleDescriptorTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Tuples/TupleDescriptorTest.cs
@@ -83,7 +83,7 @@ namespace Xtensive.Orm.Tests.Core.Tuples
           descriptors.Add(TupleDescriptor.Create(types.ToArray()));
       }
     }
-    
+
     [Test]
     public void CombinedTest()
     {
@@ -100,7 +100,7 @@ namespace Xtensive.Orm.Tests.Core.Tuples
 
       desc = TestDescriptor(null, new Type[] {typeof(string)});
       desc = TestDescriptor(desc, new Type[] {typeof(string)});
-      
+
       desc = TestDescriptor(null, new Type[] {typeof(bool), typeof(bool)});
       desc = TestDescriptor(desc, new Type[] {typeof(bool?), typeof(bool?)});
 
@@ -117,7 +117,7 @@ namespace Xtensive.Orm.Tests.Core.Tuples
       desc = TestDescriptor(desc, new Type[] {typeof(bool?), typeof(bool), typeof(bool?)});
     }
 
-    private TupleDescriptor TestDescriptor(TupleDescriptor? theSame, Type[] types)
+    private TupleDescriptor TestDescriptor(TupleDescriptor theSame, Type[] types)
     {
       var d1 = TupleDescriptor.Create(types);
       var d2 = TupleDescriptor.Create(types);

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -57,7 +57,7 @@ namespace Xtensive.Orm.Rse
     /// Gets the tuple descriptor describing
     /// a set of <see cref="Order"/> columns.
     /// </summary>
-    public TupleDescriptor? OrderTupleDescriptor {
+    public TupleDescriptor OrderTupleDescriptor {
       get {
         if (Order.Count==0) {
           return null;
@@ -330,7 +330,7 @@ namespace Xtensive.Orm.Rse
       TupleDescriptor tupleDescriptor,
       IReadOnlyList<Column> columns,
       IReadOnlyList<ColumnGroup> columnGroups,
-      TupleDescriptor? orderKeyDescriptor,
+      TupleDescriptor orderKeyDescriptor,
       DirectionCollection<ColNum> order)
     {
       ArgumentValidator.EnsureArgumentNotNull(tupleDescriptor, "tupleDescriptor");

--- a/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/TupleLayout.cs
@@ -32,7 +32,7 @@ namespace Xtensive.Tuples.Packed
       public int Val128Counter;
     }
 
-    private static class ValueFieldAccessorResolver
+    internal static class ValueFieldAccessorResolver
     {
       private static readonly ValueFieldAccessor BoolAccessor = new BooleanFieldAccessor();
       private static readonly ValueFieldAccessor ByteAccessor = new ByteFieldAccessor();

--- a/Orm/Xtensive.Orm/Tuples/TupleDescriptor.cs
+++ b/Orm/Xtensive.Orm/Tuples/TupleDescriptor.cs
@@ -320,6 +320,12 @@ namespace Xtensive.Tuples
     private TupleDescriptor(Type[] fieldTypes)
     {
       FieldTypes = fieldTypes;
+      for (int i = 0, n = fieldTypes.Length; i < n; ++i) {
+        ref var fieldType = ref fieldTypes[i];
+        if (TupleLayout.ValueFieldAccessorResolver.GetValue(fieldType) is { } valueAccessor) {
+          fieldType = valueAccessor.FieldType;
+        }
+      }
     }
 
     public TupleDescriptor(SerializationInfo info, StreamingContext context)

--- a/Orm/Xtensive.Orm/Tuples/TupleDescriptor.cs
+++ b/Orm/Xtensive.Orm/Tuples/TupleDescriptor.cs
@@ -142,6 +142,9 @@ namespace Xtensive.Tuples
     /// <inheritdoc/>
     public bool Equals(TupleDescriptor other)
     {
+      if (other is null) {
+         return false;
+      }
       if (FieldTypes == null) {
         return other.FieldTypes == null;
       }
@@ -170,7 +173,7 @@ namespace Xtensive.Tuples
       return result;
     }
 
-    public static bool operator ==(in TupleDescriptor left, in TupleDescriptor right) => left.Equals(right);
+    public static bool operator ==(in TupleDescriptor left, in TupleDescriptor right) => left?.Equals(right) == true;
     public static bool operator !=(in TupleDescriptor left, in TupleDescriptor right) => !(left == right);
 
     #endregion

--- a/Orm/Xtensive.Orm/Tuples/TupleDescriptor.cs
+++ b/Orm/Xtensive.Orm/Tuples/TupleDescriptor.cs
@@ -173,7 +173,9 @@ namespace Xtensive.Tuples
       return result;
     }
 
-    public static bool operator ==(in TupleDescriptor left, in TupleDescriptor right) => left?.Equals(right) == true;
+    public static bool operator ==(in TupleDescriptor left, in TupleDescriptor right) =>
+      (left is null && right is null) || left?.Equals(right) == true;
+
     public static bool operator !=(in TupleDescriptor left, in TupleDescriptor right) => !(left == right);
 
     #endregion


### PR DESCRIPTION
We need not to build `PackedFieldDescriptor` until materialization Stage.

There are many intermediate translation stages (e.g. JOIN) when DO operates `TupleDescriptor` but does not use its `.FieldDescriptors` property.


