### PR TITLE
Optimize `ExpressionVisitor` & `ExtendedExpressionVisitor`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
     <MSExtVersion Condition="'$(TargetFramework)' == 'net7.0'">7.0.0</MSExtVersion>
   </PropertyGroup>
   <ItemGroup Label="Nupkg Versions">
-    <PackageVersion Include="System.CodeDom"                            Version="$(MSExtVersion)" />  
+    <PackageVersion Include="System.CodeDom"                            Version="$(MSExtVersion)" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="$(MSExtVersion)" />
     <PackageVersion Include="System.Data.SQLite.Core"                   Version="1.0.109.2"   />
     <PackageVersion Include="System.Spatial"                            Version="5.8.5"       />
@@ -25,7 +25,7 @@
     <PackageVersion Include="Mono.Cecil"                                Version="0.11.5"      />
     <PackageVersion Include="MySql.Data"                                Version="8.0.30"      />
     <PackageVersion Include="NLog"                                      Version="4.5.0"       />
-    <PackageVersion Include="Npgsql"                                    Version="8.0.2"     />
+    <PackageVersion Include="Npgsql"                                    Version="8.0.3"       />
     <PackageVersion Include="NUnit"                                     Version="3.14.0"      />
     <PackageVersion Include="NUnit3TestAdapter"                         Version="4.5.0"       />
     <PackageVersion Include="Oracle.ManagedDataAccess.Core"             Version="2.18.3"      />

--- a/Extensions/Xtensive.Orm.Localization/Internals/LocalizationExpressionVisitor.cs
+++ b/Extensions/Xtensive.Orm.Localization/Internals/LocalizationExpressionVisitor.cs
@@ -20,14 +20,14 @@ namespace Xtensive.Orm.Localization
     }
 
     /// <inheritdoc/>
-    protected override Expression VisitMemberAccess(MemberExpression me)
+    protected override Expression VisitMember(MemberExpression me)
     {
       if (Map == null)
         return me;
 
       var localizationInfo = Map.Get(me.Expression?.Type ?? me.Member.ReflectedType);
       if (localizationInfo == null || !localizationInfo.LocalizationTypeInfo.Fields.Contains(me.Member.Name))
-        return base.VisitMemberAccess(me);
+        return base.VisitMember(me);
 
       var localizationSetExpression = Expression.MakeMemberAccess(me.Expression, localizationInfo.LocalizationSetProperty);
       var localizationExpression = LocalizationExpressionBuilder.BuildExpression(localizationInfo, me, Map.Configuration.DefaultCulture.Name);

--- a/Orm/Xtensive.Orm/Linq/ExpressionReplacer.cs
+++ b/Orm/Xtensive.Orm/Linq/ExpressionReplacer.cs
@@ -46,7 +46,7 @@ namespace Xtensive.Linq
     }
 
     /// <inheritdoc/>
-    protected override Expression Visit(Expression exp)
+    public override Expression Visit(Expression exp)
     {
       if (exp == searchFor)
         return replaceWith;

--- a/Orm/Xtensive.Orm/Linq/ExpressionVisitor.cs
+++ b/Orm/Xtensive.Orm/Linq/ExpressionVisitor.cs
@@ -94,7 +94,7 @@ namespace Xtensive.Linq
     protected override Expression VisitTypeBinary(TypeBinaryExpression tb) =>
       tb.NodeType == ExpressionType.TypeIs
         ? Visit(tb, tb.Expression, static (tb, expression) => Expression.TypeIs(expression, tb.TypeOperand))
-        : base.VisitTypeBinary(tb);
+        : VisitUnknown(tb);
       
 
     /// <inheritdoc/>

--- a/Orm/Xtensive.Orm/Linq/ExpressionVisitor.cs
+++ b/Orm/Xtensive.Orm/Linq/ExpressionVisitor.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq.Expressions;
 using Xtensive.Core;
+using Xtensive.Reflection;
 
 namespace Xtensive.Linq
 {
@@ -16,10 +17,39 @@ namespace Xtensive.Linq
   /// An abstract base implementation of <see cref="ExpressionVisitor{TResult}"/>
   /// returning <see cref="Expression"/> as its visit result.
   /// </summary>
-  public abstract class ExpressionVisitor : ExpressionVisitor<Expression>
+  public abstract class ExpressionVisitor(bool isCaching = false) : System.Linq.Expressions.ExpressionVisitor
   {
-    protected override IReadOnlyList<Expression> VisitExpressionList(IReadOnlyList<Expression> expressions) =>
+    private readonly Dictionary<Expression, Expression> cache = isCaching ? new() : null;
+
+    public bool IsCaching => cache != null;
+
+    protected virtual IReadOnlyList<Expression> VisitExpressionList(IReadOnlyList<Expression> expressions) =>
       VisitList(expressions, Visit);
+
+    public override Expression Visit(Expression e)
+    {
+      Expression result = default;
+      if (e is null || cache?.TryGetValue(e, out result) == true) {
+        return result;
+      }
+
+      result = base.Visit(e);
+
+      cache?.Add(e, result);
+      return result;
+    }
+
+    /// <summary>
+    /// Visits the unknown expression.
+    /// </summary>
+    /// <param name="e">The unknown expression.</param>
+    /// <returns>Visit result.</returns>
+    /// <exception cref="NotSupportedException">Thrown by the base implementation of this method, 
+    /// if unknown expression isn't recognized by its overrides.</exception>
+    protected virtual Expression VisitUnknown(Expression e) =>
+      throw new NotSupportedException(string.Format(Strings.ExUnknownExpressionType, e.GetType().GetShortName(), e.NodeType));
+
+    protected override Expression VisitExtension(Expression node) => VisitUnknown(node);
 
     /// <summary>
     /// Visits the element initializer expression.
@@ -61,8 +91,11 @@ namespace Xtensive.Linq
     }
 
     /// <inheritdoc/>
-    protected override Expression VisitTypeIs(TypeBinaryExpression tb) =>
-      Visit(tb, tb.Expression, static (tb, expression) => Expression.TypeIs(expression, tb.TypeOperand));
+    protected override Expression VisitTypeBinary(TypeBinaryExpression tb) =>
+      tb.NodeType == ExpressionType.TypeIs
+        ? Visit(tb, tb.Expression, static (tb, expression) => Expression.TypeIs(expression, tb.TypeOperand))
+        : base.VisitTypeBinary(tb);
+      
 
     /// <inheritdoc/>
     protected override Expression VisitConstant(ConstantExpression c)
@@ -97,7 +130,7 @@ namespace Xtensive.Linq
     }
 
     /// <inheritdoc/>
-    protected override Expression VisitMemberAccess(MemberExpression m) =>
+    protected override Expression VisitMember(MemberExpression m) =>
       Visit(m, m.Expression, static (m, expression) => Expression.MakeMemberAccess(expression, m.Member));
 
     /// <inheritdoc/>
@@ -117,12 +150,14 @@ namespace Xtensive.Linq
     /// </summary>
     /// <param name="ma">The member assignment expression.</param>
     /// <returns>Visit result.</returns>
-    protected virtual MemberAssignment VisitMemberAssignment(MemberAssignment ma) =>
+    protected override MemberAssignment VisitMemberAssignment(MemberAssignment ma) =>
       Visit(ma, ma.Expression, static (ma, expression) => Expression.Bind(ma.Member, expression));
 
     /// <inheritdoc/>
-    protected override Expression VisitLambda(LambdaExpression l) =>
-      Visit(l, l.Body, static (l, body) => FastExpression.Lambda(l.Type, body, l.Parameters));
+    protected override Expression VisitLambda<T>(Expression<T> l) =>
+      Visit((LambdaExpression)l, l.Body, static (l, body) => FastExpression.Lambda(l.Type, body, l.Parameters));
+
+    protected Expression VisitLambda(LambdaExpression lambda) => base.Visit(lambda);
 
     private TOriginal Visit<TOriginal, TSubExpression>(TOriginal original, TSubExpression subExpression, Func<TOriginal, Expression, TOriginal> func) where TSubExpression : Expression
     {
@@ -213,7 +248,7 @@ namespace Xtensive.Linq
     /// </summary>
     /// <param name="binding">The member member binding.</param>
     /// <returns>Visit result.</returns>
-    protected virtual MemberMemberBinding VisitMemberMemberBinding(MemberMemberBinding binding)
+    protected override MemberMemberBinding VisitMemberMemberBinding(MemberMemberBinding binding)
     {
       var bindingBindings = binding.Bindings;
       IEnumerable<MemberBinding> bindings = VisitBindingList(bindingBindings);
@@ -251,7 +286,7 @@ namespace Xtensive.Linq
       return ar?.AsSafeWrapper() ?? original;
     }
 
-    protected virtual MemberListBinding VisitMemberListBinding(MemberListBinding binding)
+    protected override MemberListBinding VisitMemberListBinding(MemberListBinding binding)
     {
       var bindingInitializers = binding.Initializers;
       IEnumerable<ElementInit> initializers = VisitElementInitializerList(bindingInitializers);
@@ -261,18 +296,5 @@ namespace Xtensive.Linq
     }
 
     #endregion
-
-    // Constructors
-
-    /// <inheritdoc/>
-    protected ExpressionVisitor()
-    {
-    }
-
-    /// <inheritdoc/>
-    protected ExpressionVisitor(bool isCaching)
-      : base(isCaching)
-    {
-    }
   }
 }

