### PR TITLE
Optimization: Get rid of `Domain.KeyCache`

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Configuration/AppConfigTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Configuration/AppConfigTest.cs
@@ -269,7 +269,6 @@ namespace Xtensive.Orm.Tests.Configuration
       Assert.That(actual.ForcedServerVersion, Is.EqualTo(expected.ForcedServerVersion));
       Assert.That(actual.ForeignKeyMode, Is.EqualTo(expected.ForeignKeyMode));
       Assert.That(actual.IncludeSqlInExceptions, Is.EqualTo(expected.IncludeSqlInExceptions));
-      Assert.That(actual.KeyCacheSize, Is.EqualTo(expected.KeyCacheSize));
       Assert.That(actual.KeyGeneratorCacheSize, Is.EqualTo(expected.KeyGeneratorCacheSize));
       Assert.That(actual.QueryCacheSize, Is.EqualTo(expected.QueryCacheSize));
       Assert.That(actual.RecordSetMappingCacheSize, Is.EqualTo(expected.RecordSetMappingCacheSize));

--- a/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchDelayedElementsTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchDelayedElementsTest.cs
@@ -62,11 +62,6 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
         var count = 0;
         foreach (var person in persons) {
           count++;
-          Key cachedKey;
-          Assert.IsTrue(Domain.KeyCache.TryGetItem(person.Key, true, out cachedKey));
-          Assert.IsTrue(cachedKey.HasExactType);
-          PrefetchTestHelper.AssertOnlySpecifiedColumnsAreLoaded(person.Key, cachedKey.TypeInfo, session,
-            PrefetchTestHelper.IsFieldToBeLoadedByDefault);
         }
         Assert.AreEqual(keys.Count, count);
       }

--- a/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchWithSmallCacheTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchWithSmallCacheTest.cs
@@ -24,7 +24,6 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
       var config = base.BuildConfiguration();
       config.Sessions.Default.CacheType = SessionCacheType.LruWeak;
       config.Sessions.Default.CacheSize = 2;
-      config.KeyCacheSize = 2;
       config.UpgradeMode = DomainUpgradeMode.Recreate;
       config.Types.Register(typeof(Supplier).Assembly, typeof(Supplier).Namespace);
       return config;

--- a/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
@@ -24,12 +24,6 @@ namespace Xtensive.Orm.Configuration
     #region Defaults
 
     /// <summary>
-    /// Default <see cref="DomainConfiguration.KeyCacheSize"/> value:
-    /// <see langword="16*1024" />.
-    /// </summary>
-    public const int DefaultKeyCacheSize = 16 * 1024;
-
-    /// <summary>
     /// Default <see cref="DomainConfiguration.KeyGeneratorCacheSize"/> value:
     /// <see langword="128" />.
     /// </summary>
@@ -135,7 +129,6 @@ namespace Xtensive.Orm.Configuration
     private LinqExtensionRegistry linqExtensions = new();
     private SessionConfigurationCollection sessions = new();
     private NamingConvention namingConvention = new();
-    private int keyCacheSize = DefaultKeyCacheSize;
     private int keyGeneratorCacheSize = DefaultKeyGeneratorCacheSize;
     private int queryCacheSize = DefaultQueryCacheSize;
     private int recordSetMappingCacheSize = DefaultRecordSetMappingCacheSize;
@@ -275,20 +268,6 @@ namespace Xtensive.Orm.Configuration
       set {
         EnsureNotLocked();
         namingConvention = value;
-      }
-    }
-
-    /// <summary>
-    /// Gets or sets the size of the key cache.
-    /// Default value is <see cref="DefaultKeyCacheSize"/>.
-    /// </summary>
-    public int KeyCacheSize
-    {
-      get => keyCacheSize;
-      set {
-        EnsureNotLocked();
-        ArgumentValidator.EnsureArgumentIsGreaterThan(value, 0, "value");
-        keyCacheSize = value;
       }
     }
 
@@ -783,7 +762,6 @@ namespace Xtensive.Orm.Configuration
       types = configuration.Types.Clone();
       linqExtensions = configuration.LinqExtensions.Clone();
       namingConvention = configuration.NamingConvention.Clone();
-      keyCacheSize = configuration.KeyCacheSize;
       keyGeneratorCacheSize = configuration.KeyGeneratorCacheSize;
       queryCacheSize = configuration.QueryCacheSize;
       recordSetMappingCacheSize = configuration.RecordSetMappingCacheSize;

--- a/Orm/Xtensive.Orm/Orm/Configuration/Elements/DomainConfigurationElement.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/Elements/DomainConfigurationElement.cs
@@ -24,7 +24,6 @@ namespace Xtensive.Orm.Configuration.Elements
     private const string ConnectionUrlElementName = "connectionUrl";
     private const string TypesElementName = "types";
     private const string NamingConventionElementName = "namingConvention";
-    private const string KeyCacheSizeElementName = "keyCacheSize";
     private const string KeyGeneratorCacheSizeElementName = "generatorCacheSize";
     private const string QueryCacheSizeElementName = "queryCacheSize";
     private const string RecordSetMappingCacheSizeElementName = "recordSetMappingCacheSizeSize";
