### PR TITLE
Refactor from `Pair<>` to `ValueTuple`

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Rse/HeaderParseTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Rse/HeaderParseTest.cs
@@ -72,7 +72,7 @@ namespace Xtensive.Orm.Tests.Rse
           ResetState(state);
 
           // Select a.Id, a.TypeId, a.Title, b.Id, b.TypeId, b.Text
-          CompilableProvider rsJoin = rsTitle.Alias("a").Join(rsText.Alias("b"), new Pair<ColNum>(0, 0), new Pair<ColNum>(1, 1));
+          CompilableProvider rsJoin = rsTitle.Alias("a").Join(rsText.Alias("b"), (0, 0), (1, 1));
           UpdateCache(session, rsJoin.GetRecordSetReader(session, parameterContext));
           state = Session.Current.EntityStateCache[key, true];
           Assert.IsNotNull(state);

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntitySetTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntitySetTask.cs
@@ -232,19 +232,19 @@ namespace Xtensive.Orm.Internals.Prefetch
       }
     }
 
-    private static Pair<ColNum>[] GetJoiningColumnIndexes(IndexInfo primaryIndex, IndexInfo associationIndex, bool hasAuxType)
+    private static (ColNum Left, ColNum Right)[] GetJoiningColumnIndexes(IndexInfo primaryIndex, IndexInfo associationIndex, bool hasAuxType)
     {
-      var joiningColumns = new Pair<ColNum>[primaryIndex.KeyColumns.Count];
+      var joiningColumns = new (ColNum Left, ColNum Right)[primaryIndex.KeyColumns.Count];
       ColNum firstColumnIndex = (ColNum) primaryIndex.Columns.IndexOf(primaryIndex.KeyColumns[0].Key);
       for (ColNum i = 0; i < joiningColumns.Length; i++) {
         if (hasAuxType) {
           joiningColumns[i] =
-            new Pair<ColNum>((ColNum) associationIndex.Columns.IndexOf(associationIndex.ValueColumns[i]),
+            ((ColNum) associationIndex.Columns.IndexOf(associationIndex.ValueColumns[i]),
               (ColNum) (firstColumnIndex + i));
         }
         else {
           joiningColumns[i] =
-            new Pair<ColNum>((ColNum) associationIndex.Columns.IndexOf(primaryIndex.KeyColumns[i].Key),
+            ((ColNum) associationIndex.Columns.IndexOf(primaryIndex.KeyColumns[i].Key),
               (ColNum) (firstColumnIndex + i));
         }
       }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
@@ -139,10 +139,10 @@ namespace Xtensive.Orm.Linq.Expressions
           var joinedIndex = typeInfo.Indexes.PrimaryIndex;
           var joinedRs = joinedIndex.GetQuery().Alias(Context.GetNextAlias());
           var keySegment = entityExpression.Key.Mapping;
-          var keyPairs = new Pair<ColNum>[keySegment.Length];
+          var keyPairs = new (ColNum Left, ColNum Right)[keySegment.Length];
           ColNum rightIndex = 0;
           foreach (var leftIndex in keySegment.GetItems()) {
-            keyPairs[rightIndex] = new Pair<ColNum>(leftIndex, rightIndex);
+            keyPairs[rightIndex] = (leftIndex, rightIndex);
             rightIndex++;
           }
           var offset = dataSource.Header.Length;
@@ -163,10 +163,10 @@ namespace Xtensive.Orm.Linq.Expressions
           var joinedIndex = typeInfo.Indexes.PrimaryIndex;
           var joinedRs = joinedIndex.GetQuery().Alias(Context.GetNextAlias());
           var keySegment = entityFieldExpression.Mapping;
-          var keyPairs = new Pair<ColNum>[keySegment.Length];
+          var keyPairs = new (ColNum Left, ColNum Right)[keySegment.Length];
           ColNum rightIndex = 0;
           foreach (var leftIndex in keySegment.GetItems()) {
-            keyPairs[rightIndex] = new Pair<ColNum>(leftIndex, rightIndex);
+            keyPairs[rightIndex] = (leftIndex, rightIndex);
             rightIndex++;
           }
           var offset = dataSource.Header.Length;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ParameterizedExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ParameterizedExpression.cs
@@ -24,16 +24,7 @@ namespace Xtensive.Orm.Linq.Expressions
     /// Check if <see cref="ParameterizedExpression"/> can be remapped 
     /// according to current <see cref="RemapContext"/>.
     /// </summary>
-    protected bool CanRemap
-    {
-      get
-      {
-        var context = RemapScope.CurrentContext;
-        return context.SubqueryParameterExpression==null 
-          ? OuterParameter==null 
-          : OuterParameter==context.SubqueryParameterExpression;
-      }
-    }
+    protected bool CanRemap => RemapScope.CurrentContext.SubqueryParameterExpression == OuterParameter;
 
     protected bool TryProcessed<T>(Dictionary<Expression, Expression> processedExpressions, out T result) where T : ParameterizedExpression
     {

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -1560,7 +1560,7 @@ namespace Xtensive.Orm.Linq
       var queryToJoin = indexToJoin.GetQuery().Alias(context.GetNextAlias());
       var keySegment = entityExpression.Key.Mapping.GetItems();
       var keyPairs = keySegment
-        .Select((leftIndex, rightIndex) => new Pair<ColNum>(leftIndex, (ColNum)rightIndex))
+        .Select((leftIndex, rightIndex) => (leftIndex, (ColNum)rightIndex))
         .ToArray();
 
       // Replace recordset.
@@ -1596,8 +1596,8 @@ namespace Xtensive.Orm.Linq
       IndexInfo joinedIndex = typeInfo.Indexes.PrimaryIndex;
       var joinedRs = joinedIndex.GetQuery().Alias(itemProjector.Context.GetNextAlias());
       Segment<ColNum> keySegment = entityExpression.Key.Mapping;
-      Pair<ColNum>[] keyPairs = keySegment.GetItems()
-        .Select((leftIndex, rightIndex) => new Pair<ColNum>(leftIndex, (ColNum)rightIndex))
+      var keyPairs = keySegment.GetItems()
+        .Select((leftIndex, rightIndex) => (leftIndex, (ColNum)rightIndex))
         .ToArray();
       ColNum offset = itemProjector.DataSource.Header.Length;
       var oldDataSource = itemProjector.DataSource;
@@ -1617,8 +1617,8 @@ namespace Xtensive.Orm.Linq
       IndexInfo joinedIndex = typeInfo.Indexes.PrimaryIndex;
       var joinedRs = joinedIndex.GetQuery().Alias(context.GetNextAlias());
       Segment<ColNum> keySegment = entityFieldExpression.Mapping;
-      Pair<ColNum>[] keyPairs = keySegment.GetItems()
-        .Select((leftIndex, rightIndex) => new Pair<ColNum>(leftIndex, (ColNum)rightIndex))
+      (ColNum Left, ColNum Right)[] keyPairs = keySegment.GetItems()
+        .Select((leftIndex, rightIndex) => (leftIndex, (ColNum)rightIndex))
         .ToArray();
       ItemProjectorExpression originalItemProjector = entityFieldExpression.OuterParameter == null
         ? context.Bindings[State.Parameters[0]].ItemProjector

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -384,7 +384,7 @@ namespace Xtensive.Orm.Linq
       var recordSet = targetTypeInfo.Indexes.PrimaryIndex.GetQuery().Alias(context.GetNextAlias()).Select(indexes);
       var keySegment = visitedSource.ItemProjector.GetColumns(ColumnExtractionModes.TreatEntityAsKey);
       var keyPairs = keySegment
-        .Select((leftIndex, rightIndex) => new Pair<ColNum>(leftIndex, (ColNum)rightIndex))
+        .Select((leftIndex, rightIndex) => (leftIndex, (ColNum)rightIndex))
         .ToArray();
 
       var dataSource = visitedSource.ItemProjector.DataSource;
@@ -1224,7 +1224,7 @@ namespace Xtensive.Orm.Linq
           innerColumnKeyExpression.EnsureKeyExpressionCompatible(outerColumnKeyExpression, expressionPart);
         }
 
-        var keyPairs = outerColumns.Zip(innerColumns, (o, i) => new Pair<ColNum>(o.First, i.First)).ToArray();
+        var keyPairs = outerColumns.Zip(innerColumns, (o, i) => (o.First, i.First)).ToArray();
 
         var outer = context.Bindings[outerParameter];
         var inner = context.Bindings[innerParameter];

--- a/Orm/Xtensive.Orm/Orm/Providers/SessionHandler.References.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SessionHandler.References.cs
@@ -131,7 +131,7 @@ namespace Xtensive.Orm.Providers
               index.GetQuery(),
               association.Reversed.OwnerField.MappingInfo
                 .GetItems()
-                .Select((l,r) => new Pair<ColNum>(l, (ColNum) r))
+                .Select((l,r) => (l, (ColNum)r))
                 .ToArray())
             .Select(nonLazyColumnsSelector);
           break;
@@ -168,7 +168,7 @@ namespace Xtensive.Orm.Providers
               index.GetQuery(),
               referencedField.MappingInfo
                 .GetItems()
-                .Select((l, r) => new Pair<ColNum>(l, (ColNum) r))
+                .Select((l, r) => (l, (ColNum)r))
                 .ToArray())
             .Select(nonLazyColumnsSelector);
           break;

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Helpers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Helpers.cs
@@ -263,7 +263,7 @@ namespace Xtensive.Orm.Providers
 
           var joinProvider = (JoinProvider) origin;
           var isRight = joinProvider.Right == compiledSource.Origin;
-          var indexes = joinProvider.EqualIndexes.Select(p => isRight ? p.Second : p.First);
+          var indexes = joinProvider.EqualIndexes.Select(p => isRight ? p.Right : p.Left);
           return (joinProvider.JoinType == JoinType.LeftOuter && filterIsUsed && isRight)
             || (containsCalculatedColumns && indexes.Any(calculatedColumnIndexes.Contains));
         }