--- a/Orm/Xtensive.Orm/Linq/ExpressionVisitor.cs
+++ b/Orm/Xtensive.Orm/Linq/ExpressionVisitor.cs
@@ -21,8 +21,6 @@ namespace Xtensive.Linq
   {
     private readonly Dictionary<Expression, Expression> cache = isCaching ? new() : null;
 
-    public bool IsCaching => cache != null;
-
     protected virtual IReadOnlyList<Expression> VisitExpressionList(IReadOnlyList<Expression> expressions) =>
       VisitList(expressions, Visit);
 
@@ -76,7 +74,7 @@ namespace Xtensive.Linq
 
     /// <inheritdoc/>
     protected override Expression VisitUnary(UnaryExpression u) =>
-      Visit(u, u.Operand, static (u, operand) => Expression.MakeUnary(u.NodeType, operand, u.Type, u.Method));
+      u.Update(Visit(u.Operand));
 
     /// <inheritdoc/>
     protected override Expression VisitBinary(BinaryExpression b)
@@ -98,35 +96,9 @@ namespace Xtensive.Linq
       
 
     /// <inheritdoc/>
-    protected override Expression VisitConstant(ConstantExpression c)
-    {
-      return c;
-    }
-
-    /// <inheritdoc/>
     protected override Expression VisitDefault(DefaultExpression d)
     {
       return d.ToConstantExpression();
-    }
-
-    /// <inheritdoc/>
-    protected override Expression VisitConditional(ConditionalExpression c)
-    {
-      var cTest = c.Test;
-      var cIfTrue = c.IfTrue;
-      var cIfFalse = c.IfFalse;
-      Expression test = Visit(cTest);
-      Expression ifTrue = Visit(cIfTrue);
-      Expression ifFalse = Visit(cIfFalse);
-      if (((test == cTest) && (ifTrue == cIfTrue)) && (ifFalse == cIfFalse))
-        return c;
-      return Expression.Condition(test, ifTrue, ifFalse);
-    }
-
-    /// <inheritdoc/>
-    protected override Expression VisitParameter(ParameterExpression p)
-    {
-      return p;
     }
 
     /// <inheritdoc/>

--- a/Orm/Xtensive.Orm/Linq/ExpressionVisitor{TResult}.cs
+++ b/Orm/Xtensive.Orm/Linq/ExpressionVisitor{TResult}.cs
@@ -8,9 +8,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq.Expressions;
-using Xtensive.Reflection;
 using Xtensive.Core;
-
+using Xtensive.Reflection;
 
 namespace Xtensive.Linq
 {
@@ -94,21 +93,6 @@ namespace Xtensive.Linq
 
       cache?.Add(e, result);
       return result;
-    }
-
-    /// <summary>
-    /// Visits the expression list.
-    /// </summary>
-    /// <param name="expressions">The expression list.</param>
-    /// <returns>Visit result.</returns>
-    protected virtual IReadOnlyList<TResult> VisitExpressionList(IReadOnlyList<Expression> expressions)
-    {
-      var n = expressions.Count;
-      var results = new TResult[n];
-      for (int i = 0; i < n; i++) {
-        results[i] = Visit(expressions[i]);
-      }
-      return results.AsSafeWrapper();
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Linq/ExpressionWriter.cs
+++ b/Orm/Xtensive.Orm/Linq/ExpressionWriter.cs
@@ -474,7 +474,7 @@ namespace Xtensive.Linq
     }
 
     /// <inheritdoc/>
-    protected override LambdaExpression VisitLambda(LambdaExpression l)
+    protected override LambdaExpression VisitLambda<T>(Expression<T> l)
     {
       if (l.Parameters.Count > 1) {
         Write("(");
@@ -512,7 +512,7 @@ namespace Xtensive.Linq
     }
 
     /// <inheritdoc/>
-    protected override MemberExpression VisitMemberAccess(MemberExpression m)
+    protected override MemberExpression VisitMember(MemberExpression m)
     {
       Visit(m.Expression);
       Write(".");
@@ -616,8 +616,11 @@ namespace Xtensive.Linq
     }
 
     /// <inheritdoc/>
-    protected override TypeBinaryExpression VisitTypeIs(TypeBinaryExpression tb)
+    protected override TypeBinaryExpression VisitTypeBinary(TypeBinaryExpression tb)
     {
+      if (tb.NodeType != ExpressionType.TypeIs) {
+        return (TypeBinaryExpression) base.VisitTypeBinary(tb);
+      }
       Visit(tb.Expression);
       Write(" is ");
       Write(GetTypeName(tb.TypeOperand));

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/PartialIndexFilterBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/PartialIndexFilterBuilder.cs
@@ -102,7 +102,7 @@ namespace Xtensive.Orm.Building.Builders
       }
     }
 
-    protected override Expression VisitMemberAccess(MemberExpression originalMemberAccess)
+    protected override Expression VisitMember(MemberExpression originalMemberAccess)
     {
       // Try to collapse series of member access expressions.
       // Finally we should reach original parameter.
@@ -120,7 +120,7 @@ namespace Xtensive.Orm.Building.Builders
         memberAccess = (MemberExpression) memberAccess.Expression;
       }
       if (memberAccessSequence.Count == 0 || !IsEntityParameter(memberAccess.Expression)) {
-        return base.VisitMemberAccess(originalMemberAccess);
+        return base.VisitMember(originalMemberAccess);
       }
       var nameBuilder = new StringBuilder();
       for (var i = memberAccessSequence.Count; i-- > 0;) {
@@ -207,7 +207,7 @@ namespace Xtensive.Orm.Building.Builders
       throw UnableToTranslate(p, string.Format(Strings.ParametersOfTypeOtherThanXAreNotSupported, declaringType.UnderlyingType));
     }
 
-    protected override Expression VisitLambda(LambdaExpression l)
+    protected override Expression VisitLambda<T>(Expression<T> l)
     {
       throw UnableToTranslate(l);
     }

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/ExpressionMapBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/ExpressionMapBuilder.cs
@@ -27,7 +27,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       return builder.result;
     }
 
-    protected override Expression Visit(Expression e)
+    public override Expression Visit(Expression e)
     {
       ValidateExpressionType(e);
       base.Visit(e);
@@ -40,7 +40,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       return p;
     }
 
-    protected override Expression VisitLambda(LambdaExpression l)
+    protected override Expression VisitLambda<T>(Expression<T> l)
     {
       var oldParameter = currentParameter;
       currentParameter = l.Parameters.First();
@@ -75,12 +75,12 @@ namespace Xtensive.Orm.Internals.Prefetch
       Visit(source);
 
       foreach (var item in subprefetches)
-        VisitLambda(item);
+        base.Visit(item);
 
       return call;
     }
 
