### PR TITLE
Optimize `VisitIndex()` case

### DIFF
--- a/Orm/Xtensive.Orm.Oracle/Orm.Providers.Oracle/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm.Oracle/Orm.Providers.Oracle/SqlCompiler.cs
@@ -20,7 +20,7 @@ namespace Xtensive.Orm.Providers.Oracle
       return Handlers.NameBuilder.ApplyNamingRules(name);
     }
 
-    protected override SqlExpression ProcessAggregate(SqlProvider source, List<SqlExpression> sourceColumns, AggregateColumn aggregateColumn)
+    protected override SqlExpression ProcessAggregate(SqlProvider source, IReadOnlyList<SqlExpression> sourceColumns, AggregateColumn aggregateColumn)
     {
       var result = base.ProcessAggregate(source, sourceColumns, aggregateColumn);
       if (aggregateColumn.AggregateType==AggregateType.Avg) {

--- a/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/SqlCompiler.cs
@@ -52,7 +52,7 @@ namespace Xtensive.Orm.Providers.PostgreSql
       return CreateProvider(select, queryAndBindings.Bindings.Append(topNBinding).Append(searchCriteriaBinding), provider);
     }
 
-    protected override SqlExpression ProcessAggregate(SqlProvider source, List<SqlExpression> sourceColumns, AggregateColumn aggregateColumn)
+    protected override SqlExpression ProcessAggregate(SqlProvider source, IReadOnlyList<SqlExpression> sourceColumns, AggregateColumn aggregateColumn)
     {
       var result = base.ProcessAggregate(source, sourceColumns, aggregateColumn);
       if (aggregateColumn.AggregateType == AggregateType.Sum || aggregateColumn.AggregateType == AggregateType.Avg) {

--- a/Orm/Xtensive.Orm.SqlServer/Orm.Providers.SqlServer/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Orm.Providers.SqlServer/SqlCompiler.cs
@@ -88,7 +88,7 @@ namespace Xtensive.Orm.Providers.SqlServer
     }
 
     protected override SqlExpression ProcessAggregate(
-      SqlProvider source, List<SqlExpression> sourceColumns, AggregateColumn aggregateColumn)
+      SqlProvider source, IReadOnlyList<SqlExpression> sourceColumns, AggregateColumn aggregateColumn)
     {
       var result = base.ProcessAggregate(source, sourceColumns, aggregateColumn);
       var aggregateReturnType = aggregateColumn.Type;

--- a/Orm/Xtensive.Orm/Linq/ConstantExtractor.cs
+++ b/Orm/Xtensive.Orm/Linq/ConstantExtractor.cs
@@ -22,6 +22,7 @@ namespace Xtensive.Linq
   public sealed class ConstantExtractor : ExpressionVisitor
   {
     private static readonly ParameterExpression ConstantParameter = Expression.Parameter(WellKnownTypes.ObjectArray, "constants");
+    private static readonly Expression[] ConstantExpressions = Enumerable.Range(0, 10).Select(i => Expression.ArrayIndex(ConstantParameter, Expr.Constant(i))).ToArray();
 
     private readonly Func<ConstantExpression, bool> constantFilter;
     private readonly LambdaExpression lambda;
@@ -60,8 +61,12 @@ namespace Xtensive.Linq
     {
       if (!constantFilter.Invoke(c))
         return c;
+      var n = constantValues.Count;       
       var result = Expression.Convert(
-        Expression.ArrayIndex(ConstantParameter, Expr.Constant(constantValues.Count)), c.Type);
+        n < ConstantExpressions.Length
+          ? ConstantExpressions[n]
+          : Expression.ArrayIndex(ConstantParameter, Expr.Constant(n))
+        , c.Type);
       constantValues.Add(c.Value);
       return result;
     }

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -101,7 +101,7 @@ namespace Xtensive.Orm.Linq
           ? e
           : ExpressionEvaluator.Evaluate(e);
       }
-      return e.NodeType == ExpressionType.Index ? VisitIndex((IndexExpression) e) : base.Visit(e);
+      return base.Visit(e);
     }
 
     protected override Expression VisitUnknown(Expression e)

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Aggregate.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Aggregate.cs
@@ -53,7 +53,7 @@ namespace Xtensive.Orm.Providers
     /// <param name="sourceColumns">The source columns.</param>
     /// <param name="aggregateColumn">The aggregate column.</param>
     /// <returns>Aggregate processing result (expression).</returns>
