### PR TITLE
Optimization: Use type covariance implementing `Clone()` to avoid casting

### DIFF
--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/QueryOperation.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/QueryOperation.cs
@@ -140,7 +140,7 @@ namespace Xtensive.Orm.BulkOperations
       var indexMapping = PrimaryIndexes[0];
       var columns = new List<ColumnInfo>();
       foreach (var columnInfo in indexMapping.PrimaryIndex.KeyColumns.Keys) {
-        var s = (SqlSelect) select.Clone();
+        var s = select.Clone();
         foreach (var column in columns) {
           var ex = SqlDml.Equals(s.From.Columns[column.Name], table.Columns[column.Name]);
           s.Where = s.Where is null ? ex : SqlDml.And(s.Where, ex);

--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/QueryOperation.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/QueryOperation.cs
@@ -140,7 +140,7 @@ namespace Xtensive.Orm.BulkOperations
       var indexMapping = PrimaryIndexes[0];
       var columns = new List<ColumnInfo>();
       foreach (var columnInfo in indexMapping.PrimaryIndex.KeyColumns.Keys) {
-        var s = select.Clone();
+        var s = (SqlSelect)((ICloneable)select).Clone();
         foreach (var column in columns) {
           var ex = SqlDml.Equals(s.From.Columns[column.Name], table.Columns[column.Name]);
           s.Where = s.Where is null ? ex : SqlDml.And(s.Where, ex);

--- a/Extensions/Xtensive.Orm.Tracking.Tests/TrackingStackFrameTests.cs
+++ b/Extensions/Xtensive.Orm.Tracking.Tests/TrackingStackFrameTests.cs
@@ -11,7 +11,7 @@ namespace Xtensive.Orm.Tracking.Tests
     [Test]
     public void SafelyInsertTheSameItemTwiceTest()
     {
-      var frame = new TrackingStackFrame(false);
+      var frame = new TrackingStackFrame();
       var key = Key.Create(Domain, typeof(MyEntity), 1);
       var item = CreateTrackingItem(key, TrackingItemState.Created);
       frame.Register(item);
@@ -21,8 +21,8 @@ namespace Xtensive.Orm.Tracking.Tests
     [Test]
     public void MergeTwoEmptyFramesTest()
     {
-      var target = new TrackingStackFrame(false);
-      var source = new TrackingStackFrame(false);
+      var target = new TrackingStackFrame();
+      var source = new TrackingStackFrame();
       target.MergeWith(source);
 
       Assert.AreEqual(0, target.Count);
@@ -32,9 +32,9 @@ namespace Xtensive.Orm.Tracking.Tests
     public void MergeEmptyFrameWithNonEmptyFrameTest()
     {
       var key = Key.Create(Domain, typeof(MyEntity), 1);
-      var target = new TrackingStackFrame(false);
+      var target = new TrackingStackFrame();
 
-      var source = new TrackingStackFrame(false);
+      var source = new TrackingStackFrame();
       source.Register(CreateTrackingItem(key, TrackingItemState.Created));
 
       target.MergeWith(source);
@@ -46,11 +46,11 @@ namespace Xtensive.Orm.Tracking.Tests
     public void MergeNonEmptyFrameWithEmptyFrameTest()
     {
       var key = Key.Create(Domain, typeof(MyEntity), 1);
-      var target = new TrackingStackFrame(false);
+      var target = new TrackingStackFrame();
       target.Register(CreateTrackingItem(key, TrackingItemState.Created));
       var count = target.Count;
 
-      var source = new TrackingStackFrame(false);
+      var source = new TrackingStackFrame();
 
       target.MergeWith(source);
 
@@ -61,11 +61,11 @@ namespace Xtensive.Orm.Tracking.Tests
     public void MergeFramesWithTheSameItemsTest()
     {
       var key = Key.Create(Domain, typeof(MyEntity), 1);
-      var target = new TrackingStackFrame(false);
+      var target = new TrackingStackFrame();
       target.Register(CreateTrackingItem(key, TrackingItemState.Created));
       var count = target.Count;
 
-      var source = new TrackingStackFrame(false);
+      var source = new TrackingStackFrame();
       source.Register(CreateTrackingItem(key, TrackingItemState.Changed));
 
       target.MergeWith(source);
@@ -79,10 +79,10 @@ namespace Xtensive.Orm.Tracking.Tests
     {
       var key1 = Key.Create(Domain, typeof(MyEntity), 1);
       var key2 = Key.Create(Domain, typeof(MyEntity), 2);
-      var target = new TrackingStackFrame(false);
+      var target = new TrackingStackFrame();
       target.Register(CreateTrackingItem(key1, TrackingItemState.Created));
 
-      var source = new TrackingStackFrame(false);
+      var source = new TrackingStackFrame();
       source.Register(CreateTrackingItem(key2, TrackingItemState.Changed));
       var count = target.Count + source.Count;
 

--- a/Extensions/Xtensive.Orm.Tracking/ChangedValue.cs
+++ b/Extensions/Xtensive.Orm.Tracking/ChangedValue.cs
@@ -4,39 +4,9 @@
 
 using Xtensive.Orm.Model;
 
-namespace Xtensive.Orm.Tracking
-{
-  /// <summary>
-  /// Represents a pair of original and changed values for a persistent field
-  /// </summary>
-  public readonly struct ChangedValue
-  {
-    /// <summary>
-    /// Gets the field.
-    /// </summary>
-    public FieldInfo Field { get; }
+namespace Xtensive.Orm.Tracking;
 
-    /// <summary>
-    /// Gets the original value.
-    /// </summary>
-    public object OriginalValue { get; }
-
-    /// <summary>
-    /// Gets the new value.
-    /// </summary>
-    public object NewValue { get; }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ChangedValue"/> class.
-    /// </summary>
-    /// <param name="field">The field.</param>
-    /// <param name="originalValue">The original value.</param>
-    /// <param name="newValue">The new value.</param>
-    public ChangedValue(FieldInfo field, object originalValue, object newValue)
-    {
-      Field = field;
-      OriginalValue = originalValue;
-      NewValue = newValue;
-    }
-  }
-}
+/// <summary>
+/// Represents a pair of original and changed values for a persistent field
+/// </summary>
+public readonly record struct ChangedValue(FieldInfo Field, object OriginalValue, object NewValue);

--- a/Extensions/Xtensive.Orm.Tracking/Internals/SessionTrackingMonitor.cs
+++ b/Extensions/Xtensive.Orm.Tracking/Internals/SessionTrackingMonitor.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Xtensive.Core;
 using Xtensive.IoC;
 using Xtensive.Orm.Services;
 
@@ -28,7 +29,7 @@ namespace Xtensive.Orm.Tracking
 
     private void OnOpenTransaction(object sender, TransactionEventArgs e)
     {
-      stack.Push(new TrackingStackFrame(false));
+      stack.Push(new TrackingStackFrame());
     }
 
     private void OnCommitTransaction(object sender, TransactionEventArgs e)
@@ -40,7 +41,7 @@ namespace Xtensive.Orm.Tracking
       if (e.Transaction.IsNested)
         return;
 
-      var items = target.Cast<ITrackingItem>().ToList().AsReadOnly();
+      var items = target.Cast<ITrackingItem>().ToList().AsSafeWrapper();
       target.Clear();
 
       RaiseTrackingCompleted(new TrackingCompletedEventArgs(session, items));
@@ -82,7 +83,7 @@ namespace Xtensive.Orm.Tracking
       this.session = session;
       this.accessor = accessor;
 
-      stack.Push(new TrackingStackFrame(false));
+      stack.Push(new TrackingStackFrame());
 
       Subscribe();
     }

--- a/Extensions/Xtensive.Orm.Tracking/Internals/TrackingItem.cs
+++ b/Extensions/Xtensive.Orm.Tracking/Internals/TrackingItem.cs
@@ -80,6 +80,7 @@ namespace Xtensive.Orm.Tracking
 
     private void MergeWith(Tuple difference)
     {
+      ArgumentNullException.ThrowIfNull(RawData);
       if (RawData.Difference == null)
         RawData.Difference = difference;
       else

--- a/Extensions/Xtensive.Orm.Tracking/Internals/TrackingItem.cs
+++ b/Extensions/Xtensive.Orm.Tracking/Internals/TrackingItem.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Xtensive.Core;
 using Xtensive.Tuples;
 using Tuple = Xtensive.Tuples.Tuple;
 
@@ -72,7 +73,7 @@ namespace Xtensive.Orm.Tracking
         changedValuesList.Add(new ChangedValue(field, origValue, changedValue));
       }
 
-      return changedValuesList.AsReadOnly();
+      return changedValuesList.AsSafeWrapper();
     }
 
     private void MergeWith(Tuple difference)
@@ -92,8 +93,7 @@ namespace Xtensive.Orm.Tracking
       }
 
       Key = key;
-      if (tuple != null)
-        RawData = (DifferentialTuple) tuple.Clone();
+      RawData = tuple?.Clone();
       State = state;
     }
   }

--- a/Extensions/Xtensive.Orm.Tracking/Internals/TrackingItem.cs
+++ b/Extensions/Xtensive.Orm.Tracking/Internals/TrackingItem.cs
@@ -37,6 +37,8 @@ namespace Xtensive.Orm.Tracking
         return;
       }
 
+      ArgumentNullException.ThrowIfNull(source.RawData);
+
       if (State == TrackingItemState.Created && source.State == TrackingItemState.Changed) {
         State = TrackingItemState.Created;
         MergeWith(source.RawData.Difference);

--- a/Extensions/Xtensive.Orm.Tracking/Internals/TrackingStackFrame.cs
+++ b/Extensions/Xtensive.Orm.Tracking/Internals/TrackingStackFrame.cs
@@ -13,7 +13,7 @@ namespace Xtensive.Orm.Tracking
 {
   internal readonly struct TrackingStackFrame : IEnumerable<TrackingItem>
   {
-    private readonly Dictionary<Key, TrackingItem> items;
+    private readonly Dictionary<Key, TrackingItem> items = new();
 
     public int Count => items.Count;
 
@@ -49,11 +49,8 @@ namespace Xtensive.Orm.Tracking
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-    // parameterless ctor not allowed in C#9
-    //TODO: remove it after moving to C#10
-    public TrackingStackFrame(bool _)
+    public TrackingStackFrame()
     {
-      items = new();
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests.Core/Collections/ExtensionCollectionTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Collections/ExtensionCollectionTest.cs
@@ -29,7 +29,7 @@ namespace Xtensive.Orm.Tests.Core.Collections
       c.Lock();
       AssertEx.Throws<InstanceIsLockedException>(() => c.Set(this));
 
-      var cc = (ExtensionCollection) c.Clone();
+      var cc = c.Clone();
       AssertEx.HasSameElements(c, cc);
 
       var o = new object();

--- a/Orm/Xtensive.Orm.Tests.Core/Tuples/DifferentialTupleTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Tuples/DifferentialTupleTest.cs
@@ -29,7 +29,7 @@ namespace Xtensive.Orm.Tests.Core.Tuples
 
       PopulateData(fieldTypes, t1, d);
       AssertAreSame(t1, d);
-      DifferentialTuple c = (DifferentialTuple)d.Clone();
+      DifferentialTuple c = d.Clone();
       AssertAreSame(d, c);
 
       d.Reset();

--- a/Orm/Xtensive.Orm.Tests/Storage/Multinode/StorageNodeManagerTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Multinode/StorageNodeManagerTest.cs
@@ -68,7 +68,7 @@ namespace Xtensive.Orm.Tests.Storage.Multinode
       nodeConfiguration.SchemaMapping.Add(dbo, Schema1);
       _ = Domain.StorageNodeManager.AddNode(nodeConfiguration);
 
-      var sameConfig = (NodeConfiguration)nodeConfiguration.Clone();
+      var sameConfig = nodeConfiguration.Clone();
       var result = Domain.StorageNodeManager.AddNode(sameConfig);
       Assert.That(result, Is.False);
     }

--- a/Orm/Xtensive.Orm/Collections/ExtensionCollection.cs
+++ b/Orm/Xtensive.Orm/Collections/ExtensionCollection.cs
@@ -106,10 +106,8 @@ namespace Xtensive.Collections
     #region ICloneable methods
 
     /// <inheritdoc/>
-    public object Clone()
-    {
-      return new ExtensionCollection(this);
-    }
+    public ExtensionCollection Clone() => new(this);
+    object ICloneable.Clone() => Clone();
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/Configuration/DatabaseConfigurationCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/DatabaseConfigurationCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2012 Xtensive LLC.
+// Copyright (C) 2012 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Denis Krjuchkov
@@ -27,13 +27,15 @@ namespace Xtensive.Orm.Configuration
     }
 
     /// <inheritdoc />
-    public object Clone()
+    public DatabaseConfigurationCollection Clone()
     {
       var result = new DatabaseConfigurationCollection();
       foreach (var alias in this)
         result.Add(alias.Clone());
       return result;
     }
+
+    object ICloneable.Clone() => Clone();
 
     /// <inheritdoc/>
     public override void Lock(bool recursive)

--- a/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
@@ -780,14 +780,14 @@ namespace Xtensive.Orm.Configuration
       connectionInfo = configuration.ConnectionInfo;
       defaultSchema = configuration.DefaultSchema;
       defaultDatabase = configuration.DefaultDatabase;
-      types = (DomainTypeRegistry) configuration.Types.Clone();
-      linqExtensions = (LinqExtensionRegistry) configuration.LinqExtensions.Clone();
-      namingConvention = (NamingConvention) configuration.NamingConvention.Clone();
+      types = configuration.Types.Clone();
+      linqExtensions = configuration.LinqExtensions.Clone();
+      namingConvention = configuration.NamingConvention.Clone();
       keyCacheSize = configuration.KeyCacheSize;
       keyGeneratorCacheSize = configuration.KeyGeneratorCacheSize;
       queryCacheSize = configuration.QueryCacheSize;
       recordSetMappingCacheSize = configuration.RecordSetMappingCacheSize;
-      sessions = (SessionConfigurationCollection) configuration.Sessions.Clone();
+      sessions = configuration.Sessions.Clone();
       upgradeMode = configuration.UpgradeMode;
       foreignKeyMode = configuration.ForeignKeyMode;
       serviceContainerType = configuration.ServiceContainerType;
@@ -801,13 +801,13 @@ namespace Xtensive.Orm.Configuration
       multidatabaseKeys = configuration.MultidatabaseKeys;
       ensureConnectionIsAlive = configuration.EnsureConnectionIsAlive;
       options = configuration.Options;
-      databases = (DatabaseConfigurationCollection) configuration.Databases.Clone();
-      mappingRules = (MappingRuleCollection) configuration.MappingRules.Clone();
-      keyGenerators = (KeyGeneratorConfigurationCollection) configuration.KeyGenerators.Clone();
-      ignoreRules = (IgnoreRuleCollection) configuration.IgnoreRules.Clone();
+      databases = configuration.Databases.Clone();
+      mappingRules = configuration.MappingRules.Clone();
+      keyGenerators = configuration.KeyGenerators.Clone();
+      ignoreRules = configuration.IgnoreRules.Clone();
       shareStorageSchemaOverNodes = configuration.ShareStorageSchemaOverNodes;
       ShareQueryCacheOverNodes = configuration.ShareQueryCacheOverNodes;
-      versioningConvention = (VersioningConvention) configuration.VersioningConvention.Clone();
+      versioningConvention = configuration.VersioningConvention.Clone();
       preferTypeIdsAsQueryParameters = configuration.PreferTypeIdsAsQueryParameters;
       maxNumberOfConditons = configuration.MaxNumberOfConditions;
     }

--- a/Orm/Xtensive.Orm/Orm/Configuration/DomainTypeRegistry.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/DomainTypeRegistry.cs
@@ -266,7 +266,7 @@ namespace Xtensive.Orm.Configuration
     #region ICloneable members
 
     /// <inheritdoc/>
-    public override object Clone() => new DomainTypeRegistry(this);
+    public override DomainTypeRegistry Clone() => new(this);
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/Configuration/IgnoreRuleCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/IgnoreRuleCollection.cs
@@ -51,13 +51,15 @@ namespace Xtensive.Orm.Configuration
     }
 
     /// <inheritdoc />
-    public object Clone()
+    public IgnoreRuleCollection Clone()
     {
       var result = new IgnoreRuleCollection();
       foreach (var rule in this)
         result.Add(rule.Clone());
       return result;
     }
+
+    object ICloneable.Clone() => Clone();
 
     /// <inheritdoc />
     public override void Lock(bool recursive)

--- a/Orm/Xtensive.Orm/Orm/Configuration/KeyGeneratorConfigurationCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/KeyGeneratorConfigurationCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2012 Xtensive LLC.
+// Copyright (C) 2012 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Denis Krjuchkov
@@ -42,7 +42,7 @@ namespace Xtensive.Orm.Configuration
     }
 
     /// <inheritdoc/>
-    public object Clone()
+    public KeyGeneratorConfigurationCollection Clone()
     {
       var result = new KeyGeneratorConfigurationCollection();
       foreach (var generator in this)
@@ -50,6 +50,7 @@ namespace Xtensive.Orm.Configuration
       return result;
     }
 
+    object ICloneable.Clone() => Clone();
     /// <inheritdoc/>
     public override void Lock(bool recursive)
     {

--- a/Orm/Xtensive.Orm/Orm/Configuration/LinqExtensionRegistry.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/LinqExtensionRegistry.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2011 Xtensive LLC.
+// Copyright (C) 2011 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Denis Krjuchkov
@@ -78,11 +78,8 @@ namespace Xtensive.Orm.Configuration
     /// Clones this instance.
     /// </summary>
     /// <returns>Clone of this instance.</returns>
-    public object Clone()
-    {
-      return new LinqExtensionRegistry(this);
-    }
-
+    public LinqExtensionRegistry Clone() => new(this);
+    object ICloneable.Clone() => Clone();
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Configuration/MappingRuleCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/MappingRuleCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2012 Xtensive LLC.
+// Copyright (C) 2012 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Denis Krjuchkov
@@ -51,13 +51,15 @@ namespace Xtensive.Orm.Configuration
     }
 
     /// <inheritdoc />
-    public object Clone()
+    public MappingRuleCollection Clone()
     {
       var result = new MappingRuleCollection();
       foreach (var rule in this)
         result.Add(rule.Clone());
       return result;
     }
+
+    object ICloneable.Clone() => Clone();
 
     /// <inheritdoc/>
     public override void Lock(bool recursive)

--- a/Orm/Xtensive.Orm/Orm/Configuration/NameMappingCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/NameMappingCollection.cs
@@ -99,10 +99,8 @@ namespace Xtensive.Orm.Configuration
     /// Creates clone of this instance.
     /// </summary>
     /// <returns>Clone of this instance.</returns>
-    public object Clone()
-    {
-      return new NameMappingCollection(this);
-    }
+    public NameMappingCollection Clone() => new(this);
+    object ICloneable.Clone() => Clone();
 
     /// <summary>
     /// Initializes new instance of this type.

--- a/Orm/Xtensive.Orm/Orm/Configuration/NamingConvention.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/NamingConvention.cs
@@ -92,7 +92,7 @@ namespace Xtensive.Orm.Configuration
     #region ICloneable members
 
     /// <inheritdoc/>
-    public object Clone()
+    public NamingConvention Clone()
     {
       EnsureNotLocked();
       var result = new NamingConvention();
@@ -102,6 +102,8 @@ namespace Xtensive.Orm.Configuration
       result.namespaceSynonyms = new Dictionary<string, string>(namespaceSynonyms);
       return result;
     }
+
+    object ICloneable.Clone() => Clone();
 
     #endregion
   }

--- a/Orm/Xtensive.Orm/Orm/Configuration/NodeConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/NodeConfiguration.cs
@@ -104,18 +104,17 @@ namespace Xtensive.Orm.Configuration
     /// Creates clone of this instance.
     /// </summary>
     /// <returns>Clone of this instance.</returns>
-    public object Clone()
-    {
-      var clone = new NodeConfiguration {
+    public NodeConfiguration Clone() =>
+      new() {
         nodeId = nodeId,
         connectionInfo = connectionInfo,
         connectionInitializationSql = connectionInitializationSql,
-        databaseMapping = (NameMappingCollection) databaseMapping.Clone(),
-        schemaMapping = (NameMappingCollection) schemaMapping.Clone(),
+        databaseMapping = databaseMapping.Clone(),
+        schemaMapping = schemaMapping.Clone(),
         TypeIdRegistry = TypeIdRegistry,
       };
-      return clone;
-    }
+
+    object ICloneable.Clone() => Clone();
 
     internal void Validate(DomainConfiguration configuration)
     {

--- a/Orm/Xtensive.Orm/Orm/Configuration/SessionConfigurationCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/SessionConfigurationCollection.cs
@@ -150,13 +150,15 @@ namespace Xtensive.Orm.Configuration
     }
 
     /// <inheritdoc/>
-    public object Clone()
+    public SessionConfigurationCollection Clone()
     {
       var result = new SessionConfigurationCollection();
       foreach (var configuration in this)
         result.Add(configuration.Clone());
       return result;
     }
+
+    object ICloneable.Clone() => Clone();
 
     private SessionConfiguration GetConfiguration(string name, SessionConfiguration fallback)
     {

--- a/Orm/Xtensive.Orm/Orm/Configuration/VersioningConvention.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/VersioningConvention.cs
@@ -45,13 +45,15 @@ namespace Xtensive.Orm.Configuration
     }
 
     /// <inheritdoc/>
-    public object Clone()
+    public VersioningConvention Clone()
     {
       var result = new VersioningConvention();
       result.EntityVersioningPolicy = entityVersioningPolicy;
       result.DenyEntitySetOwnerVersionChange = denyEntitySetOwnerVersionChange;
       return result;
     }
+
+    object ICloneable.Clone() => Clone();
 
     /// <inheritdoc/>
     public VersioningConvention()

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
@@ -253,7 +253,7 @@ namespace Xtensive.Orm.Linq.Materialization
 
         var columnMap = MaterializationHelper.CreateSingleSourceMap(tuplePrototype.Count, mappingInfo);
 
-        var persistentTupleExpression = (Expression) Expression.Call(
+        Expression persistentTupleExpression = Expression.Call(
           BuildPersistentTupleMethod,
           tupleExpression,
           Expression.Constant(tuplePrototype),
@@ -299,7 +299,7 @@ namespace Xtensive.Orm.Linq.Materialization
 
       var columnMap = MaterializationHelper.CreateSingleSourceMap(tuplePrototype.Count, mappingInfo);
 
-      var persistentTupleExpression = (Expression) Expression.Call(
+      Expression persistentTupleExpression = Expression.Call(
         BuildPersistentTupleMethod,
         tupleExpression,
         Expression.Constant(tuplePrototype),

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -1052,7 +1052,7 @@ namespace Xtensive.Orm.Linq
           var methodInfo = structureType.GetProperty(indexerPropertyName).GetGetMethod();
           propertyAccessorExpression = Expression.Call(Expression.Convert(expression, structureType), methodInfo, Expression.Constant(fieldExpression.Name));
         }
-        var memberExpression = (Expression) Expression.Condition(
+        Expression memberExpression = Expression.Condition(
           isNullExpression,
           Expression.Constant(null, nullableType),
           Expression.Convert(
@@ -1152,7 +1152,7 @@ namespace Xtensive.Orm.Linq
           var resultType = type.ToNullable();
           var baseType = type.StripNullable();
           var fieldType = (baseType.IsEnum ? Enum.GetUnderlyingType(baseType) : baseType).ToNullable();
-          var tupleAccess = (Expression) keyTupleExpression.MakeTupleAccess(fieldType, index);
+          Expression tupleAccess = keyTupleExpression.MakeTupleAccess(fieldType, index);
           if (fieldType != resultType)
             tupleAccess = Expression.Convert(tupleAccess, resultType);
           return (Expression) Expression.Condition(isNullExpression, Expression.Constant(null, resultType), tupleAccess);

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -797,7 +797,7 @@ namespace Xtensive.Orm.Linq
       }
 
       if (isRoot) {
-        var projectorBody = (Expression) ColumnExpression.Create(columnType, 0);
+        Expression projectorBody = ColumnExpression.Create(columnType, 0);
         if (convertResultColumn) {
           projectorBody = Expression.Convert(projectorBody, resultType);
         }

--- a/Orm/Xtensive.Orm/Orm/Session.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.cs
@@ -581,7 +581,7 @@ namespace Xtensive.Orm
 
       // Validation context
       ValidationContext = Configuration.Supports(SessionOptions.ValidateEntities)
-        ? (ValidationContext) new RealValidationContext()
+        ? new RealValidationContext()
         : new VoidValidationContext();
 
       // Creating Services

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/CatalogCloner.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/CatalogCloner.cs
@@ -126,7 +126,7 @@ namespace Xtensive.Orm.Upgrade.Internals
       foreach (var sourceSequence in sourceSchema.Sequences) {
         var newSequence = newSchema.CreateSequence(sourceSequence.Name);
         CopyDbName(newSequence, sourceSequence);
-        newSequence.SequenceDescriptor = (SequenceDescriptor) sourceSequence.SequenceDescriptor.Clone();
+        newSequence.SequenceDescriptor = sourceSequence.SequenceDescriptor.Clone();
       }
     }
 
@@ -200,7 +200,7 @@ namespace Xtensive.Orm.Upgrade.Internals
         newColumn.IsNullable = sourceTableColumn.IsNullable;
         newColumn.IsPersisted = sourceTableColumn.IsPersisted;
         if (sourceTableColumn.SequenceDescriptor!=null)
-          newColumn.SequenceDescriptor = (SequenceDescriptor) sourceTableColumn.SequenceDescriptor.Clone();
+          newColumn.SequenceDescriptor = sourceTableColumn.SequenceDescriptor.Clone();
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/CatalogCloner.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/CatalogCloner.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Xtensive.Core;
 using Xtensive.Orm.Providers;
+using Xtensive.Sql;
 using Xtensive.Sql.Dml;
 using Xtensive.Sql.Model;
 using Index = Xtensive.Sql.Model.Index;
@@ -159,7 +160,7 @@ namespace Xtensive.Orm.Upgrade.Internals
         CopyDbName(newView, sourceView);
         newView.CheckOptions = sourceView.CheckOptions;
         if (sourceView.Definition != null) {
-          newView.Definition = (SqlNative) sourceView.Definition.Clone();
+          newView.Definition = sourceView.Definition.Clone();
         }
         CloneViewColumns(newView, sourceView);
         CloneIndexes(newView, sourceView);

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlAction.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlAction.cs
@@ -14,6 +14,8 @@ namespace Xtensive.Sql.Ddl
       throw new NotSupportedException();
     }
 
+    internal override abstract SqlAction Clone(SqlNodeCloneContext? context = null);
+
     // Constructors
 
     protected SqlAction() : base(SqlNodeType.Action)

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlAddColumn.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlAddColumn.cs
@@ -12,9 +12,8 @@ namespace Xtensive.Sql.Ddl
   {
     public TableColumn Column { get; private set; }
 
-    internal override SqlAddColumn Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlAddColumn(t.Column));
+    internal override SqlAddColumn Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.Column));
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlAddConstraint.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlAddConstraint.cs
@@ -12,9 +12,8 @@ namespace Xtensive.Sql.Ddl
   {
     public Constraint Constraint { get; private set; }
 
-    internal override SqlAddConstraint Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlAddConstraint(t.Constraint));
+    internal override SqlAddConstraint Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.Constraint));
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlAlterIdentityInfo.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlAlterIdentityInfo.cs
@@ -14,9 +14,8 @@ namespace Xtensive.Sql.Ddl
     public SequenceDescriptor SequenceDescriptor { get; set; }
     public SqlAlterIdentityInfoOptions InfoOption { get; set; }
 
-    internal override SqlAlterIdentityInfo Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlAlterIdentityInfo(t.Column, t.SequenceDescriptor.Clone(), t.InfoOption));
+    internal override SqlAlterIdentityInfo Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.Column, t.SequenceDescriptor.Clone(), t.InfoOption));
 
     internal SqlAlterIdentityInfo(TableColumn column, SequenceDescriptor sequenceDescriptor, SqlAlterIdentityInfoOptions infoOption)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlAlterIdentityInfo.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlAlterIdentityInfo.cs
