### PR TITLE
Optimize `LambdaExpressionFactory`: avoid intermediate allocations

### DIFF
--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/QueryOperation.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/QueryOperation.cs
@@ -18,6 +18,8 @@ namespace Xtensive.Orm.BulkOperations
   internal abstract class QueryOperation<T> : Operation<T>
     where T : class, IEntity
   {
+    private static readonly ConstantExpression ComplexConditionConstant = Expression.Constant(IncludeAlgorithm.ComplexCondition);
+
     protected IQueryable<T> query;
 
     protected QueryOperation(QueryProvider queryProvider)
@@ -37,7 +39,7 @@ namespace Xtensive.Orm.BulkOperations
             var localCollection = ex.Arguments[0];//IEnumerable<T>
             var valueToCheck = ex.Arguments[1];
             var genericInMethod = WellKnownMembers.InMethod.CachedMakeGenericMethod(valueToCheck.Type);
-            ex = Expression.Call(genericInMethod, valueToCheck, Expression.Constant(IncludeAlgorithm.ComplexCondition), localCollection);
+            ex = Expression.Call(genericInMethod, valueToCheck, ComplexConditionConstant, localCollection);
             methodInfo = ex.Method;
           }
 
@@ -52,13 +54,13 @@ namespace Xtensive.Orm.BulkOperations
 
               if (algorithm == IncludeAlgorithm.Auto) {
                 var arguments = ex.Arguments.ToList();
-                arguments[1] = Expression.Constant(IncludeAlgorithm.ComplexCondition);
+                arguments[1] = ComplexConditionConstant;
                 ex = Expression.Call(methodInfo, arguments);
               }
             }
             else {
               var arguments = ex.Arguments.ToList();
-              arguments.Insert(1, Expression.Constant(IncludeAlgorithm.ComplexCondition));
+              arguments.Insert(1, ComplexConditionConstant);
               ex = Expression.Call(WellKnownMembers.InMethod.MakeGenericMethod(methodInfo.GetGenericArguments()), arguments);
             }
           }

--- a/Orm/Xtensive.Orm.Tests.Core/Linq/LambdaExpressionFactoryTests.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Linq/LambdaExpressionFactoryTests.cs
@@ -24,7 +24,7 @@ namespace Xtensive.Orm.Tests.Core.Linq
     {
       var lambda = (Func<int, int>) LambdaExpressionFactory
         .CreateFactoryFast(delegateType)
-        .Invoke(plusOne.Body, plusOne.Parameters.ToArray())
+        .Invoke(plusOne.Body, plusOne.Parameters)
         .Compile();
 
       Assert.That(lambda.Invoke(1), Is.EqualTo(2));
@@ -33,9 +33,8 @@ namespace Xtensive.Orm.Tests.Core.Linq
     [Test]
     public void ShouldCreateFactorySlow()
     {
-      var lambda = (Func<int, int>) LambdaExpressionFactory.Instance
-        .CreateFactorySlow(delegateType)
-        .Invoke(plusOne.Body, plusOne.Parameters.ToArray())
+      var lambda = (Func<int, int>) LambdaExpressionFactory.CreateFactorySlow(delegateType)
+        .Invoke(plusOne.Body, plusOne.Parameters)
         .Compile();
 
       Assert.That(lambda.Invoke(1), Is.EqualTo(2));
@@ -45,7 +44,7 @@ namespace Xtensive.Orm.Tests.Core.Linq
     public void ShouldCreateLambda()
     {
       var lambda = (Func<int, int>) LambdaExpressionFactory.Instance
-        .CreateLambda(delegateType, plusOne.Body, plusOne.Parameters.ToArray())
+        .CreateLambda(delegateType, plusOne.Body, plusOne.Parameters)
         .Compile();
 
       Assert.That(lambda.Invoke(1), Is.EqualTo(2));

--- a/Orm/Xtensive.Orm.Tests/Linq/MiscTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/MiscTest.cs
@@ -119,7 +119,7 @@ namespace Xtensive.Orm.Tests.Linq
       var selectExpression = Expression.Call(genericSelectMethodInfo, queryAllExpression, lambda);
 
       return (IQueryable) FastExpression
-        .Lambda(selectExpression, Enumerable.Empty<ParameterExpression>())
+        .Lambda(selectExpression, Array.Empty<ParameterExpression>())
         .Compile()
         .DynamicInvoke();
     }

--- a/Orm/Xtensive.Orm/Linq/FastExpression.cs
+++ b/Orm/Xtensive.Orm/Linq/FastExpression.cs
@@ -57,10 +57,8 @@ namespace Xtensive.Linq
     /// <param name="body">The body of lambda expression.</param>
     /// <param name="parameters">The parameters of lambda expression.</param>
     /// <returns>Constructed lambda expression.</returns>
-    public static LambdaExpression Lambda(Expression body, params ParameterExpression[] parameters)
-    {
-      return LambdaExpressionFactory.Instance.CreateLambda(body, parameters ?? Array.Empty<ParameterExpression>());
-    }
+    public static LambdaExpression Lambda(Expression body, params ParameterExpression[] parameters) =>
+      LambdaExpressionFactory.Instance.CreateLambda(body, parameters ?? Array.Empty<ParameterExpression>());
 
     /// <summary>
     /// Generates <see cref="LambdaExpression"/> faster than <see cref="Expression.Lambda(Expression,ParameterExpression[])"/>.
@@ -68,9 +66,7 @@ namespace Xtensive.Linq
     /// <param name="body">The body of lambda expression.</param>
     /// <param name="parameters">The parameters of lambda expression.</param>
     /// <returns>Constructed lambda expression.</returns>
-    public static LambdaExpression Lambda(Expression body, IReadOnlyList<ParameterExpression> parameters)
-    {
-      return LambdaExpressionFactory.Instance.CreateLambda(body, parameters);
-    }
+    public static LambdaExpression Lambda(Expression body, IReadOnlyList<ParameterExpression> parameters) =>
+      LambdaExpressionFactory.Instance.CreateLambda(body, parameters);
   }
 }