@@ -117,17 +116,6 @@ namespace Xtensive.Orm.Configuration.Elements
     {
       get { return (NamingConventionElement) this[NamingConventionElementName]; }
       set { this[NamingConventionElementName] = value; }
-    }
-
-    /// <summary>
-    /// <see cref="DomainConfiguration.KeyCacheSize" copy="true"/>
-    /// </summary>
-    [ConfigurationProperty(KeyCacheSizeElementName, DefaultValue = DomainConfiguration.DefaultKeyCacheSize)]
-    [IntegerValidator(MinValue = 1, MaxValue = int.MaxValue)]
-    public int KeyCacheSize
-    {
-      get { return (int) this[KeyCacheSizeElementName]; }
-      set { this[KeyCacheSizeElementName] = value; }
     }
 
     /// <summary>
@@ -446,7 +434,6 @@ namespace Xtensive.Orm.Configuration.Elements
         Name = Name,
         ConnectionInfo = ConnectionInfoParser.GetConnectionInfo(CurrentConfiguration, ConnectionUrl, Provider, ConnectionString),
         NamingConvention = NamingConvention.ToNative(),
-        KeyCacheSize = KeyCacheSize,
         KeyGeneratorCacheSize = KeyGeneratorCacheSize,
         QueryCacheSize = QueryCacheSize,
         RecordSetMappingCacheSize = RecordSetMappingCacheSize,

--- a/Orm/Xtensive.Orm/Orm/Domain.cs
+++ b/Orm/Xtensive.Orm/Orm/Domain.cs
@@ -132,8 +132,6 @@ namespace Xtensive.Orm
 
     internal FastConcurrentLruCache<object, Pair<object, ParameterizedQuery>> QueryCache { get; }
 
-    internal ICache<Key, Key> KeyCache { get; private set; }
-
     internal object UpgradeContextCookie { get; private set; }
 
     internal SqlConnection SingleConnection { get; private set; }
@@ -414,7 +412,6 @@ namespace Xtensive.Orm
       GenericKeyFactories = new ConcurrentDictionary<TypeInfo, GenericKeyFactory>();
       EntityDataReader = new EntityDataReader(this);
       KeyGenerators = new KeyGeneratorRegistry();
-      KeyCache = new LruCache<Key, Key>(Configuration.KeyCacheSize, k => k);
       QueryCache = new FastConcurrentLruCache<object, Pair<object, ParameterizedQuery>>(Configuration.QueryCacheSize, k => k.First);
       PrefetchActionMap = new Dictionary<TypeInfo, Action<SessionHandler, IEnumerable<Key>>>();
       Extensions = new ExtensionCollection();

--- a/Orm/Xtensive.Orm/Orm/Internals/EntityDataReader.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/EntityDataReader.cs
@@ -83,14 +83,13 @@ namespace Xtensive.Orm.Internals
       }
       var typeMapping = context.GetTypeMapping(groupIndex, mapping.ApproximateType, typeId, mapping.Columns);
 
-      bool canCache = accuracy == TypeReferenceAccuracy.ExactType;
       var keyTuple = tuple;
       var keyIndexes = typeMapping.KeyIndexes;
       if (typeMapping.KeyTransform.Descriptor.Count > WellKnown.MaxGenericKeyLength) {
         keyTuple = typeMapping.KeyTransform.Apply(TupleTransformType.TransformedTuple, tuple);
         keyIndexes = null;
       }
-      var key = KeyFactory.Materialize(Domain, context.Session.StorageNodeId, typeMapping.Type, keyTuple, accuracy, canCache, keyIndexes);
+      var key = KeyFactory.Materialize(Domain, context.Session.StorageNodeId, typeMapping.Type, keyTuple, accuracy, keyIndexes);
       return new Pair<Key, Tuple>(
         key,
         accuracy == TypeReferenceAccuracy.ExactType

--- a/Orm/Xtensive.Orm/Orm/Internals/KeyFactory.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/KeyFactory.cs
@@ -29,13 +29,13 @@ namespace Xtensive.Orm.Internals
       if (keyGenerator==null)
         throw new InvalidOperationException(String.Format(Strings.ExUnableToCreateKeyForXHierarchy, typeInfo.Hierarchy));
       var keyValue = keyGenerator.GenerateKey(typeInfo.Key, session);
-      var key = Materialize(domain, session.StorageNodeId, typeInfo, keyValue, TypeReferenceAccuracy.ExactType, false, null);
+      var key = Materialize(domain, session.StorageNodeId, typeInfo, keyValue, TypeReferenceAccuracy.ExactType, null);
 
       return key;
     }
 
     public static Key Materialize(Domain domain, string nodeId,
-      TypeInfo type, Tuple value, TypeReferenceAccuracy accuracy, bool canCache, IReadOnlyList<ColNum> keyIndexes)
+      TypeInfo type, Tuple value, TypeReferenceAccuracy accuracy, IReadOnlyList<ColNum> keyIndexes)
     {
       var hierarchy = type.Hierarchy;
       var keyInfo = type.Key;
@@ -51,7 +51,6 @@ namespace Xtensive.Orm.Internals
       }
       if (hierarchy!=null && hierarchy.Root.IsLeaf) {
         accuracy = TypeReferenceAccuracy.ExactType;
-        canCache = false; // No reason to cache
       }
 
       Key key;