@@ -326,20 +326,20 @@ namespace Xtensive.Orm.Providers
       JoinProvider provider, int index)
     {
       if (provider.EqualColumns.Count > index) {
-        Pair<Column> columnPair;
+        Column leftColumn, rightColumn; 
         if (providerInfo.Supports(ProviderFeatures.DateTimeEmulation)) {
-          columnPair = provider.EqualColumns[index];
-          leftExpression = CastToDateTimeVariantIfNeeded(leftExpression, columnPair.First.Type);
-          rightExpression = CastToDateTimeVariantIfNeeded(rightExpression, columnPair.Second.Type);
+          (leftColumn, rightColumn) = provider.EqualColumns[index];
+          leftExpression = CastToDateTimeVariantIfNeeded(leftExpression, leftColumn.Type);
+          rightExpression = CastToDateTimeVariantIfNeeded(rightExpression, rightColumn.Type);
         }
 
         if (providerInfo.Supports(ProviderFeatures.DateTimeOffsetEmulation)) {
-          columnPair = provider.EqualColumns[index];
-          if (columnPair.First.Type == WellKnownTypes.DateTimeOffset) {
+          (leftColumn, rightColumn) = provider.EqualColumns[index];
+          if (leftColumn.Type == WellKnownTypes.DateTimeOffset) {
             leftExpression = SqlDml.Cast(leftExpression, SqlType.DateTimeOffset);
           }
 
-          if (columnPair.Second.Type == WellKnownTypes.DateTimeOffset) {
+          if (rightColumn.Type == WellKnownTypes.DateTimeOffset) {
             rightExpression = SqlDml.Cast(rightExpression, SqlType.DateTimeOffset);
           }
         }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -203,8 +203,9 @@ namespace Xtensive.Orm.Providers
 
       SqlExpression joinExpression = null;
       for (var i = 0; i < provider.EqualIndexes.Count(); ++i) {
-        var leftExpression = leftExpressions[provider.EqualIndexes[i].First];
-        var rightExpression = rightExpressions[provider.EqualIndexes[i].Second];
+        var (leftInder, rightIndex) = provider.EqualIndexes[i];
+        var leftExpression = leftExpressions[leftInder];
+        var rightExpression = rightExpressions[rightIndex];
         joinExpression &= GetJoinExpression(leftExpression, rightExpression, provider, i);
       }
 

--- a/Orm/Xtensive.Orm/Orm/Rse/CompilableProviderExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/CompilableProviderExtensions.cs
@@ -42,7 +42,7 @@ namespace Xtensive.Orm.Rse
     }
 
     public static CompilableProvider Join(this CompilableProvider left, CompilableProvider right,
-      params Pair<ColNum>[] joinedColumnIndexes)
+      params (ColNum Left, ColNum Right)[] joinedColumnIndexes)
     {
       return new JoinProvider(left, right, JoinType.Inner, joinedColumnIndexes);
     }
@@ -54,7 +54,7 @@ namespace Xtensive.Orm.Rse
     }
 
     public static CompilableProvider LeftJoin(this CompilableProvider left, CompilableProvider right,
-      params Pair<ColNum>[] joinedColumnIndexes)
+      params (ColNum Left, ColNum Right)[] joinedColumnIndexes)
     {
       return new JoinProvider(left, right, JoinType.LeftOuter, joinedColumnIndexes);
     }

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProviderVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProviderVisitor.cs
@@ -124,7 +124,7 @@ namespace Xtensive.Orm.Rse.Providers
       return left == provider.Left && right == provider.Right
         ? provider
         : new JoinProvider(left, right, provider.JoinType,
-            equalIndexes != null ? (Pair<ColNum>[])equalIndexes : provider.EqualIndexes);
+            equalIndexes != null ? ((ColNum Left, ColNum Right)[])equalIndexes : provider.EqualIndexes);
     }
 
     /// <inheritdoc/>

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
@@ -130,7 +130,7 @@ namespace Xtensive.Orm.Rse.Transformation
 
       var newLeftProvider = provider.Left;
       var newRightProvider = provider.Right;
