### PR TITLE
Optimize allocations of collection safety wrappers

### DIFF
--- a/Orm/Xtensive.Orm/Comparison/ComparisonRules.cs
+++ b/Orm/Xtensive.Orm/Comparison/ComparisonRules.cs
@@ -144,7 +144,7 @@ namespace Xtensive.Comparison
     /// </summary>
     public IReadOnlyList<ComparisonRules> Composite {
       [DebuggerStepThrough]
-      get => Array.AsReadOnly(composite);
+      get => composite.AsSafeWrapper();
     }
     
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/TypeBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/TypeBuilder.cs
@@ -51,7 +51,7 @@ namespace Xtensive.Orm.Building.Builders
           MappingSchema = typeDef.MappingSchema,
           HasVersionRoots = TypeHelper.GetInterfacesUnordered(typeDef.UnderlyingType)
             .Any(static type => type == typeof(IHasVersionRoots)),
-          Validators = validators.AsReadOnly(),
+          Validators = validators.AsSafeWrapper(),
         };
 
         if (typeDef.StaticTypeId != null) {

--- a/Orm/Xtensive.Orm/Orm/FullTextSearchCondition/Nodes/CustomProximityTerm.cs
+++ b/Orm/Xtensive.Orm/Orm/FullTextSearchCondition/Nodes/CustomProximityTerm.cs
@@ -18,13 +18,13 @@ namespace Xtensive.Orm.FullTextSearchCondition.Nodes
   public sealed class CustomProximityTerm : Operand, ICustomProximityTerm
   {
     /// <inheritdoc/>
-    public IReadOnlyList<IProximityOperand> Terms { get; private set; }
+    public IReadOnlyList<IProximityOperand> Terms { get; }
 
     /// <inheritdoc/>
-    public long? MaxDistance { get; private set; }
+    public long? MaxDistance { get; }
 
     /// <inheritdoc/>
-    public bool MatchOrder { get; private set; }
+    public bool MatchOrder { get; }
 
     protected override void AcceptVisitorInternal(ISearchConditionNodeVisitor visitor)
     {
@@ -50,7 +50,7 @@ namespace Xtensive.Orm.FullTextSearchCondition.Nodes
       ArgumentValidator.EnsureArgumentNotNull(proximityTerms, "proximityTerms");
       ArgumentValidator.EnsureArgumentIsGreaterThanOrEqual(maxDistance, 0, "maxDistance");
 
-      Terms = proximityTerms.ToList().AsSafeWrapper();
+      Terms = proximityTerms.ToArray().AsSafeWrapper();
       MaxDistance = maxDistance;
       MatchOrder = matchOrder;
     }

--- a/Orm/Xtensive.Orm/Orm/FullTextSearchCondition/Nodes/CustomProximityTerm.cs
+++ b/Orm/Xtensive.Orm/Orm/FullTextSearchCondition/Nodes/CustomProximityTerm.cs
@@ -50,7 +50,7 @@ namespace Xtensive.Orm.FullTextSearchCondition.Nodes
       ArgumentValidator.EnsureArgumentNotNull(proximityTerms, "proximityTerms");
       ArgumentValidator.EnsureArgumentIsGreaterThanOrEqual(maxDistance, 0, "maxDistance");
 
-      Terms = proximityTerms.ToList().AsReadOnly();
+      Terms = proximityTerms.ToList().AsSafeWrapper();
       MaxDistance = maxDistance;
       MatchOrder = matchOrder;
     }

--- a/Orm/Xtensive.Orm/Orm/FullTextSearchCondition/Nodes/GenerationTerm.cs
+++ b/Orm/Xtensive.Orm/Orm/FullTextSearchCondition/Nodes/GenerationTerm.cs
@@ -39,7 +39,7 @@ namespace Xtensive.Orm.FullTextSearchCondition.Nodes
       if (terms.Any(c=>c.IsNullOrEmpty() || c.Trim().IsNullOrEmpty()))
         throw new ArgumentException(Strings.ExCollectionCannotContainAnyNeitherNullOrEmptyStringValues, "terms");
       GenerationType = generationType;
-      Terms = terms.ToList().AsReadOnly();
+      Terms = terms.ToList().AsSafeWrapper();
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/FullTextSearchCondition/Nodes/GenerationTerm.cs
+++ b/Orm/Xtensive.Orm/Orm/FullTextSearchCondition/Nodes/GenerationTerm.cs
@@ -19,10 +19,10 @@ namespace Xtensive.Orm.FullTextSearchCondition.Nodes
   public sealed class GenerationTerm : Operand, IGenerationTerm, IWeighableTerm
   {
     /// <inheritdoc/>
-    public GenerationType GenerationType { get; private set; }
+    public GenerationType GenerationType { get; }
 
     /// <inheritdoc/>
-    public IReadOnlyList<string> Terms { get; private set; }
+    public IReadOnlyList<string> Terms { get; }
 
     protected override void AcceptVisitorInternal(ISearchConditionNodeVisitor visitor)
     {
@@ -39,7 +39,7 @@ namespace Xtensive.Orm.FullTextSearchCondition.Nodes
       if (terms.Any(c=>c.IsNullOrEmpty() || c.Trim().IsNullOrEmpty()))
         throw new ArgumentException(Strings.ExCollectionCannotContainAnyNeitherNullOrEmptyStringValues, "terms");
       GenerationType = generationType;
-      Terms = terms.ToList().AsSafeWrapper();
+      Terms = terms.ToArray().AsSafeWrapper();
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/FullTextSearchCondition/Nodes/GenericProximityTerm.cs
+++ b/Orm/Xtensive.Orm/Orm/FullTextSearchCondition/Nodes/GenericProximityTerm.cs
@@ -29,7 +29,7 @@ namespace Xtensive.Orm.FullTextSearchCondition.Nodes
     {
       if (terms.Count < 2)
         throw new ArgumentException(string.Format(Strings.ExCollectionShouldContainAtLeastXElements, 2));
-      Terms = terms.ToList().AsReadOnly();
+      Terms = terms.ToArray();
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/OwnerRemover.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/OwnerRemover.cs
@@ -50,7 +50,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       var oldBindings = expression.Bindings.Values.ToArray(expression.Bindings.Count);
       var newBindings = VisitExpressionList(oldBindings);
 
-      var oldNativeBindings = expression.NativeBindings.Select(b => b.Value).ToList().AsReadOnly();
+      var oldNativeBindings = expression.NativeBindings.Select(b => b.Value).ToArray().AsSafeWrapper();
       var newNativeBindings = VisitExpressionList(oldNativeBindings);
       
       var notChanged =

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
@@ -613,7 +613,7 @@ namespace Xtensive.Orm.Model
         if (!IsLocked) {
           return result;
         }
-        versionFields = result.AsReadOnly();
+        versionFields = result.AsSafeWrapper();
       }
       return versionFields;
     }
@@ -649,7 +649,7 @@ namespace Xtensive.Orm.Model
         if (!IsLocked) {
           return result;
         }
-        versionColumns = result.AsReadOnly();
+        versionColumns = result.AsSafeWrapper();
       }
       return versionColumns;
     }