@@ -62,18 +61,6 @@ namespace Xtensive.Orm.Internals
         if (keyIndexes!=null)
           throw Exceptions.InternalError(Strings.ExKeyIndexesAreSpecifiedForNonGenericKey, OrmLog.Instance);
         key = new LongKey(nodeId, type, accuracy, value);
-      }
-      if (!canCache)
-        return key;
-      var keyCache = domain.KeyCache;
-      lock (keyCache) {
-        Key foundKey;
-        if (keyCache.TryGetItem(key, true, out foundKey))
-          key = foundKey;
-        else {
-          if (accuracy==TypeReferenceAccuracy.ExactType)
-            keyCache.Add(key);
-        }
       }
       return key;
     }
@@ -119,7 +106,7 @@ namespace Xtensive.Orm.Internals
         throw new ArgumentException(String.Format(
           Strings.ExSpecifiedValuesArentEnoughToCreateKeyForTypeX, type.Name));
 
-      return Materialize(domain, nodeId, type, tuple, accuracy, false, null);
+      return Materialize(domain, nodeId, type, tuple, accuracy, null);
     }
 
     public static bool IsValidKeyTuple(Tuple tuple)

--- a/Orm/Xtensive.Orm/Orm/Internals/KeyFactory.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/KeyFactory.cs
@@ -49,20 +49,15 @@ namespace Xtensive.Orm.Internals
             value.SetValue(typeIdColumnIndex, type.TypeId);
         }
       }
