### PR TITLE
Optimization: No need to dispose `CommandProcessorContextProvider` as it has not Unmanaged resources

### DIFF
--- a/Orm/Xtensive.Orm/Orm/CommandProcessorContextProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/CommandProcessorContextProvider.cs
@@ -10,7 +10,7 @@ using Xtensive.Orm.Providers;
 
 namespace Xtensive.Orm
 {
-  public sealed class CommandProcessorContextProvider : SessionBound, IDisposable
+  public sealed class CommandProcessorContextProvider : SessionBound
   {
     private readonly ConcurrentDictionary<CommandProcessorContext, CommandProcessorContext> providedContexts
       = new ConcurrentDictionary<CommandProcessorContext, CommandProcessorContext>();
@@ -33,8 +33,6 @@ namespace Xtensive.Orm
       context.Disposed += RemoveDisposedContext;
       return context;
     }
-
-    public void Dispose() => providedContexts.Clear();
 
     private void RemoveDisposedContext(object sender, EventArgs args)
     {

--- a/Orm/Xtensive.Orm/Orm/Session.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.cs
@@ -220,10 +220,12 @@ namespace Xtensive.Orm
     /// </summary>
     public IServiceContainer Services { get; private set; }
 
+    private Guid? guid;
+
     /// <summary>
     /// Gets the unique identifier of this session.
     /// </summary>
-    public Guid Guid { get; private set; }
+    public Guid Guid => guid ??= Guid.NewGuid();
 
     /// <summary>
     /// Provides context for <see cref="CommandProcessor"/>.
@@ -542,7 +544,6 @@ namespace Xtensive.Orm
     internal Session(Domain domain, StorageNode selectedStorageNode, SessionConfiguration configuration, bool activate)
       : base(domain)
     {
-      Guid = Guid.NewGuid();
       IsDebugEventLoggingEnabled = OrmLog.IsLogged(LogLevel.Debug); // Just to cache this value
 
       // Both Domain and Configuration are valid references here;
@@ -646,14 +647,14 @@ namespace Xtensive.Orm
         SystemEvents.NotifyDisposing();
         Events.NotifyDisposing();
 
-        Services.DisposeSafely();
+        Services?.Dispose();
         if (isAsync) {
           await Handler.DisposeSafelyAsync().ConfigureAwaitFalse();
         }
         else {
-          Handler.DisposeSafely();
+          Handler?.Dispose();
         }
-        CommandProcessorContextProvider.DisposeSafely();
+        CommandProcessorContextProvider = null;
 
         Domain.ReleaseSingleConnection();
 


### PR DESCRIPTION
`ConcurrentDictionary.Clear()` just does useless work before GC

Also:
* Generate rarely-used `Session.Guid` on demand. `Guid.NewGuid()` is slow under Linux