### PR TITLE
Optimization: Dispatch `ProviderVisitor` via virtual functions

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/SubqueryFilterRemover.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/SubqueryFilterRemover.cs
@@ -95,7 +95,7 @@ namespace Xtensive.Orm.Linq.Rewriters
 
     private readonly SubqueryFilterChecker checker;
 
-    protected override CompilableProvider VisitFilter(FilterProvider provider)
+    internal protected override CompilableProvider VisitFilter(FilterProvider provider)
     {
       return checker.Check(provider.Predicate.Body)
         ? provider.Source

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Aggregate.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Aggregate.cs
@@ -17,7 +17,7 @@ namespace Xtensive.Orm.Providers
   partial class SqlCompiler 
   {
     /// <inheritdoc/>
-    protected override SqlProvider VisitAggregate(AggregateProvider provider)
+    internal protected override SqlProvider VisitAggregate(AggregateProvider provider)
     {
       var source = Compile(provider.Source);
 

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Apply.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Apply.cs
@@ -20,7 +20,7 @@ namespace Xtensive.Orm.Providers
   public partial class SqlCompiler
   {
     /// <inheritdoc/>
-    protected override SqlProvider VisitApply(ApplyProvider provider)
+    internal protected override SqlProvider VisitApply(ApplyProvider provider)
     {
       bool processViaCrossApply;
       switch (provider.SequenceType) {

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Include.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Include.cs
@@ -18,7 +18,7 @@ namespace Xtensive.Orm.Providers
   partial class SqlCompiler 
   {
     /// <inheritdoc/>
-    protected override SqlProvider VisitInclude(IncludeProvider provider)
+    internal protected override SqlProvider VisitInclude(IncludeProvider provider)
     {
       var source = Compile(provider.Source);
       var resultQuery = ExtractSqlSelect(provider, source);

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Index.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Index.cs
@@ -43,18 +43,12 @@ namespace Xtensive.Orm.Providers
 
     private TypeMapping int32TypeMapping;
 
-    protected override SqlProvider VisitFreeText(FreeTextProvider provider)
-    {
-      throw new NotSupportedException();
-    }
+    internal protected override SqlProvider VisitFreeText(FreeTextProvider provider) => throw new NotSupportedException();
 
-    protected override SqlProvider VisitContainsTable(ContainsTableProvider provider)
-    {
-      throw new NotSupportedException();
-    }
+    internal protected override SqlProvider VisitContainsTable(ContainsTableProvider provider) => throw new NotSupportedException();
 
     /// <inheritdoc/>
-    protected override SqlProvider VisitIndex(IndexProvider provider)
+    internal protected override SqlProvider VisitIndex(IndexProvider provider)
     {
       var index = provider.Index.Resolve(Handlers.Domain.Model);
       var queryAndBindings = BuildProviderQuery(index);

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.NotSupported.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.NotSupported.cs
@@ -12,9 +12,6 @@ namespace Xtensive.Orm.Providers
   partial class SqlCompiler 
   {
     /// <inheritdoc/>
-    protected override SqlProvider VisitRaw(RawProvider provider)
-    {
-      throw new NotSupportedException();
-    }
+    internal protected override SqlProvider VisitRaw(RawProvider provider) => throw new NotSupportedException();
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Paging.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Paging.cs
@@ -18,7 +18,7 @@ namespace Xtensive.Orm.Providers
   partial class SqlCompiler 
   {
     /// <inheritdoc/>
-    protected override SqlProvider VisitTake(TakeProvider provider)
+    internal protected override SqlProvider VisitTake(TakeProvider provider)
     {
       if (providerInfo.Supports(ProviderFeatures.NativeTake))
         return VisitPagingNative(provider, provider.Count, null);
@@ -28,7 +28,7 @@ namespace Xtensive.Orm.Providers
     }
 
     /// <inheritdoc/>
-    protected override SqlProvider VisitSkip(SkipProvider provider)
+    internal protected override SqlProvider VisitSkip(SkipProvider provider)
     {
       if (providerInfo.Supports(ProviderFeatures.NativeSkip))
         return VisitPagingNative(provider, null, provider.Count);
@@ -38,7 +38,7 @@ namespace Xtensive.Orm.Providers
     }
 
     /// <inheritdoc/>
-    protected override SqlProvider VisitPaging(PagingProvider provider)
+    internal protected override SqlProvider VisitPaging(PagingProvider provider)
     {
       if (providerInfo.Supports(ProviderFeatures.NativePaging))
         return VisitPagingNative(provider, provider.Take, provider.Skip);

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -69,7 +69,7 @@ namespace Xtensive.Orm.Providers
     protected NodeConfiguration NodeConfiguration { get; private set; }
 
     /// <inheritdoc/>
-    protected override SqlProvider VisitAlias(AliasProvider provider)
+    internal protected override SqlProvider VisitAlias(AliasProvider provider)
     {
       var source = Compile(provider.Source);
 
@@ -97,7 +97,7 @@ namespace Xtensive.Orm.Providers
     }
 
     /// <inheritdoc/>
-    protected override SqlProvider VisitCalculate(CalculateProvider provider)
+    internal protected override SqlProvider VisitCalculate(CalculateProvider provider)
     {
       var source = Compile(provider.Source);
 
@@ -125,7 +125,7 @@ namespace Xtensive.Orm.Providers
     }
 
     /// <inheritdoc/>
-    protected override SqlProvider VisitDistinct(DistinctProvider provider)
+    internal protected override SqlProvider VisitDistinct(DistinctProvider provider)
     {
       var source = Compile(provider.Source);
 
@@ -145,7 +145,7 @@ namespace Xtensive.Orm.Providers
     }
 
     /// <inheritdoc/>
-    protected override SqlProvider VisitFilter(FilterProvider provider)
+    internal protected override SqlProvider VisitFilter(FilterProvider provider)
     {
       var source = Compile(provider.Source);
 
@@ -162,7 +162,7 @@ namespace Xtensive.Orm.Providers
     }
 
     /// <inheritdoc/>
-    protected override SqlProvider VisitJoin(JoinProvider provider)
+    internal protected override SqlProvider VisitJoin(JoinProvider provider)
     {
       var left = Compile(provider.Left);
       var right = Compile(provider.Right);
@@ -233,7 +233,7 @@ namespace Xtensive.Orm.Providers
     }
 
     /// <inheritdoc/>
-    protected override SqlProvider VisitPredicateJoin(PredicateJoinProvider provider)
+    internal protected override SqlProvider VisitPredicateJoin(PredicateJoinProvider provider)
     {
       var left = Compile(provider.Left);
       var right = Compile(provider.Right);
@@ -291,7 +291,7 @@ namespace Xtensive.Orm.Providers
     }
 
     /// <inheritdoc/>
-    protected override SqlProvider VisitSeek(SeekProvider provider)
+    internal protected override SqlProvider VisitSeek(SeekProvider provider)
     {
       var compiledSource = Compile(provider.Source);
 
@@ -324,7 +324,7 @@ namespace Xtensive.Orm.Providers
     }
 
     /// <inheritdoc/>
-    protected override SqlProvider VisitSelect(SelectProvider provider)
+    internal protected override SqlProvider VisitSelect(SelectProvider provider)
     {
       var compiledSource = Compile(provider.Source);
 
@@ -344,7 +344,7 @@ namespace Xtensive.Orm.Providers
       return CreateProvider(query, provider, compiledSource);
     }
 
-    protected override SqlProvider VisitTag(TagProvider provider)
+    internal protected override SqlProvider VisitTag(TagProvider provider)
     {
       var compiledSource = Compile(provider.Source);
 
@@ -354,7 +354,7 @@ namespace Xtensive.Orm.Providers
       return CreateProvider(query, provider, compiledSource);
     }
 
-    protected override SqlProvider VisitIndexHint(IndexHintProvider provider)
+    internal protected override SqlProvider VisitIndexHint(IndexHintProvider provider)
     {
       var compiledSource = Compile(provider.Source);
       
@@ -370,7 +370,7 @@ namespace Xtensive.Orm.Providers
     }
 
     /// <inheritdoc/>
-    protected override SqlProvider VisitSort(SortProvider provider)
+    internal protected override SqlProvider VisitSort(SortProvider provider)
     {
       var compiledSource = Compile(provider.Source);
 
@@ -407,7 +407,7 @@ namespace Xtensive.Orm.Providers
     }
 
     /// <inheritdoc/>
-    protected override SqlProvider VisitStore(StoreProvider provider)
+    internal protected override SqlProvider VisitStore(StoreProvider provider)
     {
       var source = provider.Source is RawProvider rawProvider
             ? (ExecutableProvider) (new Rse.Providers.ExecutableRawProvider(rawProvider))
@@ -421,7 +421,7 @@ namespace Xtensive.Orm.Providers
     }
     
     /// <inheritdoc/>
-    protected override SqlProvider VisitExistence(ExistenceProvider provider)
+    internal protected override SqlProvider VisitExistence(ExistenceProvider provider)
     {
       var source = Compile(provider.Source);
 
@@ -439,7 +439,7 @@ namespace Xtensive.Orm.Providers
     }
 
     /// <inheritdoc/>
-    protected override SqlProvider VisitIntersect(IntersectProvider provider)
+    internal protected override SqlProvider VisitIntersect(IntersectProvider provider)
     {
       var left = Compile(provider.Left);
       var right = Compile(provider.Right);
@@ -464,7 +464,7 @@ namespace Xtensive.Orm.Providers
     }
 
     /// <inheritdoc/>
-    protected override SqlProvider VisitExcept(ExceptProvider provider)
+    internal protected override SqlProvider VisitExcept(ExceptProvider provider)
     {
       var left = Compile(provider.Left);
       var right = Compile(provider.Right);
@@ -488,7 +488,7 @@ namespace Xtensive.Orm.Providers
     }
 
     /// <inheritdoc/>
-    protected override SqlProvider VisitConcat(ConcatProvider provider)
+    internal protected override SqlProvider VisitConcat(ConcatProvider provider)
     {
       var left = Compile(provider.Left);
       var right = Compile(provider.Right);
@@ -512,7 +512,7 @@ namespace Xtensive.Orm.Providers
     }
 
     /// <inheritdoc/>
-    protected override SqlProvider VisitUnion(UnionProvider provider)
+    internal protected override SqlProvider VisitUnion(UnionProvider provider)
     {
       var left = Compile(provider.Left);
       var right = Compile(provider.Right);
@@ -535,7 +535,7 @@ namespace Xtensive.Orm.Providers
       return CreateProvider(query, provider, left, right);
     }
 
-    protected override SqlProvider VisitRowNumber(RowNumberProvider provider)
+    internal protected override SqlProvider VisitRowNumber(RowNumberProvider provider)
     {
       var directionCollection = provider.Header.Order;
       if (directionCollection.Count == 0)
@@ -552,7 +552,7 @@ namespace Xtensive.Orm.Providers
     }
 
     /// <inheritdoc/>
-    protected override SqlProvider VisitLock(LockProvider provider)
+    internal protected override SqlProvider VisitLock(LockProvider provider)
     {
       var source = Compile(provider.Source);
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Compilation/Compiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Compilation/Compiler.cs
@@ -9,7 +9,7 @@ namespace Xtensive.Orm.Rse.Compilation
   /// Abstract base class for RSE <see cref="Provider"/> compilers that implements visitor pattern.
   /// Compiles <see cref="CompilableProvider"/>s into <see cref="ExecutableProvider"/>.
   /// </summary>
-  public abstract class Compiler<TResult> : ProviderVisitor<TResult>, ICompiler
+  public abstract class Compiler<TResult> : ProviderVisitor, ICompiler
     where TResult : ExecutableProvider
   {
     private readonly Stack<CompilableProvider> traversalStack = new Stack<CompilableProvider>();
@@ -56,7 +56,7 @@ namespace Xtensive.Orm.Rse.Compilation
         Initialize();
       }
       traversalStack.Push(cp);
-      TResult result = Visit(cp);
+      TResult result = (TResult)Visit(cp);
       traversalStack.Pop();
       owner = null;
       return result;

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/AggregateProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/AggregateProvider.cs
@@ -186,6 +186,8 @@ namespace Xtensive.Orm.Rse.Providers
         Strings.ExAggregateXIsNotSupportedForTypeY, aggregateType, sourceColumnType));
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitAggregate(this);
+
     #endregion
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/AliasProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/AliasProvider.cs
@@ -34,6 +34,7 @@ namespace Xtensive.Orm.Rse.Providers
       return Alias;
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitAlias(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ApplyProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ApplyProvider.cs
@@ -70,6 +70,7 @@ namespace Xtensive.Orm.Rse.Providers
     {
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitApply(this);
 
     /// <summary>
     /// Initializes a new instance of this class.

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/CalculateProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/CalculateProvider.cs
@@ -59,6 +59,7 @@ namespace Xtensive.Orm.Rse.Providers
       ResizeTransform = new MapTransform(false, Header.TupleDescriptor, columnIndexes);
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitCalculate(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ConcatProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ConcatProvider.cs
@@ -58,6 +58,7 @@ namespace Xtensive.Orm.Rse.Providers
         throw new InvalidOperationException(String.Format(Strings.ExXCantBeExecuted, "Concatenation"));
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitConcat(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ContainsTableProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ContainsTableProvider.cs
@@ -36,6 +36,8 @@ namespace Xtensive.Orm.Rse.Providers
       return indexHeader;
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitContainsTable(this);
+
     public ContainsTableProvider(FullTextIndexInfo index, Func<ParameterContext, string> searchCriteria, string rankColumnName, bool fullFeatured)
       : this(index, searchCriteria, rankColumnName, new List<ColumnInfo>(), null, fullFeatured)
     {

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/DistinctProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/DistinctProvider.cs
@@ -15,6 +15,8 @@ namespace Xtensive.Orm.Rse.Providers
   [Serializable]
   public sealed class DistinctProvider : UnaryProvider
   {
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitDistinct(this);
+
     // Constructors
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ExceptProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ExceptProvider.cs
@@ -33,6 +33,7 @@ namespace Xtensive.Orm.Rse.Providers
         throw new InvalidOperationException(String.Format(Strings.ExXCantBeExecuted, "Except operation"));
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitExcept(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ExistenceProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ExistenceProvider.cs
@@ -34,6 +34,7 @@ namespace Xtensive.Orm.Rse.Providers
         BoolTupleDescriptor, new[] { new SystemColumn(ExistenceColumnName, 0, WellKnownTypes.Bool) });
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitExistence(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/FilterProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/FilterProvider.cs
@@ -45,6 +45,7 @@ namespace Xtensive.Orm.Rse.Providers
       return Predicate.ToString(true);
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitFilter(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/FreeTextProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/FreeTextProvider.cs
@@ -38,6 +38,8 @@ namespace Xtensive.Orm.Rse.Providers
       return indexHeader;
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitFreeText(this);
+
     public FreeTextProvider(FullTextIndexInfo index, Func<ParameterContext, string> searchCriteria, string rankColumnName, bool fullFeatured)
       : this(index, searchCriteria, rankColumnName, null, fullFeatured)
     {

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/IncludeProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/IncludeProvider.cs
@@ -73,6 +73,7 @@ namespace Xtensive.Orm.Rse.Providers
       return newHeader;
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitInclude(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/IndexHintProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/IndexHintProvider.cs
@@ -15,6 +15,8 @@ namespace Xtensive.Orm.Rse.Providers
     /// </summary>
     public IndexInfoRef Index { get; }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitIndexHint(this);
+
     // Constructors
     public IndexHintProvider(CompilableProvider source, IndexInfo index)
       : base(ProviderType.IndexHint, source)
@@ -34,4 +36,3 @@ namespace Xtensive.Orm.Rse.Providers
     }
   }
 }
-

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/IndexProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/IndexProvider.cs
@@ -37,6 +37,7 @@ namespace Xtensive.Orm.Rse.Providers
       return Index.ToString();
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitIndex(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/IntersectProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/IntersectProvider.cs
@@ -33,7 +33,8 @@ namespace Xtensive.Orm.Rse.Providers
         throw new InvalidOperationException(String.Format(Strings.ExXCantBeExecuted, "Intersection"));
     }
 
-  
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitIntersect(this);
+
     // Constructors
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/JoinProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/JoinProvider.cs
@@ -61,6 +61,7 @@ namespace Xtensive.Orm.Rse.Providers
       EqualColumns = equalColumns;
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitJoin(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/LockProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/LockProvider.cs
@@ -25,6 +25,7 @@ namespace Xtensive.Orm.Rse.Providers
     /// </summary>
     public readonly Func<LockBehavior> LockBehavior;
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitLock(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/PagingProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/PagingProvider.cs
@@ -43,6 +43,7 @@ namespace Xtensive.Orm.Rse.Providers
       return "[" + Skip + "; " + Take +"]";
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitPaging(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/PredicateJoinProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/PredicateJoinProvider.cs
@@ -34,6 +34,7 @@ namespace Xtensive.Orm.Rse.Providers
     /// </summary>
     public Expression<Func<Tuple, Tuple, bool>> Predicate { get; private set; }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitPredicateJoin(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/RawProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/RawProvider.cs
@@ -54,6 +54,7 @@ namespace Xtensive.Orm.Rse.Providers
       return Source.ToString(true);
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitRaw(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/RowNumberProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/RowNumberProvider.cs
@@ -43,6 +43,7 @@ namespace Xtensive.Orm.Rse.Providers
       return Source.Header.Add(SystemColumn);
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitRowNumber(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/SeekProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/SeekProvider.cs
@@ -31,6 +31,7 @@ namespace Xtensive.Orm.Rse.Providers
       return Key.Method.ToString();
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitSeek(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/SelectProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/SelectProvider.cs
@@ -35,6 +35,7 @@ namespace Xtensive.Orm.Rse.Providers
       return Header.Columns.Select(c => c.Name).ToCommaDelimitedString();
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitSelect(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/SkipProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/SkipProvider.cs
@@ -26,6 +26,7 @@ namespace Xtensive.Orm.Rse.Providers
       return Count.ToString();
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitSkip(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/SortProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/SortProvider.cs
@@ -16,6 +16,8 @@ namespace Xtensive.Orm.Rse.Providers
   [Serializable]
   public sealed class SortProvider : OrderProviderBase
   {
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitSort(this);
+
     // Constructors
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/StoreProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/StoreProvider.cs
@@ -40,6 +40,7 @@ namespace Xtensive.Orm.Rse.Providers
       return Name;
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitStore(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/TagProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/TagProvider.cs
@@ -18,6 +18,8 @@ namespace Xtensive.Orm.Rse.Providers
   {
     public readonly string Tag;
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitTag(this);
+
     // Constructors
 
     public TagProvider(CompilableProvider source, string tag)

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/TakeProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/TakeProvider.cs
@@ -26,6 +26,7 @@ namespace Xtensive.Orm.Rse.Providers
       return Count.ToString();
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitTake(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/UnionProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/UnionProvider.cs
@@ -60,6 +60,7 @@ namespace Xtensive.Orm.Rse.Providers
         throw new InvalidOperationException(String.Format(Strings.ExXCantBeExecuted, "Union operation"));
     }
 
+    internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitUnion(this);
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/VoidProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/VoidProvider.cs
@@ -4,6 +4,7 @@
 // Created by: Denis Krjuchkov
 // Created:    2012.01.29
 
+using System;
 using Xtensive.Core;
 
 namespace Xtensive.Orm.Rse.Providers
@@ -16,6 +17,9 @@ namespace Xtensive.Orm.Rse.Providers
     {
       return header;
     }
+
+    internal override Provider Visit(ProviderVisitor visitor) =>
+      throw new NotSupportedException(Strings.ExProcessingOfVoidProviderIsNotSupported);
 
     public VoidProvider(RecordSetHeader header)
       : base(ProviderType.Void)

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProvider.cs
@@ -14,18 +14,14 @@ namespace Xtensive.Orm.Rse.Providers
   /// that requires storage-specific compilation before in can be executed.
   /// </summary>
   [Serializable]
-  public abstract class CompilableProvider : Provider
+  public abstract class CompilableProvider(ProviderType type, params Provider[] sources) : Provider(type, sources)
   {
+    internal abstract Provider Visit(ProviderVisitor visitor);
+
     // Constructors
 
-    /// <inheritdoc/>
-    protected CompilableProvider(ProviderType type, params Provider[] sources)
-      : base(type, sources)
-    {
-    }
-
     protected CompilableProvider(ProviderType type)
-      : this(type, Array.Empty<Provider>())
+      : this(type, [])
     {
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProviderVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/CompilableProviderVisitor.cs
@@ -18,9 +18,11 @@ namespace Xtensive.Orm.Rse.Providers
   /// <see cref="CompilableProvider"/> visitor class. Result is <see cref="CompilableProvider"/>.
   /// </summary>
   [Serializable]
-  public class CompilableProviderVisitor : ProviderVisitor<CompilableProvider>
+  public class CompilableProviderVisitor : ProviderVisitor
   {
     protected Func<CompilableProvider, Expression, Expression> translate;
+
+    protected override CompilableProvider Visit(CompilableProvider cp) => (CompilableProvider) base.Visit(cp);
 
     /// <summary>
     /// Visits the compilable provider.
@@ -29,7 +31,7 @@ namespace Xtensive.Orm.Rse.Providers
     public CompilableProvider VisitCompilable(CompilableProvider cp) => Visit(cp);
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitTake(TakeProvider provider)
+    internal protected override CompilableProvider VisitTake(TakeProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -38,7 +40,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitSkip(SkipProvider provider)
+    internal protected override CompilableProvider VisitSkip(SkipProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -47,7 +49,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitPaging(PagingProvider provider)
+    internal protected override CompilableProvider VisitPaging(PagingProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -56,7 +58,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitSelect(SelectProvider provider)
+    internal protected override CompilableProvider VisitSelect(SelectProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -67,7 +69,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitTag(TagProvider provider)
+    internal protected override CompilableProvider VisitTag(TagProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -78,7 +80,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
     
     /// <inheritdoc/>
-    protected override IndexHintProvider VisitIndexHint(IndexHintProvider provider)
+    internal protected override IndexHintProvider VisitIndexHint(IndexHintProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -89,7 +91,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitSeek(SeekProvider provider)
+    internal protected override CompilableProvider VisitSeek(SeekProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -98,13 +100,13 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitRaw(RawProvider provider)
+    internal protected override CompilableProvider VisitRaw(RawProvider provider)
     {
       return provider;
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitSort(SortProvider provider)
+    internal protected override CompilableProvider VisitSort(SortProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -115,7 +117,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitJoin(JoinProvider provider)
+    internal protected override CompilableProvider VisitJoin(JoinProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -128,7 +130,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitFilter(FilterProvider provider)
+    internal protected override CompilableProvider VisitFilter(FilterProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -140,7 +142,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitDistinct(DistinctProvider provider)
+    internal protected override CompilableProvider VisitDistinct(DistinctProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -149,7 +151,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitCalculate(CalculateProvider provider)
+    internal protected override CompilableProvider VisitCalculate(CalculateProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -169,7 +171,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitRowNumber(RowNumberProvider provider)
+    internal protected override CompilableProvider VisitRowNumber(RowNumberProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -179,7 +181,7 @@ namespace Xtensive.Orm.Rse.Providers
 
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitAlias(AliasProvider provider)
+    internal protected override CompilableProvider VisitAlias(AliasProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -188,7 +190,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitAggregate(AggregateProvider provider)
+    internal protected override CompilableProvider VisitAggregate(AggregateProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -206,7 +208,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitStore(StoreProvider provider)
+    internal protected override CompilableProvider VisitStore(StoreProvider provider)
     {
       var compilableSource = provider.Source;
       OnRecursionEntrance(provider);
@@ -216,7 +218,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitIndex(IndexProvider provider)
+    internal protected override CompilableProvider VisitIndex(IndexProvider provider)
     {
       OnRecursionEntrance(provider);
       _ = OnRecursionExit(provider);
@@ -224,7 +226,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitFreeText(FreeTextProvider provider)
+    internal protected override CompilableProvider VisitFreeText(FreeTextProvider provider)
     {
       OnRecursionEntrance(provider);
       _ = OnRecursionExit(provider);
@@ -232,7 +234,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitContainsTable(ContainsTableProvider provider)
+    internal protected override CompilableProvider VisitContainsTable(ContainsTableProvider provider)
     {
       OnRecursionEntrance(provider);
       _ = OnRecursionExit(provider);
@@ -240,7 +242,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitPredicateJoin(PredicateJoinProvider provider)
+    internal protected override CompilableProvider VisitPredicateJoin(PredicateJoinProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -252,7 +254,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitExistence(ExistenceProvider provider)
+    internal protected override CompilableProvider VisitExistence(ExistenceProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -261,7 +263,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitApply(ApplyProvider provider)
+    internal protected override CompilableProvider VisitApply(ApplyProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -274,7 +276,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitIntersect(IntersectProvider provider)
+    internal protected override CompilableProvider VisitIntersect(IntersectProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -286,7 +288,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitExcept(ExceptProvider provider)
+    internal protected override CompilableProvider VisitExcept(ExceptProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -298,7 +300,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitConcat(ConcatProvider provider)
+    internal protected override CompilableProvider VisitConcat(ConcatProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -310,7 +312,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitUnion(UnionProvider provider)
+    internal protected override CompilableProvider VisitUnion(UnionProvider provider)
     {
       OnRecursionEntrance(provider);
       var left = VisitCompilable(provider.Left);
@@ -322,7 +324,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitLock(LockProvider provider)
+    internal protected override CompilableProvider VisitLock(LockProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);
@@ -331,7 +333,7 @@ namespace Xtensive.Orm.Rse.Providers
     }
 
     /// <inheritdoc/>
-    protected override CompilableProvider VisitInclude(IncludeProvider provider)
+    internal protected override CompilableProvider VisitInclude(IncludeProvider provider)
     {
       OnRecursionEntrance(provider);
       var source = VisitCompilable(provider.Source);

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/ProviderVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/ProviderVisitor.cs
@@ -13,231 +13,196 @@ namespace Xtensive.Orm.Rse.Providers
   /// Abstract <see cref="CompilableProvider"/> visitor class.
   /// </summary>
   [Serializable]
-  public abstract class ProviderVisitor<TResult> where TResult : Provider
+  public abstract class ProviderVisitor
   {
     /// <summary>
     /// Visits the specified <paramref name="cp"/>.
     /// </summary>
     /// <param name="cp">The <see cref="CompilableProvider"/> to visit.</param>
     /// <returns>Visit result.</returns>
-    protected virtual TResult Visit(CompilableProvider cp) =>
-      cp == null
-        ? null
-        : cp.Type switch {
-          ProviderType.Index => VisitIndex((IndexProvider) cp),
-          ProviderType.Store => VisitStore((StoreProvider) cp),
-          ProviderType.Aggregate => VisitAggregate((AggregateProvider) cp),
-          ProviderType.Alias => VisitAlias((AliasProvider) cp),
-          ProviderType.Calculate => VisitCalculate((CalculateProvider) cp),
-          ProviderType.Distinct => VisitDistinct((DistinctProvider) cp),
-          ProviderType.Filter => VisitFilter((FilterProvider) cp),
-          ProviderType.Join => VisitJoin((JoinProvider) cp),
-          ProviderType.Sort => VisitSort((SortProvider) cp),
-          ProviderType.Raw => VisitRaw((RawProvider) cp),
-          ProviderType.Seek => VisitSeek((SeekProvider) cp),
-          ProviderType.Select => VisitSelect((SelectProvider) cp),
-          ProviderType.Tag => VisitTag((TagProvider) cp),
-          ProviderType.Skip => VisitSkip((SkipProvider) cp),
-          ProviderType.Take => VisitTake((TakeProvider) cp),
-          ProviderType.Paging => VisitPaging((PagingProvider) cp),
-          ProviderType.RowNumber => VisitRowNumber((RowNumberProvider) cp),
-          ProviderType.Apply => VisitApply((ApplyProvider) cp),
-          ProviderType.Existence => VisitExistence((ExistenceProvider) cp),
-          ProviderType.PredicateJoin => VisitPredicateJoin((PredicateJoinProvider) cp),
-          ProviderType.Intersect => VisitIntersect((IntersectProvider) cp),
-          ProviderType.Except => VisitExcept((ExceptProvider) cp),
-          ProviderType.Concat => VisitConcat((ConcatProvider) cp),
-          ProviderType.Union => VisitUnion((UnionProvider) cp),
-          ProviderType.Lock => VisitLock((LockProvider) cp),
-          ProviderType.Include => VisitInclude((IncludeProvider) cp),
-          ProviderType.FreeText => VisitFreeText((FreeTextProvider) cp),
-          ProviderType.ContainsTable => VisitContainsTable((ContainsTableProvider) cp),
-          ProviderType.IndexHint => VisitIndexHint((IndexHintProvider) cp),
-          ProviderType.Void => throw new NotSupportedException(Strings.ExProcessingOfVoidProviderIsNotSupported),
-          _ => throw new ArgumentOutOfRangeException()
-        };
+    protected virtual Provider Visit(CompilableProvider cp) => cp?.Visit(this);
 
     /// <summary>
     /// Visits <see cref="PredicateJoinProvider"/>.
     /// </summary>
     /// <param name="provider">Predicate join provider.</param>
-    protected abstract TResult VisitPredicateJoin(PredicateJoinProvider provider);
+    internal protected abstract Provider VisitPredicateJoin(PredicateJoinProvider provider);
 
     /// <summary>
     /// Visits <see cref="ExistenceProvider"/>.
     /// </summary>
     /// <param name="provider">Existence provider.</param>
-    protected abstract TResult VisitExistence(ExistenceProvider provider);
+    internal protected abstract Provider VisitExistence(ExistenceProvider provider);
 
     /// <summary>
     /// Visits <see cref="ApplyProvider"/>.
     /// </summary>
     /// <param name="provider">Apply provider.</param>
-    protected abstract TResult VisitApply(ApplyProvider provider);
+    internal protected abstract Provider VisitApply(ApplyProvider provider);
 
     /// <summary>
     /// Visits <see cref="RowNumberProvider"/>.
     /// </summary>
     /// <param name="provider">Row number provider.</param>
-    protected abstract TResult VisitRowNumber(RowNumberProvider provider);
+    internal protected abstract Provider VisitRowNumber(RowNumberProvider provider);
 
     /// <summary>
     /// Visits <see cref="TakeProvider"/>.
     /// </summary>
     /// <param name="provider">Take provider.</param>
-    protected abstract TResult VisitTake(TakeProvider provider);
+    internal protected abstract Provider VisitTake(TakeProvider provider);
 
     /// <summary>
     /// Visits <see cref="SkipProvider"/>.
     /// </summary>
     /// <param name="provider">Skip provider.</param>
-    protected abstract TResult VisitSkip(SkipProvider provider);
+    internal protected abstract Provider VisitSkip(SkipProvider provider);
 
     /// <summary>
     /// Visits <see cref="PagingProvider"/>.
     /// </summary>
     /// <param name="provider">Paging provider.</param>
-    protected abstract TResult VisitPaging(PagingProvider provider);
+    internal protected abstract Provider VisitPaging(PagingProvider provider);
 
     /// <summary>
     /// Visits <see cref="SelectProvider"/>.
     /// </summary>
     /// <param name="provider">Select provider.</param>
-    protected abstract TResult VisitSelect(SelectProvider provider);
+    internal protected abstract Provider VisitSelect(SelectProvider provider);
 
     /// <summary>
     /// Visits <see cref="TagProvider"/>.
     /// </summary>
     /// <param name="provider">Tag provider.</param>
-    protected abstract TResult VisitTag(TagProvider provider);
+    internal protected abstract Provider VisitTag(TagProvider provider);
     
     /// <summary>
     /// Visits <see cref="IndexHintProvider"/>.
     /// </summary>
     /// <param name="provider">IndexHint provider.</param>
-    protected abstract TResult VisitIndexHint(IndexHintProvider provider);
+    internal protected abstract Provider VisitIndexHint(IndexHintProvider provider);
 
     /// <summary>
     /// Visits <see cref="SeekProvider"/>.
     /// </summary>
     /// <param name="provider">Seek provider.</param>
-    protected abstract TResult VisitSeek(SeekProvider provider);
+    internal protected abstract Provider VisitSeek(SeekProvider provider);
 
     /// <summary>
     /// Visits <see cref="RawProvider"/>.
     /// </summary>
     /// <param name="provider">Raw provider.</param>
-    protected abstract TResult VisitRaw(RawProvider provider);
+    internal protected abstract Provider VisitRaw(RawProvider provider);
 
     /// <summary>
     /// Visits <see cref="SortProvider"/>.
     /// </summary>
     /// <param name="provider">Sort provider.</param>
-    protected abstract TResult VisitSort(SortProvider provider);
+    internal protected abstract Provider VisitSort(SortProvider provider);
 
     /// <summary>
     /// Visits <see cref="JoinProvider"/>.
     /// </summary>
     /// <param name="provider">Join provider.</param>
-    protected abstract TResult VisitJoin(JoinProvider provider);
+    internal protected abstract Provider VisitJoin(JoinProvider provider);
 
     /// <summary>
     /// Visits <see cref="FilterProvider"/>.
     /// </summary>
     /// <param name="provider">Filter provider.</param>
-    protected abstract TResult VisitFilter(FilterProvider provider);
+    internal protected abstract Provider VisitFilter(FilterProvider provider);
 
     /// <summary>
     /// Visits <see cref="DistinctProvider"/>.
     /// </summary>
     /// <param name="provider">Distinct provider.</param>
-    protected abstract TResult VisitDistinct(DistinctProvider provider);
+    internal protected abstract Provider VisitDistinct(DistinctProvider provider);
 
     /// <summary>
     /// Visits <see cref="CalculateProvider"/>.
     /// </summary>
     /// <param name="provider">Calculate provider.</param>
-    protected abstract TResult VisitCalculate(CalculateProvider provider);
+    internal protected abstract Provider VisitCalculate(CalculateProvider provider);
 
     /// <summary>
     /// Visits <see cref="AliasProvider"/>.
     /// </summary>
     /// <param name="provider">Alias provider.</param>
-    protected abstract TResult VisitAlias(AliasProvider provider);
+    internal protected abstract Provider VisitAlias(AliasProvider provider);
 
     /// <summary>
     /// Visits <see cref="AggregateProvider"/>.
     /// </summary>
     /// <param name="provider">Aggregate provider.</param>
     /// <returns></returns>
-    protected abstract TResult VisitAggregate(AggregateProvider provider);
+    internal protected abstract Provider VisitAggregate(AggregateProvider provider);
 
     /// <summary>
     /// Visits <see cref="StoreProvider"/>.
     /// </summary>
     /// <param name="provider">Store provider.</param>
-    protected abstract TResult VisitStore(StoreProvider provider);
+    internal protected abstract Provider VisitStore(StoreProvider provider);
 
     /// <summary>
     /// Visits <see cref="IndexProvider"/>.
     /// </summary>
     /// <param name="provider">Index provider.</param>
-    protected abstract TResult VisitIndex(IndexProvider provider);
+    internal protected abstract Provider VisitIndex(IndexProvider provider);
 
     /// <summary>
     /// Visits the <see cref="IntersectProvider"/>.
     /// </summary>
     /// <param name="provider">Intersect provider.</param>
     /// <returns></returns>
-    protected abstract TResult VisitIntersect(IntersectProvider provider);
+    internal protected abstract Provider VisitIntersect(IntersectProvider provider);
 
     /// <summary>
     /// Visits the <see cref="ExceptProvider"/>.
     /// </summary>
     /// <param name="provider">Except provider.</param>
     /// <returns></returns>
-    protected abstract TResult VisitExcept(ExceptProvider provider);
+    internal protected abstract Provider VisitExcept(ExceptProvider provider);
 
     /// <summary>
     /// Visits the <see cref="ConcatProvider"/>.
     /// </summary>
     /// <param name="provider">Concat provider.</param>
     /// <returns></returns>
-    protected abstract TResult VisitConcat(ConcatProvider provider);
+    internal protected abstract Provider VisitConcat(ConcatProvider provider);
 
     /// <summary>
     /// Visits the <see cref="UnionProvider"/>.
     /// </summary>
     /// <param name="provider">Union provider.</param>
     /// <returns></returns>
-    protected abstract TResult VisitUnion(UnionProvider provider);
+    internal protected abstract Provider VisitUnion(UnionProvider provider);
 
     /// <summary>
     /// Visits the <see cref="LockProvider"/>.
     /// </summary>
     /// <param name="provider">Lock provider.</param>
     /// <returns></returns>
-    protected abstract TResult VisitLock(LockProvider provider);
+    internal protected abstract Provider VisitLock(LockProvider provider);
 
     /// <summary>
     /// Visits the <see cref="IncludeProvider"/>.
     /// </summary>
     /// <param name="provider">Include provider.</param>
     /// <returns></returns>
-    protected abstract TResult VisitInclude(IncludeProvider provider);
+    internal protected abstract Provider VisitInclude(IncludeProvider provider);
 
     /// <summary>
     /// Visits the <see cref="FreeTextProvider"/>.
     /// </summary>
     /// <param name="provider">FreeText provider.</param>
     /// <returns></returns>
-    protected abstract TResult VisitFreeText(FreeTextProvider provider);
+    internal protected abstract Provider VisitFreeText(FreeTextProvider provider);
 
     /// <summary>
     /// Visits the <see cref="ContainsTableProvider"/>.
     /// </summary>
     /// <param name="provider">SearchCondition provider.</param>
     /// <returns></returns>
-    protected abstract TResult VisitContainsTable(ContainsTableProvider provider);
+    internal protected abstract Provider VisitContainsTable(ContainsTableProvider provider);
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
@@ -36,7 +36,7 @@ namespace Xtensive.Orm.Rse.Transformation
 
     #region Visit methods
 
-    protected override IncludeProvider VisitInclude(IncludeProvider provider)
+    internal protected override IncludeProvider VisitInclude(IncludeProvider provider)
     {
       var sourceLength = provider.Source.Header.Length;
       mappings[provider.Source] = Merge(mappings[provider].Where(i => i < sourceLength), provider.FilteredColumns);
@@ -52,7 +52,7 @@ namespace Xtensive.Orm.Rse.Transformation
         provider.FilterDataSource, provider.ResultColumnName, filteredColumns);
     }
 
-    protected override SelectProvider VisitSelect(SelectProvider provider)
+    internal protected override SelectProvider VisitSelect(SelectProvider provider)
     {
       var requiredColumns = mappings[provider];
       var remappedColumns = requiredColumns
@@ -83,31 +83,31 @@ namespace Xtensive.Orm.Rse.Transformation
     }
 
     /// <inheritdoc/>
-    protected override FreeTextProvider VisitFreeText(FreeTextProvider provider)
+    internal protected override FreeTextProvider VisitFreeText(FreeTextProvider provider)
     {
       mappings[provider] = CollectionUtils.RangeToList(0, provider.Header.Length);
       return provider;
     }
 
-    protected override CompilableProvider VisitContainsTable(ContainsTableProvider provider)
+    internal protected override CompilableProvider VisitContainsTable(ContainsTableProvider provider)
     {
       mappings[provider] = CollectionUtils.RangeToList(0, provider.Header.Length);
       return provider;
     }
 
-    protected override IndexProvider VisitIndex(IndexProvider provider)
+    internal protected override IndexProvider VisitIndex(IndexProvider provider)
     {
       mappings[provider] = CollectionUtils.RangeToList(0, provider.Header.Length);
       return provider;
     }
 
-    protected override SeekProvider VisitSeek(SeekProvider provider)
+    internal protected override SeekProvider VisitSeek(SeekProvider provider)
     {
       mappings[provider] = CollectionUtils.RangeToList(0, provider.Header.Length);
       return provider;
     }
 
-    protected override FilterProvider VisitFilter(FilterProvider provider)
+    internal protected override FilterProvider VisitFilter(FilterProvider provider)
     {
       mappings[provider.Source] = Merge(mappings[provider], mappingsGatherer.Gather(provider.Predicate));
       var newSourceProvider = VisitCompilable(provider.Source);
@@ -119,7 +119,7 @@ namespace Xtensive.Orm.Rse.Transformation
         : new FilterProvider(newSourceProvider, (Expression<Func<Tuple, bool>>) predicate);
     }
 
-    protected override JoinProvider VisitJoin(JoinProvider provider)
+    internal protected override JoinProvider VisitJoin(JoinProvider provider)
     {
       // split
 
@@ -147,7 +147,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return new JoinProvider(newLeftProvider, newRightProvider, provider.JoinType, newIndexes);
     }
 
-    protected override PredicateJoinProvider VisitPredicateJoin(PredicateJoinProvider provider)
+    internal protected override PredicateJoinProvider VisitPredicateJoin(PredicateJoinProvider provider)
     {
       var (leftMapping, rightMapping) = SplitMappings(provider);
 
@@ -168,7 +168,7 @@ namespace Xtensive.Orm.Rse.Transformation
         : new PredicateJoinProvider(newLeftProvider, newRightProvider, (Expression<Func<Tuple, Tuple, bool>>) predicate, provider.JoinType);
     }
 
-    protected override SortProvider VisitSort(SortProvider provider)
+    internal protected override SortProvider VisitSort(SortProvider provider)
     {
       mappings[provider.Source] = Merge(mappings[provider], provider.Order.Keys);
       var source = VisitCompilable(provider.Source);
@@ -187,7 +187,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return source == provider.Source ? provider : new SortProvider(source, order);
     }
 
-    protected override ApplyProvider VisitApply(ApplyProvider provider)
+    internal protected override ApplyProvider VisitApply(ApplyProvider provider)
     {
       // split
 
@@ -235,7 +235,7 @@ namespace Xtensive.Orm.Rse.Transformation
         : new ApplyProvider(applyParameter, newLeftProvider, newRightProvider, provider.IsInlined, provider.SequenceType, provider.ApplyType);
     }
 
-    protected override AggregateProvider VisitAggregate(AggregateProvider provider)
+    internal protected override AggregateProvider VisitAggregate(AggregateProvider provider)
     {
       var map = provider.AggregateColumns
         .Select(c => c.SourceIndex)
@@ -274,7 +274,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return new AggregateProvider(source, groupColumnIndexes, columns);
     }
 
-    protected override CompilableProvider VisitCalculate(CalculateProvider provider)
+    internal protected override CompilableProvider VisitCalculate(CalculateProvider provider)
     {
       var sourceLength = provider.Source.Header.Length;
       var usedColumns = mappings[provider];
@@ -311,7 +311,7 @@ namespace Xtensive.Orm.Rse.Transformation
         : new CalculateProvider(newSourceProvider, descriptors);
     }
 
-    protected override RowNumberProvider VisitRowNumber(RowNumberProvider provider)
+    internal protected override RowNumberProvider VisitRowNumber(RowNumberProvider provider)
     {
       var sourceLength = provider.Source.Header.Length;
       mappings[provider.Source] = mappings[provider].Where(i => i < sourceLength).ToList();
@@ -324,7 +324,7 @@ namespace Xtensive.Orm.Rse.Transformation
         : new RowNumberProvider(newSource, rowNumberColumn.Name);
     }
 
-    protected override CompilableProvider VisitStore(StoreProvider provider)
+    internal protected override CompilableProvider VisitStore(StoreProvider provider)
     {
       if (!(provider.Source is CompilableProvider compilableSource)) {
         return provider;
@@ -346,13 +346,13 @@ namespace Xtensive.Orm.Rse.Transformation
         : new StoreProvider(source, provider.Name);
     }
 
-    protected override CompilableProvider VisitConcat(ConcatProvider provider) => VisitSetOperationProvider(provider);
+    internal protected override CompilableProvider VisitConcat(ConcatProvider provider) => VisitSetOperationProvider(provider);
 
-    protected override CompilableProvider VisitExcept(ExceptProvider provider) => VisitSetOperationProvider(provider);
+    internal protected override CompilableProvider VisitExcept(ExceptProvider provider) => VisitSetOperationProvider(provider);
 
-    protected override CompilableProvider VisitIntersect(IntersectProvider provider) => VisitSetOperationProvider(provider);
+    internal protected override CompilableProvider VisitIntersect(IntersectProvider provider) => VisitSetOperationProvider(provider);
 
-    protected override CompilableProvider VisitUnion(UnionProvider provider) => VisitSetOperationProvider(provider);
+    internal protected override CompilableProvider VisitUnion(UnionProvider provider) => VisitSetOperationProvider(provider);
 
     private CompilableProvider VisitSetOperationProvider(BinaryProvider provider)
     {

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyProviderCorrectorRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyProviderCorrectorRewriter.cs
@@ -146,7 +146,7 @@ namespace Xtensive.Orm.Rse.Transformation
       throw new InvalidOperationException(sb.ToString());
     }
 
-    protected override CompilableProvider VisitApply(ApplyProvider provider)
+    internal protected override CompilableProvider VisitApply(ApplyProvider provider)
     {
       CompilableProvider left;
       CompilableProvider right;
@@ -165,7 +165,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return InsertCalculateProviders(provider, convertedApply);
     }
 
-    protected override CompilableProvider VisitFilter(FilterProvider provider)
+    internal protected override CompilableProvider VisitFilter(FilterProvider provider)
     {
       var source = VisitCompilable(provider.Source);
       if (calculateProviderCollector.TryAddFilter(provider))
@@ -179,7 +179,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return newProvider;
     }
 
-    protected override CompilableProvider VisitAlias(AliasProvider provider)
+    internal protected override CompilableProvider VisitAlias(AliasProvider provider)
     {
       var source = VisitCompilable(provider.Source);
       var newProvider = source!=provider.Source ? new AliasProvider(source, provider.Alias) : provider;
@@ -188,7 +188,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return newProvider;
     }
 
-    protected override SelectProvider VisitSelect(SelectProvider provider)
+    internal protected override SelectProvider VisitSelect(SelectProvider provider)
     {
       var source = VisitCompilable(provider.Source);
       var newProvider = provider;
@@ -199,7 +199,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return newProvider;
     }
 
-    protected override JoinProvider VisitJoin(JoinProvider provider)
+    internal protected override JoinProvider VisitJoin(JoinProvider provider)
     {
       CompilableProvider left;
       CompilableProvider right;
@@ -213,7 +213,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return provider;
     }
 
-    protected override PredicateJoinProvider VisitPredicateJoin(PredicateJoinProvider provider)
+    internal protected override PredicateJoinProvider VisitPredicateJoin(PredicateJoinProvider provider)
     {
       CompilableProvider left;
       CompilableProvider right;
@@ -227,7 +227,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return provider;
     }
 
-    protected override IntersectProvider VisitIntersect(IntersectProvider provider)
+    internal protected override IntersectProvider VisitIntersect(IntersectProvider provider)
     {
       CompilableProvider left;
       CompilableProvider right;
@@ -237,7 +237,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return provider;
     }
 
-    protected override ExceptProvider VisitExcept(ExceptProvider provider)
+    internal protected override ExceptProvider VisitExcept(ExceptProvider provider)
     {
       CompilableProvider left;
       CompilableProvider right;
@@ -247,7 +247,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return provider;
     }
 
-    protected override CompilableProvider VisitConcat(ConcatProvider provider)
+    internal protected override CompilableProvider VisitConcat(ConcatProvider provider)
     {
       VisitBinaryProvider(provider, out var left, out var right);
       return left == provider.Left && right == provider.Right
@@ -255,7 +255,7 @@ namespace Xtensive.Orm.Rse.Transformation
         : new ConcatProvider(left, right);
     }
 
-    protected override UnionProvider VisitUnion(UnionProvider provider)
+    internal protected override UnionProvider VisitUnion(UnionProvider provider)
     {
       CompilableProvider left;
       CompilableProvider right;
@@ -265,7 +265,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return provider;
     }
 
-    protected override CompilableProvider VisitAggregate(AggregateProvider provider)
+    internal protected override CompilableProvider VisitAggregate(AggregateProvider provider)
     {
       var source = VisitCompilable(provider.Source);
       var newProvider = provider;
@@ -275,7 +275,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return newProvider;
     }
 
-    protected override CompilableProvider VisitCalculate(CalculateProvider provider)
+    internal protected override CompilableProvider VisitCalculate(CalculateProvider provider)
     {
       var source = VisitCompilable(provider.Source);
       var newProvider = provider;
@@ -284,7 +284,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return calculateProviderCollector.TryAdd(newProvider) ? source : newProvider;
     }
 
-    protected override TakeProvider VisitTake(TakeProvider provider)
+    internal protected override TakeProvider VisitTake(TakeProvider provider)
     {
       var source = VisitCompilable(provider.Source);
       EnsureAbsenceOfApplyProviderRequiringConversion();
@@ -293,7 +293,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return provider;
     }
 
-    protected override SkipProvider VisitSkip(SkipProvider provider)
+    internal protected override SkipProvider VisitSkip(SkipProvider provider)
     {
       var source = VisitCompilable(provider.Source);
       EnsureAbsenceOfApplyProviderRequiringConversion();

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/OrderingRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/OrderingRewriter.cs
@@ -53,7 +53,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return visited;
     }
 
-    protected override CompilableProvider VisitSort(SortProvider provider)
+    internal protected override CompilableProvider VisitSort(SortProvider provider)
     {
       var source = VisitCompilable(provider.Source);
       sortOrder = provider.Order;
@@ -62,7 +62,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return source;
     }
 
-    protected override CompilableProvider VisitSelect(SelectProvider provider)
+    internal protected override CompilableProvider VisitSelect(SelectProvider provider)
     {
       var result = provider;
       var source = VisitCompilable(provider.Source);
@@ -93,7 +93,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return result;
     }
 
-    protected override CompilableProvider VisitAggregate(AggregateProvider provider)
+    internal protected override CompilableProvider VisitAggregate(AggregateProvider provider)
     {
       var result = provider;
       var source = VisitCompilable(provider.Source);
@@ -119,37 +119,37 @@ namespace Xtensive.Orm.Rse.Transformation
       return result;
     }
 
-    protected override CompilableProvider VisitIndex(IndexProvider provider)
+    internal protected override CompilableProvider VisitIndex(IndexProvider provider)
     {
       sortOrder = new();
       return provider;
     }
 
-    protected override CompilableProvider VisitFreeText(FreeTextProvider provider)
+    internal protected override CompilableProvider VisitFreeText(FreeTextProvider provider)
     {
       sortOrder = new();
       return provider;
     }
 
-    protected override CompilableProvider VisitContainsTable(ContainsTableProvider provider)
+    internal protected override CompilableProvider VisitContainsTable(ContainsTableProvider provider)
     {
       sortOrder = new();
       return provider;
     }
 
-    protected override RawProvider VisitRaw(RawProvider provider)
+    internal protected override RawProvider VisitRaw(RawProvider provider)
     {
       sortOrder = new();
       return provider;
     }
 
-    protected override CompilableProvider VisitStore(StoreProvider provider)
+    internal protected override CompilableProvider VisitStore(StoreProvider provider)
     {
       sortOrder = new();
       return provider;
     }
 
-    protected override ApplyProvider VisitApply(ApplyProvider provider)
+    internal protected override ApplyProvider VisitApply(ApplyProvider provider)
     {
       var left = VisitCompilable(provider.Left);
       var leftOrder = sortOrder;
@@ -162,7 +162,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return result;
     }
 
-    protected override JoinProvider VisitJoin(JoinProvider provider)
+    internal protected override JoinProvider VisitJoin(JoinProvider provider)
     {
       var left = VisitCompilable(provider.Left);
       var leftOrder = sortOrder;
@@ -175,7 +175,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return result;
     }
 
-    protected override PredicateJoinProvider VisitPredicateJoin(PredicateJoinProvider provider)
+    internal protected override PredicateJoinProvider VisitPredicateJoin(PredicateJoinProvider provider)
     {
       var left = VisitCompilable(provider.Left);
       var leftOrder = sortOrder;

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/SkipTakeRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/SkipTakeRewriter.cs
@@ -66,7 +66,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return base.Visit(cp);
     }
 
-    protected override CompilableProvider VisitSkip(SkipProvider provider)
+    internal protected override CompilableProvider VisitSkip(SkipProvider provider)
     {
       State.IsSkipTakeChain = true;
       var visitedSource = VisitCompilable(provider.Source);
@@ -74,7 +74,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return visitedSource;
     }
 
-    protected override CompilableProvider VisitTake(TakeProvider provider)
+    internal protected override CompilableProvider VisitTake(TakeProvider provider)
     {
       State.IsSkipTakeChain = true;
       var visitedSource = VisitCompilable(provider.Source);
@@ -82,7 +82,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return visitedSource;
     }
 
-    protected override CompilableProvider VisitPaging(PagingProvider provider)
+    internal protected override CompilableProvider VisitPaging(PagingProvider provider)
     {
       State.IsSkipTakeChain = true;
       var visitedSource = VisitCompilable(provider.Source);

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/RedundantColumnRemover.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/RedundantColumnRemover.cs
@@ -37,7 +37,7 @@ namespace Xtensive.Orm.Rse.Transformation
       return (selectProvider, requestedMapping);
     }
 
-    protected override RawProvider VisitRaw(RawProvider provider)
+    internal protected override RawProvider VisitRaw(RawProvider provider)
     {
       var mapping = mappings[provider];
       if (mapping.SequenceEqual(CollectionUtils.ColNumRange(provider.Header.Length)))


### PR DESCRIPTION
It is better than big `switch` statement with type casts