### PR TITLE
Optimization: `ColumnMap` type to minimize Linear search

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnExpression.cs
@@ -23,7 +23,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return new ColumnExpression(Type, newMapping, OuterParameter, DefaultIfEmpty);
     }
 
-    public override ColumnExpression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override ColumnExpression Remap(ColumnMap map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnMap.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnMap.cs
@@ -10,7 +10,7 @@ namespace Xtensive.Orm.Linq.Expressions
     private readonly ColNum[] reverseMap;
 
     public int IndexOf(ColNum column) =>
-      (ushort)column >= reverseMap.Length
+      (ushort) column >= reverseMap.Length
         ? -1
         : reverseMap[column];
 
@@ -23,14 +23,18 @@ namespace Xtensive.Orm.Linq.Expressions
 
     public ColumnMap(IReadOnlyList<ColNum> map)
     {
-      if (map.Count == 0) {
+      var n = map.Count == 0 ? 0 : map.Max() + 1;
+      if (n == 0) {
         reverseMap = Array.Empty<ColNum>();
       }
       else {
-        reverseMap = ArrayPool<ColNum>.Shared.Rent(map.Max() + 1);
+        reverseMap = ArrayPool<ColNum>.Shared.Rent(n);
         Array.Fill(reverseMap, (ColNum) (-1));
         for (int i = map.Count; i-- > 0;) {
-          reverseMap[map[i]] = (ColNum) i;
+          var colNum = map[i];
+          if (colNum >= 0) {
+            reverseMap[colNum] = (ColNum) i;
+          }
         }
       }
     }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnMap.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnMap.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Xtensive.Orm.Linq.Expressions
+{
+  internal readonly struct ColumnMap
+  {
+    private readonly ColNum[] reverseMap;
+
+    public ColNum IndexOf(ColNum column) =>
+      column < 0 || column >= reverseMap.Length
+        ? (ColNum) (-1)
+        : reverseMap[column];
+
+    public ColumnMap(IReadOnlyList<ColNum> map)
+    {
+      if (map.Count == 0) {
+        reverseMap = Array.Empty<ColNum>();
+      }
+      else {
+        reverseMap = new ColNum[map.Max() + 1];
+        Array.Fill(reverseMap, (ColNum) (-1));
+        for (int i = map.Count; i-- > 0;) {
+          reverseMap[map[i]] = (ColNum) i;
+        }
+      }
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnMap.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnMap.cs
@@ -9,7 +9,7 @@ namespace Xtensive.Orm.Linq.Expressions
     private readonly ColNum[] reverseMap;
 
     public ColNum IndexOf(ColNum column) =>
-      column < 0 || column >= reverseMap.Length
+      (ushort)column >= reverseMap.Length
         ? (ColNum) (-1)
         : reverseMap[column];
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnMap.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnMap.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Xtensive.Orm.Linq.Expressions
 {
-  internal readonly struct ColumnMap
+  internal readonly struct ColumnMap : IDisposable
   {
     private readonly ColNum[] reverseMap;
 
@@ -13,13 +14,20 @@ namespace Xtensive.Orm.Linq.Expressions
         ? (ColNum) (-1)
         : reverseMap[column];
 
+    public void Dispose()
+    {
+      if (reverseMap.Length > 0) {
+        ArrayPool<ColNum>.Shared.Return(reverseMap);
+      }
+    }
+
     public ColumnMap(IReadOnlyList<ColNum> map)
     {
       if (map.Count == 0) {
         reverseMap = Array.Empty<ColNum>();
       }
       else {
-        reverseMap = new ColNum[map.Max() + 1];
+        reverseMap = ArrayPool<ColNum>.Shared.Rent(map.Max() + 1);
         Array.Fill(reverseMap, (ColNum) (-1));
         for (int i = map.Count; i-- > 0;) {
           reverseMap[map[i]] = (ColNum) i;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnMap.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnMap.cs
@@ -9,9 +9,9 @@ namespace Xtensive.Orm.Linq.Expressions
   {
     private readonly ColNum[] reverseMap;
 
-    public ColNum IndexOf(ColNum column) =>
+    public int IndexOf(ColNum column) =>
       (ushort)column >= reverseMap.Length
-        ? (ColNum) (-1)
+        ? -1
         : reverseMap[column];
 
     public void Dispose()

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
@@ -74,7 +74,7 @@ namespace Xtensive.Orm.Linq
       return result;
     }
 
-    public override Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(ColumnMap map, Dictionary<Expression, Expression> processedExpressions)
     {
       Func<IMappedExpression, Expression> remapper = delegate(IMappedExpression mapped) {
         var parametrizedExpression = mapped as ParameterizedExpression;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityExpression.cs
@@ -50,7 +50,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override EntityExpression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override EntityExpression Remap(ColumnMap map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (TryProcessed<EntityExpression>(processedExpressions, out var value))
         return value;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityFieldExpression.cs
@@ -55,7 +55,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override EntityFieldExpression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override EntityFieldExpression Remap(ColumnMap map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (TryProcessed<EntityFieldExpression>(processedExpressions, out var value))
         return value;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntitySetExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntitySetExpression.cs
@@ -59,7 +59,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override EntitySetExpression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override EntitySetExpression Remap(ColumnMap map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
@@ -46,12 +46,12 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override FieldExpression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override FieldExpression Remap(ColumnMap map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (TryProcessed<FieldExpression>(processedExpressions, out var value))
         return value;
 
-      var offset = (ColNum)map.IndexOf(Mapping.Offset);
+      var offset = map.IndexOf(Mapping.Offset);
       if (offset < 0) {
         if (owner == null && !SkipOwnerCheckScope.IsActive) {
           throw new InvalidOperationException(Strings.ExUnableToRemapFieldExpression);

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
@@ -51,7 +51,7 @@ namespace Xtensive.Orm.Linq.Expressions
       if (TryProcessed<FieldExpression>(processedExpressions, out var value))
         return value;
 
-      var offset = map.IndexOf(Mapping.Offset);
+      var offset = (ColNum) map.IndexOf(Mapping.Offset);
       if (offset < 0) {
         if (owner == null && !SkipOwnerCheckScope.IsActive) {
           throw new InvalidOperationException(Strings.ExUnableToRemapFieldExpression);

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/FullTextExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/FullTextExpression.cs
@@ -59,7 +59,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return new FullTextExpression(FullTextIndex, remappedEntityExpression, remappedRankExpression, OuterParameter);
     }
 
-    public override Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(ColumnMap map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (!CanRemap)
         return this;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/GroupingExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/GroupingExpression.cs
@@ -70,7 +70,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override GroupingExpression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override GroupingExpression Remap(ColumnMap map, Dictionary<Expression, Expression> processedExpressions)
     {
       var remappedSubquery = base.Remap(map, processedExpressions);
       var remappedKeyExpression = GenericExpressionVisitor<IMappedExpression>.Process(KeyExpression, mapped => mapped.Remap(map, processedExpressions));

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Interfaces/IMappedExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Interfaces/IMappedExpression.cs
@@ -15,6 +15,6 @@ namespace Xtensive.Orm.Linq.Expressions
     Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions);
     Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions);
     Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions);
-    Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions);
+    Expression Remap(ColumnMap map, Dictionary<Expression, Expression> processedExpressions);
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
@@ -61,7 +61,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return new ItemProjectorExpression(item, dataSource, Context, AggregateType);
     }
 
-    public ItemProjectorExpression Remap(CompilableProvider dataSource, IReadOnlyList<ColNum> columnMap)
+    public ItemProjectorExpression Remap(CompilableProvider dataSource, ColumnMap columnMap)
     {
       var item = GenericExpressionVisitor<IMappedExpression>
         .Process(Item, mapped => mapped.Remap(columnMap, new Dictionary<Expression, Expression>()));

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/KeyExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/KeyExpression.cs
@@ -42,7 +42,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override KeyExpression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override KeyExpression Remap(ColumnMap map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (TryProcessed<KeyExpression>(processedExpressions, out var value))
         return value;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/LocalCollectionExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/LocalCollectionExpression.cs
@@ -42,7 +42,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(ColumnMap map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (TryProcessed<LocalCollectionExpression>(processedExpressions, out var value))
         return value;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ParameterizedExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ParameterizedExpression.cs
@@ -54,7 +54,7 @@ namespace Xtensive.Orm.Linq.Expressions
     public abstract Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions);
     public abstract Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions);
     public abstract Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions);
-    public abstract Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions);
+    public abstract Expression Remap(ColumnMap map, Dictionary<Expression, Expression> processedExpressions);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureExpression.cs
@@ -53,7 +53,7 @@ namespace Xtensive.Orm.Linq.Expressions
     }
 
     
-    public override Expression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override Expression Remap(ColumnMap map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (TryProcessed<StructureExpression>(processedExpressions, out var value))
         return value;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureFieldExpression.cs
@@ -55,7 +55,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override StructureFieldExpression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override StructureFieldExpression Remap(ColumnMap map, Dictionary<Expression, Expression> processedExpressions)
     {
       if (TryProcessed<StructureFieldExpression>(processedExpressions, out var value))
         return value;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/SubQueryExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/SubQueryExpression.cs
@@ -66,7 +66,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override SubQueryExpression Remap(IReadOnlyList<ColNum> map, Dictionary<Expression, Expression> processedExpressions)
+    public override SubQueryExpression Remap(ColumnMap map, Dictionary<Expression, Expression> processedExpressions)
     {
       // Don't check CanRemap - Remap always.
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -1443,13 +1443,13 @@ namespace Xtensive.Orm.Linq
         var subquery = (SubQueryExpression) original;
         var projectionExpression = subquery.ProjectionExpression;
         var itemProjector = projectionExpression.ItemProjector;
-        var columnIndexes = itemProjector.GetColumns(ColumnExtractionModes.KeepSegment);
+        var columnIndexes = new ColumnMap(itemProjector.GetColumns(ColumnExtractionModes.KeepSegment));
 
         var expReplacer = new ExtendedExpressionReplacer((e) => {
           if (e is GroupingExpression ge && ge.SelectManyInfo.GroupByProjection != null) {
             var geProjectionExpression = ge.ProjectionExpression;
             var geItemProjector = geProjectionExpression.ItemProjector;
-            var columnIndexes = geItemProjector.GetColumns(ColumnExtractionModes.KeepSegment);
+            var columnIndexes = new ColumnMap(geItemProjector.GetColumns(ColumnExtractionModes.KeepSegment));
 
             var newProjectionExpression = new ProjectionExpression(geProjectionExpression.Type,
               geItemProjector.Remap(geItemProjector.DataSource, columnIndexes),
@@ -1457,7 +1457,7 @@ namespace Xtensive.Orm.Linq
 
             var groupByProjection = ge.SelectManyInfo.GroupByProjection;
             var groupByProjector = groupByProjection.ItemProjector;
-            var groupByColumnIndexes = groupByProjector.GetColumns(ColumnExtractionModes.KeepSegment);
+            var groupByColumnIndexes = new ColumnMap(groupByProjector.GetColumns(ColumnExtractionModes.KeepSegment));
 
             var newGroupByProjection = new ProjectionExpression(groupByProjection.Type,
               groupByProjector.Remap(groupByProjector.DataSource, groupByColumnIndexes),

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -1443,13 +1443,13 @@ namespace Xtensive.Orm.Linq
         var subquery = (SubQueryExpression) original;
         var projectionExpression = subquery.ProjectionExpression;
         var itemProjector = projectionExpression.ItemProjector;
-        var columnIndexes = new ColumnMap(itemProjector.GetColumns(ColumnExtractionModes.KeepSegment));
+        using var columnIndexes = new ColumnMap(itemProjector.GetColumns(ColumnExtractionModes.KeepSegment));
 
         var expReplacer = new ExtendedExpressionReplacer((e) => {
           if (e is GroupingExpression ge && ge.SelectManyInfo.GroupByProjection != null) {
             var geProjectionExpression = ge.ProjectionExpression;
             var geItemProjector = geProjectionExpression.ItemProjector;
-            var columnIndexes = new ColumnMap(geItemProjector.GetColumns(ColumnExtractionModes.KeepSegment));
+            using var columnIndexes = new ColumnMap(geItemProjector.GetColumns(ColumnExtractionModes.KeepSegment));
 
             var newProjectionExpression = new ProjectionExpression(geProjectionExpression.Type,
               geItemProjector.Remap(geItemProjector.DataSource, columnIndexes),
@@ -1457,7 +1457,7 @@ namespace Xtensive.Orm.Linq
 
             var groupByProjection = ge.SelectManyInfo.GroupByProjection;
             var groupByProjector = groupByProjection.ItemProjector;
-            var groupByColumnIndexes = new ColumnMap(groupByProjector.GetColumns(ColumnExtractionModes.KeepSegment));
+            using var groupByColumnIndexes = new ColumnMap(groupByProjector.GetColumns(ColumnExtractionModes.KeepSegment));
 
             var newGroupByProjection = new ProjectionExpression(groupByProjection.Type,
               groupByProjector.Remap(groupByProjector.DataSource, groupByColumnIndexes),

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
@@ -91,7 +91,8 @@ namespace Xtensive.Orm.Linq
         usedColumns.Add(0);
       if (usedColumns.Count < origin.ItemProjector.DataSource.Header.Length) {
         var resultProvider = new SelectProvider(originProvider, usedColumns);
-        var itemProjector = origin.ItemProjector.Remap(resultProvider, new ColumnMap(usedColumns));
+        using var columnMap = new ColumnMap(usedColumns);
+        var itemProjector = origin.ItemProjector.Remap(resultProvider, columnMap);
         var result = origin.Apply(itemProjector);
         return result;
       }

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
@@ -91,7 +91,7 @@ namespace Xtensive.Orm.Linq
         usedColumns.Add(0);
       if (usedColumns.Count < origin.ItemProjector.DataSource.Header.Length) {
         var resultProvider = new SelectProvider(originProvider, usedColumns);
-        var itemProjector = origin.ItemProjector.Remap(resultProvider, usedColumns);
+        var itemProjector = origin.ItemProjector.Remap(resultProvider, new ColumnMap(usedColumns));
         var result = origin.Apply(itemProjector);
         return result;
       }

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -434,7 +434,7 @@ namespace Xtensive.Orm.Linq
       var targetEntity = EntityExpression.Create(targetTypeInfo, 0, false);
       Expression expression;
       using (new RemapScope()) {
-        expression = targetEntity.Remap(map, new Dictionary<Expression, Expression>());
+        expression = targetEntity.Remap(new ColumnMap(map), new Dictionary<Expression, Expression>());
       }
 
       var replacer = new ExtendedExpressionReplacer(e => e == sourceEntity ? expression : null);
@@ -760,7 +760,7 @@ namespace Xtensive.Orm.Linq
       var rs = itemProjector.DataSource
         .Select(columnIndexes)
         .Distinct();
-      itemProjector = itemProjector.Remap(rs, columnIndexes);
+      itemProjector = itemProjector.Remap(rs, new ColumnMap(columnIndexes));
       return new ProjectionExpression(result.Type, itemProjector, result.TupleParameterBindings);
     }
 
@@ -1028,7 +1028,7 @@ namespace Xtensive.Orm.Linq
       var keyColumns = keyFieldsRaw.Select(pair => pair.First).ToArray();
       var keyDataSource = groupingSourceProjection.ItemProjector.DataSource.Aggregate(keyColumns);
       var remappedKeyItemProjector =
-        groupingSourceProjection.ItemProjector.RemoveOwner().Remap(keyDataSource, keyColumns);
+        groupingSourceProjection.ItemProjector.RemoveOwner().Remap(keyDataSource, new ColumnMap(keyColumns));
 
       var groupingProjector = new ItemProjectorExpression(remappedKeyItemProjector.Item, keyDataSource, context);
       var groupingProjection = new ProjectionExpression(groupingSourceProjection.Type, groupingProjector,
@@ -1652,7 +1652,7 @@ namespace Xtensive.Orm.Linq
 
       var tupleParameterBindings = outer.TupleParameterBindings.Union(inner.TupleParameterBindings)
         .ToDictionary(pair => pair.Key, pair => pair.Value);
-      var itemProjector = outerItemProjector.Remap(recordSet, outerColumnList);
+      var itemProjector = outerItemProjector.Remap(recordSet, new ColumnMap(outerColumnList));
       return new ProjectionExpression(outer.Type, itemProjector, tupleParameterBindings);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -434,7 +434,8 @@ namespace Xtensive.Orm.Linq
       var targetEntity = EntityExpression.Create(targetTypeInfo, 0, false);
       Expression expression;
       using (new RemapScope()) {
-        expression = targetEntity.Remap(new ColumnMap(map), new Dictionary<Expression, Expression>());
+        using var columnMap = new ColumnMap(map);
+        expression = targetEntity.Remap(columnMap, new Dictionary<Expression, Expression>());
       }
 
       var replacer = new ExtendedExpressionReplacer(e => e == sourceEntity ? expression : null);
@@ -760,7 +761,8 @@ namespace Xtensive.Orm.Linq
       var rs = itemProjector.DataSource
         .Select(columnIndexes)
         .Distinct();
-      itemProjector = itemProjector.Remap(rs, new ColumnMap(columnIndexes));
+      using var columnMap = new ColumnMap(columnIndexes);
+      itemProjector = itemProjector.Remap(rs, columnMap);
       return new ProjectionExpression(result.Type, itemProjector, result.TupleParameterBindings);
     }
 
@@ -1027,8 +1029,8 @@ namespace Xtensive.Orm.Linq
 
       var keyColumns = keyFieldsRaw.Select(pair => pair.First).ToArray();
       var keyDataSource = groupingSourceProjection.ItemProjector.DataSource.Aggregate(keyColumns);
-      var remappedKeyItemProjector =
-        groupingSourceProjection.ItemProjector.RemoveOwner().Remap(keyDataSource, new ColumnMap(keyColumns));
+      using var columnMap = new ColumnMap(keyColumns);
+      var remappedKeyItemProjector = groupingSourceProjection.ItemProjector.RemoveOwner().Remap(keyDataSource, columnMap);
 
       var groupingProjector = new ItemProjectorExpression(remappedKeyItemProjector.Item, keyDataSource, context);
       var groupingProjection = new ProjectionExpression(groupingSourceProjection.Type, groupingProjector,
@@ -1652,7 +1654,8 @@ namespace Xtensive.Orm.Linq
 
       var tupleParameterBindings = outer.TupleParameterBindings.Union(inner.TupleParameterBindings)
         .ToDictionary(pair => pair.Key, pair => pair.Value);
-      var itemProjector = outerItemProjector.Remap(recordSet, new ColumnMap(outerColumnList));
+      using var columnMap = new ColumnMap(outerColumnList);
+      var itemProjector = outerItemProjector.Remap(recordSet, columnMap);
       return new ProjectionExpression(outer.Type, itemProjector, tupleParameterBindings);
     }
 


### PR DESCRIPTION
Profiling shows that `.IndexOf()` extension is a Hotspot as result of  `O(n²)`-complexity algorithms:

![image](https://github.com/servicetitan/dataobjects-net/assets/1176609/fa548f4f-098f-4372-b6a9-f588ed769da3)


`ColumnMap.IndexOf()` implements this operation without loop by pre-building reversed map
Because `FieldExpresion.Remap()` is invoked in loop for each Column, it is worth to pre-build the reverse map.