@@ -16,7 +16,7 @@ namespace Xtensive.Sql.Ddl
 
     internal override SqlAlterIdentityInfo Clone(SqlNodeCloneContext context) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlAlterIdentityInfo(t.Column, (SequenceDescriptor) t.SequenceDescriptor.Clone(), t.InfoOption));
+        new SqlAlterIdentityInfo(t.Column, t.SequenceDescriptor.Clone(), t.InfoOption));
 
     internal SqlAlterIdentityInfo(TableColumn column, SequenceDescriptor sequenceDescriptor, SqlAlterIdentityInfoOptions infoOption)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlDropColumn.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlDropColumn.cs
@@ -12,7 +12,7 @@ namespace Xtensive.Sql.Ddl
   {
     public TableColumn Column { get; private set; }
     
-    internal override SqlDropColumn Clone(SqlNodeCloneContext context) =>
+    internal override SqlDropColumn Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
         new SqlDropColumn(t.Column));
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlDropColumn.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlDropColumn.cs
@@ -13,8 +13,7 @@ namespace Xtensive.Sql.Ddl
     public TableColumn Column { get; private set; }
     
     internal override SqlDropColumn Clone(SqlNodeCloneContext? context = null) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlDropColumn(t.Column));
+      context.GetOrAdd(this, static (t, c) => new(t.Column));
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlDropConstraint.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlDropConstraint.cs
@@ -12,7 +12,7 @@ namespace Xtensive.Sql.Ddl
   {
     public Constraint Constraint { get; private set; }
     
-    internal override SqlDropConstraint Clone(SqlNodeCloneContext context) =>
+    internal override SqlDropConstraint Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
         new SqlDropConstraint(t.Constraint, t.Cascade));
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlDropConstraint.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlDropConstraint.cs
@@ -13,8 +13,7 @@ namespace Xtensive.Sql.Ddl
     public Constraint Constraint { get; private set; }
     
     internal override SqlDropConstraint Clone(SqlNodeCloneContext? context = null) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlDropConstraint(t.Constraint, t.Cascade));
