### PR TITLE
Optimization: Make `Entity*EventArgs` readonly struct records

### DIFF
--- a/Orm/Xtensive.Orm.Manual/ModellingDomain/AuditAndOpenGenericsTest.cs
+++ b/Orm/Xtensive.Orm.Manual/ModellingDomain/AuditAndOpenGenericsTest.cs
@@ -303,10 +303,16 @@ namespace Xtensive.Orm.Manual.ModellingDomain.AuditAndOpenGenericsTest
       }
     }
 
-    private void EntityEvent(object sender, EntityEventArgs e, bool created)
+    private void EntityEvent(object sender, object e, bool created)
     {
+      var entity = e switch {
+        EntityEventArgs o => o.Entity,
+        EntityRemoveCompletedEventArgs o => o.Entity,
+        EntityFieldValueSetCompletedEventArgs o => o.Entity,
+        EntityVersionInfoChangedEventArgs o => o.Entity,
+        _ => null
+      };
       try {
-        var entity = e.Entity;
         if (entity is AuditRecord)
           return; // Avoding recursion ;)
         if (entity is TransactionInfo)

--- a/Orm/Xtensive.Orm.Tests/Storage/SessionEventsTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/SessionEventsTest.cs
@@ -297,8 +297,8 @@ namespace Xtensive.Orm.Tests.Storage
 
           int value = entity.Value;
 
-          Assert.IsNull(eventInfo.EntityFieldValueSettingArgs);
-          Assert.IsNull(eventInfo.EntityFieldValueSetArgs);
+          Assert.IsTrue(eventInfo.EntityFieldValueSettingArgs == default);
+          Assert.IsTrue(eventInfo.EntityFieldValueSetArgs == default);
 
           Assert.IsNotNull(eventInfo.EntityFieldGettingArgs);
           Assert.AreEqual(entity, eventInfo.EntityFieldGettingArgs.Entity);
@@ -309,9 +309,9 @@ namespace Xtensive.Orm.Tests.Storage
           eventInfo.ResetEventArgs();
 
           entity.Remove();
-          Assert.IsNotNull(eventInfo.EntityRemoving);
+          Assert.IsFalse(eventInfo.EntityRemoving == default);
           Assert.AreEqual(entity, eventInfo.EntityRemoving.Entity);
-          Assert.IsNotNull(eventInfo.EntityRemoved);
+          Assert.IsFalse(eventInfo.EntityRemoved == default);
           Assert.AreEqual(entity, eventInfo.EntityRemoved.Entity);
         }
       }

--- a/Orm/Xtensive.Orm.Tests/Storage/SessionEventsTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/SessionEventsTest.cs
@@ -47,7 +47,7 @@ namespace Xtensive.Orm.Tests.Storage.SessionEventsTestModel
     public EventArgs ChangesCanceledArgs;
 
     public EntityEventArgs EntityCreatedArgs;
-    public EntityEventArgs EntityRemoving;
+    public EntityRemovingEventArgs EntityRemoving;
     public EntityEventArgs EntityRemoved;
 
     public EntityFieldEventArgs EntityFieldGettingArgs;
@@ -77,14 +77,14 @@ namespace Xtensive.Orm.Tests.Storage.SessionEventsTestModel
       ChangesCancelingArgs = null;
       ChangesCanceledArgs = null;
 
-      EntityCreatedArgs = null;
-      EntityRemoving = null;
-      EntityRemoved = null;
+      EntityCreatedArgs = default;
+      EntityRemoving = default;
+      EntityRemoved = default;
 
-      EntityFieldGettingArgs = null;
-      EntityFieldValueGetArgs = null;
-      EntityFieldValueSettingArgs = null;
-      EntityFieldValueSetArgs = null;
+      EntityFieldGettingArgs = default;
+      EntityFieldValueGetArgs = default;
+      EntityFieldValueSettingArgs = default;
+      EntityFieldValueSetArgs = default;
 
       QueryExecuting = null;
       QueryExecuted = null;