--- a/Orm/Xtensive.Orm/Orm/Operation.cs
+++ b/Orm/Xtensive.Orm/Orm/Operation.cs
@@ -25,11 +25,6 @@ namespace Xtensive.Orm
     private static readonly IReadOnlyDictionary<string, Key> EmptyIdentifiedEntities =
       new ReadOnlyDictionary<string, Key>(new Dictionary<string, Key>());
 
-    private IReadOnlyDictionary<string, Key> identifiedEntities = EmptyIdentifiedEntities;
-    private IReadOnlyList<IOperation> precedingOperations = Array.Empty<IOperation>();
-    private IReadOnlyList<IOperation> followingOperations = Array.Empty<IOperation>();
-    private IReadOnlyList<IOperation> undoOperations = Array.Empty<IOperation>();
-
     /// <inheritdoc/>
     public abstract string Title { get; }
 
@@ -42,28 +37,16 @@ namespace Xtensive.Orm
     public OperationType Type { get; internal set; }
 
     /// <inheritdoc/>
-    public IReadOnlyList<IOperation> PrecedingOperations {
-      get { return precedingOperations; }
-      internal set { precedingOperations = value; }
-    }
+    public IReadOnlyList<IOperation> PrecedingOperations { get; internal set; } = [];
 
     /// <inheritdoc/>
