### PR TITLE
Optimize `GetConstructorEx()`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
@@ -83,8 +83,7 @@ namespace Xtensive.Orm.Linq.Materialization
       var entityMaterializer = Visit(expression.EntityExpression);
       var constructorInfo = WellKnownOrmTypes.FullTextMatchOfT
         .CachedMakeGenericType(expression.EntityExpression.Type)
-        .GetConstructorEx(BindingFlags.NonPublic | BindingFlags.Instance,
-          new object[] {WellKnownTypes.Double, expression.EntityExpression.Type});
+        .GetConstructorEx(BindingFlags.NonPublic | BindingFlags.Instance, [WellKnownTypes.Double, expression.EntityExpression.Type]);
 
       return Expression.New(
         constructorInfo,

--- a/Orm/Xtensive.Orm/Reflection/MethodHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/MethodHelper.cs
@@ -98,36 +98,16 @@ namespace Xtensive.Reflection
     /// </summary>
     /// <param name="type">Type to search constructor in.</param>
     /// <param name="bindingFlags">Binding attributes.</param>
-    /// <param name="parameterTypes">Either strings or <see cref="Type"/>s of parameters (mixing is allowed).</param>
+    /// <param name="parameterTypes"><see cref="Type"/>s of parameters (mixing is allowed).</param>
     /// <returns>Found constructor, if match was found;
     /// otherwise, <see langword="null"/>.</returns>
 
     [CanBeNull]
-    public static ConstructorInfo GetConstructorEx(this Type type, BindingFlags bindingFlags, object[] parameterTypes)
+    public static ConstructorInfo GetConstructorEx(this Type type, BindingFlags bindingFlags, Type[] parameterTypes)
     {
       ArgumentValidator.EnsureArgumentNotNull(type, "type");
 
-      if (parameterTypes == null) {
-        parameterTypes = Array.Empty<object>();
-      }
-      else if (parameterTypes.All(o => o is Type)) {
-        return type.GetConstructor(bindingFlags, null,
-          parameterTypes.Select(o => (Type) o).ToArray(parameterTypes.Length), null);
-      }
-
-      ConstructorInfo lastMatch = null;
-
-      foreach (var ci in type.GetConstructors(bindingFlags)) {
-        if (CheckMethod(ci, WellKnown.CtorName, Array.Empty<string>(), parameterTypes)) {
-          if (lastMatch != null) {
-            throw new AmbiguousMatchException();
-          }
-
-          lastMatch = ci;
-        }
-      }
-
-      return lastMatch;
+      return type.GetConstructor(bindingFlags, null, parameterTypes, null);
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Reflection/MethodHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/MethodHelper.cs
@@ -107,7 +107,22 @@ namespace Xtensive.Reflection
     {
       ArgumentValidator.EnsureArgumentNotNull(type, "type");
 
-      return type.GetConstructor(bindingFlags, null, parameterTypes, null);
+      if (parameterTypes.All(o => o is not null)) {
+        return type.GetConstructor(bindingFlags, null, parameterTypes, null);
+      }
+      ConstructorInfo lastMatch = null;
+
+      foreach (var ci in type.GetConstructors(bindingFlags)) {
+        if (CheckMethod(ci, WellKnown.CtorName, Array.Empty<string>(), parameterTypes)) {
+          if (lastMatch != null) {
+            throw new AmbiguousMatchException();
+          }
+
+          lastMatch = ci;
+        }
+      }
+
+      return lastMatch;
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -636,8 +636,9 @@ namespace Xtensive.Reflection
         const BindingFlags bindingFlags =
           BindingFlags.CreateInstance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
 
-        var argumentTypes = new object[arguments.Length];
-        for (var i = 0; i < arguments.Length; i++) {
+        var n = arguments.Length;
+        var argumentTypes = new Type[n];
+        for (var i = 0; i < n; i++) {
           var o = arguments[i];
           if (o == null) {
             // Actually a case when GetConstructor will fail,
@@ -648,8 +649,7 @@ namespace Xtensive.Reflection
           argumentTypes[i] = o.GetType();
         }
 
-        var constructor = type.GetConstructorEx(bindingFlags, argumentTypes);
-        return constructor == null ? null : constructor.Invoke(arguments);
+        return type.GetConstructorEx(bindingFlags, argumentTypes)?.Invoke(arguments);
       }
       catch (Exception) {
         return null;

--- a/Version.props
+++ b/Version.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.2.0.132</DoVersion>
+    <DoVersion>7.2.0.133</DoVersion>
     <DoVersionSuffix>servicetitan</DoVersionSuffix>
 </PropertyGroup>
 


### PR DESCRIPTION
Original API `GetConstructorEx(... object[] parameterTypes)`  allowed `parameterTypes` be arrays of mix: Types or strings.
But this feature never used in the DO & App.
Restricting this parameter to be `Type[]` we save allocations and time