-    protected override Expression VisitMemberAccess(MemberExpression m)
+    protected override Expression VisitMember(MemberExpression m)
     {
       ValidateMemberAccess(m);
       result.RegisterChild(m.Expression, m);

--- a/Orm/Xtensive.Orm/Orm/Linq/ExpressionEvaluator.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ExpressionEvaluator.cs
@@ -60,7 +60,7 @@ namespace Xtensive.Orm.Linq
     }
 
     /// <inheritdoc/>
-    protected override Expression Visit(Expression e)
+    public override Expression Visit(Expression e)
     {
       if (e != null) {
         var saved = couldBeEvaluated;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnExpression.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using Xtensive.Core;
+using Xtensive.Orm.Linq.Expressions.Visitors;
 
 namespace Xtensive.Orm.Linq.Expressions
 {
@@ -57,6 +58,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return $"{base.ToString()}, Offset: {Mapping.Offset}";
     }
 
+    internal override Expression Accept(ExtendedExpressionVisitor visitor) => visitor.VisitColumnExpression(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
@@ -7,13 +7,13 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Xtensive.Collections;
 using Xtensive.Core;
 using Xtensive.Orm.Linq.Expressions;
 using Xtensive.Orm.Linq.Expressions.Visitors;
-using System.Linq;
 
 namespace Xtensive.Orm.Linq
 {
@@ -87,6 +87,8 @@ namespace Xtensive.Orm.Linq
       var newNativeBindings = NativeBindings.ToDictionary(kvp => kvp.Key, kvp => GenericExpressionVisitor<IMappedExpression>.Process(kvp.Value, remapper));
       return new ConstructorExpression(Type, newBindings, newNativeBindings, Constructor, newConstructorArguments);
     }
+
+    internal override Expression Accept(ExtendedExpressionVisitor visitor) => visitor.VisitConstructorExpression(this);
 
     public ConstructorExpression(Type type, Dictionary<MemberInfo, Expression> bindings, Dictionary<MemberInfo, Expression> nativeBindings, ConstructorInfo constructor, IReadOnlyList<Expression> constructorArguments)
       : base(ExtendedExpressionType.Constructor, type, null, false)

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityExpression.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using Xtensive.Orm.Model;
+using Xtensive.Orm.Linq.Expressions.Visitors;
 
 namespace Xtensive.Orm.Linq.Expressions
 {
@@ -205,6 +206,8 @@ namespace Xtensive.Orm.Linq.Expressions
     }
 
     public override string ToString() => $"{base.ToString()} {PersistentType.Name}";
+
+    internal override Expression Accept(ExtendedExpressionVisitor visitor) => visitor.VisitEntityExpression(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityFieldExpression.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using Xtensive.Core;
 using Xtensive.Orm.Model;
+using Xtensive.Orm.Linq.Expressions.Visitors;
 
 namespace Xtensive.Orm.Linq.Expressions
 {
@@ -183,6 +184,7 @@ namespace Xtensive.Orm.Linq.Expressions
       throw new NotSupportedException(string.Format(Strings.ExNestedFieldXIsNotSupported, nestedField.Attributes));
     }
 
+    internal override Expression Accept(ExtendedExpressionVisitor visitor) => visitor.VisitEntityFieldExpression(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntitySetExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntitySetExpression.cs
@@ -10,6 +10,7 @@ using System.Linq.Expressions;
 using Xtensive.Core;
 using Xtensive.Orm.Model;
 using Xtensive.Orm.Rse;
+using Xtensive.Orm.Linq.Expressions.Visitors;
 
 namespace Xtensive.Orm.Linq.Expressions
 {
@@ -109,6 +110,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return $"{base.ToString()} {Name}";
     }
 
+    internal override Expression Accept(ExtendedExpressionVisitor visitor) => visitor.VisitEntitySetExpression(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ExtendedExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ExtendedExpression.cs
@@ -6,26 +6,19 @@
 
 using System;
 using System.Linq.Expressions;
+using Xtensive.Orm.Linq.Expressions.Visitors;
+using Xtensive.Reflection;
 
-namespace Xtensive.Orm.Linq.Expressions
+namespace Xtensive.Orm.Linq.Expressions;
+
+internal abstract class ExtendedExpression(ExtendedExpressionType expressionType, Type type) : Expression
 {
-  internal abstract class ExtendedExpression : Expression
-  {
-    private Type type;
+  public ExtendedExpressionType ExtendedType { get; } = expressionType;
 
-    public ExtendedExpressionType ExtendedType { get; private set; }
+  public sealed override ExpressionType NodeType => (ExpressionType) ExtendedType;
 
-    public sealed override ExpressionType NodeType => (ExpressionType) ExtendedType;
+  public override Type Type => type;
 
-    public override Type Type => type;
-
-    // Constructors
-
-    protected ExtendedExpression(ExtendedExpressionType expressionType, Type type)
-      : base()
-    {
-      this.type = type;
-      ExtendedType = expressionType;
-    }
-  }
+  internal virtual Expression Accept(ExtendedExpressionVisitor visitor) =>
+    throw new NotSupportedException(string.Format(Strings.ExUnknownExpressionType, visitor.GetType().GetShortName(), NodeType));
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using Xtensive.Core;
+using Xtensive.Orm.Linq.Expressions.Visitors;
 using FieldInfo = Xtensive.Orm.Model.FieldInfo;
 
 namespace Xtensive.Orm.Linq.Expressions
@@ -120,6 +121,8 @@ namespace Xtensive.Orm.Linq.Expressions
       var mapping = new Segment<ColNum>((ColNum)(mappingInfo.Offset + offset), mappingInfo.Length);
       return new FieldExpression(ExtendedExpressionType.Field, field, mapping, null, false);
     }
+
+    internal override Expression Accept(ExtendedExpressionVisitor visitor) => visitor.VisitFieldExpression(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/FullTextExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/FullTextExpression.cs
@@ -10,6 +10,7 @@ using System.Linq.Expressions;
 using Xtensive.Core;
 using Xtensive.Orm.Internals;
 using Xtensive.Orm.Model;
+using Xtensive.Orm.Linq.Expressions.Visitors;
 using Xtensive.Reflection;
 
 namespace Xtensive.Orm.Linq.Expressions
@@ -72,6 +73,8 @@ namespace Xtensive.Orm.Linq.Expressions
       var remappedRankExpression = RankExpression.Remap(map, processedExpressions);
       return new FullTextExpression(FullTextIndex, remappedEntityExpression, remappedRankExpression, OuterParameter);
     }
+
+    internal override Expression Accept(ExtendedExpressionVisitor visitor) => visitor.VisitFullTextExpression(this);
 
     public FullTextExpression(FullTextIndexInfo fullTextIndex, EntityExpression entityExpression, ColumnExpression rankExpression, ParameterExpression parameter)
       : base(ExtendedExpressionType.FullText, WellKnownOrmTypes.FullTextMatchOfT.CachedMakeGenericType(fullTextIndex.PrimaryIndex.ReflectedType.UnderlyingType), parameter, false)

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/GroupingExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/GroupingExpression.cs
@@ -94,6 +94,8 @@ namespace Xtensive.Orm.Linq.Expressions
       return new GroupingExpression(Type, OuterParameter, DefaultIfEmpty, newProjectionExpression, newApplyParameter, KeyExpression, SelectManyInfo);
     }
 
+    internal override Expression Accept(ExtendedExpressionVisitor visitor) => visitor.VisitGroupingExpression(this);
+
     public GroupingExpression(
       Type type, 
       ParameterExpression parameterExpression, 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
@@ -176,6 +176,7 @@ namespace Xtensive.Orm.Linq.Expressions
     public override string ToString() =>
       $"ItemProjectorExpression: IsPrimitive = {IsPrimitive} Item = {Item}, DataSource = {DataSource}";
 
+    internal override Expression Accept(ExtendedExpressionVisitor visitor) => visitor.VisitItemProjectorExpression(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/KeyExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/KeyExpression.cs
@@ -10,6 +10,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using Xtensive.Core;
 using Xtensive.Orm.Internals;
+using Xtensive.Orm.Linq.Expressions.Visitors;
 using Xtensive.Orm.Model;
 using TypeInfo = Xtensive.Orm.Model.TypeInfo;
 
@@ -137,6 +138,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return new KeyExpression(entityType, fields, mapping, WellKnownMembers.IEntityKey, null, false);
     }
 
+    internal override Expression Accept(ExtendedExpressionVisitor visitor) => visitor.VisitKeyExpression(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/LocalCollectionExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/LocalCollectionExpression.cs
@@ -11,6 +11,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using Xtensive.Collections;
 using Xtensive.Core;
+using Xtensive.Orm.Linq.Expressions.Visitors;
 
 namespace Xtensive.Orm.Linq.Expressions
 {
@@ -85,6 +86,8 @@ namespace Xtensive.Orm.Linq.Expressions
       expressionAsString = sourceExpression.ToString();
       ;
     }
+
+    internal override Expression Accept(ExtendedExpressionVisitor visitor) => visitor.VisitLocalCollectionExpression(this);
 
     private LocalCollectionExpression(Type type, MemberInfo memberInfo, in string stringRepresentation)
       : base(ExtendedExpressionType.LocalCollection, type, null, true)

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/MarkerExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/MarkerExpression.cs
@@ -5,7 +5,7 @@
 // Created:    2009.06.22
 
 using System.Linq.Expressions;
-
+using Xtensive.Orm.Linq.Expressions.Visitors;
 
 namespace Xtensive.Orm.Linq.Expressions
 {
@@ -14,6 +14,7 @@ namespace Xtensive.Orm.Linq.Expressions
     public Expression Target { get; private set; }
     public MarkerType MarkerType { get; private set; }
 
+    internal override Expression Accept(ExtendedExpressionVisitor visitor) => visitor.VisitMarker(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ProjectionExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ProjectionExpression.cs
@@ -6,7 +6,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using Xtensive.Core;
+using Xtensive.Orm.Linq.Expressions.Visitors;
 using Tuple = Xtensive.Tuples.Tuple;
 
 namespace Xtensive.Orm.Linq.Expressions
@@ -23,6 +25,8 @@ namespace Xtensive.Orm.Linq.Expressions
 
     public ProjectionExpression Apply(ItemProjectorExpression itemProjectorExpression) =>
       new ProjectionExpression(Type, itemProjectorExpression, TupleParameterBindings, ResultAccessMethod);
+
+    internal override Expression Accept(ExtendedExpressionVisitor visitor) => visitor.VisitProjectionExpression(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureExpression.cs
@@ -6,10 +6,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using Xtensive.Core;
 using Xtensive.Orm.Model;
-using System.Linq;
+using Xtensive.Orm.Linq.Expressions.Visitors;
 
 namespace Xtensive.Orm.Linq.Expressions
 {
@@ -157,6 +158,8 @@ namespace Xtensive.Orm.Linq.Expressions
 
       throw new NotSupportedException(string.Format(Strings.ExNestedFieldXIsNotSupported, nestedField.Attributes));
     }
+
+    internal override Expression Accept(ExtendedExpressionVisitor visitor) => visitor.VisitStructureExpression(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureFieldExpression.cs
@@ -6,10 +6,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using Xtensive.Core;
 using Xtensive.Orm.Model;
-using System.Linq;
+using Xtensive.Orm.Linq.Expressions.Visitors;
 
 namespace Xtensive.Orm.Linq.Expressions
 {
@@ -195,8 +196,9 @@ namespace Xtensive.Orm.Linq.Expressions
 
       throw new NotSupportedException(string.Format(Strings.ExNestedFieldXIsNotSupported, nestedField.Attributes));
     }
-// ReSharper restore RedundantNameQualifier
+    // ReSharper restore RedundantNameQualifier
 
+    internal override Expression Accept(ExtendedExpressionVisitor visitor) => visitor.VisitStructureFieldExpression(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/SubQueryExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/SubQueryExpression.cs
@@ -112,6 +112,8 @@ namespace Xtensive.Orm.Linq.Expressions
       return new SubQueryExpression(Type, OuterParameter, DefaultIfEmpty, newProjectionExpression, newApplyParameter);
     }
 
+    internal override Expression Accept(ExtendedExpressionVisitor visitor) => visitor.VisitSubQueryExpression(this);
+
     public SubQueryExpression(
       Type type,
       ParameterExpression parameterExpression,

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ColumnGatherer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ColumnGatherer.cs
@@ -70,20 +70,20 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       return ordered.ToArray();
     }
 
-    protected override Expression VisitMarker(MarkerExpression expression)
+    internal override Expression VisitMarker(MarkerExpression expression)
     {
       Visit(expression.Target);
       return expression;
     }
 
-    protected override Expression VisitFieldExpression(FieldExpression f)
+    internal override Expression VisitFieldExpression(FieldExpression f)
     {
       ProcessFieldOwner(f);
       AddColumns(f, f.Mapping.GetItems());
       return f;
     }
 
-    protected override Expression VisitStructureFieldExpression(StructureFieldExpression s)
+    internal override Expression VisitStructureFieldExpression(StructureFieldExpression s)
     {
       ProcessFieldOwner(s);
       AddColumns(s,
@@ -93,13 +93,13 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       return s;
     }
 
-    protected override Expression VisitKeyExpression(KeyExpression k)
+    internal override Expression VisitKeyExpression(KeyExpression k)
     {
       AddColumns(k, k.Mapping.GetItems());
       return k;
     }
 
-    protected override Expression VisitEntityExpression(EntityExpression e)
+    internal override Expression VisitEntityExpression(EntityExpression e)
     {
       if (TreatEntityAsKey) {
         var keyExpression = (KeyExpression) e.Fields.First(f => f.ExtendedType==ExtendedExpressionType.Key);
@@ -118,7 +118,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       return e;
     }
 
-    protected override Expression VisitEntityFieldExpression(EntityFieldExpression ef)
+    internal override Expression VisitEntityFieldExpression(EntityFieldExpression ef)
     {
       var keyExpression = (KeyExpression) ef.Fields.First(f => f.ExtendedType==ExtendedExpressionType.Key);
       AddColumns(ef, keyExpression.Mapping.GetItems());
@@ -127,19 +127,19 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       return ef;
     }
 
-    protected override Expression VisitEntitySetExpression(EntitySetExpression es)
+    internal override Expression VisitEntitySetExpression(EntitySetExpression es)
     {
       VisitEntityExpression((EntityExpression) es.Owner);
       return es;
     }
 
-    protected override Expression VisitColumnExpression(ColumnExpression c)
+    internal override Expression VisitColumnExpression(ColumnExpression c)
     {
       AddColumns(c, c.Mapping.GetItems());
       return c;
     }
 
-    protected override Expression VisitStructureExpression(StructureExpression expression)
+    internal override Expression VisitStructureExpression(StructureExpression expression)
     {
       AddColumns(expression,
         expression.Fields
@@ -148,14 +148,14 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       return expression;
     }
 
-    protected override Expression VisitGroupingExpression(GroupingExpression expression)
+    internal override Expression VisitGroupingExpression(GroupingExpression expression)
     {
       Visit(expression.KeyExpression);
       VisitSubQueryExpression(expression);
       return expression;
     }
 
-    protected override Expression VisitSubQueryExpression(SubQueryExpression subQueryExpression)
+    internal override Expression VisitSubQueryExpression(SubQueryExpression subQueryExpression)
     {
       bool isTopSubquery = false;
 
@@ -178,14 +178,14 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       return subQueryExpression;
     }
 
-    protected override Expression VisitLocalCollectionExpression(LocalCollectionExpression expression)
+    internal override Expression VisitLocalCollectionExpression(LocalCollectionExpression expression)
     {
       foreach (var field in expression.Fields)
         Visit((Expression) field.Value);
       return expression;
     }
 
-    protected override Expression VisitConstructorExpression(ConstructorExpression expression)
+    internal override Expression VisitConstructorExpression(ConstructorExpression expression)
     {
       foreach (var binding in expression.Bindings)
         Visit(binding.Value);
@@ -228,7 +228,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
         columns.AddRange(expressionColumns.Select(i=>new Pair<ColNum, Expression>(i, parameterizedExpression)));
     }
 
-    protected override Expression VisitFullTextExpression(FullTextExpression expression)
+    internal override Expression VisitFullTextExpression(FullTextExpression expression)
     {
       VisitEntityExpression(expression.EntityExpression);
       VisitColumnExpression(expression.RankExpression);

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/EntityExpressionJoiner.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/EntityExpressionJoiner.cs
@@ -14,7 +14,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
     private readonly Translator translator;
     private readonly ItemProjectorExpression itemProjectorExpression;
 
-    protected override System.Linq.Expressions.Expression VisitEntityExpression(EntityExpression expression)
+    internal override System.Linq.Expressions.Expression VisitEntityExpression(EntityExpression expression)
     {
       translator.EnsureEntityFieldsAreJoined(expression, itemProjectorExpression);
       return base.VisitEntityExpression(expression);

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ExtendedExpressionReplacer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ExtendedExpressionReplacer.cs
@@ -22,7 +22,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       return Visit(e);
     }
 
-    protected override Expression Visit(Expression e)
+    public override Expression Visit(Expression e)
     {
       if (e==null)
         return null;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ExtendedExpressionReplacer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ExtendedExpressionReplacer.cs
@@ -30,7 +30,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       return result ?? base.Visit(e);
     }
 
-    protected override Expression VisitProjectionExpression(ProjectionExpression projectionExpression)
+    internal override Expression VisitProjectionExpression(ProjectionExpression projectionExpression)
     {
       var item = Visit(projectionExpression.ItemProjector.Item);
       var provider = providerVisitor.VisitCompilable(projectionExpression.ItemProjector.DataSource);
@@ -43,7 +43,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       return projectionExpression;
     }
 
-    protected override Expression VisitGroupingExpression(GroupingExpression expression)
+    internal override Expression VisitGroupingExpression(GroupingExpression expression)
     {
       var keyExpression = Visit(expression.KeyExpression);
       if (keyExpression!=expression.KeyExpression)
@@ -58,7 +58,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       return expression;
     }
 
-    protected override Expression VisitFullTextExpression(FullTextExpression expression)
+    internal override Expression VisitFullTextExpression(FullTextExpression expression)
     {
       var rankExpression = (ColumnExpression) Visit(expression.RankExpression);
       var entityExpression = (EntityExpression) Visit(expression.EntityExpression);
@@ -67,7 +67,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       return expression;
     }
 
-    protected override Expression VisitSubQueryExpression(SubQueryExpression expression)
+    internal override Expression VisitSubQueryExpression(SubQueryExpression expression)
     {
       return expression;
     }
@@ -78,42 +78,42 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       return result ?? original;
     }
 
-    protected override Expression VisitFieldExpression(FieldExpression expression)
+    internal override Expression VisitFieldExpression(FieldExpression expression)
     {
       return expression;
     }
 
-    protected override Expression VisitStructureFieldExpression(StructureFieldExpression expression)
+    internal override Expression VisitStructureFieldExpression(StructureFieldExpression expression)
     {
       return expression;
     }
 
-    protected override Expression VisitKeyExpression(KeyExpression expression)
+    internal override Expression VisitKeyExpression(KeyExpression expression)
     {
       return expression;
     }
 
-    protected override Expression VisitEntityExpression(EntityExpression expression)
+    internal override Expression VisitEntityExpression(EntityExpression expression)
     {
       return expression;
     }
 
-    protected override Expression VisitEntityFieldExpression(EntityFieldExpression expression)
+    internal override Expression VisitEntityFieldExpression(EntityFieldExpression expression)
     {
       return expression;
     }
 
-    protected override Expression VisitEntitySetExpression(EntitySetExpression expression)
+    internal override Expression VisitEntitySetExpression(EntitySetExpression expression)
     {
       return expression;
     }
 
-    protected override Expression VisitColumnExpression(ColumnExpression expression)
+    internal override Expression VisitColumnExpression(ColumnExpression expression)
     {
       return expression;
     }
 
-    protected override Expression VisitConstructorExpression(ConstructorExpression expression)
+    internal override Expression VisitConstructorExpression(ConstructorExpression expression)
     {
       var arguments = new List<Expression>();
       var bindings = new Dictionary<MemberInfo, Expression>();
@@ -147,7 +147,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
         arguments);
     }
 
-    protected override Expression VisitMarker(MarkerExpression expression)
+    internal override Expression VisitMarker(MarkerExpression expression)
     {
       var target = Visit(expression.Target);
       return target == expression.Target 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ExtendedExpressionVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ExtendedExpressionVisitor.cs
@@ -9,134 +9,33 @@ using System.Linq.Expressions;
 using Xtensive.Linq;
 using ExpressionVisitor = Xtensive.Linq.ExpressionVisitor;
 
-namespace Xtensive.Orm.Linq.Expressions.Visitors
+namespace Xtensive.Orm.Linq.Expressions.Visitors;
+
+internal abstract class ExtendedExpressionVisitor : ExpressionVisitor
 {
-  internal abstract class ExtendedExpressionVisitor : ExpressionVisitor
+  protected override Expression VisitUnknown(Expression expression) =>
+    (expression as ExtendedExpression ?? throw new NotSupportedException(string.Format(Strings.ExpressionXIsUnknown, expression)))
+      .Accept(this);
+
+  internal virtual Expression VisitFullTextExpression(FullTextExpression expression) => expression;
+  internal virtual Expression VisitConstructorExpression(ConstructorExpression expression) => expression;
+  internal virtual Expression VisitStructureExpression(StructureExpression expression) => expression;
+  internal virtual Expression VisitLocalCollectionExpression(LocalCollectionExpression expression) => expression;
+  internal virtual Expression VisitGroupingExpression(GroupingExpression expression) => expression;
+  internal virtual Expression VisitSubQueryExpression(SubQueryExpression expression) => expression;
+  internal virtual Expression VisitProjectionExpression(ProjectionExpression projectionExpression) => projectionExpression;
+  internal virtual Expression VisitFieldExpression(FieldExpression expression) => expression;
+  internal virtual Expression VisitStructureFieldExpression(StructureFieldExpression expression) => expression;
+  internal virtual Expression VisitKeyExpression(KeyExpression expression) => expression;
+  internal virtual Expression VisitEntityExpression(EntityExpression expression) => expression;
+  internal virtual Expression VisitEntityFieldExpression(EntityFieldExpression expression) => expression;
+  internal virtual Expression VisitEntitySetExpression(EntitySetExpression expression) => expression;
+  internal virtual Expression VisitItemProjectorExpression(ItemProjectorExpression itemProjectorExpression) => itemProjectorExpression;
+  internal virtual Expression VisitColumnExpression(ColumnExpression expression) => expression;
+
+  internal virtual Expression VisitMarker(MarkerExpression expression)
   {
-    protected override Expression VisitUnknown(Expression expression)
-    {
-      var extendedExpression = expression as ExtendedExpression;
-      if (extendedExpression==null)
-        throw new NotSupportedException(string.Format(Strings.ExpressionXIsUnknown, expression));
-      switch (extendedExpression.ExtendedType) {
-      case ExtendedExpressionType.Projection:
-        return VisitProjectionExpression((ProjectionExpression) expression);
-      case ExtendedExpressionType.Field:
-        return VisitFieldExpression((FieldExpression) expression);
-      case ExtendedExpressionType.StructureField:
-        return VisitStructureFieldExpression((StructureFieldExpression) expression);
-      case ExtendedExpressionType.Key:
-        return VisitKeyExpression((KeyExpression) expression);
-      case ExtendedExpressionType.Entity:
-        return VisitEntityExpression((EntityExpression) expression);
-      case ExtendedExpressionType.EntityField:
-        return VisitEntityFieldExpression((EntityFieldExpression) expression);
-      case ExtendedExpressionType.EntitySet:
-        return VisitEntitySetExpression((EntitySetExpression) expression);
-      case ExtendedExpressionType.ItemProjector:
-        return VisitItemProjectorExpression((ItemProjectorExpression) expression);
-      case ExtendedExpressionType.Column:
-        return VisitColumnExpression((ColumnExpression) expression);
-      case ExtendedExpressionType.Marker:
-        return VisitMarker((MarkerExpression) expression);
-      case ExtendedExpressionType.SubQuery:
-        return VisitSubQueryExpression((SubQueryExpression) expression);
-      case ExtendedExpressionType.Grouping:
-        return VisitGroupingExpression((GroupingExpression) expression);
-      case ExtendedExpressionType.LocalCollection:
-        return VisitLocalCollectionExpression((LocalCollectionExpression) expression);
-      case ExtendedExpressionType.Structure:
-        return VisitStructureExpression((StructureExpression) expression);
-      case ExtendedExpressionType.Constructor:
-        return VisitConstructorExpression((ConstructorExpression) expression);
-      case ExtendedExpressionType.FullText:
-        return VisitFullTextExpression((FullTextExpression) expression);
-      default:
-        return base.VisitUnknown(expression);
-      }
-    }
-
-    protected virtual Expression VisitFullTextExpression(FullTextExpression expression)
-    {
-      return expression;
-    }
-
-    protected virtual Expression VisitConstructorExpression(ConstructorExpression expression)
-    {
-      return expression;
-    }
-
-    protected virtual Expression VisitStructureExpression(StructureExpression expression)
-    {
-      return expression;
-    }
-
-    protected virtual Expression VisitLocalCollectionExpression(LocalCollectionExpression expression)
-    {
-      return expression;
-    }
-
-    protected virtual Expression VisitMarker(MarkerExpression expression)
-    {
-      var processedTarget = Visit(expression.Target);
-      if (processedTarget==expression.Target)
-        return expression;
-      return new MarkerExpression(processedTarget, expression.MarkerType);
-    }
-
-    protected virtual Expression VisitGroupingExpression(GroupingExpression expression)
-    {
-      return expression;
-    }
-
-    protected virtual Expression VisitSubQueryExpression(SubQueryExpression expression)
-    {
-      return expression;
-    }
-
-    protected virtual Expression VisitProjectionExpression(ProjectionExpression projectionExpression)
-    {
-      return projectionExpression;
-    }
-
-    protected virtual Expression VisitFieldExpression(FieldExpression expression)
-    {
-      return expression;
-    }
-
-    protected virtual Expression VisitStructureFieldExpression(StructureFieldExpression expression)
-    {
-      return expression;
-    }
-
-    protected virtual Expression VisitKeyExpression(KeyExpression expression)
-    {
-      return expression;
-    }
-
-    protected virtual Expression VisitEntityExpression(EntityExpression expression)
-    {
-      return expression;
-    }
-
-    protected virtual Expression VisitEntityFieldExpression(EntityFieldExpression expression)
-    {
-      return expression;
-    }
-
-    protected virtual Expression VisitEntitySetExpression(EntitySetExpression expression)
-    {
-      return expression;
-    }
-
-    protected virtual Expression VisitItemProjectorExpression(ItemProjectorExpression itemProjectorExpression)
-    {
-      return itemProjectorExpression;
-    }
-
-    protected virtual Expression VisitColumnExpression(ColumnExpression expression)
-    {
-      return expression;
-    }
+    var processedTarget = Visit(expression.Target);
+    return processedTarget == expression.Target ? expression : new MarkerExpression(processedTarget, expression.MarkerType);
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ExtendedExpressionVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ExtendedExpressionVisitor.cs
@@ -13,8 +13,8 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors;
 
 internal abstract class ExtendedExpressionVisitor : ExpressionVisitor
 {
-  protected override Expression VisitUnknown(Expression expression) =>
-    (expression as ExtendedExpression ?? throw new NotSupportedException(string.Format(Strings.ExpressionXIsUnknown, expression)))
+  protected override Expression VisitExtension(Expression node) =>
+    (node as ExtendedExpression ?? throw new NotSupportedException(string.Format(Strings.ExpressionXIsUnknown, node)))
       .Accept(this);
 
   internal virtual Expression VisitFullTextExpression(FullTextExpression expression) => expression;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/IncludeFilterMappingGatherer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/IncludeFilterMappingGatherer.cs
@@ -77,17 +77,17 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       return result;
     }
 
-    protected override Expression VisitMemberAccess(MemberExpression m)
+    protected override Expression VisitMember(MemberExpression m)
     {
       var target = m.Expression;
       if (target == null) {
-        return base.VisitMemberAccess(m);
+        return base.VisitMember(m);
       }
 
       if (target.NodeType == ExpressionType.Constant && ((ConstantExpression) target).Value == filteredTuple) {
         return CalculatedColumnParameter;
       }
-      return base.VisitMemberAccess(m);
+      return base.VisitMember(m);
     }
 
     private MappingEntry CreateMappingEntry(Expression expression)

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/OwnerRemover.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/OwnerRemover.cs
@@ -18,32 +18,32 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       return remover.Visit(target);
     }
 
-    protected override Expression VisitGroupingExpression(GroupingExpression expression)
+    internal override Expression VisitGroupingExpression(GroupingExpression expression)
     {
       return expression;
     }
 
-    protected override Expression VisitSubQueryExpression(SubQueryExpression expression)
+    internal override Expression VisitSubQueryExpression(SubQueryExpression expression)
     {
       return expression;
     }
 
-    protected override Expression VisitFieldExpression(FieldExpression expression)
+    internal override Expression VisitFieldExpression(FieldExpression expression)
     {
       return expression.RemoveOwner();
     }
 
-    protected override Expression VisitStructureFieldExpression(StructureFieldExpression expression)
+    internal override Expression VisitStructureFieldExpression(StructureFieldExpression expression)
     {
       return expression.RemoveOwner();
     }
 
-    protected override Expression VisitKeyExpression(KeyExpression expression)
+    internal override Expression VisitKeyExpression(KeyExpression expression)
     {
       return expression;
     }
 
-    protected override Expression VisitConstructorExpression(ConstructorExpression expression)
+    internal override Expression VisitConstructorExpression(ConstructorExpression expression)
     {
       var oldConstructorArguments = expression.ConstructorArguments;
       var newConstructorArguments = VisitExpressionList(oldConstructorArguments);
@@ -71,22 +71,22 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       return new ConstructorExpression(expression.Type, bindings, nativeBingings, expression.Constructor, newConstructorArguments);
     }
 
-    protected override Expression VisitEntityExpression(EntityExpression expression)
+    internal override Expression VisitEntityExpression(EntityExpression expression)
     {
       return expression;
     }
 
-    protected override Expression VisitEntityFieldExpression(EntityFieldExpression expression)
+    internal override Expression VisitEntityFieldExpression(EntityFieldExpression expression)
     {
       return expression.RemoveOwner();
     }
 
-    protected override Expression VisitEntitySetExpression(EntitySetExpression expression)
+    internal override Expression VisitEntitySetExpression(EntitySetExpression expression)
     {
       return expression;
     }
 
-    protected override Expression VisitColumnExpression(ColumnExpression expression)
+    internal override Expression VisitColumnExpression(ColumnExpression expression)
     {
       return expression;
     }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/PersistentExpressionVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/PersistentExpressionVisitor.cs
@@ -13,11 +13,11 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
 {
   internal abstract class PersistentExpressionVisitor : ExtendedExpressionVisitor
   {
-    protected override Expression VisitProjectionExpression(ProjectionExpression projectionExpression) =>
+    internal override Expression VisitProjectionExpression(ProjectionExpression projectionExpression) =>
       throw Exceptions.InternalError(string.Format(Strings.ExXDoesNotSupportX,
         typeof(PersistentExpressionVisitor), WellKnownOrmTypes.ProjectionExpression), OrmLog.Instance);
 
-    protected override Expression VisitItemProjectorExpression(ItemProjectorExpression itemProjectorExpression)
+    internal override Expression VisitItemProjectorExpression(ItemProjectorExpression itemProjectorExpression)
     {
       throw Exceptions.InternalError(String.Format(Strings.ExXDoesNotSupportX, typeof (PersistentExpressionVisitor), typeof (ItemProjectorExpression)), OrmLog.Instance);
     }

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
@@ -450,7 +450,7 @@ namespace Xtensive.Orm.Linq.Materialization
       }
     }
 
-    protected override Expression VisitMemberAccess(MemberExpression m)
+    protected override Expression VisitMember(MemberExpression m)
     {
       if (m.Expression!=null) {
         if ((ExtendedExpressionType) m.Expression.NodeType==ExtendedExpressionType.LocalCollection) {

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
@@ -75,7 +75,7 @@ namespace Xtensive.Orm.Linq.Materialization
 
     #region Visitor methods overrsides
 
-    protected override Expression VisitFullTextExpression(FullTextExpression expression)
+    internal override Expression VisitFullTextExpression(FullTextExpression expression)
     {
       var rankMaterializer = Visit(expression.RankExpression);
       var entityMaterializer = Visit(expression.EntityExpression);
@@ -90,7 +90,7 @@ namespace Xtensive.Orm.Linq.Materialization
         entityMaterializer);
     }
 
-    protected override Expression VisitMarker(MarkerExpression expression)
+    internal override Expression VisitMarker(MarkerExpression expression)
     {
       var target = expression.Target;
       var processedTarget = Visit(target);
@@ -105,7 +105,7 @@ namespace Xtensive.Orm.Linq.Materialization
       return processedTarget;
     }
 
-    protected override Expression VisitGroupingExpression(GroupingExpression groupingExpression)
+    internal override Expression VisitGroupingExpression(GroupingExpression groupingExpression)
     {
       // 1. Prepare subquery parameters.
       var translatedQuery = PrepareSubqueryParameters(groupingExpression,
@@ -139,7 +139,7 @@ namespace Xtensive.Orm.Linq.Materialization
       return Expression.Convert(resultExpression, groupingExpression.Type);
     }
 
-    protected override Expression VisitSubQueryExpression(SubQueryExpression subQueryExpression)
+    internal override Expression VisitSubQueryExpression(SubQueryExpression subQueryExpression)
     {
       // 1. Prepare subquery parameters.
       var translatedQuery = PrepareSubqueryParameters(
@@ -202,7 +202,7 @@ namespace Xtensive.Orm.Linq.Materialization
       }
     }
 
-    protected override Expression VisitFieldExpression(FieldExpression expression)
+    internal override Expression VisitFieldExpression(FieldExpression expression)
     {
       var tupleExpression = GetTupleExpression(expression);
 
@@ -233,11 +233,11 @@ namespace Xtensive.Orm.Linq.Materialization
       return MaterializeThroughOwner(expression, tupleExpression);
     }
 
-    protected override Expression VisitLocalCollectionExpression(LocalCollectionExpression expression) =>
+    internal override Expression VisitLocalCollectionExpression(LocalCollectionExpression expression) =>
       throw new NotSupportedException(
         string.Format(Strings.ExUnableToMaterializeBackLocalCollectionItem, expression.ToString()));
 
-    protected override Expression VisitStructureFieldExpression(StructureFieldExpression expression)
+    internal override Expression VisitStructureFieldExpression(StructureFieldExpression expression)
     {
       var tupleExpression = GetTupleExpression(expression);
 
@@ -269,7 +269,7 @@ namespace Xtensive.Orm.Linq.Materialization
       return MaterializeThroughOwner(expression, tupleExpression);
     }
 
-    protected override Expression VisitConstructorExpression(ConstructorExpression expression)
+    internal override Expression VisitConstructorExpression(ConstructorExpression expression)
     {
       var newExpression = expression.Constructor==null
         ? Expression.New(expression.Type) // Value type with default ctor (expression.Constructor is null in that case)
@@ -285,7 +285,7 @@ namespace Xtensive.Orm.Linq.Materialization
         .Select(item => Expression.Bind(item.Key, Visit(item.Value))).Cast<MemberBinding>());
     }
 
-    protected override Expression VisitStructureExpression(StructureExpression expression)
+    internal override Expression VisitStructureExpression(StructureExpression expression)
     {
       var tupleExpression = GetTupleExpression(expression);
 
@@ -312,7 +312,7 @@ namespace Xtensive.Orm.Linq.Materialization
         expression.Type);
     }
 
-    protected override Expression VisitKeyExpression(KeyExpression expression)
+    internal override Expression VisitKeyExpression(KeyExpression expression)
     {
       // TODO: http://code.google.com/p/dataobjectsdotnet/issues/detail?id=336
       Expression tupleExpression = Expression.Call(
@@ -330,7 +330,7 @@ namespace Xtensive.Orm.Linq.Materialization
         tupleExpression);
     }
 
-    protected override Expression VisitEntityExpression(EntityExpression expression)
+    internal override Expression VisitEntityExpression(EntityExpression expression)
     {
       var tupleExpression = GetTupleExpression(expression);
       return CreateEntity(expression, tupleExpression);
@@ -384,7 +384,7 @@ namespace Xtensive.Orm.Linq.Materialization
     }
 
     /// <exception cref="InvalidOperationException"><c>InvalidOperationException</c>.</exception>
-    protected override Expression VisitEntityFieldExpression(EntityFieldExpression expression)
+    internal override Expression VisitEntityFieldExpression(EntityFieldExpression expression)
     {
       if (expression.Entity!=null)
         return Visit(expression.Entity);
@@ -395,7 +395,7 @@ namespace Xtensive.Orm.Linq.Materialization
         : CreateEntity(expression, tupleExpression);
     }
 
-    protected override Expression VisitEntitySetExpression(EntitySetExpression expression)
+    internal override Expression VisitEntitySetExpression(EntitySetExpression expression)
     {
       var tupleExpression = GetTupleExpression(expression);
       var materializedEntitySetExpression = MaterializeThroughOwner(expression, tupleExpression);
@@ -408,7 +408,7 @@ namespace Xtensive.Orm.Linq.Materialization
       return prefetchEntitySetExpression;
     }
 
-    protected override Expression VisitColumnExpression(ColumnExpression expression)
+    internal override Expression VisitColumnExpression(ColumnExpression expression)
     {
       var tupleExpression = GetTupleExpression(expression);
       return tupleExpression.MakeTupleAccess(expression.Type, expression.Mapping.Offset);

--- a/Orm/Xtensive.Orm/Orm/Linq/ParameterAccessorFactory.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ParameterAccessorFactory.cs
@@ -34,7 +34,7 @@ namespace Xtensive.Orm.Linq
         return FastExpression.Lambda<Func<ParameterContext, T>>(body, parameterContextArgument);
       }
 
-      protected override Expression VisitMemberAccess(MemberExpression ma)
+      protected override Expression VisitMember(MemberExpression ma)
       {
         if (string.Equals(nameof(Parameter<T>.Value), ma.Member.Name, StringComparison.Ordinal)
           && WellKnownOrmTypes.Parameter.IsAssignableFrom(ma.Expression.Type)) {
@@ -46,7 +46,7 @@ namespace Xtensive.Orm.Linq
             GetParameterValueMethod.CachedMakeGenericMethod(parameterValueType), ma.Expression);
         }
 
-        return base.VisitMemberAccess(ma);
+        return base.VisitMember(ma);
       }
 
       public ParameterAccessorFactoryImpl(ParameterExpression parameterContextArgument)

--- a/Orm/Xtensive.Orm/Orm/Linq/ParameterExtractor.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ParameterExtractor.cs
@@ -25,10 +25,10 @@ namespace Xtensive.Orm.Linq
       return isParameter;
     }
 
-    protected override Expression VisitMemberAccess(MemberExpression m)
+    protected override Expression VisitMember(MemberExpression m)
     {
       isParameter = true;
-      return base.VisitMemberAccess(m);
+      return base.VisitMember(m);
     }
 
     protected override Expression VisitUnknown(Expression e) => e;

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/AggregateOptimizer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/AggregateOptimizer.cs
@@ -123,7 +123,7 @@ namespace Xtensive.Orm.Linq.Rewriters
           : FastExpression.Lambda(extractor.result, extractor.parameter);
       }
 
-      protected override Expression VisitMemberAccess(MemberExpression m)
+      protected override Expression VisitMember(MemberExpression m)
       {
         if (IsReferenceFieldAccess(m)) {
           var fieldAccess = m;
@@ -138,7 +138,7 @@ namespace Xtensive.Orm.Linq.Rewriters
             return m;
           }
         }
-        return base.VisitMemberAccess(m);
+        return base.VisitMember(m);
       }
 
       private static bool IsReferenceFieldAccess(MemberExpression m)

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/ApplyParameterRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/ApplyParameterRewriter.cs
@@ -25,15 +25,15 @@ namespace Xtensive.Orm.Linq.Rewriters
       return expressionRewriter.Visit(expression);
     }
 
-    protected override Expression VisitMemberAccess(MemberExpression m)
+    protected override Expression VisitMember(MemberExpression m)
     {
       if (m.Member!=WellKnownMembers.ApplyParameterValue)
-        return base.VisitMemberAccess(m);
+        return base.VisitMember(m);
       if (m.Expression.NodeType!=ExpressionType.Constant)
-        return base.VisitMemberAccess(m);
+        return base.VisitMember(m);
       var parameter = ((ConstantExpression) m.Expression).Value;
       if (parameter!=oldApplyParameter)
-        return base.VisitMemberAccess(m);
+        return base.VisitMember(m);
       return newApplyParameterValueExpression;
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/ApplyParameterRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/ApplyParameterRewriter.cs
@@ -38,7 +38,7 @@ namespace Xtensive.Orm.Linq.Rewriters
     }
 
 
-    protected override Expression VisitGroupingExpression(GroupingExpression expression)
+    internal override Expression VisitGroupingExpression(GroupingExpression expression)
     {
       var projectionExpression = expression.ProjectionExpression;
       var newProvider = Rewrite(projectionExpression.ItemProjector.DataSource, oldApplyParameter, newApplyParameter);
@@ -56,7 +56,7 @@ namespace Xtensive.Orm.Linq.Rewriters
       return expression;
     }
 
-    protected override Expression VisitSubQueryExpression(SubQueryExpression expression)
+    internal override Expression VisitSubQueryExpression(SubQueryExpression expression)
     {
       var projectionExpression = expression.ProjectionExpression;
       var newProvider = Rewrite(projectionExpression.ItemProjector.DataSource, oldApplyParameter, newApplyParameter);

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/ApplyParameterToTupleParameterRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/ApplyParameterToTupleParameterRewriter.cs
@@ -39,7 +39,7 @@ namespace Xtensive.Orm.Linq.Rewriters
       return parameterOfTupleExpression;
     }
 
-    protected override Expression VisitGroupingExpression(GroupingExpression expression)
+    internal override Expression VisitGroupingExpression(GroupingExpression expression)
     {
       var projectionExpression = expression.ProjectionExpression;
       var newProvider = Rewrite(projectionExpression.ItemProjector.DataSource, parameterOfTuple, applyParameter);
@@ -58,7 +58,7 @@ namespace Xtensive.Orm.Linq.Rewriters
       return expression;
     }
 
-    protected override Expression VisitSubQueryExpression(SubQueryExpression expression)
+    internal override Expression VisitSubQueryExpression(SubQueryExpression expression)
     {
       var projectionExpression = expression.ProjectionExpression;
       var newProvider = Rewrite(projectionExpression.ItemProjector.DataSource, parameterOfTuple, applyParameter);

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/ApplyParameterToTupleParameterRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/ApplyParameterToTupleParameterRewriter.cs
@@ -27,15 +27,15 @@ namespace Xtensive.Orm.Linq.Rewriters
       return expressionRewriter.Visit(expression);
     }
 
-    protected override Expression VisitMemberAccess(MemberExpression m)
+    protected override Expression VisitMember(MemberExpression m)
     {
       if (m.Member!=WellKnownMembers.ApplyParameterValue)
-        return base.VisitMemberAccess(m);
+        return base.VisitMember(m);
       if (m.Expression.NodeType!=ExpressionType.Constant)
-        return base.VisitMemberAccess(m);
+        return base.VisitMember(m);
       var parameter = ((ConstantExpression) m.Expression).Value;
       if (parameter!=applyParameter)
-        return base.VisitMemberAccess(m);
+        return base.VisitMember(m);
       return parameterOfTupleExpression;
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/ClosureAccessRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/ClosureAccessRewriter.cs
@@ -20,7 +20,7 @@ namespace Xtensive.Orm.Linq.Rewriters
 
     protected override Expression VisitUnknown(Expression e) => e;
 
-    protected override Expression VisitMemberAccess(MemberExpression memberExpression)
+    protected override Expression VisitMember(MemberExpression memberExpression)
     {
       if (memberExpression.Type.IsOfGenericInterface(WellKnownInterfaces.QueryableOfT)
         && memberExpression.Expression != null
@@ -45,7 +45,7 @@ namespace Xtensive.Orm.Linq.Rewriters
         }
       }
 
-      return base.VisitMemberAccess(memberExpression);
+      return base.VisitMember(memberExpression);
     }
 
     public static Expression Rewrite(Expression e, CompiledQueryProcessingScope compiledQueryScope) =>

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/EntitySetAccessRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/EntitySetAccessRewriter.cs
@@ -35,10 +35,10 @@ namespace Xtensive.Orm.Linq.Rewriters
       throw NotSupported(method);
     }
 
-    protected override Expression VisitMemberAccess(MemberExpression m)
+    protected override Expression VisitMember(MemberExpression m)
     {
       if (!IsEntitySet(m.Expression))
-        return base.VisitMemberAccess(m);
+        return base.VisitMember(m);
 
       var member = m.Member;
       if (member.Name=="Count") {

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/SelectManySelectorRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/SelectManySelectorRewriter.cs
@@ -17,11 +17,11 @@ namespace Xtensive.Orm.Linq.Rewriters
     private readonly ParameterExpression targetParameter;
     private bool processingFailed;
 
-    protected override Expression VisitMemberAccess(MemberExpression m)
+    protected override Expression VisitMember(MemberExpression m)
     {
       if (m.Expression==sourceParameter && m.Type==targetParameter.Type)
         return targetParameter;
-      return base.VisitMemberAccess(m);
+      return base.VisitMember(m);
     }
 
     protected override Expression VisitParameter(ParameterExpression p)

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/CalculateRelatedExpressionRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/CalculateRelatedExpressionRewriter.cs
@@ -33,11 +33,11 @@ namespace Xtensive.Orm.Rse.Transformation
       return (LambdaExpression) Visit(expression);
     }
 
-    protected override Expression VisitMemberAccess(MemberExpression m)
+    protected override Expression VisitMember(MemberExpression m)
     {
       if (IsApplyParameter(m.Expression))
         return substitute;
-      return base.VisitMemberAccess(m);
+      return base.VisitMember(m);
     }
 
     protected override Expression VisitMethodCall(MethodCallExpression mc)


### PR DESCRIPTION
Dispatching Visitor by virtual functions is faster than linear seach by `switch` + type casting
The main change is here: https://github.com/servicetitan/dataobjects-net/pull/228/files#diff-cf319e9d7186cc0ce46c3710889c3f84039c2e541edb0ac4ba8c4802881e74eeR17

Use .NET `ExpressionVisitor ` API https://learn.microsoft.com/en-us/dotnet/api/system.linq.expressions.expressionvisitor?view=net-8.0

Also:
* Upgrade `Npgsql`