### PR TITLE
Optimization: avoid intermediate `Pair<ColNum>` array

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Internals/EntityDataReader.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/EntityDataReader.cs
@@ -22,7 +22,7 @@ namespace Xtensive.Orm.Internals
     private readonly record struct RecordPartMapping
     (
       int TypeIdColumnIndex,
-      IReadOnlyList<Pair<ColNum>> Columns,
+      IEnumerable<(ColNum From, ColNum To)> Columns,
       TypeInfo ApproximateType
     );
 
@@ -47,7 +47,7 @@ namespace Xtensive.Orm.Internals
         for (int i = 0; i < recordPartCount; i++) {
           var columnGroup = columnGroups[i];
           var approximateType = columnGroup.TypeInfoRef.Resolve(model);
-          var columnMapping = new List<Pair<ColNum>>(columnGroup.Columns.Count);
+          var columnMapping = new List<(ColNum From, ColNum To)>(columnGroup.Columns.Count);
           var typeIdColumnIndex = -1;
           foreach (var columnIndex in columnGroup.Columns) {
             var column = (MappedColumn) columns[columnIndex];
@@ -57,7 +57,7 @@ namespace Xtensive.Orm.Internals
               if (columnInfo.Name == typeIdColumnName) {
                 typeIdColumnIndex = column.Index;
               }
-              columnMapping.Add(new Pair<ColNum>(targetColumnIndex, columnIndex));
+              columnMapping.Add((targetColumnIndex, columnIndex));
             }
           }
           mappings[i] = new RecordPartMapping(typeIdColumnIndex, columnMapping, approximateType);

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
@@ -248,10 +248,7 @@ namespace Xtensive.Orm.Linq.Materialization
         var mappingInfo = expression.Fields
           .OfType<FieldExpression>()
           .Where(f => f.ExtendedType==ExtendedExpressionType.Field)
-          .OrderBy(f => f.Field.MappingInfo.Offset)
-          .Select(f => new Pair<ColNum>(f.Field.MappingInfo.Offset, f.Mapping.Offset))
-          .Distinct()
-          .ToArray();
+          .Select(f => (f.Field.MappingInfo.Offset, f.Mapping.Offset));
 
         var columnMap = MaterializationHelper.CreateSingleSourceMap(tuplePrototype.Count, mappingInfo);
 
@@ -296,11 +293,8 @@ namespace Xtensive.Orm.Linq.Materialization
       var tuplePrototype = typeInfo.TuplePrototype;
       var mappingInfo = expression.Fields
         .OfType<FieldExpression>()
-        .Where(f => f.ExtendedType==ExtendedExpressionType.Field)
-        .OrderBy(f => f.Field.MappingInfo.Offset)
-        .Select(f => new Pair<ColNum>(f.Field.MappingInfo.Offset, f.Mapping.Offset))
-        .Distinct()
-        .ToArray();
+        .Where(f => f.ExtendedType==ExtendedExpressionType.Field)        
+        .Select(f => (f.Field.MappingInfo.Offset, f.Mapping.Offset));
 
       var columnMap = MaterializationHelper.CreateSingleSourceMap(tuplePrototype.Count, mappingInfo);
 
@@ -362,10 +356,8 @@ namespace Xtensive.Orm.Linq.Materialization
       var mappingInfo = expression.Fields
         .OfType<FieldExpression>()
         .Where(f => f.ExtendedType==ExtendedExpressionType.Field)
