### PR TITLE
Convert stateless visitors into Singletons to avoid allocations

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/EnumRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/EnumRewriter.cs
@@ -11,10 +11,9 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
 {
   internal sealed class EnumRewriter : ExpressionVisitor
   {
-    public static Expression Rewrite(Expression target)
-    {
-      return new EnumRewriter().Visit(target);
-    }
+    private static readonly EnumRewriter Instance = new EnumRewriter();
+
+    public static Expression Rewrite(Expression target) => Instance.Visit(target);
 
     protected override Expression VisitUnknown(Expression e)
     {

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/EntitySetAccessRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/EntitySetAccessRewriter.cs
@@ -15,6 +15,8 @@ namespace Xtensive.Orm.Linq.Rewriters
 {
   internal sealed class EntitySetAccessRewriter : ExpressionVisitor
   {
+    private static readonly EntitySetAccessRewriter Instance = new();
+
     protected override Expression VisitUnknown(Expression e)
     {
       return e;
@@ -65,10 +67,7 @@ namespace Xtensive.Orm.Linq.Rewriters
       return expression!=null && expression.Type.IsOfGenericType(WellKnownOrmTypes.EntitySetOfT);
     }
 
-    public static Expression Rewrite(Expression e)
-    {
-      return new EntitySetAccessRewriter().Visit(e);
-    }
+    public static Expression Rewrite(Expression e) => Instance.Visit(e);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/EqualityRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/EqualityRewriter.cs
@@ -14,6 +14,8 @@ namespace Xtensive.Orm.Linq.Rewriters
 {
   internal sealed class EqualityRewriter : ExpressionVisitor
   {
+    private static readonly EqualityRewriter Instance = new();
+
     protected override Expression VisitUnknown(Expression e)
     {
       return e;
@@ -53,10 +55,7 @@ namespace Xtensive.Orm.Linq.Rewriters
       return base.VisitMethodCall(mc);
     }
 
-    public static Expression Rewrite(Expression e)
-    {
-      return new EqualityRewriter().Visit(e);
-    }
+    public static Expression Rewrite(Expression e) => Instance.Visit(e);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/NullComparisonRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/NullComparisonRewriter.cs
@@ -10,8 +10,10 @@ using ExpressionVisitor = Xtensive.Linq.ExpressionVisitor;
 
 namespace Xtensive.Orm.Linq.Rewriters
 {
-  internal sealed class NullComparsionRewriter : ExpressionVisitor
+  internal sealed class NullComparisonRewriter : ExpressionVisitor
   {
+    private static readonly NullComparisonRewriter Instance = new();
+
     protected override Expression VisitUnknown(Expression e)
     {
       return e;
@@ -54,14 +56,11 @@ namespace Xtensive.Orm.Linq.Rewriters
       return expression.Type.IsSubclassOf(WellKnownOrmTypes.Entity);
     }
 
-    public static Expression Rewrite(Expression e)
-    {
-      return new NullComparsionRewriter().Visit(e);
-    }
+    public static Expression Rewrite(Expression e) => Instance.Visit(e);
 
     // Constructors
 
-    private NullComparsionRewriter()
+    private NullComparisonRewriter()
     {
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/SubqueryDefaultResultRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/SubqueryDefaultResultRewriter.cs
@@ -13,6 +13,8 @@ namespace Xtensive.Orm.Linq.Rewriters
 {
   internal sealed class SubqueryDefaultResultRewriter : ExpressionVisitor
   {
+    private static readonly SubqueryDefaultResultRewriter Instance = new();
+
     protected override Expression VisitUnknown(Expression e) => e;
 
     protected override Expression VisitBinary(BinaryExpression b)
@@ -58,8 +60,7 @@ namespace Xtensive.Orm.Linq.Rewriters
       && (method.Name == nameof(Queryable.FirstOrDefault)
         || method.Name == nameof(Queryable.SingleOrDefault));
 
-    public static Expression Rewrite(Expression expression) =>
-      new SubqueryDefaultResultRewriter().Visit(expression);
+    public static Expression Rewrite(Expression expression) => Instance.Visit(expression);
 
     private SubqueryDefaultResultRewriter()
     {

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -144,7 +144,7 @@ namespace Xtensive.Orm.Linq
       using (CreateLambdaScope(le, allowCalculableColumnCombine: false)) {
         Expression body = le.Body;
         if (!State.IsTailMethod)
-          body = NullComparsionRewriter.Rewrite(body);
+          body = NullComparisonRewriter.Rewrite(body);
         body = Visit(body);
         ParameterExpression parameter = le.Parameters[0];
         var nodeType = body.NodeType;

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
@@ -215,7 +215,7 @@ namespace Xtensive.Orm.Providers
         }
       }
 
-      //handle SQLite DateTime comparsion
+      //handle SQLite DateTime comparison
       if (dateTimeEmulation
           && left.NodeType != SqlNodeType.Null
           && right.NodeType != SqlNodeType.Null
@@ -234,7 +234,7 @@ namespace Xtensive.Orm.Providers
         }
       }
 
-      //handle SQLite DateTimeOffset comparsion
+      //handle SQLite DateTimeOffset comparison
       if (dateTimeOffsetEmulation
           && left.NodeType != SqlNodeType.Null
           && right.NodeType != SqlNodeType.Null


### PR DESCRIPTION
Also:
* Fix typo `NullComparsionRewriter` -> `NullComparisonRewriter`