-    public IReadOnlyList<IOperation> FollowingOperations {
-      get { return followingOperations; }
-      internal set { followingOperations = value; }
-    }
+    public IReadOnlyList<IOperation> FollowingOperations { get; internal set; } = [];
 
     /// <inheritdoc/>
-    public IReadOnlyList<IOperation> UndoOperations {
-      get { return undoOperations; }
-      internal set { undoOperations = value; }
-    }
+    public IReadOnlyList<IOperation> UndoOperations { get; internal set; } = [];
 
     /// <inheritdoc/>
-    public IReadOnlyDictionary<string, Key> IdentifiedEntities {
-      get { return identifiedEntities; }
-      set { identifiedEntities = value; }
-    }
+    public IReadOnlyDictionary<string, Key> IdentifiedEntities { get; set; } = EmptyIdentifiedEntities;
 
     /// <inheritdoc/>
     public void Prepare(OperationExecutionContext context)

--- a/Orm/Xtensive.Orm/Orm/Operation.cs
+++ b/Orm/Xtensive.Orm/Orm/Operation.cs
@@ -97,7 +97,7 @@ namespace Xtensive.Orm
           select o.Clone(false)
           ).ToList();
         if (preconditions.Count != 0)
-          clone.PrecedingOperations = preconditions.AsReadOnly();
+          clone.PrecedingOperations = preconditions.AsSafeWrapper();
       }
       if (IdentifiedEntities.Count!=0 && withIdentifiedEntities)
         clone.IdentifiedEntities = IdentifiedEntities;

--- a/Orm/Xtensive.Orm/Orm/Operation.cs
+++ b/Orm/Xtensive.Orm/Orm/Operation.cs
@@ -22,8 +22,7 @@ namespace Xtensive.Orm
   [Serializable]
   public abstract class Operation : IOperation
   {
-    private static readonly IReadOnlyDictionary<string, Key> EmptyIdentifiedEntities =
-      new ReadOnlyDictionary<string, Key>(new Dictionary<string, Key>());
+    private static readonly IReadOnlyDictionary<string, Key> EmptyIdentifiedEntities = new Dictionary<string, Key>().AsSafeWrapper();
 
     /// <inheritdoc/>
     public abstract string Title { get; }

--- a/Orm/Xtensive.Orm/Orm/Operations/OperationRegistry.cs
+++ b/Orm/Xtensive.Orm/Orm/Operations/OperationRegistry.cs
@@ -283,13 +283,13 @@ namespace Xtensive.Orm.Operations
         }
 
         if (scope.PrecedingOperations!=null)
-          operation.PrecedingOperations = scope.PrecedingOperations.AsReadOnly();
+          operation.PrecedingOperations = scope.PrecedingOperations.AsSafeWrapper();
         if (scope.FollowingOperations!=null)
-          operation.FollowingOperations = scope.FollowingOperations.AsReadOnly();
+          operation.FollowingOperations = scope.FollowingOperations.AsSafeWrapper();
         if (scope.UndoOperations!=null)
-          operation.UndoOperations = scope.UndoOperations.AsReadOnly();
+          operation.UndoOperations = scope.UndoOperations.AsSafeWrapper();
         if (scope.KeyByIdentifier!=null)