+      context.GetOrAdd(this, static (t, c) => new(t.Constraint, t.Cascade));
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlDropDefault.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlDropDefault.cs
@@ -12,7 +12,7 @@ namespace Xtensive.Sql.Ddl
   {
     public TableColumn Column { get; private set; }
 
-    internal override SqlDropDefault Clone(SqlNodeCloneContext context) =>
+    internal override SqlDropDefault Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
         new SqlDropDefault(t.Column));
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlDropDefault.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlDropDefault.cs
@@ -13,8 +13,7 @@ namespace Xtensive.Sql.Ddl
     public TableColumn Column { get; private set; }
 
     internal override SqlDropDefault Clone(SqlNodeCloneContext? context = null) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlDropDefault(t.Column));
+      context.GetOrAdd(this, static (t, c) => new(t.Column));
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlRenameColumn.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlRenameColumn.cs
@@ -15,7 +15,7 @@ namespace Xtensive.Sql.Ddl
     public TableColumn Column { get; private set; }
     public string NewName { get; private set; }
 
-    internal override SqlRenameColumn Clone(SqlNodeCloneContext context) =>
+    internal override SqlRenameColumn Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
         new SqlRenameColumn(t.Column, t.NewName));
       

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlRenameColumn.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlRenameColumn.cs
@@ -16,8 +16,7 @@ namespace Xtensive.Sql.Ddl
     public string NewName { get; private set; }
 
     internal override SqlRenameColumn Clone(SqlNodeCloneContext? context = null) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlRenameColumn(t.Column, t.NewName));
+      context.GetOrAdd(this, static (t, c) => new(t.Column, t.NewName));
       
 
     // Constructors

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlSetDefault.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlSetDefault.cs
@@ -14,7 +14,7 @@ namespace Xtensive.Sql.Ddl
     public TableColumn Column { get; private set; }
     public SqlExpression DefaultValue { get; private set; }
 
-    internal override SqlSetDefault Clone(SqlNodeCloneContext context) =>
+    internal override SqlSetDefault Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
         new SqlSetDefault(t.DefaultValue.Clone(c), t.Column));
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlSetDefault.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/Actions/SqlSetDefault.cs
@@ -15,8 +15,7 @@ namespace Xtensive.Sql.Ddl
     public SqlExpression DefaultValue { get; private set; }
 
     internal override SqlSetDefault Clone(SqlNodeCloneContext? context = null) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlSetDefault(t.DefaultValue.Clone(c), t.Column));
+      context.GetOrAdd(this, static (t, c) => new(t.DefaultValue.Clone(c), t.Column));
 
     internal SqlSetDefault(SqlExpression defaultValue, TableColumn column)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterDomain.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterDomain.cs
@@ -25,7 +25,7 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlAlterDomain Clone(SqlNodeCloneContext context) =>
+    internal override SqlAlterDomain Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
         new SqlAlterDomain(t.domain, (SqlAction)t.action.Clone(c)));
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterDomain.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterDomain.cs
@@ -26,8 +26,7 @@ namespace Xtensive.Sql.Ddl
     }
 
     internal override SqlAlterDomain Clone(SqlNodeCloneContext? context = null) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlAlterDomain(t.domain, (SqlAction)t.action.Clone(c)));
+      context.GetOrAdd(this, static (t, c) => new(t.domain, t.action.Clone(c)));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterPartitionFunction.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterPartitionFunction.cs
@@ -31,7 +31,7 @@ namespace Xtensive.Sql.Ddl
       set { option = value; }
     }
 
-    internal override SqlAlterPartitionFunction Clone(SqlNodeCloneContext context) =>
+    internal override SqlAlterPartitionFunction Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
         new SqlAlterPartitionFunction(t.partitionFunction, t.boundary, t.option));
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterPartitionFunction.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterPartitionFunction.cs
@@ -33,7 +33,7 @@ namespace Xtensive.Sql.Ddl
 
     internal override SqlAlterPartitionFunction Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlAlterPartitionFunction(t.partitionFunction, t.boundary, t.option));