@@ -109,7 +109,7 @@ namespace Xtensive.Orm.Tests.Storage.SessionEventsTestModel
     private void OnChangesCanceling(object sender, EventArgs e) => ChangesCancelingArgs = e;
     private void OnChangesCanceled(object sender, EventArgs e) => ChangesCanceledArgs = e;
     private void OnEntityCreated(object sender, EntityEventArgs e) => EntityCreatedArgs = e;
-    private void OnEntityRemoving(object sender, EntityEventArgs e) => EntityRemoving = e;
+    private void OnEntityRemoving(object sender, EntityRemovingEventArgs e) => EntityRemoving = e;
     private void OnEntityRemove(object sender, EntityEventArgs e) => EntityRemoved = e;
     private void OnEntityFieldValueGetting(object sender, EntityFieldEventArgs e) => EntityFieldGettingArgs = e;
     private void OnEntityFieldValueGet(object sender, EntityFieldValueEventArgs e) => EntityFieldValueGetArgs = e;

--- a/Orm/Xtensive.Orm/Orm/EntityEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/EntityEventArgs.cs
@@ -12,23 +12,5 @@ namespace Xtensive.Orm
   /// <summary>
   /// Describes <see cref="Entity"/>-related events.
   /// </summary>
-  public class EntityEventArgs : EventArgs
-  {
-    /// <summary>
-    /// Gets the entity to which this event is related.
-    /// </summary>
-    public Entity Entity { get; }
-
-
-    // Constructors
-
-    /// <summary>
-    /// Initializes a new instance of this class.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    public EntityEventArgs(Entity entity)
-    {
-      Entity = entity;
-    }
-  }
+  public readonly record struct EntityEventArgs(Entity Entity);
 }

--- a/Orm/Xtensive.Orm/Orm/EntityFieldEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/EntityFieldEventArgs.cs
@@ -12,26 +12,5 @@ namespace Xtensive.Orm
   /// <summary>
   /// Describes <see cref="Entity"/> field-related events.
   /// </summary>
-  public class EntityFieldEventArgs : EntityEventArgs
-  {
-    /// <summary>
-    /// Gets the field to which this event is related.
-    /// </summary>
-    public FieldInfo Field { get; }
-
-
-    // Constructors
-
-
-    /// <summary>
-    /// Initializes a new instance of this class.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <param name="field">The field.</param>
-    public EntityFieldEventArgs(Entity entity, FieldInfo field)
-      : base(entity)
-    {
-      Field = field;
-    }
-  }
+  public readonly record struct EntityFieldEventArgs(Entity Entity, FieldInfo Field);
 }

--- a/Orm/Xtensive.Orm/Orm/EntityFieldValueEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/EntityFieldValueEventArgs.cs
@@ -12,26 +12,5 @@ namespace Xtensive.Orm
   /// <summary>
   /// Describes <see cref="Entity"/> field related events containing field value.
   /// </summary>
-  public class EntityFieldValueEventArgs : EntityFieldEventArgs
-  {
-    /// <summary>
-    /// Gets the field value.
-    /// </summary>
-    public object Value { get; private set; }
-
-
-    // Constructors
-
-    /// <summary>
-    /// Initializes a new instance of this class.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <param name="field">The field.</param>
-    /// <param name="value">The <see cref="Value"/> property value.</param>
-    public EntityFieldValueEventArgs(Entity entity, FieldInfo field, object value)
-      : base(entity, field)
-    {
-      Value = value;
-    }
-  }
+  public readonly record struct EntityFieldValueEventArgs(Entity Entity, FieldInfo Field, object Value);
 }

--- a/Orm/Xtensive.Orm/Orm/EntityFieldValueGetCompletedEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/EntityFieldValueGetCompletedEventArgs.cs
@@ -13,27 +13,5 @@ namespace Xtensive.Orm
   /// <summary>
   /// Describes <see cref="Entity"/> field reading completion events.
   /// </summary>