--- a/Orm/Xtensive.Orm/Linq/FastExpression.cs
+++ b/Orm/Xtensive.Orm/Linq/FastExpression.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 
 namespace Xtensive.Linq
@@ -49,10 +48,8 @@ namespace Xtensive.Linq
     /// <param name="body">The body of lambda expression.</param>
     /// <param name="parameters">The parameters of lambda expression.</param>
     /// <returns>Constructed lambda expression.</returns>
-    public static LambdaExpression Lambda(Type delegateType, Expression body, IEnumerable<ParameterExpression> parameters)
-    {
-      return LambdaExpressionFactory.Instance.CreateLambda(delegateType, body, parameters.ToArray());
-    }
+    public static LambdaExpression Lambda(Type delegateType, Expression body, IReadOnlyList<ParameterExpression> parameters) =>
+      LambdaExpressionFactory.Instance.CreateLambda(delegateType, body, parameters);
 
     /// <summary>
     /// Generates <see cref="LambdaExpression"/> faster than <see cref="Expression.Lambda(Expression,ParameterExpression[])"/>.
@@ -71,9 +68,9 @@ namespace Xtensive.Linq
     /// <param name="body">The body of lambda expression.</param>
     /// <param name="parameters">The parameters of lambda expression.</param>
     /// <returns>Constructed lambda expression.</returns>
-    public static LambdaExpression Lambda(Expression body, IEnumerable<ParameterExpression> parameters)
+    public static LambdaExpression Lambda(Expression body, IReadOnlyList<ParameterExpression> parameters)
     {
-      return LambdaExpressionFactory.Instance.CreateLambda(body, parameters.ToArray());
+      return LambdaExpressionFactory.Instance.CreateLambda(body, parameters);
     }
   }
 }

--- a/Orm/Xtensive.Orm/Linq/FastExpression.cs
+++ b/Orm/Xtensive.Orm/Linq/FastExpression.cs
@@ -23,10 +23,8 @@ namespace Xtensive.Linq
     /// <param name="body">The body of lambda expression.</param>
     /// <param name="parameters">The parameters of lambda expression.</param>
     /// <returns>Constructed lambda expression.</returns>
-    public static LambdaExpression Lambda(Type delegateType, Expression body, params ParameterExpression[] parameters)
-    {
-      return LambdaExpressionFactory.Instance.CreateLambda(delegateType, body, parameters ?? Array.Empty<ParameterExpression>());
-    }
+    public static LambdaExpression Lambda(Type delegateType, Expression body, params ParameterExpression[] parameters) =>
+      LambdaExpressionFactory.Instance.CreateLambda(delegateType, body, parameters ?? Array.Empty<ParameterExpression>());
 
     /// <summary>
     /// Generates <see cref="LambdaExpression"/> faster than <see cref="Expression.Lambda(Type,Expression,ParameterExpression[])"/>.
@@ -35,11 +33,11 @@ namespace Xtensive.Linq
     /// <param name="body">The body of lambda expression.</param>
     /// <param name="parameters">The parameters of lambda expression.</param>
     /// <returns>Constructed lambda expression.</returns>