+        new(t.partitionFunction, t.boundary, t.option));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterPartitionScheme.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterPartitionScheme.cs
@@ -25,7 +25,7 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlAlterPartitionScheme Clone(SqlNodeCloneContext context) =>
+    internal override SqlAlterPartitionScheme Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
         new SqlAlterPartitionScheme(t.partitionSchema, t.filegroup));
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterPartitionScheme.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterPartitionScheme.cs
@@ -26,8 +26,7 @@ namespace Xtensive.Sql.Ddl
     }
 
     internal override SqlAlterPartitionScheme Clone(SqlNodeCloneContext? context = null) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlAlterPartitionScheme(t.partitionSchema, t.filegroup));
+      context.GetOrAdd(this, static (t, c) => new(t.partitionSchema, t.filegroup));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterSequence.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterSequence.cs
@@ -37,7 +37,7 @@ namespace Xtensive.Sql.Ddl
 
     internal override SqlAlterSequence Clone(SqlNodeCloneContext context) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlAlterSequence(t.sequence, (SequenceDescriptor)t.sequenceDescriptor.Clone(), t.infoOption));
+        new SqlAlterSequence(t.sequence, t.sequenceDescriptor.Clone(), t.infoOption));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterSequence.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterSequence.cs
@@ -35,7 +35,7 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlAlterSequence Clone(SqlNodeCloneContext context) =>
+    internal override SqlAlterSequence Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
         new SqlAlterSequence(t.sequence, t.sequenceDescriptor.Clone(), t.infoOption));
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterSequence.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterSequence.cs
@@ -37,7 +37,7 @@ namespace Xtensive.Sql.Ddl
 
     internal override SqlAlterSequence Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlAlterSequence(t.sequence, t.sequenceDescriptor.Clone(), t.infoOption));
+        new(t.sequence, t.sequenceDescriptor.Clone(), t.infoOption));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterTable.cs
@@ -26,9 +26,9 @@ namespace Xtensive.Sql.Ddl
     }
 
 
-    internal override SqlAlterTable Clone(SqlNodeCloneContext context) =>
+    internal override SqlAlterTable Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlAlterTable(t.table, (SqlAction)t.action.Clone(c)));
+        new SqlAlterTable(t.table, t.action.Clone(c)));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlAlterTable.cs
@@ -28,7 +28,7 @@ namespace Xtensive.Sql.Ddl
 
     internal override SqlAlterTable Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlAlterTable(t.table, t.action.Clone(c)));
+        new(t.table, t.action.Clone(c)));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCommand.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCommand.cs
@@ -14,8 +14,7 @@ namespace Xtensive.Sql.Ddl
     public SqlCommandType CommandType { get; private set; }
 
     internal override SqlCommand Clone(SqlNodeCloneContext? context = null) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlCommand(t.CommandType));
+      context.GetOrAdd(this, static (t, c) => new(t.CommandType));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCommand.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCommand.cs
@@ -13,7 +13,7 @@ namespace Xtensive.Sql.Ddl
   {
     public SqlCommandType CommandType { get; private set; }
 
-    internal override SqlCommand Clone(SqlNodeCloneContext context) =>
+    internal override SqlCommand Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
         new SqlCommand(t.CommandType));
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateAssertion.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateAssertion.cs
@@ -18,7 +18,7 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlCreateAssertion Clone(SqlNodeCloneContext context) =>
+    internal override SqlCreateAssertion Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
         new SqlCreateAssertion(t.assertion));
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateAssertion.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateAssertion.cs
@@ -19,8 +19,7 @@ namespace Xtensive.Sql.Ddl
     }
 
     internal override SqlCreateAssertion Clone(SqlNodeCloneContext? context = null) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlCreateAssertion(t.assertion));
+      context.GetOrAdd(this, static (t, c) => new(t.assertion));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateCharcterSet.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateCharcterSet.cs
@@ -19,8 +19,7 @@ namespace Xtensive.Sql.Ddl
     }
 
     internal override SqlCreateCharacterSet Clone(SqlNodeCloneContext? context = null) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlCreateCharacterSet(t.characterSet));
+      context.GetOrAdd(this, static (t, c) => new(t.characterSet));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateCharcterSet.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateCharcterSet.cs
@@ -18,7 +18,7 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlCreateCharacterSet Clone(SqlNodeCloneContext context) =>
+    internal override SqlCreateCharacterSet Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
         new SqlCreateCharacterSet(t.characterSet));
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateCollation.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateCollation.cs
@@ -19,8 +19,7 @@ namespace Xtensive.Sql.Ddl
     }
 
     internal override SqlCreateCollation Clone(SqlNodeCloneContext? context = null) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlCreateCollation(t.collation));
+      context.GetOrAdd(this, static (t, c) => new(t.collation));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateCollation.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateCollation.cs
@@ -18,7 +18,7 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlCreateCollation Clone(SqlNodeCloneContext context) =>
+    internal override SqlCreateCollation Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
         new SqlCreateCollation(t.collation));
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateDomain.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateDomain.cs
@@ -18,7 +18,7 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlCreateDomain Clone(SqlNodeCloneContext context) =>
+    internal override SqlCreateDomain Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
         new SqlCreateDomain(t.domain));
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateDomain.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateDomain.cs
@@ -19,8 +19,7 @@ namespace Xtensive.Sql.Ddl
     }
 
     internal override SqlCreateDomain Clone(SqlNodeCloneContext? context = null) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlCreateDomain(t.domain));
+      context.GetOrAdd(this, static (t, c) => new(t.domain));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateIndex.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateIndex.cs
@@ -13,7 +13,7 @@ namespace Xtensive.Sql.Ddl
   {
     public Index Index { get; private set; }
 
-    internal override SqlCreateIndex Clone(SqlNodeCloneContext context) =>
+    internal override SqlCreateIndex Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
         new SqlCreateIndex(t.Index));
 

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateIndex.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateIndex.cs
@@ -14,8 +14,7 @@ namespace Xtensive.Sql.Ddl
     public Index Index { get; private set; }
 
     internal override SqlCreateIndex Clone(SqlNodeCloneContext? context = null) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlCreateIndex(t.Index));
+      context.GetOrAdd(this, static (t, c) => new(t.Index));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreatePartitionFunction.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreatePartitionFunction.cs
@@ -18,9 +18,8 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlCreatePartitionFunction Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlCreatePartitionFunction(t.partitionFunction));
+    internal override SqlCreatePartitionFunction Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new (t.partitionFunction));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreatePartitionFunction.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreatePartitionFunction.cs
@@ -19,7 +19,7 @@ namespace Xtensive.Sql.Ddl
     }
 
     internal override SqlCreatePartitionFunction Clone(SqlNodeCloneContext? context = null) =>
-      context.GetOrAdd(this, static (t, c) => new (t.partitionFunction));
+      context.GetOrAdd(this, static (t, c) => new(t.partitionFunction));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreatePartitionScheme.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreatePartitionScheme.cs
@@ -18,9 +18,8 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlCreatePartitionScheme Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlCreatePartitionScheme(t.partitionSchema));
+    internal override SqlCreatePartitionScheme Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.partitionSchema));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateSchema.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateSchema.cs
@@ -18,9 +18,8 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlCreateSchema Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlCreateSchema(t.schema));
+    internal override SqlCreateSchema Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.schema));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateSequence.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateSequence.cs
@@ -18,9 +18,8 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlCreateSequence Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlCreateSequence(t.sequence));
+    internal override SqlCreateSequence Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.sequence));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateTable.cs
@@ -5,31 +5,15 @@
 using System;
 using Xtensive.Sql.Model;
 
-namespace Xtensive.Sql.Ddl
+namespace Xtensive.Sql.Ddl;
+
+[Serializable]
+public class SqlCreateTable(Table table) : SqlStatement(SqlNodeType.Create), ISqlCompileUnit
 {
-  [Serializable]
-  public class SqlCreateTable : SqlStatement, ISqlCompileUnit
-  {
-    private Table table;
+  public Table Table { get; } = table;
 
-    public Table Table {
-      get {
-        return table;
-      }
-    }
+  internal override SqlCreateTable Clone(SqlNodeCloneContext? context = null) =>
+    context.GetOrAdd(this, static (t, c) => new(t.Table));
 
-    internal override SqlCreateTable Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlCreateTable(t.table));
-
-    public override void AcceptVisitor(ISqlVisitor visitor)
-    {
-      visitor.Visit(this);
-    }
-
-    internal SqlCreateTable(Table table) : base(SqlNodeType.Create)
-    {
-      this.table = table;
-    }
-  }
+  public override void AcceptVisitor(ISqlVisitor visitor) => visitor.Visit(this);
 }

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateTranslation.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateTranslation.cs
@@ -18,9 +18,8 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlCreateTranslation Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlCreateTranslation(t.translation));
+    internal override SqlCreateTranslation Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.translation));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateView.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlCreateView.cs
@@ -18,9 +18,8 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlCreateView Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlCreateView(t.node));
+    internal override SqlCreateView Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.node));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropAssertion.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropAssertion.cs
@@ -18,9 +18,8 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlDropAssertion Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlDropAssertion(t.assertion));
+    internal override SqlDropAssertion Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.assertion));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropCharacterSet.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropCharacterSet.cs
@@ -18,9 +18,8 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlDropCharacterSet Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlDropCharacterSet(t.characterSet));
+    internal override SqlDropCharacterSet Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.characterSet));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropCollation.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropCollation.cs
@@ -18,9 +18,8 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlDropCollation Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlDropCollation(t.collation));
+    internal override SqlDropCollation Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.collation));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropDomain.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropDomain.cs
@@ -28,9 +28,8 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlDropDomain Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlDropDomain(t.domain));
+    internal override SqlDropDomain Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.domain));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropIndex.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropIndex.cs
@@ -59,9 +59,8 @@ namespace Xtensive.Sql.Ddl
     //  }
     //}
 
-    internal override SqlDropIndex Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlDropIndex(t.index));
+    internal override SqlDropIndex Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.index));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropPartitionFunction.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropPartitionFunction.cs
@@ -18,9 +18,8 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlDropPartitionFunction Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlDropPartitionFunction(t.partitionFunction));
+    internal override SqlDropPartitionFunction Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.partitionFunction));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropPartitionScheme.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropPartitionScheme.cs
@@ -18,9 +18,8 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlDropPartitionScheme Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlDropPartitionScheme(t.partitionSchema));
+    internal override SqlDropPartitionScheme Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.partitionSchema));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropSchema.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropSchema.cs
@@ -28,9 +28,8 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlDropSchema Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlDropSchema(t.schema));
+    internal override SqlDropSchema Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.schema));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropSequence.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropSequence.cs
@@ -28,9 +28,8 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlDropSequence Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlDropSequence(t.sequence));
+    internal override SqlDropSequence Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.sequence));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropTable.cs
@@ -28,9 +28,8 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlDropTable Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlDropTable(t.table, t.cascade));
+    internal override SqlDropTable Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.table, t.cascade));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropTranslation.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropTranslation.cs
@@ -18,9 +18,8 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlDropTranslation Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlDropTranslation(t.translation));
+    internal override SqlDropTranslation Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.translation));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlDropView.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlDropView.cs
@@ -28,9 +28,8 @@ namespace Xtensive.Sql.Ddl
       }
     }
 
-    internal override SqlDropView Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlDropView(t.view));
+    internal override SqlDropView Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.view));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlRenameTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlRenameTable.cs
@@ -15,9 +15,8 @@ namespace Xtensive.Sql.Ddl
     public Table Table { get; private set; }
     public string NewName { get; private set; }
 