-  public class EntityFieldValueGetCompletedEventArgs : EntityFieldValueEventArgs
-  {
-    /// <summary>
-    /// Gets the exception, if any, that was thrown on getting the field value.
-    /// </summary>
-    public Exception Exception { get; private set; }
-
-
-    // Constructors
-
-    /// <summary>
-    /// Initializes a new instance of this class.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <param name="field">The field.</param>
-    /// <param name="value">The <see cref="EntityFieldValueEventArgs.Value"/> value.</param>
-    /// <param name="exception">The <see cref="Exception"/> value.</param>
-    public EntityFieldValueGetCompletedEventArgs(Entity entity, FieldInfo field, object value, Exception exception)
-      : base(entity, field, value)
-    {
-      Exception = exception;
-    }
-  }
+  public readonly record struct EntityFieldValueGetCompletedEventArgs(Entity Entity, FieldInfo Field, object Value, Exception Exception);
 }

--- a/Orm/Xtensive.Orm/Orm/EntityFieldValueSetCompletedEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/EntityFieldValueSetCompletedEventArgs.cs
@@ -13,28 +13,10 @@ namespace Xtensive.Orm
   /// <summary>
   /// Describes <see cref="Entity"/> field set completion events.
   /// </summary>
-  public class EntityFieldValueSetCompletedEventArgs : EntityFieldValueSetEventArgs
-  {
-    /// <summary>
-    /// Gets the exception, if any, that was thrown on setting the field value.
-    /// </summary>
-    public Exception Exception { get; private set; }
-
-
-    // Constructors
-
-    /// <summary>
-    /// Initializes a new instance of this class.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <param name="field">The field.</param>
-    /// <param name="oldValue">The <see cref="EntityFieldValueSetEventArgs.OldValue"/> value.</param>
-    /// <param name="newValue">The <see cref="EntityFieldValueSetEventArgs.NewValue"/> value.</param>
-    /// <param name="exception">The <see cref="Exception"/> value.</param>
-    public EntityFieldValueSetCompletedEventArgs(Entity entity, FieldInfo field, object oldValue, object newValue, Exception exception)
-      : base(entity, field, oldValue, newValue)
-    {
-      Exception = exception;
-    }
-  }
+  public readonly record struct EntityFieldValueSetCompletedEventArgs(
+    Entity Entity,
+    FieldInfo Field,
+    object OldValue,
+    object NewValue,
+    Exception Exception);
 }

--- a/Orm/Xtensive.Orm/Orm/EntityFieldValueSetEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/EntityFieldValueSetEventArgs.cs
@@ -12,33 +12,5 @@ namespace Xtensive.Orm
   /// <summary>
   /// Describes <see cref="Entity"/> field-related events containing old and new field values.
   /// </summary>
-  public class EntityFieldValueSetEventArgs : EntityFieldEventArgs
-  {
-    /// <summary>
-    /// Gets the old value.
-    /// </summary>
-    public object OldValue { get; private set; }
-
-    /// <summary>
-    /// Gets the new value.
-    /// </summary>
-    public object NewValue { get; private set; }
-
-
-    // Constructors
-
-    /// <summary>
-    /// Initializes a new instance of this class.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <param name="field">The field.</param>
-    /// <param name="oldValue">The <see cref="OldValue"/> property value.</param>
-    /// <param name="newValue">The <see cref="NewValue"/> property value.</param>
-    public EntityFieldValueSetEventArgs(Entity entity, FieldInfo field, object oldValue, object newValue)
-      : base(entity, field)
-    {
-      OldValue = oldValue;
-      NewValue = newValue;
-    }
-  }
+  public readonly record struct EntityFieldValueSetEventArgs(Entity Entity, FieldInfo Field, object OldValue, object NewValue);
 }

--- a/Orm/Xtensive.Orm/Orm/EntityRemoveCompletedEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/EntityRemoveCompletedEventArgs.cs
@@ -11,26 +11,5 @@ namespace Xtensive.Orm
   /// <summary>
   /// Arguments for completing entity remove event.
   /// </summary>
