### PR TITLE
Optimize superset checking

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using Xtensive.Core;
 using Xtensive.Orm.Linq.Expressions.Visitors;
@@ -116,23 +117,7 @@ namespace Xtensive.Orm.Linq.Expressions
         if (e is EntityExpression entityExpression) {
           var typeInfo = entityExpression.PersistentType;
 
-          // Converted from LINQ to get rid of 2 closure allocations 
-          var all = true;
-          foreach (var fieldInfo in typeInfo.Fields) {
-            var isUsedInEntityExpression = false;
-            foreach (var entityField in entityExpression.Fields) {
-              if (string.Equals(entityField.Name, fieldInfo.Name, StringComparison.Ordinal)) {
-                isUsedInEntityExpression = true;
-                break;
-              }
-            }
-            if (!isUsedInEntityExpression) {
-              all = false;
-              break;
-            }
-          }
-
-          if (all) {
+          if (entityExpression.Fields.Select(o => o.Name).ToHashSet(StringComparer.Ordinal).IsSupersetOf(typeInfo.Fields.Select(o => o.Name))) {
             return entityExpression;
           }
 


### PR DESCRIPTION
This nested loop is a Hostspot:
![image](https://github.com/servicetitan/dataobjects-net/assets/1176609/9bc1aecd-016d-48bb-82b0-6cf1babb97a7)

Using `HashSet.IsSuperset()` is better for performance and readability.