-          operation.IdentifiedEntities = new ReadOnlyDictionary<string, Key>(scope.KeyByIdentifier);
+          operation.IdentifiedEntities = scope.KeyByIdentifier.AsSafeWrapper();
       }
       finally {
         RemoveCurrentScope(scope);

--- a/Orm/Xtensive.Orm/Orm/Operations/OperationRegistry.cs
+++ b/Orm/Xtensive.Orm/Orm/Operations/OperationRegistry.cs
@@ -190,8 +190,7 @@ namespace Xtensive.Orm.Operations
       var scope = GetCurrentOperationRegistrationScope();
       if (scope==null)
         return;
-      if (scope.UndoOperations==null)
-        scope.UndoOperations = new List<IOperation>();
+      scope.UndoOperations ??= new(1);
       scope.UndoOperations.Add(operation);
       // Notifying...
       NotifyUndoOperation(operation);
@@ -299,13 +298,11 @@ namespace Xtensive.Orm.Operations
       var parentScope = GetCurrentOrParentOperationRegistrationScope();
       if (parentScope != null) {
         if (!parentScope.IsOperationStarted) {
-          if (parentScope.PrecedingOperations==null)
-            parentScope.PrecedingOperations = new List<IOperation>();
+          parentScope.PrecedingOperations ??= new(1);
           parentScope.PrecedingOperations.Add(operation);
         }
         else {
-          if (parentScope.FollowingOperations==null)
-            parentScope.FollowingOperations = new List<IOperation>();
+          parentScope.FollowingOperations ??= new(1);
           parentScope.FollowingOperations.Add(operation);
         }
       }

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilderContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilderContext.cs
@@ -7,6 +7,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Xtensive.Collections;
+using Xtensive.Core;
 using Xtensive.Orm.Configuration;
 using Xtensive.Orm.Model;
 
@@ -50,7 +51,7 @@ namespace Xtensive.Orm.Providers
           return -1;
         return 0;
       });
-      AffectedIndexes = affectedIndexes.AsReadOnly();
+      AffectedIndexes = affectedIndexes.AsSafeWrapper();
 
       PrimaryIndex = Task.Type.Indexes.PrimaryIndex;
       ParameterBindings = new Dictionary<ColumnInfo, PersistParameterBinding>();

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/QueryRowFilterParameterBinding.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/QueryRowFilterParameterBinding.cs
@@ -16,17 +16,12 @@ namespace Xtensive.Orm.Providers
   /// <summary>
   /// A special version of <see cref="QueryParameterBinding"/> used for complex filters.
   /// </summary>
