### PR TITLE
Optimize `PrefetchFieldDescriptor` lists

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchTestHelper.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchTestHelper.cs
@@ -98,13 +98,13 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
     internal static void InvokePrefetch(this PrefetchManager prefetchManager, Key key, TypeInfo type,
       params PrefetchFieldDescriptor[] descriptors)
     {
-      prefetchManager.Prefetch(key, type, new List<PrefetchFieldDescriptor>(descriptors));
+      prefetchManager.Prefetch(key, type, descriptors);
     }
 
     public static void InvokePrefetch(this SessionHandler sessionHandler, Key key, TypeInfo type,
       params PrefetchFieldDescriptor[] descriptors)
     {
-      sessionHandler.Prefetch(key, type, new List<PrefetchFieldDescriptor>(descriptors));
+      sessionHandler.Prefetch(key, type, descriptors);
     }
 
     public static void FillDataBase(Session session)

--- a/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
+++ b/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
@@ -44,7 +44,6 @@ namespace Xtensive.Orm
 
     private static readonly Func<FieldInfo, EntitySetBase, EntitySetTypeState> EntitySetTypeStateFactory = BuildEntitySetTypeState;
 
-    private readonly Entity owner;
     private readonly CombineTransform auxilaryTypeKeyTransform;
     private readonly bool skipOwnerVersionChange;
     private bool isInitialized;
@@ -52,7 +51,7 @@ namespace Xtensive.Orm
     /// <summary>
     /// Gets the owner of this instance.
     /// </summary>
-    public Entity Owner => owner;
+    public Entity Owner { get; }
 
     /// <inheritdoc/>
     Persistent IFieldValueAdapter.Owner => Owner;
@@ -857,7 +856,7 @@ namespace Xtensive.Orm
       }
 
       var parameterContext = new ParameterContext();
-      parameterContext.SetValue(ownerParameter, owner);
+      parameterContext.SetValue(ownerParameter, Owner);
 
       var cachedState = GetEntitySetTypeState();
       State.TotalItemCount = Session.Query.Execute(cachedState, cachedState.ItemCountQuery, parameterContext);
