### PR TITLE
Optimization: Make `CalculatedColumnDescriptor` & `AggregateColumnDescriptor` readonly structs

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/TotalBatchingTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Providers/Sql/TotalBatchingTest.cs
@@ -94,7 +94,7 @@ namespace Xtensive.Orm.Tests.Storage.Providers.Sql
       for (int i = 0; i < amount; i++) {
         var rs = Domain.Model.Types[typeof (X)].Indexes.PrimaryIndex.GetQuery()
           .Aggregate(System.Array.Empty<ColNum>(),
-            new AggregateColumnDescriptor("_count_", 0, AggregateType.Count));
+            [new AggregateColumnDescriptor("_count_", 0, AggregateType.Count)]);
         var compiledProvider = session.Compile(rs);
         var task = new QueryTask(compiledProvider, session.GetLifetimeToken(), null);
         tasks.Add(task);

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -1212,7 +1212,7 @@ namespace Xtensive.Orm.Linq
         dataSource = calculateProvider.Source;
       }
       columns.Add(descriptor);
-      dataSource = dataSource.Calculate(isInlined, columns.ToArray());
+      dataSource = dataSource.Calculate(isInlined, columns);
 
       if (sortProvider != null)
         dataSource = dataSource.OrderBy(sortProvider.Order);

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -776,7 +776,7 @@ namespace Xtensive.Orm.Linq
       var aggregateDescriptor = new AggregateColumnDescriptor(
         context.GetNextColumnAlias(), originColumnIndex, aggregateType);
       var originDataSource = originProjection.ItemProjector.DataSource;
-      var resultDataSource = originDataSource.Aggregate(null, aggregateDescriptor);
+      var resultDataSource = originDataSource.Aggregate(null, [aggregateDescriptor]);
 
       // Some aggregate method change type of the column
       // We should take this into account when translating them
@@ -1027,7 +1027,7 @@ namespace Xtensive.Orm.Linq
         : EmptyIntSet;
 
       var keyColumns = keyFieldsRaw.Select(pair => pair.First).ToArray();
-      var keyDataSource = groupingSourceProjection.ItemProjector.DataSource.Aggregate(keyColumns);
+      var keyDataSource = groupingSourceProjection.ItemProjector.DataSource.Aggregate(keyColumns, Array.Empty<AggregateColumnDescriptor>());
       using var columnMap = new ColumnMap(keyColumns);
       var remappedKeyItemProjector = groupingSourceProjection.ItemProjector.RemoveOwner().Remap(keyDataSource, columnMap);
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -880,8 +880,7 @@ namespace Xtensive.Orm.Linq
         var rightCalculateProvider = (CalculateProvider) right;
         var calculatedColumns = leftCalculateProvider.CalculatedColumns
           .Concat(rightCalculateProvider.CalculatedColumns)