-    internal override SqlRenameTable Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlRenameTable(t.Table, t.NewName));
+    internal override SqlRenameTable Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.Table, t.NewName));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Ddl/SqlTruncateTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Ddl/SqlTruncateTable.cs
@@ -12,9 +12,8 @@ namespace Xtensive.Sql.Ddl
   {
     public Table Table { get; }
 
-    internal override SqlTruncateTable Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlTruncateTable(t.Table));
+    internal override SqlTruncateTable Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.Table));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Collections/SqlInsertValuesCollection.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Collections/SqlInsertValuesCollection.cs
@@ -107,8 +107,9 @@ namespace Xtensive.Sql.Dml.Collections
     /// <inheritdoc/>
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-    internal SqlInsertValuesCollection Clone(SqlNodeCloneContext context)
+    internal SqlInsertValuesCollection Clone(SqlNodeCloneContext? context = null)
     {
+      var ctx = context ?? new();
       var clone = new SqlInsertValuesCollection();
 
       if (rows.Count == 0) {
@@ -117,7 +118,7 @@ namespace Xtensive.Sql.Dml.Collections
 
       var clonedList = new List<SqlColumn>(columns.Count);
       foreach (var oldColumn in columns) {
-        clonedList.Add((SqlColumn) context.NodeMapping[oldColumn]);
+        clonedList.Add((SqlColumn) ctx.NodeMapping[oldColumn]);
       }
       clone.columns = clonedList;
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Collections/SqlInsertValuesCollection.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Collections/SqlInsertValuesCollection.cs
@@ -123,7 +123,7 @@ namespace Xtensive.Sql.Dml.Collections
 
       clone.rows = new List<SqlRow>(rows.Count);
       foreach(var oldRow in rows) {
-        clone.rows.Add((SqlRow) oldRow.Clone());
+        clone.rows.Add(oldRow.Clone());
       }
 
       return clone;

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlAggregate.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlAggregate.cs
@@ -39,10 +39,8 @@ namespace Xtensive.Sql.Dml
       this.expression = replacingExpression.Expression;
     }
 
-    internal override SqlAggregate Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlAggregate(t.NodeType,
-            t.expression?.Clone(c), t.distinct));
+    internal override SqlAggregate Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.NodeType, t.expression?.Clone(c), t.distinct));
 
     internal SqlAggregate(SqlNodeType nodeType, SqlExpression expression, bool distinct) : base(nodeType)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlArray{T}.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlArray{T}.cs
@@ -41,9 +41,8 @@ namespace Xtensive.Sql.Dml
       Values = replacingExpression.Values;
     }
 
-    internal override SqlArray Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlArray<T>((T[]) t.Values.Clone()));
+    internal override SqlArray Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new((T[]) t.Values.Clone()));
 
 
     // Constructors

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlBetween.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlBetween.cs
@@ -53,9 +53,9 @@ namespace Xtensive.Sql.Dml
       expression = replacingExpression.Expression;
     }
 
-    internal override SqlBetween Clone(SqlNodeCloneContext context) =>
+    internal override SqlBetween Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlBetween(t.NodeType, t.expression.Clone(c), t.left.Clone(c), t.right.Clone(c)));
+        new(t.NodeType, t.expression.Clone(c), t.left.Clone(c), t.right.Clone(c)));
 
     internal SqlBetween(SqlNodeType nodeType, SqlExpression expression, SqlExpression left, SqlExpression right)
       : base(nodeType)

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlBinary.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlBinary.cs
@@ -89,11 +89,9 @@ namespace Xtensive.Sql.Dml
       Right = replacingExpression.Right;
     }
 
-    internal override SqlBinary Clone(SqlNodeCloneContext context) =>
+    internal override SqlBinary Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlBinary(t.NodeType,
-            t.Left.Clone(c),
-            t.Right.Clone(c)));
+        new(t.NodeType, t.Left.Clone(c), t.Right.Clone(c)));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCase.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCase.cs
@@ -103,7 +103,7 @@ namespace Xtensive.Sql.Dml
         cases.Add(pair);
     }
 
-    internal override SqlCase Clone(SqlNodeCloneContext context) =>
+    internal override SqlCase Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) => {
         var clone = new SqlCase(t.value?.Clone(c));
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCast.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCast.cs
@@ -20,9 +20,8 @@ namespace Xtensive.Sql.Dml
       Type = replacingExpression.Type;
     }
 
-    internal override SqlCast Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlCast(t.Operand.Clone(c), t.Type));
+    internal override SqlCast Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.Operand.Clone(c), t.Type));
     
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCollate.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCollate.cs
@@ -41,9 +41,8 @@ namespace Xtensive.Sql.Dml
       collation = replacingExpression.Collation;
     }
 
-    internal override SqlCollate Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlCollate(t.operand.Clone(c), t.collation));
+    internal override SqlCollate Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.operand.Clone(c), t.collation));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlColumn.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlColumn.cs
@@ -38,6 +38,8 @@ namespace Xtensive.Sql.Dml
       name = replacingExpression.Name;
     }
 
+    internal override abstract SqlColumn Clone(SqlNodeCloneContext? context = null);
+
     // Constructor
 
     internal SqlColumn(SqlTable sqlTable, string name) : base(SqlNodeType.Column)
@@ -59,6 +61,5 @@ namespace Xtensive.Sql.Dml
     internal SqlColumn() : base(SqlNodeType.Column)
     {
     }
-
   }
 }

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlColumnRef.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlColumnRef.cs
@@ -23,11 +23,9 @@ namespace Xtensive.Sql.Dml
       SqlColumn = ArgumentValidator.EnsureArgumentIs<SqlColumnRef>(expression).SqlColumn;
     }
 
-    internal override SqlColumnRef Clone(SqlNodeCloneContext context) =>
+    internal override SqlColumnRef Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlColumnRef(
-            t.SqlTable?.Clone(c),
-            (SqlColumn) t.SqlColumn.Clone(c), t.Name));
+        new(t.SqlTable?.Clone(c), t.SqlColumn.Clone(c), t.Name));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlColumnStub.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlColumnStub.cs
@@ -13,11 +13,8 @@ namespace Xtensive.Sql.Dml
   {
     public SqlColumn Column { get; set; }
 
-    internal override SqlColumnStub Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlColumnStub(
-            t.SqlTable?.Clone(c), 
-            t.Column));
+    internal override SqlColumnStub Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.SqlTable?.Clone(c), t.Column));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {}

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlComment.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlComment.cs
@@ -23,9 +23,8 @@ namespace Xtensive.Sql.Dml
       Text = replacingExpression.Text;
     }
 
-    internal override SqlComment Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlComment(t.Text));
+    internal override SqlComment Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.Text));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlConcat.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlConcat.cs
@@ -14,15 +14,16 @@ namespace Xtensive.Sql.Dml
   [Serializable]
   public class SqlConcat : SqlExpressionList
   {
-    internal override SqlConcat Clone(SqlNodeCloneContext context)
+    internal override SqlConcat Clone(SqlNodeCloneContext? context = null)
     {
-      if (context.NodeMapping.TryGetValue(this, out var value)) {
+      var ctx = context ?? new();
+      if (ctx.NodeMapping.TryGetValue(this, out var value)) {
         return (SqlConcat)value;
       }
 
       var expressionsClone = new List<SqlExpression>();
       foreach (var e in expressions)
-        expressionsClone.Add(e.Clone(context));
+        expressionsClone.Add(e.Clone(ctx));
 
       var clone = new SqlConcat(expressionsClone);
       return clone;

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlContainer.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlContainer.cs
@@ -27,9 +27,8 @@ namespace Xtensive.Sql.Dml
       Value = replacingExpression.Value;
     }
 
-    internal override SqlContainer Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlContainer(t.Value));
+    internal override SqlContainer Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.Value));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCursor.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCursor.cs
@@ -168,10 +168,7 @@ namespace Xtensive.Sql.Dml
       throw new NotImplementedException();
     }
 
-    internal override SqlCursor Clone(SqlNodeCloneContext context)
-    {
-      throw new NotImplementedException();
-    }
+    internal override SqlCursor Clone(SqlNodeCloneContext? context = null) => throw new NotImplementedException();
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCustomFunctionCall.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCustomFunctionCall.cs
@@ -28,9 +28,9 @@ namespace Xtensive.Sql.Dml
       Arguments = replacingExpression.Arguments;
     }
 
-    internal override SqlCustomFunctionCall Clone(SqlNodeCloneContext context) =>
+    internal override SqlCustomFunctionCall Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlCustomFunctionCall(t.FunctionType, t.Arguments.Select(o => o.Clone(c)).ToArray(t.Arguments.Count)));
+        new(t.FunctionType, t.Arguments.Select(o => o.Clone(c)).ToArray(t.Arguments.Count)));
 
     public override void AcceptVisitor(ISqlVisitor visitor) => visitor.Visit(this);
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlDefaultValue.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlDefaultValue.cs
@@ -16,10 +16,7 @@ namespace Xtensive.Sql.Dml
       ArgumentValidator.EnsureArgumentIs<SqlDefaultValue>(expression);
     }
     
-    internal override SqlDefaultValue Clone(SqlNodeCloneContext context)
-    {
-      return this;
-    }
+    internal override SqlDefaultValue Clone(SqlNodeCloneContext? context = null) => this;
     
     internal SqlDefaultValue() : base(SqlNodeType.DefaultValue)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlDynamicFilter.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlDynamicFilter.cs
@@ -15,7 +15,7 @@ namespace Xtensive.Sql.Dml
 
     public List<SqlExpression> Expressions { get; private set; }
 
-    internal override SqlDynamicFilter Clone(SqlNodeCloneContext context) =>
+    internal override SqlDynamicFilter Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) => {
         var clone = new SqlDynamicFilter(t.Id);
         foreach (var expression in t.Expressions) {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlExpression.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlExpression.cs
@@ -241,8 +241,6 @@ namespace Xtensive.Sql.Dml
 
     public sealed override bool Equals(object obj) => ReferenceEquals(this, obj);
 
-    public override SqlExpression Clone() => Clone(new SqlNodeCloneContext(false));
-
     internal override abstract SqlExpression Clone(SqlNodeCloneContext context);
 
     // Constructor

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlExpression.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlExpression.cs
@@ -241,7 +241,7 @@ namespace Xtensive.Sql.Dml
 
     public sealed override bool Equals(object obj) => ReferenceEquals(this, obj);
 
-    internal override abstract SqlExpression Clone(SqlNodeCloneContext context);
+    internal override abstract SqlExpression Clone(SqlNodeCloneContext? context = null);
 
     // Constructor
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlExtract.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlExtract.cs
@@ -67,8 +67,8 @@ namespace Xtensive.Sql.Dml
       Operand = replacingExpression.Operand;
     }
 
-    internal override SqlExtract Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) => new SqlExtract(t.internalValue, t.typeMarker, t.Operand.Clone(c)));
+    internal override SqlExtract Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.internalValue, t.typeMarker, t.Operand.Clone(c)));
         //t.DateTimePart != SqlDateTimePart.Nothing
         //  ? new SqlExtract(t.DateTimePart, t.Operand.Clone(c))
         //  : t.IntervalPart != SqlIntervalPart.Nothing

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlFunctionCall.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlFunctionCall.cs
@@ -25,9 +25,9 @@ namespace Xtensive.Sql.Dml
       Arguments = replacingExpression.Arguments;
     }
 