-      if (hierarchy!=null && hierarchy.Root.IsLeaf) {
+      if (hierarchy?.Root.IsLeaf == true) {
         accuracy = TypeReferenceAccuracy.ExactType;
       }
 
-      Key key;
       var isGenericKey = keyInfo.TupleDescriptor.Count <= WellKnown.MaxGenericKeyLength;
-      if (isGenericKey)
-        key = CreateGenericKey(domain, nodeId, type, accuracy, value, keyIndexes);
-      else {
-        if (keyIndexes!=null)
-          throw Exceptions.InternalError(Strings.ExKeyIndexesAreSpecifiedForNonGenericKey, OrmLog.Instance);
-        key = new LongKey(nodeId, type, accuracy, value);
-      }
-      return key;
+      return isGenericKey
+        ? CreateGenericKey(domain, nodeId, type, accuracy, value, keyIndexes)
+        : keyIndexes == null ? new LongKey(nodeId, type, accuracy, value)
+        : throw Exceptions.InternalError(Strings.ExKeyIndexesAreSpecifiedForNonGenericKey, OrmLog.Instance);
     }
 
     public static Key Materialize(Domain domain, string nodeId,

--- a/Orm/Xtensive.Orm/Orm/Internals/KeyGeneratorRegistry.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/KeyGeneratorRegistry.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2012 Xtensive LLC.
+// Copyright (C) 2012 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Denis Krjuchkov
@@ -12,33 +12,17 @@ namespace Xtensive.Orm.Internals
 {
   internal sealed class KeyGeneratorRegistry : LockableBase
   {
-    private readonly Dictionary<KeyInfo, KeyGenerator> generators
-      = new Dictionary<KeyInfo, KeyGenerator>();
-
-    private readonly Dictionary<KeyInfo, TemporaryKeyGenerator> temporaryGenerators
-      = new Dictionary<KeyInfo, TemporaryKeyGenerator>();
+    private readonly Dictionary<KeyInfo, KeyGenerator> generators = new();
+    private readonly Dictionary<KeyInfo, TemporaryKeyGenerator> temporaryGenerators = new();
 
     // Compatibility indexer
-    public KeyGenerator this[KeyInfo key] { get { return Get(key); } }
+    public KeyGenerator this[KeyInfo key] => Get(key);
 
-    public KeyGenerator Get(KeyInfo key)
-    {
-      KeyGenerator result;
-      generators.TryGetValue(key, out result);
-      return result;
-    }
+    public KeyGenerator Get(KeyInfo key) => generators.GetValueOrDefault(key);
 
-    public KeyGenerator Get(KeyInfo key, bool isTemporary)
-    {
-      return isTemporary ? GetTemporary(key) : Get(key);
-    }
+    public KeyGenerator Get(KeyInfo key, bool isTemporary) => isTemporary ? GetTemporary(key) : Get(key);
 
-    public TemporaryKeyGenerator GetTemporary(KeyInfo key)
-    {
-      TemporaryKeyGenerator result;
-      temporaryGenerators.TryGetValue(key, out result);
-      return result;
-    }
+    public TemporaryKeyGenerator GetTemporary(KeyInfo key) => temporaryGenerators.GetValueOrDefault(key);
 
     public void Register(KeyInfo key, KeyGenerator generator)
     {

--- a/Orm/Xtensive.Orm/Orm/Internals/Key{T1,T2,T3,T4}.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Key{T1,T2,T3,T4}.cs
@@ -41,26 +41,14 @@ namespace Xtensive.Orm.Internals
       return result;
     }
 
-    protected override bool ValueEquals(Key other)
-    {
-      var otherKey = other as Key<T1, T2, T3, T4>;
-      if (otherKey == null)
-        return false;
-      return
-        EqualityComparer4.Invoke(value4, otherKey.value4) &&
-        EqualityComparer3.Invoke(value3, otherKey.value3) &&
-        EqualityComparer2.Invoke(value2, otherKey.value2) &&
-        EqualityComparer1.Invoke(value1, otherKey.value1);
-    }
+    protected override bool ValueEquals(Key other) =>
+      other is Key<T1, T2, T3, T4> otherKey
+        && EqualityComparer4(value4, otherKey.value4)
+        && EqualityComparer3(value3, otherKey.value3)
+        && EqualityComparer2(value2, otherKey.value2)
+        && EqualityComparer1(value1, otherKey.value1);
 
-    protected override int CalculateHashCode()
-    {
-      var result = value1.GetHashCode();
-      result = Tuple.HashCodeMultiplier * result ^ value2.GetHashCode();
-      result = Tuple.HashCodeMultiplier * result ^ value3.GetHashCode();
-      result = Tuple.HashCodeMultiplier * result ^ value4.GetHashCode();
-      return result;
-    }
+    protected override int CalculateHashCode() => HashCode.Combine(value1, value2, value3, value4);
 
     [UsedImplicitly]
     public static Key Create(string nodeId, TypeInfo type, Tuple tuple, TypeReferenceAccuracy accuracy, IReadOnlyList<ColNum> keyIndexes)

--- a/Orm/Xtensive.Orm/Orm/Internals/Key{T1,T2,T3}.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Key{T1,T2,T3}.cs
@@ -37,24 +37,13 @@ namespace Xtensive.Orm.Internals
       return result;
     }
 
-    protected override bool ValueEquals(Key other)
-    {
-      var otherKey = other as Key<T1, T2, T3>;
-      if (otherKey == null)
-        return false;
-      return
-        EqualityComparer3.Invoke(value3, otherKey.value3) &&
-        EqualityComparer2.Invoke(value2, otherKey.value2) &&
-        EqualityComparer1.Invoke(value1, otherKey.value1);
-    }
+    protected override bool ValueEquals(Key other) =>
+      other is Key<T1, T2, T3> otherKey
+        && EqualityComparer3(value3, otherKey.value3)
+        && EqualityComparer2(value2, otherKey.value2)
+        && EqualityComparer1(value1, otherKey.value1);
 
-    protected override int CalculateHashCode()
-    {
-      var result = value1.GetHashCode();
-      result = Tuple.HashCodeMultiplier * result ^ value2.GetHashCode();
-      result = Tuple.HashCodeMultiplier * result ^ value3.GetHashCode();
-      return result;
-    }
+    protected override int CalculateHashCode() => HashCode.Combine(value1, value2, value3);
 
     [UsedImplicitly]
     public static Key Create(string nodeId, TypeInfo type, Tuple tuple, TypeReferenceAccuracy accuracy, IReadOnlyList<ColNum> keyIndexes)

--- a/Orm/Xtensive.Orm/Orm/Internals/Key{T1,T2}.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Key{T1,T2}.cs
@@ -33,20 +33,12 @@ namespace Xtensive.Orm.Internals
       return result;
     }
 
-    protected override bool ValueEquals(Key other)
-    {
-      var otherKey = other as Key<T1, T2>;
-      if (otherKey == null)
-        return false;
-      return
-        EqualityComparer2.Invoke(value2, otherKey.value2) &&
-        EqualityComparer1.Invoke(value1, otherKey.value1);
-    }
+    protected override bool ValueEquals(Key other) =>
+      other is Key<T1, T2> otherKey
+        && EqualityComparer2(value2, otherKey.value2)
+        && EqualityComparer1(value1, otherKey.value1);
 
-    protected override int CalculateHashCode()
-    {
-      return Tuple.HashCodeMultiplier * value1.GetHashCode() ^ value2.GetHashCode();
-    }
+    protected override int CalculateHashCode() => HashCode.Combine(value1, value2);
 
     [UsedImplicitly]
     public static Key Create(string nodeId, TypeInfo type, Tuple tuple, TypeReferenceAccuracy accuracy, IReadOnlyList<ColNum> keyIndexes)

--- a/Orm/Xtensive.Orm/Orm/Internals/Key{T}.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Key{T}.cs
@@ -29,19 +29,10 @@ namespace Xtensive.Orm.Internals
       return result;
     }
 
-    protected override bool ValueEquals(Key other)
-    {
-      var otherKey = other as Key<T>;
-      if (otherKey == null)
-        return false;
-      return
-        EqualityComparer1.Invoke(value1, otherKey.value1);
-    }
+    protected override bool ValueEquals(Key other) =>
+      other is Key<T> otherKey && EqualityComparer1(value1, otherKey.value1);
 
-    protected override int CalculateHashCode()
-    {
-      return value1.GetHashCode();
-    }
+    protected override int CalculateHashCode() => value1.GetHashCode();
 
     [UsedImplicitly]
     public static Key Create(string nodeId, TypeInfo type, Tuple tuple, TypeReferenceAccuracy accuracy, IReadOnlyList<ColNum> keyIndexes)