-  public class QueryRowFilterParameterBinding : QueryParameterBinding
+  public class QueryRowFilterParameterBinding(IReadOnlyList<TypeMapping> rowTypeMapping, Func<ParameterContext, object> valueAccessor)
+    : QueryParameterBinding(null, valueAccessor, QueryParameterBindingType.RowFilter)
   {
     /// <summary>
     /// Gets the complex type mapping.
     /// </summary>
-    public IReadOnlyList<TypeMapping> RowTypeMapping { get; private set; }
-
-    public QueryRowFilterParameterBinding(IEnumerable<TypeMapping> rowTypeMapping, Func<ParameterContext, object> valueAccessor)
-      : base(null, valueAccessor, QueryParameterBindingType.RowFilter)
-    {
-      RowTypeMapping = rowTypeMapping.ToList().AsReadOnly();
-    }
+    public IReadOnlyList<TypeMapping> RowTypeMapping => rowTypeMapping;
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Include.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Include.cs
@@ -78,7 +78,7 @@ namespace Xtensive.Orm.Providers
       IReadOnlyList<SqlExpression> sourceColumns, out QueryParameterBinding binding)
     {
       var filterTupleDescriptor = provider.FilteredColumnsExtractionTransform.Descriptor;
-      var mappings = filterTupleDescriptor.Select(type => Driver.GetTypeMapping(type));
+      var mappings = filterTupleDescriptor.Select(type => Driver.GetTypeMapping(type)).ToArray(filterTupleDescriptor.Count).AsSafeWrapper();
       binding = new QueryRowFilterParameterBinding(mappings, valueAccessor);
       var resultExpression = SqlDml.DynamicFilter(binding);
       resultExpression.Expressions.AddRange(provider.FilteredColumns.Select(index => sourceColumns[index]));

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ContainsTableProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ContainsTableProvider.cs
@@ -57,7 +57,7 @@ namespace Xtensive.Orm.Rse.Providers
       PrimaryIndex = new IndexInfoRef(index.PrimaryIndex);
       TargetColumns = targetColumns.Select(tc => index.Columns.First(c => c.Column == tc))
         .ToList(targetColumns.Count)
-        .AsReadOnly();
+        .AsSafeWrapper();
       TopN = topNByRank;
       if (FullFeatured) {
         var primaryIndexRecordsetHeader =

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ContainsTableProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ContainsTableProvider.cs
@@ -29,7 +29,7 @@ namespace Xtensive.Orm.Rse.Providers
 
     public Func<ParameterContext, int> TopN { get; private set; }
 
-    public IReadOnlyList<FullTextColumnInfo> TargetColumns { get; private set; }
+    public IReadOnlyList<FullTextColumnInfo> TargetColumns { get; }
 
     protected override RecordSetHeader BuildHeader()
     {
@@ -56,7 +56,7 @@ namespace Xtensive.Orm.Rse.Providers
       FullFeatured = fullFeatured;
       PrimaryIndex = new IndexInfoRef(index.PrimaryIndex);
       TargetColumns = targetColumns.Select(tc => index.Columns.First(c => c.Column == tc))
-        .ToList(targetColumns.Count)
+        .ToArray(targetColumns.Count)
         .AsSafeWrapper();
       TopN = topNByRank;
       if (FullFeatured) {

--- a/Orm/Xtensive.Orm/Orm/Session.Validation.cs
+++ b/Orm/Xtensive.Orm/Orm/Session.Validation.cs
@@ -29,6 +29,6 @@ namespace Xtensive.Orm
     /// and returns all validation errors.
     /// </summary>
     /// <returns>List errors occurred during validation.</returns>
-    public IList<EntityErrorInfo> ValidateAndGetErrors() => ValidationContext.ValidateAndGetErrors();
+    public IReadOnlyList<EntityErrorInfo> ValidateAndGetErrors() => ValidationContext.ValidateAndGetErrors();
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/HintGenerator.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/HintGenerator.cs
@@ -615,7 +615,7 @@ namespace Xtensive.Orm.Upgrade
           throw Exceptions.InternalError(string.Format(
             Strings.ExInheritanceSchemaIsInvalid, inheritanceSchema), UpgradeLog.Instance);
       }
-      hint.AffectedTables = affectedTables.AsReadOnly();
+      hint.AffectedTables = affectedTables.AsSafeWrapper();
     }
 
     private void UpdateAffectedColumns(ChangeFieldTypeHint hint)
@@ -633,8 +633,7 @@ namespace Xtensive.Orm.Upgrade
         throw FieldNotFound(currentTypeName, hint.FieldName);
       }
 
-      var affectedColumns = GetAffectedColumns(currentType, currentField);
-      hint.AffectedColumns = affectedColumns.AsReadOnly();
+      hint.AffectedColumns = GetAffectedColumns(currentType, currentField).AsSafeWrapper();
     }
 
     private void UpdateAffectedColumns(RemoveFieldHint hint)
@@ -675,8 +674,7 @@ namespace Xtensive.Orm.Upgrade
         throw FieldNotFound(typeName, hint.Field);
       }
 