-    public static Expression<TDelegate> Lambda<TDelegate>(Expression body, params ParameterExpression[] parameters)
-    {
-      return (Expression<TDelegate>) LambdaExpressionFactory.Instance
-        .CreateLambda(typeof(TDelegate), body, parameters ?? Array.Empty<ParameterExpression>());
-    }
+    public static Expression<TDelegate> Lambda<TDelegate>(Expression body, params ParameterExpression[] parameters) =>
+      (Expression<TDelegate>) LambdaExpressionFactory.Instance.CreateLambda(typeof(TDelegate), body, parameters ?? Array.Empty<ParameterExpression>());
+
+    public static Expression<TDelegate> Lambda<TDelegate>(Expression body, IReadOnlyList<ParameterExpression> parameters) =>
+      (Expression<TDelegate>) LambdaExpressionFactory.Instance.CreateLambda(typeof(TDelegate), body, parameters);
 
     /// <summary>
     /// Generates <see cref="LambdaExpression"/> faster than <see cref="Expression.Lambda(Type,Expression,IEnumerable{ParameterExpression})"/>.

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/Internals/SerializableExpressionToExpressionConverter.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/Internals/SerializableExpressionToExpressionConverter.cs
@@ -163,7 +163,7 @@ namespace Xtensive.Linq.SerializableExpressions.Internals
 
     private Expression VisitLambda(SerializableLambdaExpression l)
     {
-      return FastExpression.Lambda(l.Type, Visit(l.Body), l.Parameters.Select(p => (ParameterExpression) Visit(p)));
+      return FastExpression.Lambda(l.Type, Visit(l.Body), l.Parameters.Select(p => (ParameterExpression) Visit(p)).ToArray());
     }
 
     private Expression VisitNew(SerializableNewExpression n)

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/PartialIndexFilterBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/PartialIndexFilterBuilder.cs
@@ -27,6 +27,7 @@ namespace Xtensive.Orm.Building.Builders
   internal sealed class PartialIndexFilterBuilder : ExpressionVisitor
   {
     private static readonly ParameterExpression Parameter = Expression.Parameter(WellKnownOrmTypes.Tuple, "tuple");
+    private static readonly IReadOnlyList<ParameterExpression> Parameters = [Parameter];
 
     private readonly TypeInfo declaringType;
     private readonly TypeInfo reflectedType;
@@ -40,7 +41,7 @@ namespace Xtensive.Orm.Building.Builders
       var builder = new PartialIndexFilterBuilder(index);
       var body = builder.Visit(index.FilterExpression.Body);
       var filter = new PartialIndexFilterInfo {
-        Expression = FastExpression.Lambda(body, Parameter),
+        Expression = FastExpression.Lambda(body, Parameters),
         Fields = builder.usedFields,
       };
       index.Filter = filter;

--- a/Orm/Xtensive.Orm/Orm/Internals/Activator.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Activator.cs
@@ -19,53 +19,40 @@ namespace Xtensive.Orm.Internals
     private const string OrmFactoryMethodName = "CreateObject";
     private const string OtherFactoryMethodName = "~Xtensive.Orm.CreateObject";
 
-    private static readonly ConcurrentDictionary<Type, Func<Session, EntityState, Entity>> EntityActivators
-      = new ConcurrentDictionary<Type, Func<Session, EntityState, Entity>>();
-    private static readonly ConcurrentDictionary<Type, Func<Session, Tuple, Structure>> DetachedStructureActivators
-      = new ConcurrentDictionary<Type, Func<Session, Tuple, Structure>>();
-    private static readonly ConcurrentDictionary<Type, Func<Persistent, FieldInfo, Structure>> StructureActivators
-      = new ConcurrentDictionary<Type, Func<Persistent, FieldInfo, Structure>>();
-    private static readonly ConcurrentDictionary<Type, Func<Entity, FieldInfo, EntitySetBase>> EntitySetActivators
-      = new ConcurrentDictionary<Type, Func<Entity, FieldInfo, EntitySetBase>>();
-
-    public static Entity CreateEntity(Session session, Type type, EntityState state)
+    private static class Traits<TArg1, TArg2, TResult> where TArg1 : class where TArg2 : class
     {
-      var activator = EntityActivators.GetOrAdd(type, GetActivator<Session, EntityState, Entity>);
-      return activator.Invoke(session, state);
+      private static readonly Type DelegateType = typeof(Func<TArg1, TArg2, TResult>);
+      private static readonly Type[] TypeParams = [typeof(TArg1), typeof(TArg2)];
+
+      public static readonly Func<Type, Func<TArg1, TArg2, TResult>> Activator = type => {
+        var methodName = type.Assembly == OrmAssembly ? OrmFactoryMethodName : OtherFactoryMethodName;
+        var method = type.GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic, null, TypeParams, null)
+                     ?? throw new InvalidOperationException(string.Format(
+                       Strings.ExUnableToFindFactoryMethodForTypeXMakeSureAssemblyYProcessedByWeaver,
+                       type.FullName, type.Assembly));
+        return (Func<TArg1, TArg2, TResult>) Delegate.CreateDelegate(DelegateType, method);
+      };
     }
+
+    private static readonly ConcurrentDictionary<Type, Func<Session, EntityState, Entity>> EntityActivators = new();
+    private static readonly ConcurrentDictionary<Type, Func<Session, Tuple, Structure>> DetachedStructureActivators = new();
+    private static readonly ConcurrentDictionary<Type, Func<Persistent, FieldInfo, Structure>> StructureActivators = new();
+    private static readonly ConcurrentDictionary<Type, Func<Entity, FieldInfo, EntitySetBase>> EntitySetActivators = new();
+
+    public static Entity CreateEntity(Session session, Type type, EntityState state) =>
+      EntityActivators.GetOrAdd(type, Traits<Session, EntityState, Entity>.Activator).Invoke(session, state);
 
     public static Structure CreateStructure(Type type, Persistent owner, FieldInfo field)
     {
-      var activator = StructureActivators.GetOrAdd(type, GetActivator<Persistent, FieldInfo, Structure>);
-      var result = activator.Invoke(owner, field);
+      var result = StructureActivators.GetOrAdd(type, Traits<Persistent, FieldInfo, Structure>.Activator).Invoke(owner, field);
       result.SystemInitialize(true);
       return result;
     }
 
-    public static Structure CreateStructure(Session session, Type type, Tuple tuple)
-    {
-      var activator = DetachedStructureActivators.GetOrAdd(type, GetActivator<Session, Tuple, Structure>);
-      return activator.Invoke(session, tuple);
-    }
+    public static Structure CreateStructure(Session session, Type type, Tuple tuple) =>
+      DetachedStructureActivators.GetOrAdd(type, Traits<Session, Tuple, Structure>.Activator).Invoke(session, tuple);
 
