### PR TITLE
Refactoring and missing async

### DIFF
--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/QueryOperation.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/QueryOperation.cs
@@ -59,8 +59,7 @@ namespace Xtensive.Orm.BulkOperations
             else {
               var arguments = ex.Arguments.ToList();
               arguments.Insert(1, Expression.Constant(IncludeAlgorithm.ComplexCondition));
-              ex = Expression.Call(WellKnownMembers.InMethod.MakeGenericMethod(methodInfo.GetGenericArguments()),
-                arguments.ToArray());
+              ex = Expression.Call(WellKnownMembers.InMethod.MakeGenericMethod(methodInfo.GetGenericArguments()), arguments);
             }
           }
 

--- a/Orm/Xtensive.Orm.Manual/Prefetch/PrefetchTest.cs
+++ b/Orm/Xtensive.Orm.Manual/Prefetch/PrefetchTest.cs
@@ -142,7 +142,7 @@ namespace Xtensive.Orm.Manual.Prefetch
     public async Task MainAsyncTest()
     {
       await using (var session = await Domain.OpenSessionAsync())
-      using (var transactionScope = session.OpenTransaction()) {
+      using (var transactionScope = await session.OpenTransactionAsync()) {
         var employee = new Person(session) { Name = "Employee", Photo = new byte[] { 8, 0 } };
         var manager = new Person(session) { Name = "Manager", Photo = new byte[] { 8, 0 } };
         _ = manager.Employees.Add(employee);
@@ -150,7 +150,7 @@ namespace Xtensive.Orm.Manual.Prefetch
       }
 
       await using (var session = await Domain.OpenSessionAsync())
-      using (var transactionScope = session.OpenTransaction()) {
+      using (var transactionScope = await session.OpenTransactionAsync()) {
         var people = session.Query.All<Person>()
           .Prefetch(p => p.Photo) // Lazy load field
           .Prefetch(p => p.Employees // EntitySet Employees
@@ -164,7 +164,7 @@ namespace Xtensive.Orm.Manual.Prefetch
       }
 
       await using (var session = await Domain.OpenSessionAsync())
-      using (var transactionScope = session.OpenTransaction()) {
+      using (var transactionScope = await session.OpenTransactionAsync()) {
         var personIds = session.Query.All<Person>().Select(p => p.Id);
         var prefetchedPeople = session.Query.Many<Person, int>(personIds)
           .Prefetch(p => new { p.Photo, p.Manager }) // Lazy load field and Referenced entity
@@ -178,7 +178,7 @@ namespace Xtensive.Orm.Manual.Prefetch
       }
 
       await using (var session = await Domain.OpenSessionAsync())
-      using (var transactionScope = session.OpenTransaction()) {
+      using (var transactionScope = await session.OpenTransactionAsync()) {
         var people = session.Query.All<Person>()
           .Prefetch(p => p.Photo) // Lazy load field
           .Prefetch(p => p.Employees.Prefetch(e => e.Photo)) // EntitySet Employees and lazy load field of each of its items with the limit on number of items to be loaded
@@ -250,12 +250,12 @@ namespace Xtensive.Orm.Manual.Prefetch
       var count = 1000;
 
       await using (var session = await Domain.OpenSessionAsync())
-      using (var transactionScope = session.OpenTransaction()) {
+      using (var transactionScope = await session.OpenTransactionAsync()) {
         var people = new Person[count];
         for (var i = 0; i < count; i++) {
           people[i] = new Person(session) { Name = i.ToString(), Photo = new[] { (byte) (i % 256) } };
         }
-        session.SaveChanges();
+        await session.SaveChangesAsync();
 
         var random = new Random(10);
         for (var i = 0; i < count; i++) {
@@ -268,7 +268,7 @@ namespace Xtensive.Orm.Manual.Prefetch
       }
 
       await using (var session = await Domain.OpenSessionAsync())
-      using (var transactionScope = session.OpenTransaction()) {
+      using (var transactionScope = await session.OpenTransactionAsync()) {
         var prefetchedPeople = (
           from person in session.Query.All<Person>()
           orderby person.Name
@@ -339,7 +339,7 @@ namespace Xtensive.Orm.Manual.Prefetch
     public async Task DelayedQueryAsyncTest()
     {
       await using (var session = await Domain.OpenSessionAsync())
-      using (var transactionScope = session.OpenTransaction()) {
+      using (var transactionScope = await session.OpenTransactionAsync()) {
         var employee = new Person(session) { Name = "Employee", Photo = new byte[] { 8, 0 } };
         var manager = new Person(session) { Name = "Manager", Photo = new byte[] { 8, 0 } };
         _ = manager.Employees.Add(employee);
@@ -347,7 +347,7 @@ namespace Xtensive.Orm.Manual.Prefetch
       }
 
       await using (var session = await Domain.OpenSessionAsync())// no session activation!
-      using (var transactionScope = session.OpenTransaction()) {
+      using (var transactionScope = await session.OpenTransactionAsync()) {
         var people = session.Query.CreateDelayedQuery(q => q.All<Person>())
           .Prefetch(p => p.Photo) // Lazy load field
           .Prefetch(p => p.Employees // EntitySet Employees
@@ -360,7 +360,7 @@ namespace Xtensive.Orm.Manual.Prefetch
       }
 
       await using (var session = await Domain.OpenSessionAsync())// no session activation!
-      using (var transactionScope = session.OpenTransaction()) {
+      using (var transactionScope = await session.OpenTransactionAsync()) {
         var people = session.Query.CreateDelayedQuery(q => q.All<Person>())
           .Prefetch(p => p.Photo) // Lazy load field
           .Prefetch(p => p.Employees.Prefetch(e => e.Photo)) // EntitySet Employees and lazy load field of each of its items with the limit on number of items to be loaded
@@ -409,7 +409,7 @@ namespace Xtensive.Orm.Manual.Prefetch
     public async Task DelayedQueryAsyncShouldMaterializeAsyncTest()
     {
       await using (var session = await Domain.OpenSessionAsync()) {
-        using (var transactionScope = session.OpenTransaction()) {
+        using (var transactionScope = await session.OpenTransactionAsync()) {
           var employee = new Person(session) { Name = "Employee", Photo = new byte[] { 8, 0 } };
           var manager = new Person(session) { Name = "Manager", Photo = new byte[] { 8, 0 } };
           _ = manager.Employees.Add(employee);
@@ -425,7 +425,7 @@ namespace Xtensive.Orm.Manual.Prefetch
         var moq = new QueryCounterSessionHandlerMoq(handler);
         using (sessionAccessor.ChangeSessionHandler(moq))
 
-        using (var transactionScope = session.OpenTransaction()) {
+        using (var transactionScope = await session.OpenTransactionAsync()) {
           var people = session.Query.CreateDelayedQuery(q => q.All<Person>())
             .Prefetch(p => p.Photo) // Lazy load field
             .Prefetch(p => p.Employees // EntitySet Employees
@@ -448,7 +448,7 @@ namespace Xtensive.Orm.Manual.Prefetch
         var moq = new QueryCounterSessionHandlerMoq(handler);
         using (sessionAccessor.ChangeSessionHandler(moq))
 
-        using (var transactionScope = session.OpenTransaction()) {
+        using (var transactionScope = await session.OpenTransactionAsync()) {
           var people = session.Query.CreateDelayedQuery(q => q.All<Person>())
             .Prefetch(p => p.Photo) // Lazy load field
             .Prefetch(p => p.Employees.Prefetch(e => e.Photo)) // EntitySet Employees and lazy load field of each of its items with the limit on number of items to be loaded
@@ -519,7 +519,7 @@ namespace Xtensive.Orm.Manual.Prefetch
     public async Task CachedQueryAsyncTest()
     {
       await using (var session = await Domain.OpenSessionAsync())
-      using (var transactionScope = session.OpenTransaction()) {
+      using (var transactionScope = await session.OpenTransactionAsync()) {
         var employee = new Person(session) { Name = "Employee", Photo = new byte[] { 8, 0 } };
         var manager = new Person(session) { Name = "Manager", Photo = new byte[] { 8, 0 } };
         _ = manager.Employees.Add(employee);
@@ -527,7 +527,7 @@ namespace Xtensive.Orm.Manual.Prefetch
       }
 
       await using (var session = await Domain.OpenSessionAsync())// no session activation!
-      using (var transactionScope = session.OpenTransaction()) {
+      using (var transactionScope = await session.OpenTransactionAsync()) {
         var people = (await session.Query.ExecuteAsync(q => q.All<Person>()))
           .Prefetch(p => p.Photo) // Lazy load field
           .Prefetch(p => p.Employees // EntitySet Employees
@@ -540,7 +540,7 @@ namespace Xtensive.Orm.Manual.Prefetch
       }
 
       await using (var session = await Domain.OpenSessionAsync())// no session activation!
-      using (var transactionScope = session.OpenTransaction()) {
+      using (var transactionScope = await session.OpenTransactionAsync()) {
         var people = (await session.Query.ExecuteAsync(q => q.All<Person>()))
           .Prefetch(p => p.Photo) // Lazy load field
           .Prefetch(p => p.Employees.Prefetch(e => e.Photo)) // EntitySet Employees and lazy load field of each of its items with the limit on number of items to be loaded

--- a/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/DriverFactory.cs
+++ b/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/DriverFactory.cs
@@ -148,7 +148,7 @@ namespace Xtensive.Sql.Drivers.MySql
         SqlHelper.ExecuteInitializationSql(connection, configuration);
       }
       else {
-        await connection.OpenAsync().ConfigureAwait(false);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         await SqlHelper.ExecuteInitializationSqlAsync(connection, configuration, cancellationToken).ConfigureAwait(false);
       }
     }

--- a/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/DriverFactory.cs
+++ b/Orm/Xtensive.Orm.Oracle/Sql.Drivers.Oracle/DriverFactory.cs
@@ -140,7 +140,7 @@ namespace Xtensive.Sql.Drivers.Oracle
         SqlHelper.ExecuteInitializationSql(connection, configuration);
       }
       else {
-        await connection.OpenAsync().ConfigureAwait(false);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         await SqlHelper.ExecuteInitializationSqlAsync(connection, configuration, cancellationToken).ConfigureAwait(false);
       }
     }

--- a/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/DriverFactory.cs
+++ b/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/DriverFactory.cs
@@ -118,7 +118,7 @@ namespace Xtensive.Sql.Drivers.Sqlite
         SqlHelper.ExecuteInitializationSql(connection, configuration);
       }
       else {
-        await connection.OpenAsync().ConfigureAwait(false);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         await SqlHelper.ExecuteInitializationSqlAsync(connection, configuration, cancellationToken).ConfigureAwait(false);
       }
     }

--- a/Orm/Xtensive.Orm.Tests.Core/Collections/EnumerableExtensionsTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Collections/EnumerableExtensionsTest.cs
@@ -123,10 +123,10 @@ namespace Xtensive.Orm.Tests.Core.Collections
       const int maximalBatchSize = 32;
       const int fastFirstCount = 10;
       var result = source.Batch(fastFirstCount, initialBatchSize, maximalBatchSize);
-      Assert.AreEqual(fastFirstCount, result.TakeWhile(e => !(e is List<int>)).Count());
+      Assert.AreEqual(fastFirstCount, result.TakeWhile(e => e.Count() == 1).Count());
       var batchSize = initialBatchSize;
       Assert.IsTrue(result.Skip(fastFirstCount).All(e => {
-        var r = ((List<int>) e).Count==batchSize;
+        var r = e.Count()==batchSize;
         if(batchSize < maximalBatchSize)
           batchSize *= 2;
         return r;

--- a/Orm/Xtensive.Orm.Tests.Core/Helpers/StringExtensionsTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Helpers/StringExtensionsTest.cs
@@ -5,79 +5,120 @@
 // Created:    2009.03.17
 
 using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using Xtensive.Core;
-using Xtensive.Orm.Tests;
 
 namespace Xtensive.Orm.Tests.Core.Helpers
 {
   [TestFixture]
   public class StringExtensionsTest
   {
-    [Test]
-    public void RevertibleSplitJoinTest()
+    [TestCase(new[] { "" }, '\\', ',', ExpectedResult = "")]
+    [TestCase(new[] { "A" }, '\\', ',', ExpectedResult = "A")]
+    [TestCase(new[] { "A", "B" }, '\\', ',', ExpectedResult = "A,B")]
+    [TestCase(new[] { "A", "B", "C" }, '\\', ',', ExpectedResult = "A,B,C")]
+    [TestCase(new[] { "," }, '\\', ',', ExpectedResult = "\\,")]
+    [TestCase(new[] { "\\" }, '\\', ',', ExpectedResult = "\\\\")]
+    [TestCase(new[] { ",", "" }, '\\', ',', ExpectedResult = "\\,,")]
+    [TestCase(new[] { "", "," }, '\\', ',', ExpectedResult = ",\\,")]
+    [TestCase(new[] { "", "" }, '\\', ',', ExpectedResult = ",")]
+    public string RevertibleJoinTest(IEnumerable<string> source, char escape, char delimiter)
     {
-      Assert.AreEqual("A,B,C", new[] {"A", "B", "C"}.RevertibleJoin('\\', ','));
-      AssertEx.HasSameElements(new[] {"A", "B", "C"}, "A,B,C".RevertibleSplit('\\', ','));
-
-      Assert.AreEqual("A,B", new[] {"A", "B"}.RevertibleJoin('\\', ','));
-      AssertEx.HasSameElements(new[] {"A", "B"}, "A,B".RevertibleSplit('\\', ','));
-
-      Assert.AreEqual("A", new[] {"A"}.RevertibleJoin('\\', ','));
-      AssertEx.HasSameElements(new[] {"A"}, "A".RevertibleSplit('\\', ','));
-
-      Assert.AreEqual("", new[] {""}.RevertibleJoin('\\', ','));
-      Assert.AreEqual("", new string[] {}.RevertibleJoin('\\', ','));
-      AssertEx.HasSameElements(new[] {""}, "".RevertibleSplit('\\', ','));
-
-      Assert.AreEqual("\\,", new[] {","}.RevertibleJoin('\\', ','));
-      AssertEx.HasSameElements(new[] {","}, "\\,".RevertibleSplit('\\', ','));
-
-      Assert.AreEqual("\\,,", new[] {",",""}.RevertibleJoin('\\', ','));
-      AssertEx.HasSameElements(new[] {",", ""}, "\\,,".RevertibleSplit('\\', ','));
+      return source.RevertibleJoin(escape, delimiter);
     }
 
-    [Test]
-    public void IndentTest()
+    [TestCase("", '\\', ',', ExpectedResult = new[] { "" })]
+    [TestCase("A", '\\', ',', ExpectedResult = new[] { "A" })]
+    [TestCase("A,B", '\\', ',', ExpectedResult = new[] { "A", "B" })]
+    [TestCase("A,B,C", '\\', ',', ExpectedResult = new[] { "A", "B", "C" })]
+    [TestCase("\\", '\\', ',', ExpectedResult = new[] { "" })]
+    [TestCase("\\,", '\\', ',', ExpectedResult = new[] { "," })]
+    [TestCase("\\\\", '\\', ',', ExpectedResult = new[] { "\\" })]
+    [TestCase("\\,,", '\\', ',', ExpectedResult = new[] { ",", "" })]
+    [TestCase(",\\,", '\\', ',', ExpectedResult = new[] { "", "," })]
+    [TestCase(",", '\\', ',', ExpectedResult = new[] { "", "" })]
+    [TestCase("A,\\,", '\\', ',', ExpectedResult = new[] { "A", "," })]
+    [TestCase("\\A", '\\', ',', ExpectedResult = new[] { "A" })]
+    [TestCase("A\\", '\\', ',', ExpectedResult = new[] { "A" })]
+    [TestCase("A,", '\\', ',', ExpectedResult = new[] { "A", "" })]
+    [TestCase("\\A\\B", '\\', ',', ExpectedResult = new[] { "AB" })]
+    [TestCase("\\A\\B\\", '\\', ',', ExpectedResult = new[] { "AB" })]
+    public IEnumerable<string> RevertibleSplitTest(string source, char escape, char delimiter)
     {
-      Assert.AreEqual("A".Indent(0), "A");
-      Assert.AreEqual("A".Indent(1), " A");
-      Assert.AreEqual("A".Indent(2), "  A");
-
-      Assert.AreEqual("A".Indent(1, false), "A");
-      Assert.AreEqual("A\r\nB".Indent(1, false), "A\r\n B");
-      Assert.AreEqual("A\r\nB".Indent(1, true), " A\r\n B");
+      return source.RevertibleSplit(escape, delimiter);
     }
 
-    [Test]
-    public void LikeExtensionTest()
+    [TestCase("", '\\', ',', ExpectedResult = new[] { "", null })]
+    [TestCase("A", '\\', ',', ExpectedResult = new[] { "A", null })]
+    [TestCase("A,B", '\\', ',', ExpectedResult = new[] { "A", "B" })]
+    [TestCase("A,B,C", '\\', ',', ExpectedResult = new[] { "A", "B,C" })]
+    [TestCase("\\", '\\', ',', ExpectedResult = new[] { "", null })]
+    [TestCase("\\,", '\\', ',', ExpectedResult = new[] { ",", null })]
+    [TestCase("\\\\", '\\', ',', ExpectedResult = new[] { "\\", null })]
+    [TestCase("\\,,", '\\', ',', ExpectedResult = new[] { ",", "" })]
+    [TestCase(",\\,", '\\', ',', ExpectedResult = new[] { "", "\\," })]
+    [TestCase(",", '\\', ',', ExpectedResult = new[] { "", "" })]
+    [TestCase("A,\\,", '\\', ',', ExpectedResult = new[] { "A", "\\," })]
+    [TestCase("\\A", '\\', ',', ExpectedResult = new[] { "A", null })]
+    [TestCase("A\\", '\\', ',', ExpectedResult = new[] { "A", null })]
+    [TestCase("A,", '\\', ',', ExpectedResult = new[] { "A", "" })]
+    [TestCase("\\A\\B", '\\', ',', ExpectedResult = new[] { "AB", null })]
+    [TestCase("\\A\\B\\", '\\', ',', ExpectedResult = new[] { "AB", null })]
+    public string[] RevertibleSplitFirstAndTailTest(string source, char escape, char delimiter)
     {
-      _ = Assert.Throws<ArgumentException>(() => {
-        Assert.AreEqual("uewryewsf".Like("%sf"), true);
-        Assert.AreEqual("s__asdf".Like("_%asdf"), true);
-        Assert.AreEqual("dsfEEEE".Like("dsf%"), true);
-        Assert.AreEqual("Afigdf".Like("_figdf"), true);
-        Assert.AreEqual("fsdfASDsdfs".Like("fsdf___sdfs"), true);
-        Assert.AreEqual("my name is Alex.".Like("my name is _____"), true);
-        Assert.AreEqual("how old are you?".Like("how old % you_"), true);
-        Assert.AreEqual("hi, I'm alex. I'm 26".Like("hi, I'm ____. I'm %"), true);
-        Assert.AreEqual("it's another test string%%%".Like("it's another test string!%!%!%"), false);
-        Assert.AreEqual("it's another test string%%%".Like("it's another test string!%!%!%", '!'), true);
-        Assert.AreEqual("string with error.".Like("String with error_"), false);
-        Assert.AreEqual("Another string with error.".Like("another string with err%."), false);
-        Assert.AreEqual("aRRRRa%".Like("a%a%%", '%'), true);
-      });
+      var result = source.RevertibleSplitFirstAndTail(escape, delimiter);
+      return [result.First, result.Second];
     }
 
-    [Test]
-    public void TrimRoundBracketsSymetricallyTest()
+    [TestCase("A", 0, false, ExpectedResult = "A")]
+    [TestCase("A", 1, false, ExpectedResult = "A")]
+    [TestCase("A", 2, false, ExpectedResult = "A")]
+    [TestCase("A", 0, true, ExpectedResult = "A")]
+    [TestCase("A", 1, true, ExpectedResult = " A")]
+    [TestCase("A", 2, true, ExpectedResult = "  A")]
+
+    [TestCase("A\r\nB", 1, false, ExpectedResult = "A\r\n B")]
+    [TestCase("A\r\nB", 1, true, ExpectedResult = " A\r\n B")]
+    public string IndentTest(string source, int amount, bool firstLine)
     {
-      Assert.That("(abc)".StripRoundBrackets(), Is.EqualTo("abc"));
-      Assert.That("abc".StripRoundBrackets(), Is.EqualTo("abc"));
-      Assert.That("((((Convert(abc)))))".StripRoundBrackets(), Is.EqualTo("Convert(abc)"));
-      Assert.That("(Convert(abc))".StripRoundBrackets(), Is.EqualTo("Convert(abc)"));
-      Assert.That("((((abc))".StripRoundBrackets(), Is.EqualTo("((abc"));
-      Assert.That("((abc))))".StripRoundBrackets(), Is.EqualTo("abc))"));
+      return source.Indent(amount, firstLine);
+    }
+
+    [TestCase("uewryewsf", "%sf", ExpectedResult = true)]
+    [TestCase("s__asdf", "_%asdf", ExpectedResult = true)]
+    [TestCase("dsfEEEE", "dsf%", ExpectedResult = true)]
+    [TestCase("Afigdf", "_figdf", ExpectedResult = true)]
+    [TestCase("fsdfASDsdfs", "fsdf___sdfs", ExpectedResult = true)]
+    [TestCase("my name is Alex.", "my name is _____", ExpectedResult = true)]
+    [TestCase("how old are you?", "how old % you_", ExpectedResult = true)]
+    [TestCase("hi, I'm alex. I'm 26", "hi, I'm ____. I'm %", ExpectedResult = true)]
+    [TestCase("it's another test string%%%", "it's another test string!%!%!%", ExpectedResult = false)]
+    [TestCase("it's another test string%%%", "it's another test string!%!%!%", '!', ExpectedResult = true)]
+    [TestCase("string with error.", "String with error_", ExpectedResult = false)]
+    [TestCase("Another string with error.", "another string with err%.", ExpectedResult = false)]
+    public bool LikeExtensionTest(string source, string what, char escape = ' ')
+    {
+      if (escape == ' ')
+        return source.Like(what);
+      return source.Like(what, escape);
+    }
+
+    [TestCase("aRRRRa%", "a%a%%", '%')]
+    public void LikeExtensionTestThrows(string source, string what, char escape = ' ')
+    {
+      _ = Assert.Throws<ArgumentException>(() => source.Like(what, escape));
+    }
+
+    [TestCase("(abc)", ExpectedResult = "abc")]
+    [TestCase("abc", ExpectedResult = "abc")]
+    [TestCase("((((Convert(abc)))))", ExpectedResult = "Convert(abc)")]
+    [TestCase("(Convert(abc))", ExpectedResult = "Convert(abc)")]
+    [TestCase("((((abc))", ExpectedResult = "((abc")]
+    [TestCase("((abc))))", ExpectedResult = "abc))")]
+    public string TrimRoundBracketsSymmetricallyTest(string source)
+    {
+      return source.StripRoundBrackets();
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0180_ChangeNullabilityViaUpgradeHints/Upgrader.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0180_ChangeNullabilityViaUpgradeHints/Upgrader.cs
@@ -101,9 +101,7 @@ namespace Xtensive.Orm.Tests.Issues.IssueJira0180_ChangeNullabilityViaUpgradeHin
     public override bool IsTypeAvailable(Type type, UpgradeStage upgradeStage)
     {
       string suffix = ".Version" + runningVersion;
-      var originalNamespace = type.Namespace;
-      var nameSpace = originalNamespace.TryCutSuffix(suffix);
-      return nameSpace!=originalNamespace 
+      return type.Namespace.EndsWith(suffix, StringComparison.Ordinal)
         && base.IsTypeAvailable(type, upgradeStage);
     }
   }

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0208_IncorrectUpgradeSequence/Upgrader.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0208_IncorrectUpgradeSequence/Upgrader.cs
@@ -102,9 +102,7 @@ namespace Xtensive.Orm.Tests.Issues.IssueJira0208_IncorrectUpgradeSequence
     public override bool IsTypeAvailable(Type type, UpgradeStage upgradeStage)
     {
       string suffix = ".Version" + runningVersion;
-      var originalNamespace = type.Namespace;
-      var nameSpace = originalNamespace.TryCutSuffix(suffix);
-      return nameSpace!=originalNamespace 
+      return type.Namespace.EndsWith(suffix, StringComparison.Ordinal)
         && base.IsTypeAvailable(type, upgradeStage);
     }
   }

--- a/Orm/Xtensive.Orm.Tests/Issues/Issue_0694_SchemaUpgradeBug/Upgrader.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/Issue_0694_SchemaUpgradeBug/Upgrader.cs
@@ -85,8 +85,8 @@ namespace Xtensive.Orm.Tests.Issues.Issue_0694_SchemaUpgradeBug
         if (ns.EndsWith(oldVersionSuffix)) {
           string newNs = ns.Substring(0, ns.Length - oldVersionSuffix.Length) + newVersionSuffix;
           string newFullName = newNs + "." + name;
-          Type newType = upgradeContext.Configuration.Types.SingleOrDefault(t => t.FullName==newFullName);
-          if (newType!=null)
+          Type newType = upgradeContext.Configuration.Types.SingleOrDefault(t => t.FullName == newFullName);
+          if (newType != null)
             hints.Add(new RenameTypeHint(fullName, newType));
         }
       }
@@ -96,9 +96,7 @@ namespace Xtensive.Orm.Tests.Issues.Issue_0694_SchemaUpgradeBug
     public override bool IsTypeAvailable(Type type, UpgradeStage upgradeStage)
     {
       string suffix = ".Version" + runningVersion;
-      var originalNamespace = type.Namespace;
-      var nameSpace = originalNamespace.TryCutSuffix(suffix);
-      return nameSpace!=originalNamespace 
+      return type.Namespace.EndsWith(suffix)
         && base.IsTypeAvailable(type, upgradeStage);
     }
   }

--- a/Orm/Xtensive.Orm.Tests/Issues/Issue_0716_UpgradeFailsInValidateMode/Upgrader.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/Issue_0716_UpgradeFailsInValidateMode/Upgrader.cs
@@ -100,9 +100,7 @@ namespace Xtensive.Orm.Tests.Issues.Issue_0716_UpgradeFailsInValidateMode
     public override bool IsTypeAvailable(Type type, UpgradeStage upgradeStage)
     {
       string suffix = ".Version" + runningVersion;
-      var originalNamespace = type.Namespace;
-      var nameSpace = originalNamespace.TryCutSuffix(suffix);
-      return nameSpace!=originalNamespace 
+      return type.Namespace.EndsWith(suffix, StringComparison.Ordinal)
         && base.IsTypeAvailable(type, upgradeStage);
     }
   }

--- a/Orm/Xtensive.Orm.Tests/Issues/Issue_0743_UpgradeToNonNullableTypes/Upgrader.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/Issue_0743_UpgradeToNonNullableTypes/Upgrader.cs
@@ -107,9 +107,7 @@ namespace Xtensive.Orm.Tests.Issues.Issue_0743_UpgradeToNonNullableTypes
     public override bool IsTypeAvailable(Type type, UpgradeStage upgradeStage)
     {
       string suffix = ".Version" + runningVersion;
-      var originalNamespace = type.Namespace;
-      var nameSpace = originalNamespace.TryCutSuffix(suffix);
-      return nameSpace!=originalNamespace 
+      return type.Namespace.EndsWith(suffix, StringComparison.Ordinal)
         && base.IsTypeAvailable(type, upgradeStage);
     }
   }

--- a/Orm/Xtensive.Orm.Tests/Issues/Issue_0769_ByteArrayColumnUpgrade/Upgrader.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/Issue_0769_ByteArrayColumnUpgrade/Upgrader.cs
@@ -105,9 +105,7 @@ namespace Xtensive.Orm.Tests.Issues.Issue_0769_ByteArrayColumnUpgrade
     public override bool IsTypeAvailable(Type type, UpgradeStage upgradeStage)
     {
       string suffix = ".Version" + runningVersion;
-      var originalNamespace = type.Namespace;
-      var nameSpace = originalNamespace.TryCutSuffix(suffix);
-      return nameSpace!=originalNamespace 
+      return type.Namespace.EndsWith(suffix, StringComparison.Ordinal)
         && base.IsTypeAvailable(type, upgradeStage);
     }
   }

--- a/Orm/Xtensive.Orm.Tests/Issues/Issue_0837_HintGeneratorBug/Upgrader.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/Issue_0837_HintGeneratorBug/Upgrader.cs
@@ -99,9 +99,7 @@ namespace Xtensive.Orm.Tests.Issues.Issue_0834_HintGeneratorBug
     public override bool IsTypeAvailable(Type type, UpgradeStage upgradeStage)
     {
       string suffix = ".Version" + runningVersion;
-      var originalNamespace = type.Namespace;
-      var nameSpace = originalNamespace.TryCutSuffix(suffix);
-      return nameSpace!=originalNamespace 
+      return type.Namespace.EndsWith(suffix, StringComparison.Ordinal)
         && base.IsTypeAvailable(type, upgradeStage);
     }
   }

--- a/Orm/Xtensive.Orm.Tests/Issues/Issue_0841_HintGeneratorBug/Upgrader.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/Issue_0841_HintGeneratorBug/Upgrader.cs
@@ -101,9 +101,7 @@ namespace Xtensive.Orm.Tests.Issues.Issue_0841_HintGeneratorBug
     public override bool IsTypeAvailable(Type type, UpgradeStage upgradeStage)
     {
       string suffix = ".Version" + runningVersion;
-      var originalNamespace = type.Namespace;
-      var nameSpace = originalNamespace.TryCutSuffix(suffix);
-      return nameSpace!=originalNamespace 
+      return type.Namespace.EndsWith(suffix, StringComparison.Ordinal)
         && base.IsTypeAvailable(type, upgradeStage);
     }
   }

--- a/Orm/Xtensive.Orm.Tests/Issues/Issue_0841_HintGeneratorBug2/Upgrader.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/Issue_0841_HintGeneratorBug2/Upgrader.cs
@@ -126,9 +126,7 @@ namespace Xtensive.Orm.Tests.Issues.Issue_0841_HintGeneratorBug2
     public override bool IsTypeAvailable(Type type, UpgradeStage upgradeStage)
     {
       string suffix = ".Version" + runningVersion;
-      var originalNamespace = type.Namespace;
-      var nameSpace = originalNamespace.TryCutSuffix(suffix);
-      return nameSpace!=originalNamespace 
+      return type.Namespace.EndsWith(suffix, StringComparison.Ordinal)
         && base.IsTypeAvailable(type, upgradeStage);
     }
   }

--- a/Orm/Xtensive.Orm.Tests/Issues/Issue_0841_HintGeneratorBug3/Upgrader.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/Issue_0841_HintGeneratorBug3/Upgrader.cs
@@ -141,9 +141,7 @@ namespace Xtensive.Orm.Tests.Issues.Issue_0841_HintGeneratorBug3
     public override bool IsTypeAvailable(Type type, UpgradeStage upgradeStage)
     {
       string suffix = ".Version" + runningVersion;
-      var originalNamespace = type.Namespace;
-      var nameSpace = originalNamespace.TryCutSuffix(suffix);
-      return nameSpace!=originalNamespace 
+      return type.Namespace.EndsWith(suffix, StringComparison.Ordinal)
         && base.IsTypeAvailable(type, upgradeStage);
     }
   }

--- a/Orm/Xtensive.Orm.Tests/Issues/Issue_0841_HintGeneratorBug4/Upgrader.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/Issue_0841_HintGeneratorBug4/Upgrader.cs
@@ -99,9 +99,7 @@ namespace Xtensive.Orm.Tests.Issues.Issue_0841_HintGeneratorBug4
     public override bool IsTypeAvailable(Type type, UpgradeStage upgradeStage)
     {
       string suffix = ".Version" + runningVersion;
-      var originalNamespace = type.Namespace;
-      var nameSpace = originalNamespace.TryCutSuffix(suffix);
-      return nameSpace!=originalNamespace 
+      return type.Namespace.EndsWith(suffix, StringComparison.Ordinal)
         && base.IsTypeAvailable(type, upgradeStage);
     }
   }

--- a/Orm/Xtensive.Orm.Tests/Upgrade/DataUpgrade/Upgrader.cs
+++ b/Orm/Xtensive.Orm.Tests/Upgrade/DataUpgrade/Upgrader.cs
@@ -57,9 +57,7 @@ namespace Xtensive.Orm.Tests.Upgrade.DataUpgrade
     public override bool IsTypeAvailable(Type type, UpgradeStage upgradeStage)
     {
       string suffix = ".Version" + runningVersion;
-      var originalNamespace = type.Namespace;
-      var nameSpace = originalNamespace.TryCutSuffix(suffix);
-      return nameSpace != originalNamespace
+      return type.Namespace.EndsWith(suffix, StringComparison.Ordinal)
         && base.IsTypeAvailable(type, upgradeStage);
     }
 

--- a/Orm/Xtensive.Orm.Tests/Upgrade/EntitySetUpgrade/Upgrader.cs
+++ b/Orm/Xtensive.Orm.Tests/Upgrade/EntitySetUpgrade/Upgrader.cs
@@ -88,9 +88,7 @@ namespace Xtensive.Orm.Tests.Upgrade.EntitySetUpgradeTest
     public override bool IsTypeAvailable(Type type, UpgradeStage upgradeStage)
     {
       string suffix = ".Version" + runningVersion;
-      var originalNamespace = type.Namespace;
-      var nameSpace = originalNamespace.TryCutSuffix(suffix);
-      return nameSpace != originalNamespace
+      return type.Namespace.EndsWith(suffix, StringComparison.Ordinal)
         && base.IsTypeAvailable(type, upgradeStage);
     }
   }

--- a/Orm/Xtensive.Orm.Tests/Upgrade/Recycled/Upgrader.cs
+++ b/Orm/Xtensive.Orm.Tests/Upgrade/Recycled/Upgrader.cs
@@ -94,12 +94,8 @@ namespace Xtensive.Orm.Tests.Upgrade.Recycled
     public override bool IsTypeAvailable(Type type, UpgradeStage upgradeStage)
     {
       string suffix = ".Version" + runningVersion;
-      var originalNamespace = type.Namespace;
-      var nameSpace = originalNamespace.TryCutSuffix(suffix);
-      return nameSpace!=originalNamespace 
+      return type.Namespace.EndsWith(suffix, StringComparison.Ordinal)
         && base.IsTypeAvailable(type, upgradeStage);
     }
-
-    
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Upgrade/Sample3/Upgrader.cs
+++ b/Orm/Xtensive.Orm.Tests/Upgrade/Sample3/Upgrader.cs
@@ -88,9 +88,7 @@ namespace Xtensive.Orm.Tests.Upgrade.Sample3
     public override bool IsTypeAvailable(Type type, UpgradeStage upgradeStage)
     {
       string suffix = ".Version" + runningVersion;
-      var originalNamespace = type.Namespace;
-      var nameSpace = originalNamespace.TryCutSuffix(suffix);
-      return nameSpace!=originalNamespace 
+      return type.Namespace.EndsWith(suffix, StringComparison.Ordinal)
         && base.IsTypeAvailable(type, upgradeStage);
     }
   }

--- a/Orm/Xtensive.Orm.Tests/Upgrade/SimpleUpgrader.cs
+++ b/Orm/Xtensive.Orm.Tests/Upgrade/SimpleUpgrader.cs
@@ -83,9 +83,7 @@ namespace Xtensive.Orm.Tests.Upgrade
     public override bool IsTypeAvailable(Type type, UpgradeStage upgradeStage)
     {
       var suffix = "." + runningVersion;
-      var originalNamespace = type.Namespace;
-      var nameSpace = originalNamespace.TryCutSuffix(suffix);
-      return nameSpace != originalNamespace
+      return type.Namespace.EndsWith(suffix, StringComparison.Ordinal)
         && base.IsTypeAvailable(type, upgradeStage);
     }
   }

--- a/Orm/Xtensive.Orm.Tests/Upgrade/UpgradeAndNamingRules/Upgrader.cs
+++ b/Orm/Xtensive.Orm.Tests/Upgrade/UpgradeAndNamingRules/Upgrader.cs
@@ -97,9 +97,7 @@ namespace Xtensive.Orm.Tests.Upgrade.UpgradeAndNamingRules
     public override bool IsTypeAvailable(Type type, UpgradeStage upgradeStage)
     {
       string suffix = ".Version" + runningVersion;
-      var originalNamespace = type.Namespace;
-      var nameSpace = originalNamespace.TryCutSuffix(suffix);
-      return nameSpace!=originalNamespace 
+      return type.Namespace.EndsWith(suffix, StringComparison.Ordinal)
         && base.IsTypeAvailable(type, upgradeStage);
     }
   }

--- a/Orm/Xtensive.Orm.Tests/Upgrade/UpgradeToStructure/Upgrader.cs
+++ b/Orm/Xtensive.Orm.Tests/Upgrade/UpgradeToStructure/Upgrader.cs
@@ -97,9 +97,7 @@ namespace Xtensive.Orm.Tests.Upgrade.UpgradeToStructure
     public override bool IsTypeAvailable(Type type, UpgradeStage upgradeStage)
     {
       string suffix = ".Version" + runningVersion;
-      var originalNamespace = type.Namespace;
-      var nameSpace = originalNamespace.TryCutSuffix(suffix);
-      return nameSpace!=originalNamespace 
+      return type.Namespace.EndsWith(suffix, StringComparison.Ordinal)
         && base.IsTypeAvailable(type, upgradeStage);
     }
   }

--- a/Orm/Xtensive.Orm.Tests/Upgrade/Upgrader.cs
+++ b/Orm/Xtensive.Orm.Tests/Upgrade/Upgrader.cs
@@ -53,9 +53,7 @@ namespace Xtensive.Orm.Tests.Upgrade
     public override bool IsTypeAvailable(Type type, UpgradeStage upgradeStage)
     {
       string suffix = ".Version" + runningVersion;
-      var originalNamespace = type.Namespace;
-      var nameSpace = originalNamespace.TryCutSuffix(suffix);
-      return nameSpace!=originalNamespace 
+      return type.Namespace.EndsWith(suffix, StringComparison.Ordinal)
         && base.IsTypeAvailable(type, upgradeStage);
     }
 

--- a/Orm/Xtensive.Orm/Collections/BindingCollection.cs
+++ b/Orm/Xtensive.Orm/Collections/BindingCollection.cs
@@ -37,13 +37,11 @@ namespace Xtensive.Collections
           return;
         }
 
-        if (prevValueExists) {
-          if (!owner.permanentBindings.Contains(key)) {
+        if (!owner.permanentBindings.Contains(key)) {
+          if (prevValueExists) {
             owner.bindings[key] = prevValue;
           }
-        }
-        else {
-          if (!owner.permanentBindings.Contains(key)) {
+          else {
             owner.bindings.Remove(key);
           }
         }

--- a/Orm/Xtensive.Orm/Conversion/Internals/StringRoughAdvancedConverter.cs
+++ b/Orm/Xtensive.Orm/Conversion/Internals/StringRoughAdvancedConverter.cs
@@ -10,8 +10,8 @@ using System.Globalization;
 namespace Xtensive.Conversion
 {
   [Serializable]
-  internal class StringRoughAdvancedConverter :
-    RoughAdvancedConverterBase,
+  internal class StringRoughAdvancedConverter(IAdvancedConverterProvider provider) :
+    RoughAdvancedConverterBase(provider),
     IAdvancedConverter<string, bool>,
     IAdvancedConverter<string, byte>,
     IAdvancedConverter<string, sbyte>,
@@ -28,19 +28,22 @@ namespace Xtensive.Conversion
     IAdvancedConverter<string, TimeSpan>,
     IAdvancedConverter<string, Guid>
   {
-    bool IAdvancedConverter<string, bool>.Convert(string value)
-    {
-      return Boolean.Parse(value);
-    }
+    private const string HexPrefix = "0x";
+    private static readonly string[] DateTimeFormatStrings = ["yyyy/MM/dd hh:mm:ss.fffffff tt K "];
+
+    bool IAdvancedConverter<string, bool>.Convert(string value) =>
+      bool.Parse(value);
 
     byte IAdvancedConverter<string, byte>.Convert(string value)
     {
       try {
-        return Byte.Parse(value, NumberStyles.Any, CultureInfo.InvariantCulture);
+        return byte.Parse(value, NumberStyles.Any, CultureInfo.InvariantCulture);
       }
       catch (FormatException) {
-        if (value.Substring(0, 2).ToUpper().Equals("0X"))
-          return Byte.Parse(value.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        if (value.StartsWith(HexPrefix, StringComparison.OrdinalIgnoreCase)) {
+          return byte.Parse(value.AsSpan(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        }
+
         throw;
       }
     }
@@ -48,11 +51,13 @@ namespace Xtensive.Conversion
     sbyte IAdvancedConverter<string, sbyte>.Convert(string value)
     {
       try {
-        return SByte.Parse(value, NumberStyles.Any, CultureInfo.InvariantCulture);
+        return sbyte.Parse(value, NumberStyles.Any, CultureInfo.InvariantCulture);
       }
       catch (FormatException) {
-        if (value.Substring(0, 2).ToUpper().Equals("0X"))
-          return SByte.Parse(value.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        if (value.StartsWith(HexPrefix, StringComparison.OrdinalIgnoreCase)) {
+          return sbyte.Parse(value.AsSpan(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        }
+
         throw;
       }
     }
@@ -63,8 +68,10 @@ namespace Xtensive.Conversion
         return short.Parse(value, NumberStyles.Any, CultureInfo.InvariantCulture);
       }
       catch (FormatException) {
-        if (value.Substring(0, 2).ToUpper().Equals("0X"))
-          return short.Parse(value.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        if (value.StartsWith(HexPrefix, StringComparison.OrdinalIgnoreCase)) {
+          return short.Parse(value.AsSpan(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        }
+
         throw;
       }
     }
@@ -75,8 +82,10 @@ namespace Xtensive.Conversion
         return ushort.Parse(value, NumberStyles.Any, CultureInfo.InvariantCulture);
       }
       catch (FormatException) {
-        if (value.Substring(0, 2).ToUpper().Equals("0X"))
-          return ushort.Parse(value.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        if (value.StartsWith(HexPrefix, StringComparison.OrdinalIgnoreCase)) {
+          return ushort.Parse(value.AsSpan(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        }
+
         throw;
       }
     }
@@ -87,8 +96,10 @@ namespace Xtensive.Conversion
         return int.Parse(value, NumberStyles.Any, CultureInfo.InvariantCulture);
       }
       catch (FormatException) {
-        if (value.Substring(0, 2).ToUpper().Equals("0X"))
-          return int.Parse(value.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        if (value.StartsWith(HexPrefix, StringComparison.OrdinalIgnoreCase)) {
+          return int.Parse(value.AsSpan(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        }
+
         throw;
       }
     }
@@ -99,8 +110,10 @@ namespace Xtensive.Conversion
         return uint.Parse(value, NumberStyles.Any, CultureInfo.InvariantCulture);
       }
       catch (FormatException) {
-        if (value.Substring(0, 2).ToUpper().Equals("0X"))
-          return uint.Parse(value.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        if (value.StartsWith(HexPrefix, StringComparison.OrdinalIgnoreCase)) {
+          return uint.Parse(value.AsSpan(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        }
+
         throw;
       }
     }
@@ -111,8 +124,10 @@ namespace Xtensive.Conversion
         return long.Parse(value, NumberStyles.Any, CultureInfo.InvariantCulture);
       }
       catch (FormatException) {
-        if (value.Substring(0, 2).ToUpper().Equals("0X"))
-          return long.Parse(value.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        if (value.StartsWith(HexPrefix, StringComparison.OrdinalIgnoreCase)) {
+          return long.Parse(value.AsSpan(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        }
+
         throw;
       }
     }
@@ -123,54 +138,37 @@ namespace Xtensive.Conversion
         return ulong.Parse(value, NumberStyles.Any, CultureInfo.InvariantCulture);
       }
       catch (FormatException) {
-        if (value.Substring(0, 2).ToUpper().Equals("0X"))
-          return ulong.Parse(value.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        if (value.StartsWith(HexPrefix, StringComparison.OrdinalIgnoreCase)) {
+          return ulong.Parse(value.AsSpan(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        }
+
         throw;
       }
     }
 
-    float IAdvancedConverter<string, float>.Convert(string value)
-    {
-      return float.Parse(value, NumberStyles.Any, CultureInfo.InvariantCulture);
-    }
+    float IAdvancedConverter<string, float>.Convert(string value) =>
+      float.Parse(value, NumberStyles.Any, CultureInfo.InvariantCulture);
 
-    double IAdvancedConverter<string, double>.Convert(string value)
-    {
-      return double.Parse(value, NumberStyles.Any, CultureInfo.InvariantCulture);
-    }
+    double IAdvancedConverter<string, double>.Convert(string value) =>
+      double.Parse(value, NumberStyles.Any, CultureInfo.InvariantCulture);
 
-    decimal IAdvancedConverter<string, decimal>.Convert(string value)
-    {
-      return decimal.Parse(value, NumberStyles.Any, CultureInfo.InvariantCulture);
-    }
+    decimal IAdvancedConverter<string, decimal>.Convert(string value) =>
+      decimal.Parse(value, NumberStyles.Any, CultureInfo.InvariantCulture);
 
     DateTime IAdvancedConverter<string, DateTime>.Convert(string value)
     {
-      string[] strings = {"yyyy/MM/dd hh:mm:ss.fffffff tt K "};
       try {
-        return DateTime.ParseExact(value, strings, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+        return DateTime.ParseExact(value, DateTimeFormatStrings, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
       }
       catch (FormatException) {
         return DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
       }
     }
 
-    TimeSpan IAdvancedConverter<string, TimeSpan>.Convert(string value)
-    {
-      return TimeSpan.Parse(value);
-    }
+    TimeSpan IAdvancedConverter<string, TimeSpan>.Convert(string value) =>
+      TimeSpan.Parse(value);
 
-    Guid IAdvancedConverter<string, Guid>.Convert(string value)
-    {
-      return new Guid(value);
-    }
-
-
-    // Constructors
-
-    public StringRoughAdvancedConverter(IAdvancedConverterProvider provider)
-      : base(provider)
-    {
-    }
+    Guid IAdvancedConverter<string, Guid>.Convert(string value) => 
+      new(value);
   }
 }

--- a/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
@@ -449,7 +449,7 @@ namespace Xtensive.Core
           yield return buffer.Take(currentCount);
         }
         finally {
-          ArrayPool<T>.Shared.Return(buffer);
+          ArrayPool<T>.Shared.Return(buffer, true);
         }
       }
     }

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/Node.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/Node.cs
@@ -59,7 +59,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     protected virtual string GetDescription()
     {
-      var nodeName = GetType().Name.TryCutSuffix(typeof (Node).Name);
+      var nodeName = GetType().Name.AsSpan().TryCutSuffix(nameof(Node));
       return $"{nodeName}({Path})";
     }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/BatchingCommandProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/BatchingCommandProcessor.cs
@@ -257,10 +257,10 @@ namespace Xtensive.Orm.Providers
             var queryTask = context.ActiveTasks[currentQueryTask];
             var accessor = queryTask.Request.GetAccessor();
             var result = queryTask.Output;
-            while (command.NextRow()) {
+            while (await command.NextRowAsync(token).ConfigureAwaitFalse()) {
               result.Add(command.ReadTupleWith(accessor));
             }
-            _ = command.NextResult();
+            _ = await command.NextResultAsync(token).ConfigureAwaitFalse();
             currentQueryTask++;
           }
         }

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Provider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Provider.cs
@@ -21,7 +21,6 @@ namespace Xtensive.Orm.Rse.Providers
   public abstract class Provider
   {
     private const string ToString_ProviderTypeSuffix = "Provider";
-    private const string ToString_Parameters = " ({0})";
     private const int    ToString_IndentSize = 2;
 
     private RecordSetHeader header;
@@ -102,15 +101,9 @@ namespace Xtensive.Orm.Rse.Providers
 
     private string TitleToString()
     {
-      var sb = new StringBuilder();
       var type = GetType();
-      var providerName = (type.IsGenericType ? type.GetShortName() : type.Name).TryCutSuffix(ToString_ProviderTypeSuffix);
-      var parameters = ParametersToString();
-
-      sb.Append(providerName);
-      if (!parameters.IsNullOrEmpty())
-        sb.AppendFormat(ToString_Parameters, parameters);
-      return sb.ToString();
+      var providerName = (type.IsGenericType ? type.GetShortName() : type.Name).AsSpan().TryCutSuffix(ToString_ProviderTypeSuffix);
+      return $"{providerName}({ParametersToString()})";
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -200,7 +200,7 @@ namespace Xtensive.Orm.Rse
           .Where(g => g.Keys.All(k => columnsMap[k] >= 0))
           .Select(g => new ColumnGroup(
             g.TypeInfoRef,
-            g.Keys.Select(k => columnsMap[k]).ToArray(),
+            g.Keys.Select(k => columnsMap[k]).ToArray(g.Keys.Count),
             g.Columns
               .Select(c => columnsMap[c])
               .Where(c => c >= 0).ToList()));

--- a/Orm/Xtensive.Orm/Orm/Session.Persist.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.Persist.cs
@@ -309,7 +309,7 @@ namespace Xtensive.Orm
     private async Task SaveLocalChangesAsync(CancellationToken token = default)
     {
       Validate();
-      var transaction = OpenTransaction(TransactionOpenMode.New);
+      var transaction = await OpenTransactionAsync(TransactionOpenMode.New, token).ConfigureAwaitFalse();
       await using (transaction.ConfigureAwaitFalse()) {
         try {
           await PersistAsync(PersistReason.Manual, token).ConfigureAwaitFalse();

--- a/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
@@ -427,7 +427,7 @@ namespace Xtensive.Orm.Upgrade
       var session = await domain.OpenSessionAsync(SessionType.System, token).ConfigureAwaitFalse();
       await using (session.ConfigureAwaitFalse()) {
         using (session.Activate()) {
-          var transaction = session.OpenTransaction();
+          var transaction = await session.OpenTransactionAsync(token).ConfigureAwaitFalse();
           await using (transaction.ConfigureAwaitFalse()) {
             var upgrader = new SchemaUpgrader(context, session);
             var extractor = new SchemaExtractor(context, session);


### PR DESCRIPTION
- refactored `StringExtensions` and `StringRoughAdvancedConverter` to use `Span` overloads and minimize allocations
- refactored `StringExtensionsTests` and added some missing tests for easier maintenance.
- refactored `Batch` in `EnumerableExtensions` to use `ArrayPool` instead of `new List<>`
- fixed missing async flows using sync overloads.
- fixed async calls with missing cancellation support.