-          .Select(c => new CalculatedColumnDescriptor(c.Name, c.Type, c.Expression))
-          .ToArray();
+          .Select(c => new CalculatedColumnDescriptor(c.Name, c.Type, c.Expression));
         if (aggregateDescriptor.SourceIndex >= source.Header.Length) {
           aggregateDescriptor = new AggregateColumnDescriptor(
             aggregateDescriptor.Name,

--- a/Orm/Xtensive.Orm/Orm/Rse/AggregateColumnDescriptor.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/AggregateColumnDescriptor.cs
@@ -14,46 +14,14 @@ namespace Xtensive.Orm.Rse
   /// Descriptor of the calculated column.
   /// </summary>
   [Serializable]
-  public class AggregateColumnDescriptor
+  public readonly record struct AggregateColumnDescriptor
+  (
+    string Name,
+    ColNum SourceIndex,
+    AggregateType AggregateType
+  )
   {
-    private const string ToStringFormat = "{0} = {1} on ({2})";
-
-    /// <summary>
-    /// Gets the column index.
-    /// </summary>
-    public string Name { get; private set; }
-
-    /// <summary>
-    /// Gets the column index.
-    /// </summary>
-    public ColNum SourceIndex { get; private set; }
-
-    /// <summary>
-    /// Gets the column type.
-    /// </summary>
-    public AggregateType AggregateType { get; private set; }
-
     /// <inheritdoc/>
-    public override string ToString()
-    {
-      return string.Format(ToStringFormat,
-        base.ToString(), AggregateType, SourceIndex);
-    }
-
-
-    // Constructors
-
-    /// <summary>
-    /// Initializes a new instance of this class.
-    /// </summary>
-    /// <param name="name"><see cref="Name"/> property value.</param>
-    /// <param name="index"><see cref="SourceIndex"/> property value.</param>
-    /// <param name="aggregateType">The <see cref="AggregateType"/> property value.</param>
-    public AggregateColumnDescriptor(string name, ColNum index, AggregateType aggregateType)
-    {
-      Name = name;
-      SourceIndex = index;
-      AggregateType = aggregateType;
-    }
+    public override string ToString() => $"{base.ToString()} = {AggregateType} on ({SourceIndex})";
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Rse/CalculatedColumnDescriptor.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/CalculatedColumnDescriptor.cs
@@ -8,7 +8,6 @@ using System;
 using System.Linq.Expressions;
 using Xtensive.Core;
 
-using Xtensive.Linq;
 using Xtensive.Reflection;
 using Xtensive.Tuples;
 using Tuple = Xtensive.Tuples.Tuple;
@@ -19,46 +18,13 @@ namespace Xtensive.Orm.Rse
   /// Descriptor of the calculated column.
   /// </summary>
   [Serializable]
-  public class CalculatedColumnDescriptor
+  public readonly record struct CalculatedColumnDescriptor
+  (
+    string Name,
+    Type Type,
+    Expression<Func<Tuple, object>> Expression
+  )
   {
-    private const string ToStringFormat = "{0} {1} = {2}";
-
-    /// <summary>
-    /// Gets the column name.
-    /// </summary>
-    public string Name { get; private set; }
-
-    /// <summary>
-    /// Gets the column type.
-    /// </summary>
-    public Type Type { get; private set; }
-
-    /// <summary>
-    /// Gets the column expression.
-    /// </summary>
-    public Expression<Func<Tuple, object>> Expression { get; private set; }
-
-    /// <inheritdoc/>
-    public override string ToString()
-    {
-      return string.Format(ToStringFormat,
-        Type.GetShortName(), Name, Expression.ToString(true));
-    }
-
-
-    // Constructors
-
-    /// <summary>
-    /// Initializes a new instance of this class.
-    /// </summary>
-    /// <param name="name">The <see cref="Name"/> property value.</param>
-    /// <param name="type">The <see cref="Type"/> property value.</param>
-    /// <param name="expression">The <see cref="Expression"/> property value.</param>
-    public CalculatedColumnDescriptor(string name, Type type, Expression<Func<Tuple, object>> expression)
-    {
-      Name = name;
-      Type = type;
-      Expression = expression;
-    }
+    public override string ToString() => $"{Type.GetShortName()} {Name} = {Expression.ToString(true)}";
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Rse/CompilableProviderExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/CompilableProviderExtensions.cs
@@ -31,7 +31,7 @@ namespace Xtensive.Orm.Rse
     }
 
     public static CompilableProvider Calculate(this CompilableProvider source, bool isInlined,
-      params CalculatedColumnDescriptor[] columns)
+      IEnumerable<CalculatedColumnDescriptor> columns)
     {
       return new CalculateProvider(source, isInlined, columns);
     }

--- a/Orm/Xtensive.Orm/Orm/Rse/CompilableProviderExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/CompilableProviderExtensions.cs
@@ -98,7 +98,7 @@ namespace Xtensive.Orm.Rse
     }
 
     public static CompilableProvider Aggregate(this CompilableProvider recordQuery,
-      ColNum[] groupIndexes, params AggregateColumnDescriptor[] descriptors)
+      ColNum[] groupIndexes, IEnumerable<AggregateColumnDescriptor> descriptors)
     {
       return new AggregateProvider(recordQuery, groupIndexes, descriptors);
     }

--- a/Orm/Xtensive.Orm/Orm/Rse/ProviderExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/ProviderExtensions.cs
@@ -43,7 +43,7 @@ namespace Xtensive.Orm.Rse
       ArgumentValidator.EnsureArgumentNotNull(provider, nameof(provider));
       ArgumentValidator.EnsureArgumentNotNull(session, nameof(session));
       using var recordSetReader = provider