--- a/Orm/Xtensive.Orm/Orm/Internals/LongKey.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/LongKey.cs
@@ -11,36 +11,16 @@ using Tuple = Xtensive.Tuples.Tuple;
 namespace Xtensive.Orm.Internals
 {
   [Serializable]
-  internal sealed class LongKey : Key
+  internal sealed class LongKey(string nodeId, TypeInfo type, TypeReferenceAccuracy accuracy, Tuple value) : Key(nodeId, type, accuracy, value)
   {
     /// <inheritdoc/>
-    protected override Tuple GetValue()
-    {
-      return value;
-    }
+    protected override Tuple GetValue() => value;
 
     /// <inheritdoc/>
-    protected override int CalculateHashCode()
-    {
-      return value.GetHashCode();
-    }
+    protected override int CalculateHashCode() => value.GetHashCode();
 
     /// <inheritdoc/>
-    protected override bool ValueEquals(Key other)
-    {
-      var otherKey = other as LongKey;
-      if (otherKey==null)
-        return false;
-
-      return value.Equals(otherKey.value);
-    }
-
-
-    // Constructors
-
-    internal LongKey(string nodeId, TypeInfo type, TypeReferenceAccuracy accuracy, Tuple value)
-      : base(nodeId, type, accuracy, value)
-    {
-    }
+    protected override bool ValueEquals(Key other) =>
+      other is LongKey otherKey && value.Equals(otherKey.value);
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Key.cs
+++ b/Orm/Xtensive.Orm/Orm/Key.cs
@@ -110,16 +110,9 @@ namespace Xtensive.Orm
     /// <summary>
     /// Determines whether <see cref="TypeInfo"/> property has exact type value or not.
     /// </summary>
-    internal bool HasExactType
-    {
-      get { return TypeReference.Accuracy==TypeReferenceAccuracy.ExactType; }
-    }
+    internal bool HasExactType => TypeReference.Accuracy == TypeReferenceAccuracy.ExactType;
 
-    internal Tuple CreateTuple()
-    {
-      var descriptor = TypeReference.Type.Key.TupleDescriptor;
-      return Tuple.Create(descriptor);
-    }
+    internal Tuple CreateTuple() => Tuple.Create(TypeReference.Type.Key.TupleDescriptor);
 
     #region Equals, GetHashCode, ==, != 
 
@@ -132,25 +125,22 @@ namespace Xtensive.Orm
         return false;
       var thisType = TypeReference.Type;
       var otherType = other.TypeReference.Type;
-      if (HasExactType && other.HasExactType && thisType!=otherType)
+      if (HasExactType && other.HasExactType && thisType != otherType)
         return false;
-      if (!thisType.IsInterface && !otherType.IsInterface && thisType.Hierarchy!=otherType.Hierarchy)
+      var thisTypeIsInterface = thisType.IsInterface;
+      var otherTypeIsInterface = otherType.IsInterface;
+      if (!thisTypeIsInterface && !otherTypeIsInterface && thisType.Hierarchy != otherType.Hierarchy
+          || thisType.Key.EqualityIdentifier != otherType.Key.EqualityIdentifier
+          || NodeId != other.NodeId)
         return false;
-      if (thisType.Key.EqualityIdentifier!=otherType.Key.EqualityIdentifier)
-        return false;
-      if (NodeId!=other.NodeId)
-        return false;
-      if (thisType.IsInterface && !otherType.IsInterface) {
-        if (!thisType.UnderlyingType.IsAssignableFrom(otherType.UnderlyingType))
+      if (thisTypeIsInterface) {
+        if (!otherTypeIsInterface && !thisType.UnderlyingType.IsAssignableFrom(otherType.UnderlyingType))
           return false;
       }
-      else if (otherType.IsInterface && !thisType.IsInterface) {
-        if (!otherType.UnderlyingType.IsAssignableFrom(thisType.UnderlyingType))
+      else if (otherTypeIsInterface && !otherType.UnderlyingType.IsAssignableFrom(thisType.UnderlyingType)) {
           return false;
       }
-      if (other.GetType().IsGenericType)
-        return other.ValueEquals(this);
-      return ValueEquals(other);
+      return other.GetType().IsGenericType ? other.ValueEquals(this) : ValueEquals(other);
     }
 
     /// <inheritdoc/>

--- a/Orm/Xtensive.Orm/Orm/Key.cs
+++ b/Orm/Xtensive.Orm/Orm/Key.cs
@@ -40,15 +40,7 @@ namespace Xtensive.Orm
     /// <summary>
     /// Gets the key value.
     /// </summary>
-    public Tuple Value
-    {
-      get
-      {
-        if (value==null)
-          value = GetValue();
-        return value;
-      }
-    }
+    public Tuple Value => value ??= GetValue();
 
     /// <summary>
     /// Gets the <see cref="TypeReference"/> object
@@ -59,31 +51,21 @@ namespace Xtensive.Orm
     /// <summary>
     /// Gets node identifier for this instance.
     /// </summary>
-    public string NodeId { get; private set; }
+    public string NodeId { get; }
 
     /// <summary>
     /// Gets the type of <see cref="Entity"/> this instance identifies.
     /// </summary>
     [CanBeNull]
-    public TypeInfo TypeInfo
-    {
-      get
-      {
-        return TypeReference.Accuracy==TypeReferenceAccuracy.ExactType ? TypeReference.Type : null;
-      }
-    }
+    public TypeInfo TypeInfo => TypeReference.Accuracy == TypeReferenceAccuracy.ExactType ? TypeReference.Type : null;
 
     /// <summary>
     /// Determines whether this key is a temporary key in the specified <paramref name="domain"/>.
     /// </summary>
     /// <param name="domain">The domain.</param>
     /// <returns>Check result.</returns>
-    public bool IsTemporary(Domain domain)
-    {
-      var keyInfo = TypeReference.Type.Key;
-      var keyGenerator = domain.KeyGenerators.GetTemporary(keyInfo);
-      return keyGenerator!=null && keyGenerator.IsTemporaryKey(Value);
-    }
+    public bool IsTemporary(Domain domain) =>
+      domain.KeyGenerators.GetTemporary(TypeReference.Type.Key)?.IsTemporaryKey(Value) == true;
 
     /// <summary>
     /// Resolves the type of <see cref="Entity"/> this instance identifies.
@@ -100,16 +82,6 @@ namespace Xtensive.Orm
         return TypeReference.Type;
 
       var domain = session.Domain;
-      var keyCache = domain.KeyCache;
-      Key cachedKey;
-
-      lock (keyCache)
-        keyCache.TryGetItem(this, true, out cachedKey);
-      if (cachedKey!=null) {
-        TypeReference = cachedKey.TypeReference;
-        return TypeReference.Type;
-      }
-
       var hierarchy = TypeReference.Type.Hierarchy;
       if (hierarchy!=null && hierarchy.Types.Count==1) {
         TypeReference = new TypeReference(hierarchy.Types[0], TypeReferenceAccuracy.ExactType);
@@ -154,10 +126,10 @@ namespace Xtensive.Orm
     /// <inheritdoc/>
     public bool Equals(Key other)
     {
-      if (other is null)
-        return false;
       if (ReferenceEquals(this, other))
         return true;
+      if (other is null)
+        return false;
       var thisType = TypeReference.Type;
       var otherType = other.TypeReference.Type;
       if (HasExactType && other.HasExactType && thisType!=otherType)
@@ -182,10 +154,7 @@ namespace Xtensive.Orm
     }
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      return Equals(obj as Key);
-    }
+    public override bool Equals(object obj) => Equals(obj as Key);
 
     /// <summary>
     /// Implements the operator ==.
@@ -196,10 +165,7 @@ namespace Xtensive.Orm
     /// The result of the operator.
     /// </returns>
     [DebuggerStepThrough]
-    public static bool operator ==(Key left, Key right)
-    {
-      return Equals(left, right);
-    }
+    public static bool operator ==(Key left, Key right) => Equals(left, right);
 
     /// <summary>
     /// Implements the operator !=.
@@ -210,19 +176,11 @@ namespace Xtensive.Orm
     /// The result of the operator.
     /// </returns>
     [DebuggerStepThrough]
-    public static bool operator !=(Key left, Key right)
-    {
-      return !Equals(left, right);
-    }
+    public static bool operator !=(Key left, Key right) => !Equals(left, right);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      var result = CalculateHashCode();
-      result = result * Tuple.HashCodeMultiplier ^ NodeId.GetHashCode();
-      result = result * Tuple.HashCodeMultiplier ^ TypeReference.Type.Key.EqualityIdentifier.GetHashCode();
-      return result;
-    }
+    public override int GetHashCode() =>
+      HashCode.Combine(CalculateHashCode(), NodeId, TypeReference.Type.Key.EqualityIdentifier);
 
     /// <summary>
     /// Compares key value for equality.
@@ -433,7 +391,7 @@ namespace Xtensive.Orm
 
     internal static Key Create(Domain domain, string nodeId, TypeInfo type, TypeReferenceAccuracy accuracy, Tuple value)
     {
-      return KeyFactory.Materialize(domain, nodeId, type, value, accuracy, false, null);
+      return KeyFactory.Materialize(domain, nodeId, type, value, accuracy, null);
     }
 
     #endregion

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ItemMaterializationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ItemMaterializationContext.cs
@@ -45,17 +45,16 @@ namespace Xtensive.Orm.Linq.Materialization
       if (typeId==TypeInfo.NoTypeId)
         return null;
 
-      var canCache = accuracy==TypeReferenceAccuracy.ExactType;
       var materializationInfo = MaterializationContext.GetTypeMapping(entityIndex, type, typeId, entityColumns);
       Key key;
       var keyIndexes = materializationInfo.KeyIndexes;
       if (!KeyFactory.IsValidKeyTuple(tuple, keyIndexes))
         return null;
       if (keyIndexes.Count <= WellKnown.MaxGenericKeyLength)
-        key = KeyFactory.Materialize(Session.Domain, Session.StorageNodeId, materializationInfo.Type, tuple, accuracy, canCache, keyIndexes);
+        key = KeyFactory.Materialize(Session.Domain, Session.StorageNodeId, materializationInfo.Type, tuple, accuracy, keyIndexes);
       else {
         var keyTuple = materializationInfo.KeyTransform.Apply(TupleTransformType.TransformedTuple, tuple);
-        key = KeyFactory.Materialize(Session.Domain, Session.StorageNodeId, materializationInfo.Type, keyTuple, accuracy, canCache, null);
+        key = KeyFactory.Materialize(Session.Domain, Session.StorageNodeId, materializationInfo.Type, keyTuple, accuracy, null);
       }
       if (accuracy==TypeReferenceAccuracy.ExactType) {
         var entityTuple = materializationInfo.Transform.Apply(TupleTransformType.Tuple, tuple);

--- a/Orm/Xtensive.Orm/Orm/TransactionalStateContainer.cs
+++ b/Orm/Xtensive.Orm/Orm/TransactionalStateContainer.cs
@@ -21,11 +21,7 @@ namespace Xtensive.Orm
     /// <summary>
     /// Gets a value indicating whether state is loaded and actual.
     /// </summary>
-    public bool IsActual {
-      get {
-        return LifetimeToken!=null && LifetimeToken.IsActive;
-      }
-    }
+    public bool IsActual => LifetimeToken?.IsActive == true;
 
     /// <summary>
     /// Gets the transactional state.

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
@@ -65,18 +65,15 @@ namespace Xtensive.Tuples.Packed
 
     public override int GetHashCode()
     {
-      var count = Count;
       var fieldDescriptors = PackedDescriptor.FieldDescriptors;
-      int result = 0;
-      for (int i = 0; i < count; i++) {
+      HashCode hashCode = new();
+      for (int i = Count; i-- > 0;) {
         var descriptor = fieldDescriptors[i];
-        var state = GetFieldState(descriptor);
-        var fieldHash = state == TupleFieldState.Available
+        hashCode.Add(GetFieldState(descriptor) == TupleFieldState.Available
           ? descriptor.Accessor.GetValueHashCode(this, descriptor)
-          : 0;
-        result = HashCodeMultiplier * result ^ fieldHash;
+          : 0);
       }
-      return result;
+      return hashCode.ToHashCode();
     }
 
     public override TupleFieldState GetFieldState(int fieldIndex) =>

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
@@ -63,6 +63,7 @@ namespace Xtensive.Tuples.Packed
       return true;
     }
 
+    // Must be compatible with Tuple.GetHashCode() - return the same result
     public override int GetHashCode()
     {
       var fieldDescriptors = PackedDescriptor.FieldDescriptors;

--- a/Orm/Xtensive.Orm/Tuples/Tuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Tuple.cs
@@ -23,21 +23,16 @@ namespace Xtensive.Tuples
   [Serializable]
   public abstract class Tuple : ITuple, IEquatable<Tuple>
   {
-    /// <summary>
-    /// Per-field hash code multiplier used in <see cref="GetHashCode"/> calculation.
-    /// </summary>
-    public const int HashCodeMultiplier = 397;
-
     /// <inheritdoc />
     [IgnoreDataMember]
     public abstract TupleDescriptor Descriptor { get; }
 
     /// <inheritdoc />
     [IgnoreDataMember]
-    public virtual int Count
-    {
+    
+    public virtual int Count {
       [DebuggerStepThrough]
-      get { return Descriptor.Count; }
+      get => Descriptor.Count;
     }
 
     /// <inheritdoc/>
@@ -206,10 +201,10 @@ namespace Xtensive.Tuples
     /// <inheritdoc/>
     public virtual bool Equals(Tuple other)
     {
-      if (other is null)
-        return false;
       if (ReferenceEquals(other, this))
         return true;
+      if (other is null)
+        return false;
       if (Descriptor!=other.Descriptor)
         return false;
 
@@ -234,13 +229,11 @@ namespace Xtensive.Tuples
     public override int GetHashCode()
     {
       var count = Count;
-      int result = 0;
+      HashCode hashCode = new();
       for (int i = 0; i < count; i++) {
-        TupleFieldState state;
-        object value = GetValue(i, out state);
-        result = HashCodeMultiplier * result ^ (value!=null ? value.GetHashCode() : 0);
+        hashCode.Add(GetValue(i, out var state));
       }
-      return result;
+      return hashCode.ToHashCode();
     }
 
     #endregion

--- a/Orm/Xtensive.Orm/Tuples/Tuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Tuple.cs
@@ -228,9 +228,8 @@ namespace Xtensive.Tuples
     /// <inheritdoc/>
     public override int GetHashCode()
     {
-      var count = Count;
       HashCode hashCode = new();
-      for (int i = 0; i < count; i++) {
+      for (int i = Count; i-- > 0;) {
         hashCode.Add(GetValue(i, out var state));
       }
       return hashCode.ToHashCode();

--- a/Orm/Xtensive.Orm/Tuples/Tuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Tuple.cs
@@ -6,10 +6,7 @@
 
 using System;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
-using System.Text;
-using Xtensive.Comparison;
 using Xtensive.Core;
 using Xtensive.Reflection;
 using Xtensive.Tuples.Packed;
@@ -36,34 +33,19 @@ namespace Xtensive.Tuples
     }
 
     /// <inheritdoc/>
-    Tuple ITupleFactory.CreateNew()
-    {
-      return CreateNew();
-    }
+    Tuple ITupleFactory.CreateNew() => CreateNew();
 
     /// <inheritdoc/>
-    Tuple ITuple.Clone()
-    {
-      return Clone();
-    }
+    Tuple ITuple.Clone() => Clone();
 
     /// <inheritdoc/>
-    object ICloneable.Clone()
-    {
-      return Clone();
-    }
+    object ICloneable.Clone() => Clone();
 
     /// <see cref="ITupleFactory.CreateNew" copy="true" />
-    public virtual Tuple CreateNew()
-    {
-      return Create(Descriptor);
-    }
+    public virtual Tuple CreateNew() => Create(Descriptor);
 
     /// <see cref="ITuple.Clone" copy="true" />
-    public virtual Tuple Clone()
-    {
-      return (Tuple) MemberwiseClone();
-    }
+    public virtual Tuple Clone() => (Tuple) MemberwiseClone();
 
     /// <inheritdoc />
     public abstract TupleFieldState GetFieldState(int fieldIndex);
@@ -77,16 +59,14 @@ namespace Xtensive.Tuples
     /// <exception cref="InvalidOperationException">Field value is not available.</exception>
     public object GetValue(int fieldIndex)
     {
-      TupleFieldState state;
-      var result = GetValue(fieldIndex, out state);
+      var result = GetValue(fieldIndex, out var state);
       return state.IsNull() ? null : result;
     }
 
     /// <inheritdoc/>
     public object GetValueOrDefault(int fieldIndex)
     {
-      TupleFieldState state;
-      var value = GetValue(fieldIndex, out state);
+      var value = GetValue(fieldIndex, out var state);
       return state==TupleFieldState.Available ? value : null;
     }
 
@@ -128,16 +108,11 @@ namespace Xtensive.Tuples
     /// but <typeparamref name="T"/> is not a <see cref="Nullable{T}"/> type.</exception>
     public T GetValue<T>(int fieldIndex)
     {
-      TupleFieldState fieldState;
-      var result = GetValue<T>(fieldIndex, out fieldState);
+      var result = GetValue<T>(fieldIndex, out var fieldState);
 
-      if (fieldState.IsNull()) {
-        if (default(T)!=null)
-          throw new InvalidCastException(string.Format(Strings.ExUnableToCastNullValueToXUseXInstead, typeof (T)));
-        return default(T);
-      }
-
-      return result;
+      return !fieldState.IsNull() ? result
+        : default(T) != null ? throw new InvalidCastException(string.Format(Strings.ExUnableToCastNullValueToXUseXInstead, typeof(T)))
+        : default(T);
     }
 
     /// <summary>
@@ -155,8 +130,7 @@ namespace Xtensive.Tuples
     /// but <typeparamref name="T"/> is not a <see cref="Nullable{T}"/> type.</exception>
     public T GetValueOrDefault<T>(int fieldIndex)
     {
-      TupleFieldState fieldState;
-      var result = GetValue<T>(fieldIndex, out fieldState);
+      var result = GetValue<T>(fieldIndex, out var fieldState);
       return fieldState==TupleFieldState.Available ? result : default(T);
     }
 
@@ -193,10 +167,7 @@ namespace Xtensive.Tuples
     #region Equals, GetHashCode
 
     /// <inheritdoc/>
-    public override sealed bool Equals(object obj)
-    {
-      return Equals(obj as Tuple);
-    }
+    public override sealed bool Equals(object obj) => Equals(obj as Tuple);
 
     /// <inheritdoc/>
     public virtual bool Equals(Tuple other)
@@ -210,16 +181,12 @@ namespace Xtensive.Tuples
 
       var count = Count;
       for (int i = 0; i < count; i++) {
-        TupleFieldState thisState;
-        TupleFieldState otherState;
-        var thisValue = GetValue(i, out thisState);
-        var otherValue = other.GetValue(i, out otherState);
-        if (thisState!=otherState)
+        var thisValue = GetValue(i, out var thisState);
+        var otherValue = other.GetValue(i, out var otherState);
+        if (thisState != otherState
+            || thisState == TupleFieldState.Available && !Equals(thisValue, otherValue)) {
           return false;
-        if (thisState!=TupleFieldState.Available)
-          continue;
-        if (!Equals(thisValue, otherValue))
-          return false;
+        }          
       }
 
       return true;


### PR DESCRIPTION
The only signficant usage of this cache was `Key.ResolveTypeInfo()` method, invoked only from tests.

In other case the cache just returns functionally identical `Key` instance. May be it can save some memory because of shared `Key`s instances, but the price of global lock is very high.

`Domain.KeyCache` was globally locked on every lookup/addition

The `KeyCache` was introduced 16 years ago, but looks like lost its original purpose
https://github.com/DataObjects-NET/dataobjects-net/commit/b426e1b3c59dc5f1eff715a6bb76731297368045#diff-ef9c7facacff2dc960d81ba31e8f55a03a37433962786882f8088ca2cce668ff

Also:
* Refactor `Key` classes to contemporary C# syntax
* Use `HashCode.Combine()` API instead of custom hash calculations with magic constants