-    public static EntitySetBase CreateEntitySet(Entity owner, FieldInfo field)
-    {
-      var activator = EntitySetActivators.GetOrAdd(field.ValueType, GetActivator<Entity, FieldInfo, EntitySetBase>);
-      return activator.Invoke(owner, field);
-    }
-
-    private static Func<TArg1, TArg2, TResult> GetActivator<TArg1, TArg2, TResult>(Type type)
-      where TArg1 : class
-      where TArg2 : class
-    {
-      var methodName = type.Assembly==OrmAssembly ? OrmFactoryMethodName : OtherFactoryMethodName;
-      var parameters = new[] {typeof (TArg1), typeof (TArg2)};
-      var method = type.GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic, null, parameters, null);
-      if (method==null)
-        throw new InvalidOperationException(string.Format(
-          Strings.ExUnableToFindFactoryMethodForTypeXMakeSureAssemblyYProcessedByWeaver,
-          type.FullName, type.Assembly));
-      return (Func<TArg1, TArg2, TResult>) Delegate.CreateDelegate(typeof (Func<TArg1, TArg2, TResult>), method);
-    }
+    public static EntitySetBase CreateEntitySet(Entity owner, FieldInfo field) =>
+      EntitySetActivators.GetOrAdd(field.ValueType, Traits<Entity, FieldInfo, EntitySetBase>.Activator).Invoke(owner, field);
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/ExpressionExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ExpressionExtensions.cs
@@ -18,7 +18,7 @@ namespace Xtensive.Orm.Linq
 {
   internal static class ExpressionExtensions
   {
-    private static readonly ConcurrentDictionary<Type, MemberType> memberTypeByType = new;
+    private static readonly ConcurrentDictionary<Type, MemberType> memberTypeByType = new();
 
     private static readonly Func<Type, MemberType> memberTypeFactory = type =>
       WellKnownOrmTypes.Key.IsAssignableFrom(type) ? MemberType.Key

--- a/Orm/Xtensive.Orm/Orm/Linq/ExpressionExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ExpressionExtensions.cs
@@ -18,7 +18,7 @@ namespace Xtensive.Orm.Linq
 {
   internal static class ExpressionExtensions
   {
-    private static readonly ConcurrentDictionary<Type, MemberType> memberTypeByType = new ConcurrentDictionary<Type, MemberType>();
+    private static readonly ConcurrentDictionary<Type, MemberType> memberTypeByType = new;
 
     private static readonly Func<Type, MemberType> memberTypeFactory = type =>
       WellKnownOrmTypes.Key.IsAssignableFrom(type) ? MemberType.Key

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/IncludeFilterMappingGatherer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/IncludeFilterMappingGatherer.cs
@@ -4,13 +4,13 @@
 // Created by: Alexey Gamzov
 // Created:    2009.11.16
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using Xtensive.Core;
 using Xtensive.Linq;
 using Xtensive.Orm.Internals;
 using Xtensive.Orm.Rse;
-using Xtensive.Tuples;
 
 namespace Xtensive.Orm.Linq.Expressions.Visitors
 {
@@ -35,6 +35,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
     }
 
     private static readonly ParameterExpression CalculatedColumnParameter = Expression.Parameter(WellKnownOrmTypes.Tuple, "filteredRow");
+    private static readonly IReadOnlyList<ParameterExpression> CalculatedColumnParameters = [CalculatedColumnParameter];
 
     private readonly Expression filterDataTuple;
     private readonly ApplyParameter filteredTuple;
@@ -97,7 +98,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
         return new MappingEntry(tupleAccess.GetTupleAccessArgument());
       }
       expression = ExpressionReplacer.Replace(expression, filterDataTuple, CalculatedColumnParameter);
-      return new MappingEntry(FastExpression.Lambda(expression, CalculatedColumnParameter));
+      return new MappingEntry(FastExpression.Lambda(expression, CalculatedColumnParameters));
     }
 
     private IncludeFilterMappingGatherer(Expression filterDataTuple, ApplyParameter filteredTuple, MappingEntry[] resultMapping)

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/OwnerRemover.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/OwnerRemover.cs
@@ -12,11 +12,10 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
 {
   internal sealed class OwnerRemover : PersistentExpressionVisitor
   {
-    public static Expression RemoveOwner(Expression target)
-    {
-      var remover = new OwnerRemover();
-      return remover.Visit(target);
-    }
+    private static readonly OwnerRemover Instance = new();
+
+    public static Expression RemoveOwner(Expression target) =>
+      Instance.Visit(target);
 
     internal override Expression VisitGroupingExpression(GroupingExpression expression)
     {
@@ -90,5 +89,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
     {
       return expression;
     }
+
+    private OwnerRemover() { }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/ItemToTupleConverter{TItem}.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ItemToTupleConverter{TItem}.cs
@@ -191,7 +191,7 @@ namespace Xtensive.Orm.Linq
     }
 
 
-    private IMappedExpression BuildField(Type type, ref ColNum index, TupleTypeCollection types)
+    private ParameterizedExpression BuildField(Type type, ref ColNum index, TupleTypeCollection types)
     {
 //      if (type.IsOfGenericType(typeof (Ref<>))) {
 //        var entityType = type.GetGenericType(typeof (Ref<>)).GetGenericArguments()[0];
@@ -208,7 +208,7 @@ namespace Xtensive.Orm.Linq
         var typeInfo = model.Types[type];
         var keyInfo = typeInfo.Key;
         var keyTupleDescriptor = keyInfo.TupleDescriptor;
-        IMappedExpression expression;
+        ParameterizedExpression expression;
         if (IsKeyConverter)
           expression = KeyExpression.Create(typeInfo, index);
         else {
@@ -247,7 +247,7 @@ namespace Xtensive.Orm.Linq
       ColNum index = 0;
       var types = new TupleTypeCollection();
       if (IsPersistableType(itemType)) {
-        Expression = (Expression) BuildField(itemType, ref index, types);
+        Expression = BuildField(itemType, ref index, types);
         TupleDescriptor = TupleDescriptor.Create(types.ToArray(types.Count));
       }
       else {

--- a/Orm/Xtensive.Orm/Orm/Linq/ItemToTupleConverter{TItem}.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ItemToTupleConverter{TItem}.cs
@@ -163,7 +163,6 @@ namespace Xtensive.Orm.Linq
       if (!processedTypes.Add(type))
         throw new InvalidOperationException(string.Format(Strings.ExUnableToPersistTypeXBecauseOfLoopReference, type.FullName));
 
-
       var members = type
         .GetProperties(BindingFlags.Instance | BindingFlags.Public)
         .Where(propertyInfo => propertyInfo.CanRead)

--- a/Orm/Xtensive.Orm/Orm/Linq/ItemToTupleConverter{TItem}.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ItemToTupleConverter{TItem}.cs
@@ -52,7 +52,7 @@ namespace Xtensive.Orm.Linq
       }
     }
 
-    private static readonly ParameterExpression ParamContext = Expression.Parameter(WellKnownOrmTypes.ParameterContext, "context");
+    private static readonly IReadOnlyList<ParameterExpression> ParamContextParams = [Expression.Parameter(WellKnownOrmTypes.ParameterContext, "context")];
     private static readonly MethodInfo SelectMethod = WellKnownMembers.Enumerable.Select.MakeGenericMethod(typeof(TItem), WellKnownOrmTypes.Tuple);
 
     private readonly Func<ParameterContext, IEnumerable<TItem>> enumerableFunc;
@@ -65,9 +65,9 @@ namespace Xtensive.Orm.Linq
 
     public override Expression<Func<ParameterContext, IEnumerable<Tuple>>> GetEnumerable()
     {
-      var call = Expression.Call(Expression.Constant(enumerableFunc.Target), enumerableFunc.Method, ParamContext);
+      var call = Expression.Call(Expression.Constant(enumerableFunc.Target), enumerableFunc.Method, ParamContextParams);
       var select = Expression.Call(SelectMethod, call, Expression.Constant(converter));
-      return FastExpression.Lambda<Func<ParameterContext, IEnumerable<Tuple>>>(select, ParamContext);
+      return FastExpression.Lambda<Func<ParameterContext, IEnumerable<Tuple>>>(select, ParamContextParams);
     }
 
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
@@ -36,7 +36,9 @@ namespace Xtensive.Orm.Linq.Materialization
     private static readonly PropertyInfo ParameterContextProperty = WellKnownOrmTypes.ItemMaterializationContext.GetProperty(nameof(ItemMaterializationContext.ParameterContext));
     private static readonly MethodInfo GetTupleParameterValueMethod = GetParameterValueMethod.CachedMakeGenericMethod(WellKnownOrmTypes.Tuple);
     private static readonly ParameterExpression TupleParameter = Expression.Parameter(WellKnownOrmTypes.Tuple, "tuple");
+    private static readonly IReadOnlyList<ParameterExpression> TupleParameters = [TupleParameter];
     private static readonly ParameterExpression MaterializationContextParameter = Expression.Parameter(WellKnownOrmTypes.ItemMaterializationContext, "mc");
+    private static readonly IReadOnlyList<ParameterExpression> TupleAndMaterializationContextParameters = [TupleParameter, MaterializationContextParameter];
     private static readonly ConstantExpression TypeReferenceAccuracyConstantExpression = Expression.Constant(TypeReferenceAccuracy.BaseType);
     private static readonly MethodInfo GetTypeInfoMethod = typeof(ItemMaterializationContext).GetMethod(nameof(ItemMaterializationContext.GetTypeInfo));
 
@@ -59,14 +61,14 @@ namespace Xtensive.Orm.Linq.Materialization
     {
       var visitor = new ExpressionMaterializer(context, null, EmptyTupleParameters);
       var processedExpression = OwnerRemover.RemoveOwner(expression);
-      return FastExpression.Lambda(visitor.Visit(processedExpression), TupleParameter);
+      return FastExpression.Lambda(visitor.Visit(processedExpression), TupleParameters);
     }
 
     public static MaterializationInfo MakeMaterialization(ItemProjectorExpression projector, TranslatorContext context,
       IReadOnlySet<Parameter<Tuple>> tupleParameters)
     {
       var visitor = new ExpressionMaterializer(context, MaterializationContextParameter, tupleParameters);
-      var lambda = FastExpression.Lambda(visitor.Visit(projector.Item), TupleParameter, MaterializationContextParameter);
+      var lambda = FastExpression.Lambda(visitor.Visit(projector.Item), TupleAndMaterializationContextParameters);
       var count = visitor.entityRegistry.Count;
       return new MaterializationInfo(count, lambda);
     }

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
@@ -361,18 +361,19 @@ namespace Xtensive.Orm.Linq.Materialization
         .Select(f => (f.Field.MappingInfo.Offset, f.Mapping.Offset))
         .ToHashSet();
 
+      var exprIndex = Expr.Constant(index);
       var isMaterializedExpression = Expression.Call(
         itemMaterializationContextParameter,
         ItemMaterializationContext.IsMaterializedMethodInfo,
-        Expr.Constant(index));
+        exprIndex);
       var getEntityExpression = Expression.Call(
         itemMaterializationContextParameter,
         ItemMaterializationContext.GetEntityMethodInfo,
-        Expr.Constant(index));
+        exprIndex);
       var materializeEntityExpression = Expression.Call(
         itemMaterializationContextParameter,
         ItemMaterializationContext.MaterializeMethodInfo,
-        Expr.Constant(index),
+        exprIndex,
         Expr.Constant(typeIdIndex),
         Expression.Constant(expression.PersistentType),
         Expression.Constant(mappingInfo),

--- a/Orm/Xtensive.Orm/Orm/Linq/ParameterExtractor.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ParameterExtractor.cs
@@ -9,9 +9,8 @@ using ExpressionVisitor = Xtensive.Linq.ExpressionVisitor;
 
 namespace Xtensive.Orm.Linq
 {
-  internal sealed class ParameterExtractor : ExpressionVisitor
+  internal sealed class ParameterExtractor(ExpressionEvaluator evaluator) : ExpressionVisitor
   {
-    private readonly ExpressionEvaluator evaluator;
     private bool isParameter;
 
     public bool IsParameter(Expression e)
@@ -35,19 +34,8 @@ namespace Xtensive.Orm.Linq
 
     protected override Expression VisitConstant(ConstantExpression c)
     {
-      isParameter = c.GetMemberType() switch {
-        MemberType.Entity => true,
-        MemberType.Structure => true,
-        _ => isParameter
-      };
+      isParameter |= c.GetMemberType() is MemberType.Entity or MemberType.Structure;
       return c;
-    }
-
-    // Constructors
-
-    public ParameterExtractor(ExpressionEvaluator evaluator)
-    {
-      this.evaluator = evaluator;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/QueryHelper.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/QueryHelper.cs
@@ -36,6 +36,7 @@ namespace Xtensive.Orm.Linq
     }
 
     private static readonly ParameterExpression TupleParameter = Expression.Parameter(WellKnownOrmTypes.Tuple, "tuple");
+    private static readonly IReadOnlyList<ParameterExpression> TupleParameters = [TupleParameter];
 
     public static Expression<Func<Tuple, bool>> BuildFilterLambda(int startIndex, IReadOnlyList<Type> keyColumnTypes, Parameter<Tuple> keyParameter)
     {
@@ -59,7 +60,7 @@ namespace Xtensive.Orm.Linq
           filterExpression = Expression.And(filterExpression,
             Expression.Equal(tupleParameterFieldAccess, keyParameterFieldAccess));
       }
-      return FastExpression.Lambda<Func<Tuple, bool>>(filterExpression, TupleParameter);
+      return FastExpression.Lambda<Func<Tuple, bool>>(filterExpression, TupleParameters);
     }
 
     private static Expression CreateEntityQuery(Type elementType)

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -1257,7 +1257,7 @@ namespace Xtensive.Orm.Linq
 
     private Expression BuildSubqueryResult(ProjectionExpression subQuery, Type resultType)
     {
-      if (State.Parameters.Length == 0)
+      if (State.Parameters.Count == 0)
         throw Exceptions.InternalError(String.Format(Strings.ExUnableToBuildSubqueryResultForExpressionXStateContainsNoParameters, subQuery), OrmLog.Instance);
 
       if (!resultType.IsOfGenericInterface(WellKnownInterfaces.EnumerableOfT))

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -33,7 +33,7 @@ namespace Xtensive.Orm.Linq
 {
   internal sealed partial class Translator
   {
-    private static readonly ParameterExpression ParameterContextParam = Expression.Parameter(WellKnownOrmTypes.ParameterContext, "context");
+    private static readonly IReadOnlyList<ParameterExpression> ParameterContextParams = [Expression.Parameter(WellKnownOrmTypes.ParameterContext, "context")];
     private static readonly ConstantExpression
       NullExpression = Expression.Constant(null),
       NullKeyExpression = Expression.Constant(null, WellKnownOrmTypes.Key),
@@ -560,7 +560,7 @@ namespace Xtensive.Orm.Linq
         if (compiledQueryScope == null) {
           var originalSearchCriteria = (Expression<Func<string>>) searchCriteria;
           var body = originalSearchCriteria.Body;
-          var searchCriteriaLambda = FastExpression.Lambda<Func<ParameterContext, string>>(body, ParameterContextParam);
+          var searchCriteriaLambda = FastExpression.Lambda<Func<ParameterContext, string>>(body, ParameterContextParams);
           compiledParameter = searchCriteriaLambda.CachingCompile();
         }
         else {
@@ -627,7 +627,7 @@ namespace Xtensive.Orm.Linq
       func.Invoke(SearchConditionNodeFactory.CreateConditonRoot()).AcceptVisitor(conditionCompiler);
 
       var preparedSearchCriteria = FastExpression.Lambda<Func<ParameterContext, string>>(
-        Expression.Constant(conditionCompiler.CurrentOutput), ParameterContextParam);
+        Expression.Constant(conditionCompiler.CurrentOutput), ParameterContextParams);
 
       if (compiledQueryScope == null) {
         compiledParameter = preparedSearchCriteria.CachingCompile();

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
@@ -32,6 +32,7 @@ namespace Xtensive.Orm.Linq
     private static readonly ParameterExpression ParameterContext = Expression.Parameter(WellKnownOrmTypes.ParameterContext, "parameterContext");
     private static readonly ParameterExpression TupleReader = Expression.Parameter(typeof(RecordSetReader), "tupleReader");
     private static readonly ParameterExpression Session = Expression.Parameter(typeof(Session), "session");
+    private static readonly IReadOnlyList<ParameterExpression> TupleReaderSessionParameterContext = [TupleReader, Session, ParameterContext];
 
     private readonly CompiledQueryProcessingScope compiledQueryScope;
 
@@ -152,8 +153,7 @@ namespace Xtensive.Orm.Linq
         ParameterContext,
         Expression.Constant(itemMaterializer));
 
-      var projectorExpression = FastExpression.Lambda<Func<RecordSetReader, Session, ParameterContext, object>>(
-        body, TupleReader, Session, ParameterContext);
+      var projectorExpression = FastExpression.Lambda<Func<RecordSetReader, Session, ParameterContext, object>>(body, TupleReaderSessionParameterContext);
       return new Materializer(projectorExpression.CachingCompile());
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -1329,13 +1329,11 @@ namespace Xtensive.Orm.Linq
         }
 
         ProjectionExpression innerProjection;
-        var outerParameters = State.OuterParameters
-          .Concat(State.Parameters)
-          .Concat(collectionSelector.Parameters)
-          .Append(outerParameter)
-          .ToArray(State.OuterParameters.Length + State.Parameters.Length + collectionSelector.Parameters.Count + 1);
         using (CreateScope(new TranslatorState(State) {
-          OuterParameters = outerParameters,
+          OuterParameters = State.OuterParameters
+            .Concat(State.Parameters)
+            .Concat(collectionSelector.Parameters)
+            .Append(outerParameter),
           Parameters = Array.Empty<ParameterExpression>(),
           RequestCalculateExpressionsOnce = true
         })) {
@@ -1840,12 +1838,9 @@ namespace Xtensive.Orm.Linq
 
     private TranslatorState.TranslatorScope CreateLambdaScope(LambdaExpression le, bool allowCalculableColumnCombine)
     {
-      var newOuterParameters = new ParameterExpression[State.OuterParameters.Length + State.Parameters.Length];
-      State.OuterParameters.CopyTo(newOuterParameters, 0);
-      State.Parameters.CopyTo(newOuterParameters, State.OuterParameters.Length);
       return CreateScope(new TranslatorState(State) {
-        OuterParameters = newOuterParameters,
-        Parameters = le.Parameters.ToArray(le.Parameters.Count),
+        OuterParameters = State.OuterParameters.Concat(State.Parameters),
+        Parameters = le.Parameters,
         CurrentLambda = le,
         AllowCalculableColumnCombine = allowCalculableColumnCombine
       });

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -33,7 +33,8 @@ namespace Xtensive.Orm.Linq
 
     private static readonly Type IEnumerableOfKeyType = typeof(IEnumerable<Key>);
     private static readonly ParameterExpression TupleParameter = Expression.Parameter(WellKnownOrmTypes.Tuple, "tuple");
-    private static readonly ParameterExpression ParameterContextContextParameter = Expression.Parameter(WellKnownOrmTypes.ParameterContext, "context");
+    private static readonly IReadOnlyList<ParameterExpression> TupleParameters = [TupleParameter];
+    private static readonly IReadOnlyList<ParameterExpression> ParameterContextContextParameters = [Expression.Parameter(WellKnownOrmTypes.ParameterContext, "context")];
 
     private readonly TranslatorContext context;
     private readonly bool tagsEnabled;
@@ -612,8 +613,8 @@ namespace Xtensive.Orm.Linq
         ParameterExpression contextParameter;
         if (compiledQueryScope == null) {
           var indexLambda = (Expression<Func<int>>) index;
-          contextParameter = ParameterContextContextParameter;
-          elementAtIndex = FastExpression.Lambda<Func<ParameterContext, int>>(indexLambda.Body, contextParameter);
+          contextParameter = ParameterContextContextParameters[0];
+          elementAtIndex = FastExpression.Lambda<Func<ParameterContext, int>>(indexLambda.Body, ParameterContextContextParameters);
         }
         else {
           var replacer = compiledQueryScope.QueryParameterReplacer;
@@ -690,7 +691,7 @@ namespace Xtensive.Orm.Linq
       if (take.Type == typeof(Func<int>)) {
         if (compiledQueryScope == null) {
           var takeLambda = (Expression<Func<int>>) take;
-          var newTakeLambda = FastExpression.Lambda<Func<ParameterContext, int>>(takeLambda.Body, ParameterContextContextParameter);
+          var newTakeLambda = FastExpression.Lambda<Func<ParameterContext, int>>(takeLambda.Body, ParameterContextContextParameters);
           compiledParameter = newTakeLambda.CachingCompile();
         }
         else {
@@ -1098,7 +1099,7 @@ namespace Xtensive.Orm.Linq
               ExpressionType.AndAlso);
           });
 
-      var filter = FastExpression.Lambda(filterBody, TupleParameter);
+      var filter = FastExpression.Lambda(filterBody, TupleParameters);
       var subqueryProjection = sequence.Apply(new ItemProjectorExpression(
           sequence.ItemProjector.Item,
           groupingSourceProjection.ItemProjector.DataSource.Filter((Expression<Func<Tuple, bool>>) filter),

--- a/Orm/Xtensive.Orm/Orm/Linq/TranslatorState.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/TranslatorState.cs
@@ -5,6 +5,7 @@
 // Created:    2010.01.21
 
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 
@@ -53,9 +54,9 @@ namespace Xtensive.Orm.Linq
 
     private readonly TranslatorStateFlags flags;
 
-    public ParameterExpression[] Parameters { get; init; }
+    public IReadOnlyList<ParameterExpression> Parameters { get; init; }
 
-    public ParameterExpression[] OuterParameters { get; init; }
+    public IEnumerable<ParameterExpression> OuterParameters { get; init; }
 
     public LambdaExpression CurrentLambda { get; init; }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
@@ -211,12 +211,14 @@ namespace Xtensive.Orm.Providers
       return instances.ToArray();
     }
 
-    private static Func<IDbConnectionAccessor> CreateNewAccessor<T>() where T : IDbConnectionAccessor
+    private static class Traits<T> where T : IDbConnectionAccessor
     {
-      return FastExpression.Lambda<Func<IDbConnectionAccessor>>(
-        Expression.Convert(Expression.New(typeof(T)), typeof(IDbConnectionAccessor)))
+      public static readonly Func<IDbConnectionAccessor> NewAccessor = FastExpression.Lambda<Func<IDbConnectionAccessor>>(
+          Expression.Convert(Expression.New(typeof(T)), typeof(IDbConnectionAccessor)))
         .Compile();
     }
+
+    private static Func<IDbConnectionAccessor> CreateNewAccessor<T>() where T : IDbConnectionAccessor => Traits<T>.NewAccessor;
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
@@ -118,7 +118,7 @@ namespace Xtensive.Orm
       ArgumentValidator.EnsureArgumentNotNull(searchCriteria, "searchCriteria");
       ArgumentValidator.EnsureArgumentIsGreaterThan(topNByRank, 0, "topNByRank");
       var method = WellKnownMembers.Query.FreeTextStringTopNByRank.CachedMakeGenericMethod(typeof (T));
-      var expression = Expression.Call(method, Expression.Constant(searchCriteria), Expression.Constant(topNByRank));
+      var expression = Expression.Call(method, Expression.Constant(searchCriteria), Expr.Constant(topNByRank));
       return Provider.CreateQuery<FullTextMatch<T>>(expression);
     }
 
@@ -136,7 +136,7 @@ namespace Xtensive.Orm
     {
       ArgumentValidator.EnsureArgumentNotNull(searchCriteria, "searchCriteria");
       var method = WellKnownMembers.Query.FreeTextExpression.CachedMakeGenericMethod(typeof(T));
-      var expression = Expression.Call(null, method, new[] { searchCriteria });
+      var expression = Expression.Call(null, method, [searchCriteria]);
       return Provider.CreateQuery<FullTextMatch<T>>(expression);
     }
 
@@ -157,7 +157,7 @@ namespace Xtensive.Orm
       ArgumentValidator.EnsureArgumentNotNull(searchCriteria, "searchCriteria");
       ArgumentValidator.EnsureArgumentIsGreaterThan(topNByRank, 0, "topNByRank");
       var method = WellKnownMembers.Query.FreeTextExpressionTopNByRank.CachedMakeGenericMethod(typeof (T));
-      var expression = Expression.Call(null, method, searchCriteria, Expression.Constant(topNByRank));
+      var expression = Expression.Call(null, method, searchCriteria, Expr.Constant(topNByRank));
       return Provider.CreateQuery<FullTextMatch<T>>(expression);
     }
 
@@ -220,7 +220,7 @@ namespace Xtensive.Orm
       ArgumentValidator.EnsureArgumentNotNull(searchCriteria, "searchCriteria");
       ArgumentValidator.EnsureArgumentIsGreaterThan(topNByRank, 0, "topNByRank");
       var method = WellKnownMembers.Query.ContainsTableExprTopNByRank.CachedMakeGenericMethod(typeof(T));
-      var expression = Expression.Call(null, method, searchCriteria, Expression.Constant(topNByRank));
+      var expression = Expression.Call(null, method, searchCriteria, Expr.Constant(topNByRank));
       return Provider.CreateQuery<FullTextMatch<T>>(expression);
     }
 
@@ -248,7 +248,7 @@ namespace Xtensive.Orm
       ArgumentValidator.EnsureArgumentNotNull(targetFields, "targetFields");
       ArgumentValidator.EnsureArgumentIsGreaterThan(topNByRank, 0, "topNByRank");
       var method = WellKnownMembers.Query.ContainsTableExprTopNByRank.CachedMakeGenericMethod(typeof(T));
-      var expression = Expression.Call(null, method, searchCriteria, Expression.Constant(targetFields), Expression.Constant(topNByRank));
+      var expression = Expression.Call(null, method, searchCriteria, Expression.Constant(targetFields), Expr.Constant(topNByRank));
       return Provider.CreateQuery<FullTextMatch<T>>(expression);
     }
 

--- a/Orm/Xtensive.Orm/Reflection/DelegateHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/DelegateHelper.cs
@@ -476,12 +476,10 @@ namespace Xtensive.Reflection
     public static Type MakeDelegateType(Type returnType, params Type[] parameterTypes)
     {
       ArgumentValidator.EnsureArgumentNotNull(parameterTypes, "parameterTypes");
-      if (parameterTypes.Length > MaxNumberOfGenericDelegateParameters)
-        throw new NotSupportedException();
+      var n = parameterTypes.Length;
+      ArgumentOutOfRangeException.ThrowIfGreaterThan(n, MaxNumberOfGenericDelegateParameters);
       if (returnType == WellKnownTypes.Void || returnType == null) {
-        if (parameterTypes.Length == 0)
-          return ActionTypes[0];
-        return ActionTypes[parameterTypes.Length].MakeGenericType(parameterTypes);
+        return n == 0 ? ActionTypes[0] : ActionTypes[n].MakeGenericType(parameterTypes);
       }
       var funcGenericParameters = parameterTypes.Append(returnType);
       return FuncTypes[funcGenericParameters.Length - 1].MakeGenericType(funcGenericParameters);


### PR DESCRIPTION
Use `IReadOnlyList<ParameterExpression>` instead of `ParameterExpression[]` to avoid `.ToArray()` invocations