### PR TITLE
ACC-22203: Fix race condition in `FieldInfo.GetHashCode()`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
@@ -59,7 +59,6 @@ namespace Xtensive.Orm.Model
     private int adapterIndex = -1;
     private ColumnInfoCollection columns;
     private int fieldId;
-    private int? cachedHashCode;
 
     private Segment<ColNum> mappingInfo;
 
@@ -719,47 +718,18 @@ namespace Xtensive.Orm.Model
     #region Equals, GetHashCode methods
 
     /// <inheritdoc/>
-    public bool Equals(FieldInfo obj)
-    {
-      if (obj is null)
-        return false;
-      if (ReferenceEquals(this, obj))
-        return true;
-      return
-        obj.declaringType == declaringType &&
-        obj.valueType == valueType &&
-        obj.Name == Name;
-    }
+    public bool Equals(FieldInfo other) =>
+      ReferenceEquals(this, other)
+      || other is not null
+          && other.declaringType == declaringType
+          && other.valueType == valueType
+          && other.Name == Name;
 
     /// <inheritdoc/>
-    public override bool Equals(object obj) =>
-      ReferenceEquals(this, obj)
-        || obj is FieldInfo other && Equals(other);
+    public override bool Equals(object obj) => obj is FieldInfo other && Equals(other);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      if (cachedHashCode.HasValue)
-        return cachedHashCode.Value;
-      if (!IsLocked)
-        return CalculateHashCode();
-      lock (this) {
-        if (cachedHashCode.HasValue)
-          return cachedHashCode.Value;
-        cachedHashCode = CalculateHashCode();
-        return cachedHashCode.Value;
-      }
-    }
-
-    private int CalculateHashCode()
-    {
-      unchecked {
-        return
-          (declaringType.GetHashCode() * 397) ^
-          (valueType.GetHashCode() * 631) ^
-          Name.GetHashCode();
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(declaringType, valueType, Name);
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Diagnostics;
 using System.Reflection;
+using System.Threading;
 using Xtensive.Collections;
 using Xtensive.Core;
 using Xtensive.Orm.Internals;
@@ -59,6 +60,7 @@ namespace Xtensive.Orm.Model
     private int adapterIndex = -1;
     private ColumnInfoCollection columns;
     private int fieldId;
+    private long cachedHashCode;
 
     private Segment<ColNum> mappingInfo;
 
@@ -729,7 +731,13 @@ namespace Xtensive.Orm.Model
     public override bool Equals(object obj) => obj is FieldInfo other && Equals(other);
 
     /// <inheritdoc/>
-    public override int GetHashCode() => HashCode.Combine(declaringType, valueType, Name);
+    public override int GetHashCode()
+    {
+      if (cachedHashCode == 0) {
+        Volatile.Write(ref cachedHashCode, (uint)HashCode.Combine(declaringType, valueType, Name) | (1L << 63));
+      }
+      return (int)cachedHashCode;
+    }
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
@@ -735,11 +735,10 @@ namespace Xtensive.Orm.Model
     {
       var h = Volatile.Read(ref cachedHashCode);
       if (h == 0) {
-        var hashCode = HashCode.Combine(declaringType, valueType, Name);
-        if (!IsLocked) {
-          return hashCode;
+        h = (uint)HashCode.Combine(declaringType, valueType, Name);
+        if (IsLocked) {
+          Volatile.Write(ref cachedHashCode, h | (1L << 63)); // Set the highest bit as HasValue flag even when `hashCode == 0`
         }
-        Volatile.Write(ref cachedHashCode, h = (uint)hashCode | (1L << 63));
       }
       return (int)h;
     }

--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
@@ -733,14 +733,15 @@ namespace Xtensive.Orm.Model
     /// <inheritdoc/>
     public override int GetHashCode()
     {
-      if (cachedHashCode == 0) {
+      var h = Volatile.Read(ref cachedHashCode);
+      if (h == 0) {
         var hashCode = HashCode.Combine(declaringType, valueType, Name);
         if (!IsLocked) {
           return hashCode;
         }
-        Volatile.Write(ref cachedHashCode, (uint)hashCode | (1L << 63));
+        Volatile.Write(ref cachedHashCode, h = (uint)hashCode | (1L << 63));
       }
-      return (int)cachedHashCode;
+      return (int)h;
     }
 
     #endregion

--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
@@ -734,7 +734,11 @@ namespace Xtensive.Orm.Model
     public override int GetHashCode()
     {
       if (cachedHashCode == 0) {
-        Volatile.Write(ref cachedHashCode, (uint)HashCode.Combine(declaringType, valueType, Name) | (1L << 63));
+        var hashCode = HashCode.Combine(declaringType, valueType, Name);
+        if (!IsLocked) {
+          return hashCode;
+        }
+        Volatile.Write(ref cachedHashCode, (uint)hashCode | (1L << 63));
       }
       return (int)cachedHashCode;
     }

--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfoRef.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfoRef.cs
@@ -98,10 +98,7 @@ namespace Xtensive.Orm.Model
     }
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      return unchecked( FieldName.GetHashCode() + 29*TypeRef.GetHashCode() );
-    }
+    public override int GetHashCode() => HashCode.Combine(FieldName, TypeRef);
 
     #endregion
 


### PR DESCRIPTION
`Nullable<int>` is not thread safe type

the `cachedHashCode` could have `HasValue == true` but still `.Value == 0` because reading is not under lock.

Looking at the generated code confirms that `HasValue` flag is updated before `Value`:
![image](https://github.com/servicetitan/dataobjects-net/assets/1176609/081236a0-9f28-461a-928e-60fe8c296795)



That is 15-year-old code:
https://github.com/servicetitan/dataobjects-net/blame/e80be4b454fb53f0752d1d8cc63ba1813cedadb8/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs#L764

Apparently this was the cause of very rare errors like "FieldInfo not found in dictionary"


We can implement caching of the Hash code by Atomic operations with `long`

Also:
* Refactor `FieldInfo.Equals()`
* `FieldInfoRef.GetHashCode()` to use `HashCode.Combine()`