-      VisitJoin(ref leftMapping, ref newLeftProvider, ref rightMapping, ref newRightProvider);
+      VisitJoin(ref leftMapping, ref newLeftProvider, ref rightMapping, ref newRightProvider, true);
 
       mappings[provider] = MergeMappings(provider.Left, leftMapping, rightMapping);
 
@@ -157,7 +157,7 @@ namespace Xtensive.Orm.Rse.Transformation
 
       var newLeftProvider = provider.Left;
       var newRightProvider = provider.Right;
-      VisitJoin(ref leftMapping, ref newLeftProvider, ref rightMapping, ref newRightProvider);
+      VisitJoin(ref leftMapping, ref newLeftProvider, ref rightMapping, ref newRightProvider, false);
       mappings[provider] = MergeMappings(provider.Left, leftMapping, rightMapping);
       var predicate = TranslateJoinPredicate(leftMapping, rightMapping, provider.Predicate);
 
@@ -481,10 +481,12 @@ namespace Xtensive.Orm.Rse.Transformation
     }
 
     private void VisitJoin(ref List<ColNum> leftMapping, ref CompilableProvider left, ref List<ColNum> rightMapping,
-      ref CompilableProvider right)
+      ref CompilableProvider right, bool sourceMappingsAreOrdered)
     {
-      leftMapping = leftMapping.Distinct().OrderBy(i => i).ToList();
-      rightMapping = rightMapping.Distinct().OrderBy(i => i).ToList();
+      if (!sourceMappingsAreOrdered) {
+        leftMapping = leftMapping.Distinct().OrderBy(i => i).ToList();
+        rightMapping = rightMapping.Distinct().OrderBy(i => i).ToList();
+      }
 
       // visit
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
@@ -124,8 +124,9 @@ namespace Xtensive.Orm.Rse.Transformation
 
       var (leftMapping, rightMapping) = SplitMappings(provider);
 
-      leftMapping = Merge(leftMapping, provider.EqualIndexes.Select(p => p.Left));
-      rightMapping = Merge(rightMapping, provider.EqualIndexes.Select(p => p.Right));
+      var equalIndexes = provider.EqualIndexes;
+      leftMapping = Merge(leftMapping, equalIndexes.Select(p => p.Left));
+      rightMapping = Merge(rightMapping, equalIndexes.Select(p => p.Right));
 
       var newLeftProvider = provider.Left;
       var newRightProvider = provider.Right;
@@ -137,11 +138,12 @@ namespace Xtensive.Orm.Rse.Transformation
         return provider;
       }
 