@@ -1026,7 +1025,7 @@ namespace Xtensive.Orm
     protected EntitySetBase(Entity owner, FieldInfo field)
       : base(owner.Session)
     {
-      this.owner = owner;
+      Owner = owner;
       Field = field;
       State = new EntitySetState(this);
       var association = Field.Associations.Last();

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntitySetTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntitySetTask.cs
@@ -257,11 +257,10 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     // Constructors
 
-    public EntitySetTask(Key ownerKey, PrefetchFieldDescriptor referencingFieldDescriptor, bool isOwnerCached,
+    public EntitySetTask(Key ownerKey, in PrefetchFieldDescriptor referencingFieldDescriptor, bool isOwnerCached,
       PrefetchManager manager)
     {
       ArgumentValidator.EnsureArgumentNotNull(ownerKey, "ownerKey");
-      ArgumentValidator.EnsureArgumentNotNull(referencingFieldDescriptor, "referencingFieldDescriptor");
       ArgumentValidator.EnsureArgumentNotNull(manager, "processor");
 
       this.ownerKey = ownerKey;

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/GraphContainer.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/GraphContainer.cs
@@ -59,12 +59,12 @@ namespace Xtensive.Orm.Internals.Prefetch
     }
 
     public void RegisterReferencedEntityContainer(
-      EntityState ownerState, PrefetchFieldDescriptor referencingFieldDescriptor)
+      EntityState ownerState, in PrefetchFieldDescriptor referencingFieldDescriptor)
     {
-      if (referencedEntityContainers != null
-        && referencedEntityContainers.ContainsKey(referencingFieldDescriptor.Field))
+      var field = referencingFieldDescriptor.Field;
+      if (referencedEntityContainers?.ContainsKey(field) == true)
         return;
-      if (!AreAllForeignKeyColumnsLoaded(ownerState, referencingFieldDescriptor.Field))
+      if (!AreAllForeignKeyColumnsLoaded(ownerState, field))
         RegisterFetchByUnknownForeignKey(referencingFieldDescriptor);
       else
         RegisterFetchByKnownForeignKey(referencingFieldDescriptor, ownerState);
@@ -72,8 +72,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     public void RegisterEntitySetTask(EntityState ownerState, in PrefetchFieldDescriptor referencingFieldDescriptor)
     {
-      if (entitySetTasks == null)
-        entitySetTasks = new Dictionary<FieldInfo, EntitySetTask>();
+      entitySetTasks ??= new();
       if (RootEntityContainer == null)
         AddEntityColumns(Key.TypeReference.Type.Fields
           .Where(field => field.IsPrimaryKey || field.IsSystem).SelectMany(field => field.Columns));

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/GraphContainer.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/GraphContainer.cs
@@ -70,7 +70,7 @@ namespace Xtensive.Orm.Internals.Prefetch
         RegisterFetchByKnownForeignKey(referencingFieldDescriptor, ownerState);
     }
 
-    public void RegisterEntitySetTask(EntityState ownerState, PrefetchFieldDescriptor referencingFieldDescriptor)
+    public void RegisterEntitySetTask(EntityState ownerState, in PrefetchFieldDescriptor referencingFieldDescriptor)
     {
       if (entitySetTasks == null)
         entitySetTasks = new Dictionary<FieldInfo, EntitySetTask>();
@@ -138,7 +138,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       return true;
     }
 
-    private void RegisterFetchByKnownForeignKey(PrefetchFieldDescriptor referencingFieldDescriptor,
+    private void RegisterFetchByKnownForeignKey(in PrefetchFieldDescriptor referencingFieldDescriptor,
       EntityState ownerState)
     {
       var association = referencingFieldDescriptor.Field.Associations.Last();
@@ -173,10 +173,9 @@ namespace Xtensive.Orm.Internals.Prefetch
         graphContainer.RootEntityContainer.SetParametersOfReference(referencingFieldDescriptor, referencedKey);
     }
 
-    private void RegisterFetchByUnknownForeignKey(PrefetchFieldDescriptor referencingFieldDescriptor)
+    private void RegisterFetchByUnknownForeignKey(in PrefetchFieldDescriptor referencingFieldDescriptor)
     {
-      if (referencedEntityContainers == null)
-        referencedEntityContainers = new Dictionary<FieldInfo, ReferencedEntityContainer>();
+      referencedEntityContainers ??= new();
       referencedEntityContainers.Add(referencingFieldDescriptor.Field, new ReferencedEntityContainer(Key,
         referencingFieldDescriptor, exactType, Manager));
     }

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchFieldDescriptor.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchFieldDescriptor.cs
@@ -15,7 +15,7 @@ namespace Xtensive.Orm.Internals.Prefetch
   /// Descriptor of a field's fetching request.
   /// </summary>
   [Serializable]
-  public sealed class PrefetchFieldDescriptor
+  public readonly struct PrefetchFieldDescriptor
   {
     private readonly Action<Key, FieldInfo, Key> keyExtractionSubscriber;
 
@@ -46,27 +46,17 @@ namespace Xtensive.Orm.Internals.Prefetch
     public readonly Guid? PrefetchOperationId;
 
     /// <inheritdoc/>
-    public bool Equals(PrefetchFieldDescriptor other)
-    {
-      return Equals(other.Field, Field);
-    }
+    public bool Equals(PrefetchFieldDescriptor other) => Field.Equals(other.Field);
 
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
       obj is PrefetchFieldDescriptor other && Equals(other);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      return Field.GetHashCode();
-    }
+    public override int GetHashCode() => Field.GetHashCode();
 
-    internal void NotifySubscriber(Key ownerKey, Key referencedKey)
-    {
-      if (keyExtractionSubscriber != null) {
-        keyExtractionSubscriber.Invoke(ownerKey, Field, referencedKey);
-      }
-    }
+    internal void NotifySubscriber(Key ownerKey, Key referencedKey) =>
+      keyExtractionSubscriber?.Invoke(ownerKey, Field, referencedKey);
 
 
     // Constructors
@@ -136,18 +126,8 @@ namespace Xtensive.Orm.Internals.Prefetch
       bool fetchFieldsOfReferencedEntity,
       bool fetchLazyFields,
       Action<Key, FieldInfo, Key> keyExtractionSubscriber)
-    {
-      ArgumentValidator.EnsureArgumentNotNull(field, "field");
-      if (entitySetItemCountLimit != null) {
-        ArgumentValidator.EnsureArgumentIsGreaterThan(entitySetItemCountLimit.Value, 0,
-          "entitySetItemCountLimit");
-      }
-      Field = field;
-      FetchFieldsOfReferencedEntity = fetchFieldsOfReferencedEntity;
-      EntitySetItemCountLimit = entitySetItemCountLimit;
-      FetchLazyFields = fetchLazyFields;
-      this.keyExtractionSubscriber = keyExtractionSubscriber;
-    }
+      : this(field, entitySetItemCountLimit, fetchFieldsOfReferencedEntity, fetchLazyFields, keyExtractionSubscriber, null)
+    {}
 
     /// <summary>
     /// Initializes a new instance of this class.
@@ -172,10 +152,9 @@ namespace Xtensive.Orm.Internals.Prefetch
       Action<Key, FieldInfo, Key> keyExtractionSubscriber,
       Guid? prefetchOperationId)
     {
-      ArgumentValidator.EnsureArgumentNotNull(field, "field");
+      ArgumentNullException.ThrowIfNull(field);
       if (entitySetItemCountLimit != null) {
-        ArgumentValidator.EnsureArgumentIsGreaterThan(entitySetItemCountLimit.Value, 0,
-          "entitySetItemCountLimit");
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(entitySetItemCountLimit.Value, 0);
       }
       Field = field;
       FetchFieldsOfReferencedEntity = fetchFieldsOfReferencedEntity;

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchFieldDescriptor.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchFieldDescriptor.cs
@@ -5,7 +5,6 @@
 // Created:    2009.09.23
 
 using System;
-using Xtensive.Core;
 
 using Xtensive.Orm.Model;
 

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/ReferencedEntityContainer.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/ReferencedEntityContainer.cs
@@ -116,11 +116,10 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     // Constructors
 
-    public ReferencedEntityContainer(Key ownerKey, PrefetchFieldDescriptor referencingFieldDescriptor,
+    public ReferencedEntityContainer(Key ownerKey, in PrefetchFieldDescriptor referencingFieldDescriptor,
       bool isOwnerTypeKnown, PrefetchManager manager)
       : base(null, referencingFieldDescriptor.Field.Associations.Last().TargetType, true, manager)
     {
-      ArgumentValidator.EnsureArgumentNotNull(referencingFieldDescriptor, "referencingFieldDescriptor");
       ArgumentValidator.EnsureArgumentNotNull(ownerKey, "ownerKey");
       this.ownerKey = ownerKey;
       this.referencingFieldDescriptor = referencingFieldDescriptor;

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/RootEntityContainer.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/RootEntityContainer.cs
@@ -26,7 +26,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       return Task;
     }
 
-    public void SetParametersOfReference(PrefetchFieldDescriptor referencingField, Key key)
+    public void SetParametersOfReference(in PrefetchFieldDescriptor referencingField, Key key)
     {
       referencingFieldDescriptor = referencingField;
       ownerKey = key;

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationHelper.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationHelper.cs
@@ -107,10 +107,11 @@ namespace Xtensive.Orm.Linq.Materialization
     public static TEntitySet PrefetechEntitySet<TEntitySet>(TEntitySet entitySet, ItemMaterializationContext context)
       where TEntitySet : EntitySetBase
     {
+      var owner = entitySet.Owner;
       context.Session.Handler.Prefetch(
-        entitySet.Owner.Key,
-        entitySet.Owner.TypeInfo,
-        new List<PrefetchFieldDescriptor>{new PrefetchFieldDescriptor(entitySet.Field, WellKnown.EntitySetPreloadCount)});
+        owner.Key,
+        owner.TypeInfo,
+        [new(entitySet.Field, WellKnown.EntitySetPreloadCount)]);
       return entitySet;
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.Fetching.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.Fetching.cs
@@ -80,8 +80,7 @@ namespace Xtensive.Orm.Providers
     public override void FetchField(Key key, FieldInfo field)
     {
       var type = key.TypeReference.Type;
-      var descriptor = new PrefetchFieldDescriptor(field, false, false);
-      var descriptors = new List<PrefetchFieldDescriptor> {descriptor};
+      PrefetchFieldDescriptor[] descriptors = [new(field, false, false)];
       prefetchManager.Prefetch(key, type, descriptors);
       prefetchManager.ExecuteTasks(true);
     }
@@ -96,8 +95,7 @@ namespace Xtensive.Orm.Providers
     public override void FetchEntitySet(Key ownerKey, FieldInfo field, int? itemCountLimit)
     {
       var ownerType = ownerKey.TypeReference.Type;
-      var descriptor = new PrefetchFieldDescriptor(field, itemCountLimit);
-      var descriptors = new List<PrefetchFieldDescriptor> { descriptor };
+      PrefetchFieldDescriptor[] descriptors = [new(field, itemCountLimit)];
       Session.Handler.Prefetch(ownerKey, ownerType, descriptors);
       Session.Handler.ExecutePrefetchTasks();
     }


### PR DESCRIPTION
* Use arrays instead of `List<>` to save allocations
* convert `PrefetchFieldDescriptor` to `readonly struct`