-      var affectedColumns = GetAffectedColumns(storedType, storedField);
-      hint.AffectedColumns = affectedColumns.AsReadOnly();
+      hint.AffectedColumns = GetAffectedColumns(storedType, storedField).AsSafeWrapper();
     }
 
     #endregion

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/UpgradeHintsProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/UpgradeHintsProcessor.cs
@@ -433,9 +433,7 @@ namespace Xtensive.Orm.Upgrade.Internals
         // Generating affected columns list explicitly for a situation when "type" is renamed to "targetType"
         if (type != targetType) {
           hint.IsExplicit = true;
-          hint.AffectedColumns = Array.AsReadOnly(new string[] {
-            GetColumnPath(targetType, targetTypeIdField.MappingName)
-          });
+          hint.AffectedColumns = (new[] { GetColumnPath(targetType, targetTypeIdField.MappingName) }).AsSafeWrapper();
         }
         result.Add(hint);
       }

--- a/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
@@ -330,7 +330,7 @@ namespace Xtensive.Orm.Upgrade
 
     private static void BuildModules(UpgradeServiceAccessor serviceAccessor, IServiceContainer serviceContainer)
     {
-      serviceAccessor.Modules = serviceContainer.GetAll<IModule>().ToList().AsReadOnly();
+      serviceAccessor.Modules = serviceContainer.GetAll<IModule>().ToList().AsSafeWrapper();
     }
 
     private static void BuildUpgradeHandlers(UpgradeServiceAccessor serviceAccessor, IServiceContainer serviceContainer)
@@ -376,7 +376,7 @@ namespace Xtensive.Orm.Upgrade
 
       // Storing the result
       serviceAccessor.UpgradeHandlers = new ReadOnlyDictionary<Assembly, IUpgradeHandler>(handlers);
-      serviceAccessor.OrderedUpgradeHandlers = sortedHandlers.ToList().AsReadOnly();
+      serviceAccessor.OrderedUpgradeHandlers = sortedHandlers.ToList().AsSafeWrapper();
     }
 
     private static void BuildFullTextCatalogResolver(UpgradeServiceAccessor serviceAccessor, IServiceContainer serviceContainer)

--- a/Orm/Xtensive.Orm/Orm/Validation/EntityErrorInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Validation/EntityErrorInfo.cs
@@ -12,24 +12,24 @@ namespace Xtensive.Orm.Validation
   /// <summary>
   /// Entity validation error info.
   /// </summary>