-    internal override SqlFunctionCall Clone(SqlNodeCloneContext context) =>
+    internal override SqlFunctionCall Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlFunctionCall(t.FunctionType, t.Arguments.Select(o => o.Clone(c)).ToArray(t.Arguments.Count)));
+        new(t.FunctionType, t.Arguments.Select(o => o.Clone(c)).ToArray(t.Arguments.Count)));
 
     public override void AcceptVisitor(ISqlVisitor visitor) => visitor.Visit(this);
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlLike.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlLike.cs
@@ -63,9 +63,9 @@ namespace Xtensive.Sql.Dml
       not = replacingExpression.Not;
     }
 
-    internal override SqlLike Clone(SqlNodeCloneContext context) =>
+    internal override SqlLike Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlLike(t.expression.Clone(c),
+        new(t.expression.Clone(c),
             t.pattern.Clone(c),
             t.escape?.Clone(c), t.not));
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlLiteral{T}.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlLiteral{T}.cs
@@ -32,9 +32,9 @@ namespace Xtensive.Sql.Dml
       Value = replacingExpression.Value;
     }
 
-    internal override SqlLiteral<T> Clone(SqlNodeCloneContext context) =>
+    internal override SqlLiteral<T> Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlLiteral<T>(t.Value));
+        new(t.Value));
 
     // Constructor
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlMatch.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlMatch.cs
@@ -59,12 +59,9 @@ namespace Xtensive.Sql.Dml
       unique = replacingExpression.Unique;
     }
 
-    internal override SqlMatch Clone(SqlNodeCloneContext context) =>
+    internal override SqlMatch Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlMatch(t.value.Clone(c),
-                                    t.subQuery.Clone(c),
-                                    t.unique,
-                                    t.matchType));
+        new(t.value.Clone(c), t.subQuery.Clone(c), t.unique, t.matchType));
 
     internal SqlMatch(SqlExpression value, SqlSubQuery subQuery, bool unique, SqlMatchType matchType)
       : base(SqlNodeType.Match)

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlMetadata.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlMetadata.cs
@@ -23,9 +23,8 @@ namespace Xtensive.Sql.Dml
       Value = source.Value;
     }
 
-    internal override SqlMetadata Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlMetadata(t.Expression.Clone(c), t.Value));
+    internal override SqlMetadata Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.Expression.Clone(c), t.Value));
 
     public override void AcceptVisitor(ISqlVisitor visitor) => visitor.Visit(this);
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlNative.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlNative.cs
@@ -21,9 +21,8 @@ namespace Xtensive.Sql.Dml
       Value = replacingExpression.Value;
     }
 
-    internal override SqlNative Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlNative(t.Value));
+    internal override SqlNative Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.Value));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlNextValue.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlNextValue.cs
@@ -42,9 +42,8 @@ namespace Xtensive.Sql.Dml
       increment = replacingExpression.Increment;
     }
 
-    internal override SqlNextValue Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlNextValue(t.sequence, t.increment));
+    internal override SqlNextValue Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.sequence, t.increment));
 
     internal SqlNextValue(Sequence sequence) : base(SqlNodeType.NextValue)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlNull.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlNull.cs
@@ -15,10 +15,7 @@ namespace Xtensive.Sql.Dml
       _ = ArgumentValidator.EnsureArgumentIs<SqlNull>(expression);
     }
     
-    internal override SqlNull Clone(SqlNodeCloneContext context)
-    {
-      return this;
-    }
+    internal override SqlNull Clone(SqlNodeCloneContext? context = null) => this;
 
     internal SqlNull() : base(SqlNodeType.Null)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlParameterRef.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlParameterRef.cs
@@ -23,11 +23,8 @@ namespace Xtensive.Sql.Dml
       Parameter = replacingExpression.Parameter;
     }
 
-    internal override SqlParameterRef Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        t.Name != null
-            ? new SqlParameterRef(t.Name)
-            : new SqlParameterRef(t.Parameter));
+    internal override SqlParameterRef Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.Name ?? t.Parameter));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlPlaceholder.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlPlaceholder.cs
@@ -12,9 +12,8 @@ namespace Xtensive.Sql.Dml
   {
     public object Id { get; private set; }
 
-    internal override SqlPlaceholder Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlPlaceholder(t.Id));
+    internal override SqlPlaceholder Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.Id));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlRound.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlRound.cs
@@ -26,12 +26,9 @@ namespace Xtensive.Sql.Dml
       Mode = replacingExpression.Mode;
     }
 
-    internal override SqlRound Clone(SqlNodeCloneContext context) =>
+    internal override SqlRound Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlRound(
-            t.Argument.Clone(c),
-            t.Length?.Clone(c),
-            t.Type, t.Mode));
+        new(t.Argument.Clone(c), t.Length?.Clone(c), t.Type, t.Mode));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlRow.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlRow.cs
@@ -12,15 +12,17 @@ namespace Xtensive.Sql.Dml
   [Serializable]
   public class SqlRow: SqlExpressionList
   {
-    internal override SqlRow Clone(SqlNodeCloneContext context)
+    internal override SqlRow Clone(SqlNodeCloneContext? context = null)
     {
-      if (context.TryGet(this) is SqlRow value) {
+      SqlNodeCloneContext ctx = context ?? new();
+
+      if (ctx.TryGet(this) is SqlRow value) {
         return value;
       }
 
       var expressionsClone = new List<SqlExpression>(expressions.Count);
       foreach (var e in expressions)
-        expressionsClone.Add(e.Clone(context));
+        expressionsClone.Add(e.Clone(ctx));
 
       var clone = new SqlRow(expressionsClone);
       return clone;

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlRowNumber.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlRowNumber.cs
@@ -12,7 +12,7 @@ namespace Xtensive.Sql.Dml
   {
     public SqlOrderCollection OrderBy { get; private set; }
 
-    internal override SqlRowNumber Clone(SqlNodeCloneContext context) =>
+    internal override SqlRowNumber Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) => {
         var clone = new SqlRowNumber();
         foreach (SqlOrder so in t.OrderBy)

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlSubQuery.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlSubQuery.cs
@@ -31,17 +31,13 @@ namespace Xtensive.Sql.Dml
       query = replacingExpression.Query;
     }
 
-    internal override SqlSubQuery Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) => {
-        SqlSubQuery clone;
-        SqlSelect select = t.query as SqlSelect;
-        SqlQueryExpression expression = t.query as SqlQueryExpression;
-        if (select != null)
-          clone = new SqlSubQuery(select.Clone(c));
-        else 
-          clone = new SqlSubQuery(expression.Clone(c));
-        return clone;
-      });
+    internal override SqlSubQuery Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) =>
+        new(t.query is SqlSelect select
+          ? select.Clone(c)
+          : (t.query as SqlQueryExpression).Clone(c)
+          )
+      );
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlTableColumn.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlTableColumn.cs
@@ -22,16 +22,13 @@ namespace Xtensive.Sql.Dml
       base.ReplaceWith(expression);
     }
 
-    internal override SqlTableColumn Clone(SqlNodeCloneContext context) =>
+    internal override SqlTableColumn Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) => {
         var table = t.SqlTable;
-        SqlNode clonedTable;
-        if (c.NodeMapping.TryGetValue(t.SqlTable, out clonedTable)) {
+        if (c.NodeMapping.TryGetValue(t.SqlTable, out var clonedTable)) {
           table = (SqlTable) clonedTable;
         }
-      
-        var clone = new SqlTableColumn(table, t.Name);
-        return clone;
+        return new(table, t.Name);
       });
 
     // Constructors

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlTrim.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlTrim.cs
@@ -49,9 +49,9 @@ namespace Xtensive.Sql.Dml
       trimType = replacingExpression.TrimType;
     }
 
-    internal override SqlTrim Clone(SqlNodeCloneContext context) =>
+    internal override SqlTrim Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlTrim(t.expression.Clone(c), t.trimCharacters, t.trimType));
+        new(t.expression.Clone(c), t.trimCharacters, t.trimType));
 
     internal SqlTrim(SqlExpression expression, string trimCharacters, SqlTrimType trimType) : base (SqlNodeType.Trim)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlUnary.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlUnary.cs
@@ -26,9 +26,9 @@ namespace Xtensive.Sql.Dml
       Operand = replacingExpression.Operand;
     }
 
-    internal override SqlUnary Clone(SqlNodeCloneContext context) =>
+    internal override SqlUnary Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlUnary(t.NodeType, t.Operand.Clone(c)));
+        new(t.NodeType, t.Operand.Clone(c)));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlUserColumn.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlUserColumn.cs
@@ -27,9 +27,8 @@ namespace Xtensive.Sql.Dml
       this.expression = replacingExpression.Expression;
     }
 
-    internal override SqlUserColumn Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlUserColumn(t.expression.Clone(c)));
+    internal override SqlUserColumn Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.expression.Clone(c)));
 
     // Constructor
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlUserFunctionCall.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlUserFunctionCall.cs
@@ -25,9 +25,9 @@ namespace Xtensive.Sql.Dml
       Arguments = replacingExpression.Arguments;
     }
 
-    internal override SqlUserFunctionCall Clone(SqlNodeCloneContext context) =>
+    internal override SqlUserFunctionCall Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlUserFunctionCall(t.Name, t.Arguments.Select(o => (SqlExpression) o.Clone(c)).ToArray(t.Arguments.Count)));
+        new(t.Name, t.Arguments.Select(o => o.Clone(c)).ToArray(t.Arguments.Count)));
 
     internal SqlUserFunctionCall(string name, IReadOnlyList<SqlExpression> arguments)
       : base(SqlFunctionType.UserDefined, arguments)

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlVariable.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlVariable.cs
@@ -42,9 +42,8 @@ namespace Xtensive.Sql.Dml
       name = replacingExpression.Name;
     }
 
-    internal override SqlVariable Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlVariable(t.name, t.type));
+    internal override SqlVariable Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.name, t.type));
 
     internal SqlVariable(string name, SqlValueType type)
       : base(SqlNodeType.Variable)

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlVariant.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlVariant.cs
@@ -22,9 +22,9 @@ namespace Xtensive.Sql.Dml
       Id = replacingExpression.Id;
     }
 
-    internal override SqlVariant Clone(SqlNodeCloneContext context) =>
+    internal override SqlVariant Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlVariant(t.Id, t.Main.Clone(c), t.Alternative.Clone(c)));
+        new(t.Id, t.Main.Clone(c), t.Alternative.Clone(c)));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlFastFirstRowsHint.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlFastFirstRowsHint.cs
@@ -15,9 +15,8 @@ namespace Xtensive.Sql.Dml
     /// <value>The row amount.</value>
     public int Amount { get; private set; }
 
-    internal override SqlFastFirstRowsHint Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlFastFirstRowsHint(t.Amount));
+    internal override SqlFastFirstRowsHint Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.Amount));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlForceJoinOrderHint.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlForceJoinOrderHint.cs
@@ -21,7 +21,7 @@ namespace Xtensive.Sql.Dml
 
     internal override SqlForceJoinOrderHint Clone(SqlNodeCloneContext context) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlForceJoinOrderHint(t.tables?.Select(table => (SqlTable) table.Clone()).ToArray(t.tables.Length)));
+        new SqlForceJoinOrderHint(t.tables?.Select(table => table.Clone()).ToArray(t.tables.Length)));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlForceJoinOrderHint.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlForceJoinOrderHint.cs
@@ -19,9 +19,9 @@ namespace Xtensive.Sql.Dml
     /// </summary>
     public IEnumerable<SqlTable> Tables { get { return tables; } }
 