-  public class EntityRemoveCompletedEventArgs : EntityEventArgs
-  {
-    /// <summary>
-    /// Gets the exception.
-    /// </summary>
-    /// <value>The exception.</value>
-    public Exception Exception { get; }
-
-
-    // Constructors
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <param name="exception">The <see cref="Exception"/> initial value.</param>
-    public EntityRemoveCompletedEventArgs(Entity entity, Exception exception)
-      : base(entity)
-    {
-      Exception = exception;
-    }
-  }
+  public readonly record struct EntityRemoveCompletedEventArgs(Entity Entity, Exception Exception);
 }

--- a/Orm/Xtensive.Orm/Orm/EntityRemovingEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/EntityRemovingEventArgs.cs
@@ -14,18 +14,5 @@ namespace Xtensive.Orm
   /// <summary>
   /// Describes <see cref="Entity"/>-removing related events.
   /// </summary>
-  public class EntityRemovingEventArgs : EntityEventArgs
-  {
-    /// <summary>
-    /// Gets the entity remove reason.
-    /// </summary>
-    public EntityRemoveReason Reason { get; }
-
-    // Constructors
-    public EntityRemovingEventArgs(Entity entity, EntityRemoveReason reason)
-      : base(entity)
-    {
-      Reason = reason;
-    }
-  }
+  public readonly record struct EntityRemovingEventArgs(Entity Entity, EntityRemoveReason Reason);
 }

--- a/Orm/Xtensive.Orm/Orm/EntitySetActionCompletedEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/EntitySetActionCompletedEventArgs.cs
@@ -13,7 +13,7 @@ namespace Xtensive.Orm
   /// <summary>
   /// Describes an event related to <see cref="EntitySet{TItem}"/> item action completion.
   /// </summary>