-        .Aggregate(null, new AggregateColumnDescriptor("$Count", 0, AggregateType.Count))
+        .Aggregate(null, [new AggregateColumnDescriptor("$Count", 0, AggregateType.Count)])
         .GetRecordSetReader(session, new ParameterContext());
       return recordSetReader.MoveNext() && recordSetReader.Current != null
         ? recordSetReader.Current.GetValue<long>(0)

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/AggregateProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/AggregateProvider.cs
@@ -196,18 +196,15 @@ namespace Xtensive.Orm.Rse.Providers
     /// <param name="source">The <see cref="UnaryProvider.Source"/> property value.</param>
     /// <param name="columnDescriptors">The descriptors of <see cref="AggregateColumns"/>.</param>
     /// <param name="groupIndexes">The column indexes to group by.</param>
-    public AggregateProvider(CompilableProvider source, IReadOnlyList<ColNum> groupIndexes, IReadOnlyList<AggregateColumnDescriptor> columnDescriptors)
+    public AggregateProvider(CompilableProvider source, IReadOnlyList<ColNum> groupIndexes, IEnumerable<AggregateColumnDescriptor> columnDescriptors)
       : base(ProviderType.Aggregate, source)
     {
-      groupIndexes = groupIndexes ?? Array.Empty<ColNum>();
-      var columns = new AggregateColumn[columnDescriptors.Count];
-      for (int i = 0; i < columnDescriptors.Count; i++) {
-        AggregateColumnDescriptor descriptor = columnDescriptors[i];
-        var type = GetAggregateColumnType(Source.Header.Columns[descriptor.SourceIndex].Type, descriptor.AggregateType);
-        columns[i] = new AggregateColumn(descriptor, (ColNum)(groupIndexes.Count + i), type);
-      }
-      AggregateColumns = columns;
-      GroupColumnIndexes = groupIndexes;
+      GroupColumnIndexes = groupIndexes ?? Array.Empty<ColNum>();
+      var baseIndex = GroupColumnIndexes.Count;
+      var columns = Source.Header.Columns;
+      AggregateColumns = columnDescriptors
+        .Select((d, i) => new AggregateColumn(d, (ColNum)(baseIndex + i), GetAggregateColumnType(columns[d.SourceIndex].Type, d.AggregateType)))
+        .ToArray();
       Initialize();
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/CalculateProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/CalculateProvider.cs
@@ -5,6 +5,8 @@
 // Created:    2008.09.09
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Xtensive.Core;
 
 using Xtensive.Tuples.Transform;
@@ -65,7 +67,7 @@ namespace Xtensive.Orm.Rse.Providers
     /// </summary>
     /// <param name="source">The <see cref="UnaryProvider.Source"/> property value.</param>
     /// <param name="columnDescriptors">The descriptors of <see cref="CalculatedColumns"/>.</param>
-    public CalculateProvider(CompilableProvider source, params CalculatedColumnDescriptor[] columnDescriptors)
+    public CalculateProvider(CompilableProvider source, IEnumerable<CalculatedColumnDescriptor> columnDescriptors)
       : this(source, false, columnDescriptors)
     {
     }
@@ -76,16 +78,12 @@ namespace Xtensive.Orm.Rse.Providers
     /// <param name="source">The <see cref="UnaryProvider.Source"/> property value.</param>
     /// <param name="isInlined">The <see cref="IsInlined"/> property value.</param>
     /// <param name="columnDescriptors">The descriptors of <see cref="CalculatedColumns"/>.</param>
-    public CalculateProvider(CompilableProvider source, bool isInlined, params CalculatedColumnDescriptor[] columnDescriptors)
+    public CalculateProvider(CompilableProvider source, bool isInlined, IEnumerable<CalculatedColumnDescriptor> columnDescriptors)
       : base(ProviderType.Calculate, source)
     {
       IsInlined = isInlined;
-      var columns = new CalculatedColumn[columnDescriptors.Length];
-      for (int i = 0; i < columnDescriptors.Length; i++) {
-        var col = new CalculatedColumn(columnDescriptors[i], (ColNum) (Source.Header.Length + i));
-        columns.SetValue(col, i);
-      }
-      CalculatedColumns = columns;
+      var baseIndex = Source.Header.Length;
+      CalculatedColumns = columnDescriptors.Select((desc, i) => new CalculatedColumn(desc, (ColNum) (baseIndex + i))).ToArray();
       Initialize();
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProviderVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProviderVisitor.cs
@@ -196,9 +196,10 @@ namespace Xtensive.Orm.Rse.Providers
       if (source == provider.Source)
         return provider;
       if (resultParameters == null) {
-        var acd = new List<AggregateColumnDescriptor>(provider.AggregateColumns.Length);
-        acd.AddRange(provider.AggregateColumns.Select(ac => new AggregateColumnDescriptor(ac.Name, ac.SourceIndex, ac.AggregateType)));
-        return new AggregateProvider(source, provider.GroupColumnIndexes, acd);
+        return new AggregateProvider(source,
+          provider.GroupColumnIndexes,
+          provider.AggregateColumns.Select(ac => new AggregateColumnDescriptor(ac.Name, ac.SourceIndex, ac.AggregateType))
+        );
       }
       var result = (Pair<ColNum[], AggregateColumnDescriptor[]>) resultParameters;
       return new AggregateProvider(source, result.First, result.Second);

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProviderVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProviderVisitor.cs
@@ -155,17 +155,17 @@ namespace Xtensive.Orm.Rse.Providers
       var source = VisitCompilable(provider.Source);
       _ = OnRecursionExit(provider);
       var translated = false;
-      var descriptors = new List<CalculatedColumnDescriptor>(provider.CalculatedColumns.Length);
+      var descriptors = new CalculatedColumnDescriptor[provider.CalculatedColumns.Length];
+      int i = 0;
       foreach (var column in provider.CalculatedColumns) {
         var expression = translate(provider, column.Expression);
         if (expression != column.Expression)
           translated = true;
-        var ccd = new CalculatedColumnDescriptor(column.Name, column.Type, (Expression<Func<Tuple, object>>) expression);
-        descriptors.Add(ccd);
+        descriptors[i++] = new CalculatedColumnDescriptor(column.Name, column.Type, (Expression<Func<Tuple, object>>) expression);
       }
       return !translated && source == provider.Source
         ? provider
-        : new CalculateProvider(source, descriptors.ToArray());
+        : new CalculateProvider(source, descriptors);
     }
 
     /// <inheritdoc/>

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
@@ -307,7 +307,7 @@ namespace Xtensive.Orm.Rse.Transformation
 
       return !translated && newSourceProvider == provider.Source && descriptors.Count == provider.CalculatedColumns.Length
         ? provider
-        : new CalculateProvider(newSourceProvider, descriptors.ToArray());
+        : new CalculateProvider(newSourceProvider, descriptors);
     }
 
     protected override RowNumberProvider VisitRowNumber(RowNumberProvider provider)

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyProviderCorrectorRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyProviderCorrectorRewriter.cs
@@ -388,7 +388,7 @@ namespace Xtensive.Orm.Rse.Transformation
     {
       var acd = provider.AggregateColumns.Select(
         ac => new AggregateColumnDescriptor(ac.Name, ac.SourceIndex, ac.AggregateType));
-      return new AggregateProvider(source, provider.GroupColumnIndexes, acd.ToArray());
+      return new AggregateProvider(source, provider.GroupColumnIndexes, acd);
     }
 
     private static CalculateProvider RecreateCalculate(CalculateProvider provider,

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyProviderCorrectorRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyProviderCorrectorRewriter.cs
@@ -396,7 +396,7 @@ namespace Xtensive.Orm.Rse.Transformation
     {
       var ccd = provider.CalculatedColumns.Select(
         column => new CalculatedColumnDescriptor(column.Name, column.Type, column.Expression));
-      return new CalculateProvider(source, ccd.ToArray());
+      return new CalculateProvider(source, ccd);
     }
 
     private CalculateProvider RewriteCalculateColumnExpressions(
@@ -410,7 +410,7 @@ namespace Xtensive.Orm.Rse.Transformation
           var currentName = providerPair.Second.Single(c => c.Index==column.Index).Name;
           return new CalculatedColumnDescriptor(currentName, column.Type, newColumnExpression);
         });
-      return new CalculateProvider(source, ccd.ToArray());
+      return new CalculateProvider(source, ccd);
     }
 
     #endregion

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/OrderingRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/OrderingRewriter.cs
@@ -100,7 +100,7 @@ namespace Xtensive.Orm.Rse.Transformation
       if (source != provider.Source) {
         var acds = provider.AggregateColumns
            .Select(ac => new AggregateColumnDescriptor(ac.Name, ac.SourceIndex, ac.AggregateType));
-        result = new AggregateProvider(source, provider.GroupColumnIndexes, acds.ToArray());
+        result = new AggregateProvider(source, provider.GroupColumnIndexes, acds);
       }
       if (sortOrder.Count > 0) {
         var selectOrdering = new DirectionCollection<ColNum>();


### PR DESCRIPTION
Avoid intermediate arrays when creating `CalculateProvider` & `AggregateProvider`