-    internal override SqlForceJoinOrderHint Clone(SqlNodeCloneContext context) =>
+    internal override SqlForceJoinOrderHint Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlForceJoinOrderHint(t.tables?.Select(table => table.Clone()).ToArray(t.tables.Length)));
+        new(t.tables?.Select(table => table.Clone()).ToArray(t.tables.Length)));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlHint.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlHint.cs
@@ -9,6 +9,8 @@ namespace Xtensive.Sql.Dml
   [Serializable]
   public abstract class SqlHint : SqlNode
   {
+    internal abstract override SqlHint Clone(SqlNodeCloneContext? context = null);
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SqlHint"/> class.
     /// </summary>

--- a/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlIndexHint.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlIndexHint.cs
@@ -13,9 +13,8 @@ namespace Xtensive.Sql.Dml
 
     public SqlTableRef From { get; }
 
-    internal override SqlIndexHint Clone(SqlNodeCloneContext context) => 
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlIndexHint(t.IndexName, t.From));
+    internal override SqlIndexHint Clone(SqlNodeCloneContext? context = null) => 
+      context.GetOrAdd(this, static (t, c) => new(t.IndexName, t.From));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlJoinHint.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlJoinHint.cs
@@ -25,7 +25,7 @@ namespace Xtensive.Sql.Dml
 
     internal override SqlJoinHint Clone(SqlNodeCloneContext context) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlJoinHint(t.Method, (SqlTable) t.Table.Clone()));
+        new SqlJoinHint(t.Method, t.Table.Clone()));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlJoinHint.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlJoinHint.cs
@@ -23,9 +23,8 @@ namespace Xtensive.Sql.Dml
     /// </summary>
     public SqlTable Table { get; private set; }
 
-    internal override SqlJoinHint Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlJoinHint(t.Method, t.Table.Clone()));
+    internal override SqlJoinHint Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.Method, t.Table.Clone()));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlNativeHint.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlNativeHint.cs
@@ -15,9 +15,8 @@ namespace Xtensive.Sql.Dml
     /// <value>The hint text.</value>
     public string HintText { get; private set; }
 
-    internal override SqlNativeHint Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlNativeHint(t.HintText));
+    internal override SqlNativeHint Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.HintText));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlContainsTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlContainsTable.cs
@@ -18,10 +18,7 @@ namespace Xtensive.Sql.Dml
 
     public SqlExpression TopNByRank { get; private set; }
 
-    internal override SqlContainsTable Clone(SqlNodeCloneContext context)
-    {
-      throw new NotImplementedException();
-    }
+    internal override SqlContainsTable Clone(SqlNodeCloneContext? context = null) => throw new NotImplementedException();
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlFragment.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlFragment.cs
@@ -10,9 +10,8 @@ namespace Xtensive.Sql.Dml
   {
     public SqlExpression Expression { get; private set; }
 
-    internal override SqlFragment Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlFragment(t.Expression.Clone(c)));
+    internal override SqlFragment Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.Expression.Clone(c)));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlFreeTextTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlFreeTextTable.cs
@@ -24,10 +24,7 @@ namespace Xtensive.Sql.Dml
 
     public SqlExpression TopNByRank { get; private set; }
 
-    internal override SqlFreeTextTable Clone(SqlNodeCloneContext context)
-    {
-      throw new NotImplementedException();
-    }
+    internal override SqlFreeTextTable Clone(SqlNodeCloneContext? context = null) => throw new NotImplementedException();
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlJoinExpression.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlJoinExpression.cs
@@ -34,9 +34,9 @@ namespace Xtensive.Sql.Dml
     /// <value>The expression.</value>
     public SqlExpression Expression { get; private set; }
 
-    internal override SqlJoinExpression Clone(SqlNodeCloneContext context) =>
+    internal override SqlJoinExpression Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlJoinExpression(t.JoinType,
+        new(t.JoinType,
             t.Left?.Clone(c),
             t.Right?.Clone(c),
             t.Expression?.Clone(c)));

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlJoinedTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlJoinedTable.cs
@@ -29,9 +29,9 @@ namespace Xtensive.Sql.Dml
     /// <value>Aliased columns.</value>
     public SqlColumnCollection AliasedColumns { get; private set; }
 
-    internal override SqlJoinedTable Clone(SqlNodeCloneContext context) =>
+    internal override SqlJoinedTable Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlJoinedTable(t.joinExpression.Clone(c)) {
+        new(t.joinExpression.Clone(c)) {
             AliasedColumns = new SqlColumnCollection(new List<SqlColumn>(t.AliasedColumns))
           });
 

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlOrder.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlOrder.cs
@@ -30,11 +30,11 @@ namespace Xtensive.Sql.Dml
     /// <value><see langword="true"/> if ascending; otherwise, <see langword="false"/>.</value>
     public bool Ascending { get; private set; }
 
-    internal override SqlOrder Clone(SqlNodeCloneContext context) =>
+    internal override SqlOrder Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
         t.Expression is null
-            ? new SqlOrder(t.Position, t.Ascending)
-            : new SqlOrder(t.Expression.Clone(c), t.Ascending));
+            ? new(t.Position, t.Ascending)
+            : new(t.Expression.Clone(c), t.Ascending));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlQueryRef.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlQueryRef.cs
@@ -22,11 +22,11 @@ namespace Xtensive.Sql.Dml
       get { return query; }
     }
 
-    internal override SqlQueryRef Clone(SqlNodeCloneContext context) =>
+    internal override SqlQueryRef Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
         t.query is SqlSelect ss
-          ? new SqlQueryRef(ss.Clone(c), t.Name)
-          : new SqlQueryRef(((SqlQueryExpression) t.query).Clone(c), t.Name));
+          ? new(ss.Clone(c), t.Name)
+          : new(((SqlQueryExpression) t.query).Clone(c), t.Name));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlTable.cs
@@ -139,7 +139,7 @@ namespace Xtensive.Sql.Dml
       return GetEnumerator();
     }
 
-    internal abstract override SqlTable Clone(SqlNodeCloneContext context);
+    internal abstract override SqlTable Clone(SqlNodeCloneContext? context = null);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlTableRef.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlTableRef.cs
@@ -30,10 +30,13 @@ namespace Xtensive.Sql.Dml
     /// <value>The table.</value>
     public DataTable DataTable { get; private set; }
 
-    internal override SqlTableRef Clone(SqlNodeCloneContext context) =>
-      context.NodeMapping.TryGetValue(this, out var clone)
-        ? (SqlTableRef)clone
-        : CreateClone(context);
+    internal override SqlTableRef Clone(SqlNodeCloneContext? context = null)
+    {
+      var ctx = context ?? new();
+      return ctx.NodeMapping.TryGetValue(this, out var clone)
+        ? (SqlTableRef) clone
+        : CreateClone(ctx);
+    }
 
     private SqlTableRef CreateClone(SqlNodeCloneContext context)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlAssignment.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlAssignment.cs
@@ -30,9 +30,9 @@ namespace Xtensive.Sql.Dml
       }
     }
 
-    internal override SqlAssignment Clone(SqlNodeCloneContext context) =>
+    internal override SqlAssignment Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlAssignment((ISqlLValue)t.left.Clone(), t.right.Clone(c)));
+        new((ISqlLValue)t.left.Clone(), t.right.Clone(c)));
 
     internal SqlAssignment(ISqlLValue left, SqlExpression right)
       : base(SqlNodeType.Assign)

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlBatch.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlBatch.cs
@@ -105,11 +105,11 @@ namespace Xtensive.Sql.Dml
 
     #endregion
 
-    internal override SqlBatch Clone(SqlNodeCloneContext context) =>
+    internal override SqlBatch Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) => {
         var clone = new SqlBatch();
         foreach (SqlStatement s in t.statements)
-          clone.Add((SqlStatement) s.Clone(c));
+          clone.Add(s.Clone(c));
         return clone;
       });
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlBreak.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlBreak.cs
@@ -9,7 +9,7 @@ namespace Xtensive.Sql.Dml
   [Serializable]
   public class SqlBreak : SqlStatement
   {
-    internal override SqlBreak Clone(SqlNodeCloneContext context) => this;
+    internal override SqlBreak Clone(SqlNodeCloneContext? context = null) => this;
 
     internal SqlBreak()
       : base(SqlNodeType.Break)

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlCloseCursor.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlCloseCursor.cs
@@ -21,7 +21,7 @@ namespace Xtensive.Sql.Dml
       }
     }
 
-    internal override SqlCloseCursor Clone(SqlNodeCloneContext context) => throw new NotImplementedException();
+    internal override SqlCloseCursor Clone(SqlNodeCloneContext? context = null) => throw new NotImplementedException();
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlContinue.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlContinue.cs
@@ -9,7 +9,7 @@ namespace Xtensive.Sql.Dml
   [Serializable]
   public class SqlContinue : SqlStatement
   {
-    internal override SqlContinue Clone(SqlNodeCloneContext context) => this;
+    internal override SqlContinue Clone(SqlNodeCloneContext? context = null) => this;
 
     internal SqlContinue()
       : base(SqlNodeType.Continue)

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlDeclareCursor.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlDeclareCursor.cs
@@ -17,7 +17,7 @@ namespace Xtensive.Sql.Dml
       }
     }
 
-    internal override SqlDeclareCursor Clone(SqlNodeCloneContext context) => throw new NotImplementedException();
+    internal override SqlDeclareCursor Clone(SqlNodeCloneContext? context = null) => throw new NotImplementedException();
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlDeclareVariable.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlDeclareVariable.cs
@@ -20,9 +20,8 @@ namespace Xtensive.Sql.Dml
       get { return variable; }
     }
 
-    internal override SqlDeclareVariable Clone(SqlNodeCloneContext context) =>
-      context.GetOrAdd(this, static (t, c) =>
-        new SqlDeclareVariable(t.variable));
+    internal override SqlDeclareVariable Clone(SqlNodeCloneContext? context = null) =>
+      context.GetOrAdd(this, static (t, c) => new(t.variable));
 
     internal SqlDeclareVariable(SqlVariable variable)
       : base(SqlNodeType.DeclareVariable)

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlDelete.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlDelete.cs
@@ -60,7 +60,7 @@ namespace Xtensive.Sql.Dml
       set { limit = value; }
     }
 
-    internal override SqlDelete Clone(SqlNodeCloneContext context) =>
+    internal override SqlDelete Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) => {
         SqlDelete clone = new SqlDelete();
         if (t.Delete != null)
@@ -72,7 +72,7 @@ namespace Xtensive.Sql.Dml
 
         if (t.Hints.Count > 0)
           foreach (SqlHint hint in t.Hints)
-            clone.Hints.Add((SqlHint) hint.Clone(c));
+            clone.Hints.Add(hint.Clone(c));
 
         return clone;
       });

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlFetch.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlFetch.cs
@@ -53,7 +53,7 @@ namespace Xtensive.Sql.Dml
       get { return targets; }
     }
 
-    internal override SqlFetch Clone(SqlNodeCloneContext context) => throw new NotImplementedException();
+    internal override SqlFetch Clone(SqlNodeCloneContext? context = null) => throw new NotImplementedException();
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlIf.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlIf.cs
@@ -56,11 +56,11 @@ namespace Xtensive.Sql.Dml
       }
     }
 
-    internal override SqlIf Clone(SqlNodeCloneContext context) =>
+    internal override SqlIf Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlIf(t.condition.Clone(c),
-            (SqlStatement) t.trueStatement.Clone(c),
-            t.falseStatement == null ? null : (SqlStatement) t.falseStatement.Clone(c)));
+        new(t.condition.Clone(c),
+            t.trueStatement.Clone(c),
+            t.falseStatement?.Clone(c)));
 
     internal SqlIf(SqlExpression condition, SqlStatement trueStatement, SqlStatement falseStatement)
       : base(SqlNodeType.Conditional)

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlInsert.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlInsert.cs
@@ -37,7 +37,7 @@ namespace Xtensive.Sql.Dml
     /// </summary>
     public SqlSelect From { get; set; }
 