-  public sealed class EntityErrorInfo
+  public class EntityErrorInfo
   {
     /// <summary>
     /// Gets validated entity.
     /// </summary>
-    public Entity Target { get; private set; }
+    public Entity Target { get;}
 
     /// <summary>
     /// Gets or sets validation errors.
     /// </summary>
-    public IList<ValidationResult> Errors { get; private set; }
+    public IReadOnlyList<ValidationResult> Errors { get;}
 
     /// <summary>
     /// Initializes new instance of this type.
     /// </summary>
     /// <param name="target">Validated entity.</param>
     /// <param name="errors">A collection of <see cref="ValidationResult"/>s for an errors discovered.</param>
-    public EntityErrorInfo(Entity target, IList<ValidationResult> errors)
+    public EntityErrorInfo(Entity target, IReadOnlyList<ValidationResult> errors)
     {
       ArgumentValidator.EnsureArgumentNotNull(target, "target");
       ArgumentValidator.EnsureArgumentNotNull(errors, "errors");

--- a/Orm/Xtensive.Orm/Orm/Validation/Exceptions/ValidationFailedException.cs
+++ b/Orm/Xtensive.Orm/Orm/Validation/Exceptions/ValidationFailedException.cs
@@ -12,12 +12,12 @@ namespace Xtensive.Orm.Validation
   public class ValidationFailedException : StorageException
   {
     [NonSerialized]
-    private IList<EntityErrorInfo> validationErrors;
+    private IReadOnlyList<EntityErrorInfo> validationErrors;
 
     /// <summary>
     /// Gets validation errors associated with this instance.
     /// </summary>
-    public IList<EntityErrorInfo> ValidationErrors
+    public IReadOnlyList<EntityErrorInfo> ValidationErrors
     {
       get { return validationErrors; }
       set

--- a/Orm/Xtensive.Orm/Orm/Validation/Internals/ValidationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Validation/Internals/ValidationContext.cs
@@ -11,9 +11,9 @@ namespace Xtensive.Orm.Validation
 {
   internal abstract class ValidationContext
   {
-    protected static IList<EntityErrorInfo> EmptyEntityErrorCollection = new List<EntityErrorInfo>().AsReadOnly();
+    protected static IReadOnlyList<EntityErrorInfo> EmptyEntityErrorCollection = [];
 
-    protected static IList<ValidationResult> EmptyValidationResultCollection = new List<ValidationResult>().AsReadOnly();
+    protected static IReadOnlyList<ValidationResult> EmptyValidationResultCollection = [];
 
     public abstract void Reset();
 
@@ -21,11 +21,11 @@ namespace Xtensive.Orm.Validation
 
     public abstract void Validate(Entity target);
 
-    public abstract IList<EntityErrorInfo> ValidateAndGetErrors();
+    public abstract IReadOnlyList<EntityErrorInfo> ValidateAndGetErrors();
 
-    public abstract IList<ValidationResult> ValidateAndGetErrors(Entity target);
+    public abstract IReadOnlyList<ValidationResult> ValidateAndGetErrors(Entity target);
 
-    public abstract IList<ValidationResult> ValidateOnceAndGetErrors(Entity target);
+    public abstract IReadOnlyList<ValidationResult> ValidateOnceAndGetErrors(Entity target);
 
     public abstract void ValidateSetAttempt(Entity target, FieldInfo field, object value);
 

--- a/Orm/Xtensive.Orm/Orm/Validation/Internals/VoidValidationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Validation/Internals/VoidValidationContext.cs
@@ -23,20 +23,11 @@ namespace Xtensive.Orm.Validation
     {
     }
 
-    public override IList<EntityErrorInfo> ValidateAndGetErrors()
-    {
-      return EmptyEntityErrorCollection;
-    }
+    public override IReadOnlyList<EntityErrorInfo> ValidateAndGetErrors() => EmptyEntityErrorCollection;
 
-    public override IList<ValidationResult> ValidateAndGetErrors(Entity target)
-    {
-      return EmptyValidationResultCollection;
-    }
+    public override IReadOnlyList<ValidationResult> ValidateAndGetErrors(Entity target) => EmptyValidationResultCollection;
 
-    public override IList<ValidationResult> ValidateOnceAndGetErrors(Entity target)
-    {
-      return EmptyValidationResultCollection;
-    }
+    public override IReadOnlyList<ValidationResult> ValidateOnceAndGetErrors(Entity target) => EmptyValidationResultCollection;
 
     public override void ValidateSetAttempt(Entity target, FieldInfo field, object value)
     {

--- a/Orm/Xtensive.Orm/Sql/Compiler/Internals/PostCompiler.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/Internals/PostCompiler.cs
@@ -75,20 +75,21 @@ namespace Xtensive.Sql.Compiler
 
     public override void Visit(CycleNode node)
     {
-      List<string[]> items;
-      if (!configuration.DynamicFilterValues.TryGetValue(node.Id, out items))
+      if (!configuration.DynamicFilterValues.TryGetValue(node.Id, out var items))
         throw new InvalidOperationException(string.Format(Strings.ExItemsForCycleXAreNotSpecified, node.Id));
       if (items==null || items.Count==0) {
         VisitNodes(node.EmptyCase);
         return;
       }
-      for (int i = 0; i < items.Count - 1; i++) {
+
+      var count = items.Count;
+      for (int i = 0; i < count; i++) {
         currentCycleItem = items[i];
         VisitNodes(node.Body);
-        result.Append(node.Delimiter);
+        if (i < count - 1) {
+          result.Append(node.Delimiter);
+        }
       }
-      currentCycleItem = items[items.Count - 1];
-      VisitNodes(node.Body);
     }
 
     #endregion

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlPostCompilerConfiguration.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlPostCompilerConfiguration.cs
@@ -21,23 +21,23 @@ namespace Xtensive.Sql.Compiler
   /// </summary>
   public sealed class SqlPostCompilerConfiguration
   {
-    public HashSet<object> AlternativeBranches { get; private set; } = new HashSet<object>();
+    public HashSet<object> AlternativeBranches { get; } = new();
 
     public TypeIdRegistry TypeIdRegistry { get; }
 
-    public Dictionary<object, string> PlaceholderValues { get; private set; } = new Dictionary<object, string>();
+    public Dictionary<object, string> PlaceholderValues { get; } = new();
 
-    public Dictionary<object, List<string[]>> DynamicFilterValues { get; private set; } = new Dictionary<object, List<string[]>>();
-
-    /// <summary>
-    /// Gets database mapping.
-    /// </summary>
-    public IReadOnlyDictionary<string, string> SchemaMapping { get; private set; }
+    public Dictionary<object, IReadOnlyList<string[]>> DynamicFilterValues { get; } = new();
 
     /// <summary>
     /// Gets database mapping.
     /// </summary>
-    public IReadOnlyDictionary<string, string> DatabaseMapping { get; private set; }
+    public IReadOnlyDictionary<string, string> SchemaMapping { get; }
+
+    /// <summary>
+    /// Gets database mapping.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> DatabaseMapping { get; }
 
     internal void AppendPlaceholderValue(StringBuilder sb, PlaceholderNode node)
     {

--- a/Orm/Xtensive.Orm/Tuples/Transform/CombineTransform.cs
+++ b/Orm/Xtensive.Orm/Tuples/Transform/CombineTransform.cs
@@ -28,7 +28,7 @@ namespace Xtensive.Tuples.Transform
     public IReadOnlyList<TupleDescriptor> Sources
     {
       [DebuggerStepThrough]
-      get => Array.AsReadOnly(sources);
+      get => sources.AsSafeWrapper();
     }
 
     /// <see cref="MapTransform.Apply(TupleTransformType,Tuple,Tuple)" copy="true" />

--- a/Orm/Xtensive.Orm/Tuples/Transform/CutInTransform.cs
+++ b/Orm/Xtensive.Orm/Tuples/Transform/CutInTransform.cs
@@ -36,7 +36,7 @@ namespace Xtensive.Tuples.Transform
     public IReadOnlyList<TupleDescriptor> Sources
     {
       [DebuggerStepThrough]
-      get => Array.AsReadOnly(sources);
+      get => sources.AsSafeWrapper();
     }
 
     /// <see cref="MapTransform.Apply(TupleTransformType,Tuple)" copy="true" />

--- a/Orm/Xtensive.Orm/Tuples/Transform/Internals/MapTransformTuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Transform/Internals/MapTransformTuple.cs
@@ -24,7 +24,7 @@ namespace Xtensive.Tuples.Transform.Internals
     public override IReadOnlyList<object> Arguments
     {
       [DebuggerStepThrough]
-      get => Array.AsReadOnly(tuples);
+      get => tuples.AsSafeWrapper();
     }
 
     #region GetFieldState, GetValue, SetValue methods

--- a/Orm/Xtensive.Orm/Tuples/Transform/MapTransform.cs
+++ b/Orm/Xtensive.Orm/Tuples/Transform/MapTransform.cs
@@ -61,8 +61,7 @@ namespace Xtensive.Tuples.Transform
     /// </summary>
     public IReadOnlyList<Pair<ColNum, ColNum>> Map
     {
-      [DebuggerStepThrough]
-      get { return Array.AsReadOnly(map); }
+      [DebuggerStepThrough] get => map.AsSafeWrapper();
     }
 
     protected void SetSingleSourceMap(IReadOnlyList<ColNum> singleSourceMap)


### PR DESCRIPTION
`.AsSafeWrapper()` is no-op in our conditional compilation

Also:
* Use string interpolation instead of `string.Format()`
* Use array instead of list when number of elements is known