### PR TITLE
Optimization: replace `.ToChainedBuffer()` by `.ToList()`

### DIFF
--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/QueryOperation.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/QueryOperation.cs
@@ -145,7 +145,7 @@ namespace Xtensive.Orm.BulkOperations
           var ex = SqlDml.Equals(s.From.Columns[column.Name], table.Columns[column.Name]);
           s.Where = s.Where is null ? ex : SqlDml.And(s.Where, ex);
         }
-        var existingColumns = s.Columns.ToChainedBuffer();
+        var existingColumns = s.Columns.ToList();
         s.Columns.Clear();
         var columnToAdd = existingColumns.First(c => c.Name.Equals(columnInfo.Name, StringComparison.Ordinal));
         s.Columns.Add(columnToAdd);

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.ClassTable.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.ClassTable.cs
@@ -54,7 +54,7 @@ namespace Xtensive.Orm.Building.Builders
 
       // Building inherited from interfaces indexes
       foreach (var @interface in interfaces) {
-        foreach (var interfaceIndex in @interface.Indexes.Find(IndexAttributes.Primary, MatchType.None).ToChainedBuffer()) {
+        foreach (var interfaceIndex in @interface.Indexes.Find(IndexAttributes.Primary, MatchType.None).ToList()) {
           if (interfaceIndex.DeclaringIndex != interfaceIndex &&
               parent != null &&
               parent.Indexes.Any(i => i.DeclaringIndex == interfaceIndex)) {
@@ -78,7 +78,7 @@ namespace Xtensive.Orm.Building.Builders
 
       // Build typed indexes
       if (type == root) {
-        foreach (var realIndex in type.Indexes.Find(IndexAttributes.Real).ToChainedBuffer()) {
+        foreach (var realIndex in type.Indexes.Find(IndexAttributes.Real).ToList()) {
           if (!untypedIndexes.Contains(realIndex)) {
             continue;
           }
@@ -130,7 +130,7 @@ namespace Xtensive.Orm.Building.Builders
       // Build virtual secondary index
       var primaryOrVirtualIndexes = ancestors
         .SelectMany(
-          ancestor => ancestor.Indexes.Find(IndexAttributes.Primary | IndexAttributes.Virtual, MatchType.None).ToChainedBuffer());
+          ancestor => ancestor.Indexes.Find(IndexAttributes.Primary | IndexAttributes.Virtual, MatchType.None).ToList());
 
       foreach (var ancestorIndex in primaryOrVirtualIndexes) {
         if (ancestorIndex.DeclaringIndex != ancestorIndex) {

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.ConcreteTable.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.ConcreteTable.cs
@@ -56,7 +56,7 @@ namespace Xtensive.Orm.Building.Builders
 
       // Building inherited from interfaces indexes
       foreach (var @interface in type.AllInterfaces) {
-        foreach (var parentIndex in @interface.Indexes.Find(IndexAttributes.Primary, MatchType.None).ToChainedBuffer()) {
+        foreach (var parentIndex in @interface.Indexes.Find(IndexAttributes.Primary, MatchType.None).ToList()) {
           if (parentIndex.DeclaringIndex != parentIndex) {
             continue;
           }
@@ -75,7 +75,7 @@ namespace Xtensive.Orm.Building.Builders
       }
 
       // Build typed indexes
-      foreach (var realIndex in type.Indexes.Find(IndexAttributes.Real).ToChainedBuffer()) {
+      foreach (var realIndex in type.Indexes.Find(IndexAttributes.Real).ToList()) {
         if (!untypedIndexes.Contains(realIndex)) {
           continue;
         }
@@ -104,7 +104,7 @@ namespace Xtensive.Orm.Building.Builders
       // Build inherited secondary indexes
       var primaryOrVirtualIndexes = ancestors
         .SelectMany(
-          ancestor => ancestor.Indexes.Find(IndexAttributes.Primary | IndexAttributes.Virtual, MatchType.None).ToChainedBuffer());
+          ancestor => ancestor.Indexes.Find(IndexAttributes.Primary | IndexAttributes.Virtual, MatchType.None).ToList());
 
       foreach (var ancestorIndex in primaryOrVirtualIndexes) {
         if (ancestorIndex.DeclaringIndex != ancestorIndex) {
@@ -127,7 +127,7 @@ namespace Xtensive.Orm.Building.Builders
 
       // Build virtual secondary indexes
       if (descendants.Count > 0) {
-        foreach (var index in type.Indexes.Where(static i => !i.IsPrimary && !i.IsVirtual).ToChainedBuffer()) {
+        foreach (var index in type.Indexes.Where(static i => !i.IsPrimary && !i.IsVirtual).ToList()) {
           var isUntyped = untypedIndexes.Contains(index);
           var indexToUnion = isUntyped
             ? type.Indexes.Single(i => i.DeclaringIndex == index.DeclaringIndex && i.IsTyped)

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.SingleTable.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.SingleTable.cs
@@ -44,7 +44,7 @@ namespace Xtensive.Orm.Building.Builders
       var parent = type.Ancestor;
       // Building inherited from interfaces indexes
       foreach (var @interface in type.DirectInterfaces) {
-        foreach (var interfaceIndex in @interface.Indexes.Find(IndexAttributes.Primary, MatchType.None).ToChainedBuffer()) {
+        foreach (var interfaceIndex in @interface.Indexes.Find(IndexAttributes.Primary, MatchType.None).ToList()) {
           if (root.Indexes.Any(i => i.DeclaringIndex == interfaceIndex.DeclaringIndex && i.ReflectedType == type)) {
             continue;
           }
@@ -59,7 +59,7 @@ namespace Xtensive.Orm.Building.Builders
       _ = types.Add(type);
 
       // Build typed indexes
-      foreach (var realIndex in root.Indexes.Find(IndexAttributes.Real).ToChainedBuffer()) {
+      foreach (var realIndex in root.Indexes.Find(IndexAttributes.Real).ToList()) {
         if (!types.Contains(realIndex.ReflectedType)) {
           continue;
         }
@@ -95,7 +95,7 @@ namespace Xtensive.Orm.Building.Builders
         .Select(i => untypedIndexes.Contains(i)
           ? root.Indexes.Single(index => index.DeclaringIndex == i.DeclaringIndex && index.ReflectedType == type && index.IsTyped)
           : i)
-        .ToChainedBuffer();
+        .ToList();
       foreach (var ancestorIndex in ancestorIndexes) {
         if (type.Indexes.Any(i =>
             i.DeclaringIndex == ancestorIndex.DeclaringIndex &&

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
@@ -89,7 +89,7 @@ namespace Xtensive.Orm.Building.Builders
 
       // Build virtual inherited interface index
       foreach (var parent in interfaces) {
-        foreach (var parentIndex in parent.Indexes.Find(IndexAttributes.Primary, MatchType.None).ToChainedBuffer()) {
+        foreach (var parentIndex in parent.Indexes.Find(IndexAttributes.Primary, MatchType.None).ToList()) {
           var index = BuildInheritedIndex(@interface, parentIndex, false);
           if (@interface.Indexes.Contains(index.Name)) {
             index.Dispose();
@@ -747,7 +747,7 @@ namespace Xtensive.Orm.Building.Builders
       var actualColumnMapping = valueColumns
         .Zip(columnMap, static (column, sourceIndex) => (column, sourceIndex))
         .OrderBy(p => reflectedType.Columns.IndexOf(p.column))
-        .ToChainedBuffer();
+        .ToList();
       valueColumns.Clear();
       columnMap.Clear();
       columnMap.AddRange(CollectionUtils.ColNumRange(keyLength));
@@ -893,7 +893,7 @@ namespace Xtensive.Orm.Building.Builders
       var primaryIndex = typeInfo.Indexes.PrimaryIndex;
       foreach (var descendant in typeInfo.AllDescendants.Where(static t => t.IsEntity)) {
         descendant.AffectedIndexes.Add(primaryIndex);
-        foreach (var indexInfo in typeInfo.Indexes.Find(IndexAttributes.Primary, MatchType.None).ToChainedBuffer()) {
+        foreach (var indexInfo in typeInfo.Indexes.Find(IndexAttributes.Primary, MatchType.None).ToList()) {
           var descendantIndex = descendant.Indexes.Where(i => i.DeclaringIndex == indexInfo.DeclaringIndex).FirstOrDefault();
           if (descendantIndex != null) {
             foreach (var pair in descendantIndex.KeyColumns) {

--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/BatchingCommandProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/BatchingCommandProcessor.cs
@@ -35,7 +35,7 @@ namespace Xtensive.Orm.Providers
         context.CurrentTask = null;
         return;
       }
-      var sequence = Factory.CreatePersistParts(task, GetParameterPrefix(context)).ToChainedBuffer();
+      var sequence = Factory.CreatePersistParts(task, GetParameterPrefix(context)).ToList();
       if (PendCommandParts(context.ActiveCommand, sequence)) {
         // higly recommended to no tear apart persist actions if they are batchable
         return;

--- a/Orm/Xtensive.Orm/Orm/StorageNodeManager.cs
+++ b/Orm/Xtensive.Orm/Orm/StorageNodeManager.cs
@@ -69,7 +69,7 @@ namespace Xtensive.Orm
         }
 
         var queryCache = (Caching.FastConcurrentLruCache<object, Pair<object, Linq.ParameterizedQuery>>) handlers.Domain.QueryCache;
-        foreach (var key in queryCache.Keys.Where(k => k is Pair<object, string> pair && pair.Second == nodeId).ToChainedBuffer()) {
+        foreach (var key in queryCache.Keys.Where(k => k is Pair<object, string> pair && pair.Second == nodeId).ToList()) {
           queryCache.RemoveKey(key);
         }
       }

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SqlWorker.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SqlWorker.cs
@@ -104,8 +104,8 @@ namespace Xtensive.Orm.Upgrade
     {
       var driver = services.StorageDriver;
       var extractionResult = ExtractSchema(services, executor);
-      var schemas = extractionResult.Catalogs.SelectMany(c => c.Schemas).ToChainedBuffer();
-      var tables = schemas.SelectMany(s => s.Tables).ToChainedBuffer();
+      var schemas = extractionResult.Catalogs.SelectMany(c => c.Schemas).ToList();
+      var tables = schemas.SelectMany(s => s.Tables).ToList();
       var sequences = schemas.SelectMany(s => s.Sequences);
 
       DropForeignKeys(driver, tables, executor);
@@ -116,7 +116,7 @@ namespace Xtensive.Orm.Upgrade
     private static void DropSequences(StorageDriver driver, IEnumerable<Sequence> sequences, ISqlExecutor executor)
     {
       var statements = BreakEvery(sequences
-        .Select(s => driver.Compile(SqlDdl.Drop(s)).GetCommandText()), 25).ToChainedBuffer();
+        .Select(s => driver.Compile(SqlDdl.Drop(s)).GetCommandText()), 25).ToList();
       executor.ExecuteMany(statements);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/UpgradeHintsProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/UpgradeHintsProcessor.cs
@@ -77,8 +77,8 @@ namespace Xtensive.Orm.Upgrade.Internals
 
     private void ProcessFieldChanges()
     {
-      var renameFieldHints = hints.GetItems<RenameFieldHint>().ToChainedBuffer();
-      var changeFieldTypeHints = hints.GetItems<ChangeFieldTypeHint>().ToChainedBuffer();
+      var renameFieldHints = hints.GetItems<RenameFieldHint>().ToList();
+      var changeFieldTypeHints = hints.GetItems<ChangeFieldTypeHint>().ToList();
       BuildFieldMapping(renameFieldHints, changeFieldTypeHints);
     }
 
@@ -89,7 +89,7 @@ namespace Xtensive.Orm.Upgrade.Internals
 
     private void ProcessFieldMovements()
     {
-      var moveFieldHints = hints.GetItems<MoveFieldHint>().ToChainedBuffer();
+      var moveFieldHints = hints.GetItems<MoveFieldHint>().ToList();
       hints.AddRange(RewriteMoveFieldHints(moveFieldHints));
       hints.AddRange(GenerateTypeIdFieldRemoveHintsForConcreteTable());
     }
@@ -269,7 +269,7 @@ namespace Xtensive.Orm.Upgrade.Internals
       }
 
       // Will be modified, so we need to copy sequence into independant collection
-      foreach (var pair in fieldMapping.ToChainedBuffer()) {
+      foreach (var pair in fieldMapping.ToList()) {
         MapNestedFields(pair.Key, pair.Value);
       }
     }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 { 
   "sdk": {
-    "allowPrerelease": true,
-    "version": "7.0.302",
+    "allowPrerelease": false,
+    "version": "8.0.302",
     "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
Algorithms of `ChainedBuffer>?` & `List<>` are similar (exponential grow) 
But `ChainedBuffer` makes 2 allocations on every grow-step (for `Node` & array)
and `List<>` makes 1 allocation + memory copy
And memory copying (especially very small chunks) as in DO is cheaper than garbage-collecting yet one object

Also `ChainedBuffer`  Enumerator creates more allocations that `List<>`'s which is optimized

