### PR TITLE
`Expr.Constant(int)` helper to Memoize int `ConstantExpression`s

### DIFF
--- a/Orm/Xtensive.Orm/Core/Expr.cs
+++ b/Orm/Xtensive.Orm/Core/Expr.cs
@@ -1,13 +1,4 @@
-using System;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
-using Xtensive.Linq;
-using Xtensive.Linq.SerializableExpressions;
-using Xtensive.Linq.SerializableExpressions.Internals;
-
-using Xtensive.Reflection;
-using System.Collections.Concurrent;
 
 namespace Xtensive.Core
 {

--- a/Orm/Xtensive.Orm/Core/Expr.cs
+++ b/Orm/Xtensive.Orm/Core/Expr.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Xtensive.Linq;
+using Xtensive.Linq.SerializableExpressions;
+using Xtensive.Linq.SerializableExpressions.Internals;
+
+using Xtensive.Reflection;
+using System.Collections.Concurrent;
+
+namespace Xtensive.Core
+{
+  internal static class Expr
+  {
+    private static readonly ConstantExpression[] IntConstantExpressions = new ConstantExpression[2000];
+
+    public static ConstantExpression Constant(int v) =>
+        (uint)v < IntConstantExpressions.Length
+            ? IntConstantExpressions[v] ??= Expression.Constant(v)
+            : Expression.Constant(v);
+  }
+}

--- a/Orm/Xtensive.Orm/Linq/ConstantExtractor.cs
+++ b/Orm/Xtensive.Orm/Linq/ConstantExtractor.cs
@@ -61,7 +61,7 @@ namespace Xtensive.Linq
       if (!constantFilter.Invoke(c))
         return c;
       var result = Expression.Convert(
-        Expression.ArrayIndex(ConstantParameter, Expression.Constant(constantValues.Count)), c.Type);
+        Expression.ArrayIndex(ConstantParameter, Expr.Constant(constantValues.Count)), c.Type);
       constantValues.Add(c.Value);
       return result;
     }

--- a/Orm/Xtensive.Orm/Linq/ExpressionExtensions.cs
+++ b/Orm/Xtensive.Orm/Linq/ExpressionExtensions.cs
@@ -38,7 +38,7 @@ namespace Xtensive.Linq
       Expression.Call(
         target,
         valueAccessors.GetOrAdd(accessorType, TupleValueAccessorFactory),
-        Expression.Constant(index)
+        Expr.Constant(index)
       );
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/PartialIndexFilterBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/PartialIndexFilterBuilder.cs
@@ -162,7 +162,7 @@ namespace Xtensive.Orm.Building.Builders
       usedFields.Add(field);
       return Expression.Call(Parameter,
         WellKnownMembers.Tuple.GenericAccessor.CachedMakeGenericMethod(valueType),
-        Expression.Constant(fieldIndex));
+        Expr.Constant(fieldIndex));
     }
 
     private Expression BuildFieldCheck(FieldInfo field, ExpressionType nodeType)

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
@@ -366,16 +366,16 @@ namespace Xtensive.Orm.Linq.Materialization
       var isMaterializedExpression = Expression.Call(
         itemMaterializationContextParameter,
         ItemMaterializationContext.IsMaterializedMethodInfo,
-        Expression.Constant(index));
+        Expr.Constant(index));
       var getEntityExpression = Expression.Call(
         itemMaterializationContextParameter,
         ItemMaterializationContext.GetEntityMethodInfo,
-        Expression.Constant(index));
+        Expr.Constant(index));
       var materializeEntityExpression = Expression.Call(
         itemMaterializationContextParameter,
         ItemMaterializationContext.MaterializeMethodInfo,
-        Expression.Constant(index),
-        Expression.Constant(typeIdIndex),
+        Expr.Constant(index),
+        Expr.Constant(typeIdIndex),
         Expression.Constant(expression.PersistentType),
         Expression.Constant(mappingInfo),
         tupleExpression);