-  public class EntitySetActionCompletedEventArgs
+  public readonly struct EntitySetActionCompletedEventArgs
   {
     public Entity Entity { get; }
     public FieldInfo Field { get; }

--- a/Orm/Xtensive.Orm/Orm/EntitySetActionCompletedEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/EntitySetActionCompletedEventArgs.cs
@@ -6,19 +6,27 @@
 
 using System;
 using System.Diagnostics;
-
+using Xtensive.Orm.Model;
 
 namespace Xtensive.Orm
 {
   /// <summary>
   /// Describes an event related to <see cref="EntitySet{TItem}"/> item action completion.
   /// </summary>
-  public class EntitySetActionCompletedEventArgs : EntitySetEventArgs
+  public class EntitySetActionCompletedEventArgs
   {
+    public Entity Entity { get; }
+    public FieldInfo Field { get; }
+
+    /// <summary>
+    /// Gets the <see cref="EntitySetBase"/> to which this event is related.
+    /// </summary>
+    public EntitySetBase EntitySet { get; }
+
     /// <summary>
     /// Gets the exception, if any, that was thrown on setting the field value.
     /// </summary>
-    public Exception Exception { get; private set; }
+    public Exception Exception { get; }
 
 
     // Cosntructors
@@ -29,8 +37,10 @@ namespace Xtensive.Orm
     /// <param name="entitySet">The entity set.</param>
     /// <param name="exception">The <see cref="Exception"/> property value.</param>
     public EntitySetActionCompletedEventArgs(EntitySetBase entitySet, Exception exception)
-      : base(entitySet)
     {
+      Entity = entitySet.Owner;
+      Field = entitySet.Field;
+      EntitySet = entitySet;
       Exception = exception;
     }
   }

--- a/Orm/Xtensive.Orm/Orm/EntitySetEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/EntitySetEventArgs.cs
@@ -4,20 +4,22 @@
 // Created by: Alexis Kochetov
 // Created:    2009.10.23
 
-using System;
-
+using Xtensive.Orm.Model;
 
 namespace Xtensive.Orm
 {
   /// <summary>
   /// Describes <see cref="Orm.EntitySet{TItem}"/>-related events.
   /// </summary>
-  public class EntitySetEventArgs : EntityFieldEventArgs
+  public readonly struct EntitySetEventArgs
   {
+    public Entity Entity { get; }
+    public FieldInfo Field { get; }
+
     /// <summary>
     /// Gets the <see cref="EntitySetBase"/> to which this event is related.
     /// </summary>
-    public EntitySetBase EntitySet { get; private set; }
+    public EntitySetBase EntitySet { get; }
 
 
     // Constructors
@@ -27,8 +29,9 @@ namespace Xtensive.Orm
     /// </summary>
     /// <param name="entitySet">The entity set.</param>
     public EntitySetEventArgs(EntitySetBase entitySet)
-      : base(entitySet.Owner, entitySet.Field)
     {
+      Entity = entitySet.Owner;
+      Field = entitySet.Field;
       EntitySet = entitySet;
     }
   }

--- a/Orm/Xtensive.Orm/Orm/EntitySetItemEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/EntitySetItemEventArgs.cs
@@ -4,21 +4,27 @@
 // Created by: Alexis Kochetov
 // Created:    2009.10.23
 
-using System;
-using System.Diagnostics;
-
+using Xtensive.Orm.Model;
 
 namespace Xtensive.Orm
 {
   /// <summary>
   /// Describes an event related to <see cref="EntitySet{TItem}"/> item.
   /// </summary>
-  public class EntitySetItemEventArgs : EntitySetEventArgs
+  public class EntitySetItemEventArgs
   {
+    public Entity Entity { get; }
+    public FieldInfo Field { get; }
+
+    /// <summary>
+    /// Gets the <see cref="EntitySetBase"/> to which this event is related.
+    /// </summary>
+    public EntitySetBase EntitySet { get; }
+
     /// <summary>
     /// Gets the item to which this event is related.
     /// </summary>
-    public Entity Item { get; private set; }
+    public Entity Item { get; }
 
 
     // Cosntructors
@@ -29,8 +35,10 @@ namespace Xtensive.Orm
     /// <param name="entitySet">The entity set.</param>
     /// <param name="item">The item.</param>
     public EntitySetItemEventArgs(EntitySetBase entitySet, Entity item)
-      : base(entitySet)
     {
+      Entity = entitySet.Owner;
+      Field = entitySet.Field;
+      EntitySet = entitySet;
       Item = item;
     }
   }

--- a/Orm/Xtensive.Orm/Orm/EntityVersionInfoChangedEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/EntityVersionInfoChangedEventArgs.cs
@@ -4,8 +4,6 @@
 // Created by: Alexis Kochetov
 // Created:    2009.10.22
 
-using System;
-
 using Xtensive.Orm.Model;
 
 namespace Xtensive.Orm
@@ -13,27 +11,5 @@ namespace Xtensive.Orm
   /// <summary>
   /// Describes <see cref="Entity"/>.<see cref="Entity.VersionInfo"/> change-related events.
   /// </summary>
-  public class EntityVersionInfoChangedEventArgs : EntityFieldEventArgs
-  {
-    /// <summary>
-    /// Gets or sets a value indicating whether 
-    /// <see cref="Entity.VersionInfo"/> was changed or not.
-    /// </summary>
-    public bool Changed { get; private set; }
-
-
-    // Constructors
-
-    /// <summary>
-    /// Initializes a new instance of this class.
-    /// </summary>
-    /// <param name="changedEntity">The entity that was changed.</param>
-    /// <param name="changedField">The field that was changed.</param>
-    /// <param name="changed"><see cref="Changed"/> property value.</param>
-    public EntityVersionInfoChangedEventArgs(Entity changedEntity, FieldInfo changedField, bool changed)
-      : base(changedEntity, changedField)
-    {
-      Changed = changed;
-    }
-  }
+  public readonly record struct EntityVersionInfoChangedEventArgs(Entity Entity, FieldInfo Field, bool Changed);
 }


### PR DESCRIPTION
This saves allocations
Every event handler uses its own, statically known event argument.
No need to inherit them from the same base