-    protected virtual SqlExpression ProcessAggregate(SqlProvider source, List<SqlExpression> sourceColumns, AggregateColumn aggregateColumn)
+    protected virtual SqlExpression ProcessAggregate(SqlProvider source, IReadOnlyList<SqlExpression> sourceColumns, AggregateColumn aggregateColumn)
     {
       switch (aggregateColumn.AggregateType) {
       case AggregateType.Avg:

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Helpers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Helpers.cs
@@ -83,12 +83,8 @@ namespace Xtensive.Orm.Providers
       return sourceSelect.ShallowClone();
     }
 
-    protected List<SqlExpression> ExtractColumnExpressions(SqlSelect query)
-    {
-      var result = new List<SqlExpression>(query.Columns.Count);
-      result.AddRange(query.Columns.Select(ExtractColumnExpression));
-      return result;
-    }
+    protected IReadOnlyList<SqlExpression> ExtractColumnExpressions(SqlSelect query) =>
+      query.Columns.Select(ExtractColumnExpression).ToArray(query.Columns.Count);
 
     protected SqlExpression ExtractColumnExpression(SqlColumn column)
     {

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Include.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Include.cs
@@ -75,7 +75,7 @@ namespace Xtensive.Orm.Providers
 
     protected SqlExpression CreateIncludeViaComplexConditionExpression(
       IncludeProvider provider, Func<ParameterContext, object> valueAccessor,
-      IList<SqlExpression> sourceColumns, out QueryParameterBinding binding)
+      IReadOnlyList<SqlExpression> sourceColumns, out QueryParameterBinding binding)
     {
       var filterTupleDescriptor = provider.FilteredColumnsExtractionTransform.Descriptor;
       var mappings = filterTupleDescriptor.Select(type => Driver.GetTypeMapping(type));
@@ -86,7 +86,7 @@ namespace Xtensive.Orm.Providers
     }
 
     protected SqlExpression CreateIncludeViaTemporaryTableExpression(
-      IncludeProvider provider, IList<SqlExpression> sourceColumns,
+      IncludeProvider provider, IReadOnlyList<SqlExpression> sourceColumns,
       out TemporaryTableDescriptor tableDescriptor)
     {
       var filterTupleDescriptor = provider.FilteredColumnsExtractionTransform.Descriptor;

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -179,22 +179,22 @@ namespace Xtensive.Orm.Providers
       var leftTable = leftShouldUseReference
         ? left.PermanentReference
         : left.Request.Statement.From;
-      var leftColumns = leftShouldUseReference
-        ? (IReadOnlyList<SqlColumn>) leftTable.Columns
+      IReadOnlyList<SqlColumn> leftColumns = leftShouldUseReference
+        ? leftTable.Columns
         : left.Request.Statement.Columns;
-      var leftExpressions = leftShouldUseReference
-        ? leftTable.Columns.Cast<SqlExpression>().ToList()
+      IReadOnlyList<SqlExpression> leftExpressions = leftShouldUseReference
+        ? leftTable.Columns.Cast<SqlExpression>().ToArray()
         : ExtractColumnExpressions(left.Request.Statement);
 
       var rightShouldUseReference = strictJoinWorkAround || ShouldUseQueryReference(provider, right);
       var rightTable = rightShouldUseReference
         ? right.PermanentReference
         : right.Request.Statement.From;
-      var rightColumns = rightShouldUseReference
-        ? (IReadOnlyList<SqlColumn>) rightTable.Columns
+      IReadOnlyList<SqlColumn> rightColumns = rightShouldUseReference
+        ? rightTable.Columns
         : right.Request.Statement.Columns;
       var rightExpressions = rightShouldUseReference
-        ? rightTable.Columns.Cast<SqlExpression>().ToList()
+        ? rightTable.Columns.Cast<SqlExpression>().ToArray()
         : ExtractColumnExpressions(right.Request.Statement);
 
       var joinType = provider.JoinType==JoinType.LeftOuter
@@ -202,7 +202,7 @@ namespace Xtensive.Orm.Providers
         : SqlJoinType.InnerJoin;
 
       SqlExpression joinExpression = null;
-      for (var i = 0; i < provider.EqualIndexes.Count(); ++i) {
+      for (int i = 0, n = provider.EqualIndexes.Count(); i < n; ++i) {
         var (leftInder, rightIndex) = provider.EqualIndexes[i];
         var leftExpression = leftExpressions[leftInder];
         var rightExpression = rightExpressions[rightIndex];


### PR DESCRIPTION
Also:
* Preallocate first 10 indexed constant expressions in `ConstantExtractor` to save GC
* Use `.ToArray()` instead of `.ToList()` in `ExtractColumnExpressions()`