--- a/Orm/Xtensive.Orm/Orm/Linq/QueryHelper.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/QueryHelper.cs
@@ -48,11 +48,11 @@ namespace Xtensive.Orm.Linq
         var tupleParameterFieldAccess = Expression.Call(
           TupleParameter,
           getValueMethod,
-          Expression.Constant(startIndex + i));
+          Expr.Constant(startIndex + i));
         var keyParameterFieldAccess = Expression.Call(
           keyValue,
           getValueMethod,
-          Expression.Constant(i));
+          Expr.Constant(i));
         if (filterExpression==null)
           filterExpression = Expression.Equal(tupleParameterFieldAccess, keyParameterFieldAccess);
         else

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -72,7 +72,7 @@ namespace Xtensive.Orm.Linq
           boolExpression = MakeBooleanExpression(
             boolExpression,
             memberExpression,
-            Expression.Constant(typeId),
+            Expr.Constant(typeId),
             ExpressionType.Equal,
             ExpressionType.OrElse);
         }

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
@@ -139,7 +139,7 @@ namespace Xtensive.Orm.Linq
       Expression<Func<Session, int, MaterializationContext>> materializationContextCtor =
         (s, entityCount) => new MaterializationContext(s, entityCount);
       var materializationContextExpression = materializationContextCtor
-        .BindParameters(Session, Expression.Constant(materializationInfo.EntitiesInRow));
+        .BindParameters(Session, Expr.Constant(materializationInfo.EntitiesInRow));
 
       Expression body = Expression.Call(
         materializeMethod,

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -623,8 +623,8 @@ namespace Xtensive.Orm.Linq
         }
 
         compiledParameter = elementAtIndex.CachingCompile();
-        var skipComparison = Expression.LessThan(elementAtIndex.Body, Expression.Constant(0));
-        var condition = Expression.Condition(skipComparison, Expression.Constant(0), Expression.Constant(1));
+        var skipComparison = Expression.LessThan(elementAtIndex.Body, Expr.Constant(0));
+        var condition = Expression.Condition(skipComparison, Expr.Constant(0), Expr.Constant(1));
         var takeParameter = FastExpression.Lambda<Func<ParameterContext, int>>(condition, contextParameter);
         rs = projection.ItemProjector.DataSource.Skip(compiledParameter).Take(takeParameter.CachingCompile());
       }

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyFilterRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyFilterRewriter.cs
@@ -38,7 +38,7 @@ namespace Xtensive.Orm.Rse.Transformation
           return Expression.Call(LeftTupleParameter, mc.Method, mc.Arguments[0]);
         var name = sourceColumns.Single(column => column.Index == sourceIndex).Name;
         int currentIndex = targetColumns[name].Index;
-        return Expression.Call(mc.Object, mc.Method, Expression.Constant(currentIndex));
+        return Expression.Call(mc.Object, mc.Method, Expr.Constant(currentIndex));
       }
       return base.VisitMethodCall(mc);
     }

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/CalculateRelatedExpressionRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/CalculateRelatedExpressionRewriter.cs
@@ -48,7 +48,7 @@ namespace Xtensive.Orm.Rse.Transformation
         var sourceIndex = visited.GetTupleAccessArgument();
         var name = sourceColumns.Single(column => column.Index == sourceIndex).Name;
         int currentIndex = targetColumns[name].Index;
-        return Expression.Call(visited.Object, visited.Method, Expression.Constant(currentIndex));
+        return Expression.Call(visited.Object, visited.Method, Expr.Constant(currentIndex));
       }
       return visited;
     }

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/TupleAccessRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/TupleAccessRewriter.cs
@@ -40,7 +40,7 @@ namespace Xtensive.Orm.Rse.Transformation
           : Mappings.IndexOf(columnIndex);
         if ((newIndex < 0 && ignoreMissing) || newIndex == columnIndex)
           return mc;
-        return Expression.Call(mc.Object, mc.Method, Expression.Constant(newIndex));
+        return Expression.Call(mc.Object, mc.Method, Expr.Constant(newIndex));
       }
       return base.VisitMethodCall(mc);
     }


### PR DESCRIPTION
Frequently called in DO `Expression.Constant(int)` makes 2 allocations:
For boxing and for `ConstantExpression` object.

Expression objects are immutable. We can memoize them for first 2000 ints (~ number of TypeIDs)