### PR TITLE
Optimize `NotifyQueryExecuting`: don't allocate `QueryEventArgs` is there are no event handlers

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Session.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.cs
@@ -447,14 +447,7 @@ namespace Xtensive.Orm
     #region IHasExtensions members
 
     /// <inheritdoc/>
-    public IExtensionCollection Extensions
-    {
-      get {
-        if (extensions == null)
-          extensions = new ExtensionCollection();
-        return extensions;
-      }
-    }
+    public IExtensionCollection Extensions => extensions ??= new ExtensionCollection();
 
     #endregion
 
@@ -666,7 +659,7 @@ namespace Xtensive.Orm
         EntityStateCache = null;
         ReferenceFieldsChangesRegistry = null;
         NonPairedReferencesRegistry = null;
-        Extensions.Clear();
+        extensions?.Clear();
       }
       finally {
         isDisposed = true;

--- a/Orm/Xtensive.Orm/Orm/SessionEventAccessor.cs
+++ b/Orm/Xtensive.Orm/Orm/SessionEventAccessor.cs
@@ -274,6 +274,9 @@ namespace Xtensive.Orm
 
     internal Expression NotifyQueryExecuting(Expression expression)
     {
+      if (QueryExecuting == null) {
+        return expression;
+      }
       var args = new QueryEventArgs(expression);
       QueryExecuting?.Invoke(this, args);
       return args.Expression;

--- a/Orm/Xtensive.Orm/Orm/SessionEventAccessor.cs
+++ b/Orm/Xtensive.Orm/Orm/SessionEventAccessor.cs
@@ -278,7 +278,7 @@ namespace Xtensive.Orm
         return expression;
       }
       var args = new QueryEventArgs(expression);
-      QueryExecuting?.Invoke(this, args);
+      QueryExecuting.Invoke(this, args);
       return args.Expression;
     }
 


### PR DESCRIPTION
Also:
* Don't create `ExtensionCollection()` on `Session` disposing if `Session.extensions == null`