-        .OrderBy(f => f.Field.MappingInfo.Offset)
-        .Select(f => new Pair<ColNum>(f.Field.MappingInfo.Offset, f.Mapping.Offset))
-        .Distinct()
-        .ToArray();
+        .Select(f => (f.Field.MappingInfo.Offset, f.Mapping.Offset))
+        .ToHashSet();
 
       var isMaterializedExpression = Expression.Call(
         itemMaterializationContextParameter,

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ItemMaterializationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ItemMaterializationContext.cs
@@ -3,6 +3,7 @@
 // See the License.txt file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using Xtensive.Core;
 using Xtensive.Orm.Internals;
@@ -34,7 +35,7 @@ namespace Xtensive.Orm.Linq.Materialization
 
     public TypeInfo GetTypeInfo(int typeId) => typeId == TypeInfo.NoTypeId ? null : typeIdRegistry[typeId];
 
-    public Entity Materialize(int entityIndex, int typeIdIndex, TypeInfo type, Pair<ColNum>[] entityColumns, Tuple tuple)
+    public Entity Materialize(int entityIndex, int typeIdIndex, TypeInfo type, IEnumerable<(ColNum From, ColNum To)> entityColumns, Tuple tuple)
     {
       var result = entities[entityIndex];
       if (result!=null)

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
@@ -58,7 +58,7 @@ namespace Xtensive.Orm.Linq.Materialization
     /// </summary>
     public Queue<Action> MaterializationQueue { get; set; }
 
-    public TypeMapping GetTypeMapping(int entityIndex, TypeInfo approximateType, int typeId, IReadOnlyList<Pair<ColNum>> columns)
+    public TypeMapping GetTypeMapping(int entityIndex, TypeInfo approximateType, int typeId, IEnumerable<(ColNum From, ColNum To)> columns)
     {
       TypeMapping result;
       ref var cache = ref entityMappings[entityIndex];
@@ -75,19 +75,12 @@ namespace Xtensive.Orm.Linq.Materialization
       var keyInfo = type.Key;
       var descriptor = type.TupleDescriptor;
 
-      var typeColumnMap = columns;
+      IEnumerable<(ColNum From, ColNum To)> typeColumnMap = columns;
       if (approximateType.IsInterface) {
         // fixup target index
-        var newColumns = new Pair<ColNum>[columns.Count];
-        for (int i = columns.Count; i-- > 0;) {
-          var pair = columns[i];
-          var approxTargetIndex = pair.First;
-          var interfaceField = approximateType.Columns[approxTargetIndex].Field;
-          var field = type.FieldMap[interfaceField];
-          var targetIndex = field.MappingInfo.Offset;
-          newColumns[i] = new Pair<ColNum>(targetIndex, pair.Second);
-        }
-        typeColumnMap = newColumns;
+        var fieldMap = type.FieldMap;
+        var approximateTypeColumns = approximateType.Columns;
+        typeColumnMap = columns.Select(p => (fieldMap[approximateTypeColumns[p.From].Field].MappingInfo.Offset, p.To));
       }
 
       ArraySegment<ColNum> allIndexes = MaterializationHelper.CreateSingleSourceMap(descriptor.Count, typeColumnMap);

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationHelper.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationHelper.cs
@@ -43,18 +43,13 @@ namespace Xtensive.Orm.Linq.Materialization
     public static readonly MethodInfo PrefetchEntitySetMethodInfo = typeof(MaterializationHelper)
         .GetMethod(nameof(PrefetechEntitySet), BindingFlags.Public | BindingFlags.Static);
 
-    public static ColNum[] CreateSingleSourceMap(int targetLength, IReadOnlyList<Pair<ColNum>> remappedColumns)
+    public static ColNum[] CreateSingleSourceMap(int targetLength, IEnumerable<(ColNum From, ColNum To)> remappedColumns)
     {
       var map = new ColNum[targetLength];
       Array.Fill(map, MapTransform.NoMapping);
-
-      for (int i = 0, count = remappedColumns.Count; i < count; i++) {
-        var remappedColumn = remappedColumns[i];
-        var targetIndex = remappedColumn.First;
-        var sourceIndex = remappedColumn.Second;
-        map[targetIndex] = sourceIndex;
+      foreach (var p in remappedColumns) {
+        map[p.From] = p.To;
       }
-
       return map;
     }
 


### PR DESCRIPTION
Mapping does not depend on orderring and uniqueness of column maps
So we can skip heavy `.OrderBy()`, & `.Distinct()` LINQ operations