-    internal override SqlInsert Clone(SqlNodeCloneContext context) =>
+    internal override SqlInsert Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) => {
         var clone = new SqlInsert {
           Into = t.Into?.Clone(c),
@@ -47,7 +47,7 @@ namespace Xtensive.Sql.Dml
 
         if (t.Hints.Count > 0) {
           foreach (SqlHint hint in t.Hints)
-            clone.Hints.Add((SqlHint) hint.Clone(c));
+            clone.Hints.Add(hint.Clone(c));
         }
         return clone;
       });

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlOpenCursor.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlOpenCursor.cs
@@ -21,7 +21,7 @@ namespace Xtensive.Sql.Dml
       }
     }
 
-    internal override SqlOpenCursor Clone(SqlNodeCloneContext context) => throw new NotImplementedException();
+    internal override SqlOpenCursor Clone(SqlNodeCloneContext? context = null) => throw new NotImplementedException();
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlQueryExpression.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlQueryExpression.cs
@@ -32,9 +32,9 @@ namespace Xtensive.Sql.Dml
       get { return all; }
     }
 
-    internal override SqlQueryExpression Clone(SqlNodeCloneContext context) =>
+    internal override SqlQueryExpression Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) =>
-        new SqlQueryExpression(t.NodeType,
+        new(t.NodeType,
           (ISqlQueryExpression)((SqlNode) t.left).Clone(c),
           (ISqlQueryExpression)((SqlNode) t.right).Clone(c), t.all));
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlSelect.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlSelect.cs
@@ -187,7 +187,7 @@ namespace Xtensive.Sql.Dml
     /// </summary>
     public bool HasOffset => Offset is not null;
 
-    internal override SqlSelect Clone(SqlNodeCloneContext context) =>
+    internal override SqlSelect Clone(SqlNodeCloneContext? context = null ) =>
       context.GetOrAdd(this, static (t, c) => {
         SqlSelect clone = new SqlSelect(t.from==null ? null : t.from.Clone(c));
 
@@ -211,7 +211,7 @@ namespace Xtensive.Sql.Dml
 
         if (t.Hints.Count > 0)
           foreach (SqlHint hint in t.Hints)
-            clone.Hints.Add((SqlHint)hint.Clone(c));
+            clone.Hints.Add(hint.Clone(c));
 
         return clone;
       });

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlStatementBlock.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlStatementBlock.cs
@@ -98,11 +98,11 @@ namespace Xtensive.Sql.Dml
 
     #endregion
 
-    internal override SqlStatementBlock Clone(SqlNodeCloneContext context) =>
+    internal override SqlStatementBlock Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) => {
-        SqlStatementBlock clone = new SqlStatementBlock();
+        SqlStatementBlock clone = new();
         foreach (SqlStatement s in t.statements)
-          clone.Add((SqlStatement) s.Clone(c));
+          clone.Add(s.Clone(c));
         return clone;
       });
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlUpdate.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlUpdate.cs
@@ -67,7 +67,7 @@ namespace Xtensive.Sql.Dml
       set { limit = value; }
     }
 
-    internal override SqlUpdate Clone(SqlNodeCloneContext context) =>
+    internal override SqlUpdate Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) => {
         var clone = new SqlUpdate();
         if (t.update != null)
@@ -83,7 +83,7 @@ namespace Xtensive.Sql.Dml
           clone.Limit = t.where.Clone(c);
         if (t.Hints.Count > 0)
           foreach (SqlHint hint in t.Hints)
-            clone.Hints.Add((SqlHint) hint.Clone(c));
+            clone.Hints.Add(hint.Clone(c));
 
         return clone;
       });

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlWhile.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlWhile.cs
@@ -43,11 +43,11 @@ namespace Xtensive.Sql.Dml
       }
     }
 
-    internal override SqlWhile Clone(SqlNodeCloneContext context) =>
+    internal override SqlWhile Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) => {
-        SqlWhile clone = new SqlWhile(t.condition.Clone(c));
+        SqlWhile clone = new(t.condition.Clone(c));
         if (t.statement!=null)
-          clone.Statement = (SqlStatement) t.statement.Clone(c);
+          clone.Statement = t.statement.Clone(c);
         return clone;
       });
     

--- a/Orm/Xtensive.Orm/Sql/Internals/SqlNodeCloneContext.cs
+++ b/Orm/Xtensive.Orm/Sql/Internals/SqlNodeCloneContext.cs
@@ -9,8 +9,8 @@ namespace Xtensive.Sql
 {
   internal readonly struct SqlNodeCloneContext
   {
-    private readonly Dictionary<SqlNode, SqlNode> nodeMapping;
-    
+    private readonly Dictionary<SqlNode, SqlNode> nodeMapping = new();
+
     public Dictionary<SqlNode, SqlNode> NodeMapping => nodeMapping;
 
     public T TryGet<T>(T node) where T : SqlNode =>
@@ -18,19 +18,22 @@ namespace Xtensive.Sql
         ? (T) clone
         : null;
 
-    public T GetOrAdd<T>(T node, Func<T, SqlNodeCloneContext, T> factory) where T : SqlNode
+    public SqlNodeCloneContext()
     {
-      if (NodeMapping.TryGetValue(node, out var clone)) {
-        return (T)clone;
-      }
-      var result = factory(node, this);
-      NodeMapping[node] = result;
-      return result;
     }
+  }
 
-    public SqlNodeCloneContext(bool _)
+  internal static class SqlNodeCloneContextExtensions
+  {
+    public static T GetOrAdd<T>(this SqlNodeCloneContext? context, T node, Func<T, SqlNodeCloneContext, T> factory) where T : SqlNode
     {
-      nodeMapping = new();
+      var ctx = context ?? new();
+      if (ctx.NodeMapping.TryGetValue(node, out var clone)) {
+        return (T) clone;
+      }
+      var result = factory(node, ctx);
+      ctx.NodeMapping[node] = result;
+      return result;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Sql/Model/SequenceDescriptor.cs
+++ b/Orm/Xtensive.Orm/Sql/Model/SequenceDescriptor.cs
@@ -140,10 +140,8 @@ namespace Xtensive.Sql.Model
     ///<returns>
     ///A new object that is a copy of this instance.
     ///</returns>
-    public object Clone()
-    {
-      return new SequenceDescriptor(owner, startValue, increment, maxValue, minValue, isCyclic);
-    }
+    public SequenceDescriptor Clone() => new(owner, startValue, increment, maxValue, minValue, isCyclic);
+    object ICloneable.Clone() => Clone();
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Sql/SqlNode.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlNode.cs
@@ -18,9 +18,9 @@ namespace Xtensive.Sql
     /// <value>The type of the node.</value>
     public SqlNodeType NodeType { get; internal set; }
 
-    object ICloneable.Clone() => Clone(new SqlNodeCloneContext(false));
+    object ICloneable.Clone() => Clone();
 
-    internal abstract SqlNode Clone(SqlNodeCloneContext context);
+    internal abstract SqlNode Clone(SqlNodeCloneContext? context = null);
 
     internal SqlNode(SqlNodeType nodeType)
     {
@@ -28,16 +28,5 @@ namespace Xtensive.Sql
     }
 
     public abstract void AcceptVisitor(ISqlVisitor visitor);
-  }
-
-  public static class SqlNodeExtensions
-  {
-    /// <summary>
-    /// Creates a new object that is a copy of the current instance.
-    /// </summary>
-    /// <returns>
-    /// A new object that is a copy of this instance.
-    /// </returns>
-    public static T Clone<T>(this T node) where T : SqlNode => (T) node.Clone(new SqlNodeCloneContext(false));
   }
 }

--- a/Orm/Xtensive.Orm/Sql/SqlNode.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlNode.cs
@@ -18,14 +18,6 @@ namespace Xtensive.Sql
     /// <value>The type of the node.</value>
     public SqlNodeType NodeType { get; internal set; }
 
-    /// <summary>
-    /// Creates a new object that is a copy of the current instance.
-    /// </summary>
-    /// <returns>
-    /// A new object that is a copy of this instance.
-    /// </returns>
-    public virtual SqlNode Clone() => Clone(new SqlNodeCloneContext(false));
-
     object ICloneable.Clone() => Clone(new SqlNodeCloneContext(false));
 
     internal abstract SqlNode Clone(SqlNodeCloneContext context);
@@ -36,5 +28,16 @@ namespace Xtensive.Sql
     }
 
     public abstract void AcceptVisitor(ISqlVisitor visitor);
+  }
+
+  public static class SqlNodeExtensions
+  {
+    /// <summary>
+    /// Creates a new object that is a copy of the current instance.
+    /// </summary>
+    /// <returns>
+    /// A new object that is a copy of this instance.
+    /// </returns>
+    public static T Clone<T>(this T node) where T : SqlNode => (T) node.Clone(new SqlNodeCloneContext(false));
   }
 }

--- a/Orm/Xtensive.Orm/Sql/SqlStatement.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlStatement.cs
@@ -12,6 +12,8 @@ namespace Xtensive.Sql
   [Serializable]
   public abstract class SqlStatement : SqlNode
   {
+    internal abstract override SqlStatement Clone(SqlNodeCloneContext? context = null);
+
     protected SqlStatement(SqlNodeType nodeType) : base(nodeType)
     {
     }

--- a/Orm/Xtensive.Orm/Tuples/DifferentialTuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/DifferentialTuple.cs
@@ -105,7 +105,7 @@ namespace Xtensive.Tuples
     internal void BackupDifference()
     {
       if (difference != null)
-        backupedDifference = (DifferentialTuple) this.Clone();
+        backupedDifference = this.Clone();
     }
 
     internal void DropBackedUpDifference()
@@ -176,13 +176,8 @@ namespace Xtensive.Tuples
     }
 
     /// <inheritdoc/>
-    public override Tuple Clone()
-    {
-      return new DifferentialTuple(
-        origin.Clone(), 
-        difference==null ? null : difference.Clone(), 
-        backupedDifference==null ? null : (DifferentialTuple) backupedDifference.Clone());
-    }
+    public override DifferentialTuple Clone() =>
+      new DifferentialTuple(origin.Clone(), difference?.Clone(), backupedDifference?.Clone());
 
     /// <summary>
     /// Resets all the changes in <see cref="Difference"/> by re-creating it.

--- a/Orm/Xtensive.Orm/Tuples/DifferentialTuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/DifferentialTuple.cs
@@ -177,7 +177,7 @@ namespace Xtensive.Tuples
 
     /// <inheritdoc/>
     public override DifferentialTuple Clone() =>
-      new DifferentialTuple(origin.Clone(), difference?.Clone(), backupedDifference?.Clone());
+      new(origin.Clone(), difference?.Clone(), backupedDifference?.Clone());
 
     /// <summary>
     /// Resets all the changes in <see cref="Difference"/> by re-creating it.


### PR DESCRIPTION
Also:
* Avoid safety wrapper in `TrackingItem`
* Parameterless constructor for `TrackingStackFrame` as allowed by C#10
* Convert `ChangedValue` into record syntax
* Check `source.RawData != null` in `TrackingItem.MergeWith()` as see flaky NRE https://teamcity.st.dev/buildConfiguration/Services_ServiceTitan_TestBackend/4936620?expandBuildDeploymentsSection=false&hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true