-      var newIndexes = new List<(ColNum Left, ColNum Right)>(provider.EqualIndexes.Count);
-      foreach (var pair in provider.EqualIndexes) {
-        newIndexes.Add(((ColNum) leftMapping.IndexOf(pair.Left), (ColNum) rightMapping.IndexOf(pair.Right)));
+      var newIndexes = new (ColNum Left, ColNum Right)[equalIndexes.Count];
+      for (int i = equalIndexes.Count; i-- > 0;) {
+        var (left, right) = equalIndexes[i];
+        newIndexes[i] = ((ColNum) leftMapping.IndexOf(left), (ColNum) rightMapping.IndexOf(right));
       }
-      return new JoinProvider(newLeftProvider, newRightProvider, provider.JoinType, newIndexes.ToArray());
+      return new JoinProvider(newLeftProvider, newRightProvider, provider.JoinType, newIndexes);
     }
 
     protected override PredicateJoinProvider VisitPredicateJoin(PredicateJoinProvider provider)

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
@@ -423,14 +423,8 @@ namespace Xtensive.Orm.Rse.Transformation
 
     #region Private methods
 
-    private static List<ColNum> Merge(IEnumerable<ColNum> left, IEnumerable<ColNum> right)
-    {
-      return left
-        .Union(right)
-        .Distinct()
-        .OrderBy(i => i)
-        .ToList();
-    }
+    private static List<ColNum> Merge(IEnumerable<ColNum> left, IEnumerable<ColNum> right) =>
+      left.Union(right).OrderBy(i => i).ToList();
 
     private static List<ColNum> MergeMappings(Provider originalLeft, IReadOnlyList<ColNum> leftMap, IReadOnlyList<ColNum> rightMap)
     {

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
@@ -124,8 +124,8 @@ namespace Xtensive.Orm.Rse.Transformation
 
       var (leftMapping, rightMapping) = SplitMappings(provider);
 
-      leftMapping = Merge(leftMapping, provider.EqualIndexes.Select(p => p.First));
-      rightMapping = Merge(rightMapping, provider.EqualIndexes.Select(p => p.Second));
+      leftMapping = Merge(leftMapping, provider.EqualIndexes.Select(p => p.Left));
+      rightMapping = Merge(rightMapping, provider.EqualIndexes.Select(p => p.Right));
 
       var newLeftProvider = provider.Left;
       var newRightProvider = provider.Right;
@@ -137,11 +137,9 @@ namespace Xtensive.Orm.Rse.Transformation
         return provider;
       }
 
-      var newIndexes = new List<Pair<ColNum>>(provider.EqualIndexes.Count);
+      var newIndexes = new List<(ColNum Left, ColNum Right)>(provider.EqualIndexes.Count);
       foreach (var pair in provider.EqualIndexes) {
-        var newLeftIndex = (ColNum) leftMapping.IndexOf(pair.First);
-        var newRightIndex = (ColNum) rightMapping.IndexOf(pair.Second);
-        newIndexes.Add(new Pair<ColNum>(newLeftIndex, newRightIndex));
+        newIndexes.Add(((ColNum) leftMapping.IndexOf(pair.Left), (ColNum) rightMapping.IndexOf(pair.Right)));
       }
       return new JoinProvider(newLeftProvider, newRightProvider, provider.JoinType, newIndexes.ToArray());
     }


### PR DESCRIPTION
Also:
* Minor array optimizations
* Don't call LINQ `.Distinct()` after `.Union()`. `.Union()` result guaranties no duplicates