### PR TITLE
Optimization: Make `SqlParameterNameProvider` struct

### DIFF
--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerContext.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerContext.cs
@@ -18,9 +18,9 @@ namespace Xtensive.Sql.Compiler
 
     public bool ParametrizeSchemaNames { get; set; }
 
-    public SqlTableNameProvider TableNameProvider { get; }
+    public SqlTableNameProvider TableNameProvider;
 
-    public SqlParameterNameProvider ParameterNameProvider { get; }
+    public SqlParameterNameProvider ParameterNameProvider;
 
     public ContainerNode Output { get; private set; }
 

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerContext.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerContext.cs
@@ -12,9 +12,8 @@ namespace Xtensive.Sql.Compiler
   /// </summary>
   public class SqlCompilerContext
   {
-    private SqlNode[] traversalPath;
-    private readonly Stack<SqlNode> traversalStack = new Stack<SqlNode>();
-    private readonly HashSet<SqlNode> traversalTable = new HashSet<SqlNode>();
+    private readonly Stack<SqlNode> traversalStack = new();
+    private readonly HashSet<SqlNode> traversalTable = new();
 
     public bool ParametrizeSchemaNames { get; set; }
 
@@ -26,8 +25,7 @@ namespace Xtensive.Sql.Compiler
 
     public SqlCompilerNamingOptions NamingOptions { get; private set; }
 
-    public SqlNode[] GetTraversalPath() =>
-      traversalPath ??= traversalStack.ToArray();
+    public IEnumerable<SqlNode> GetTraversalPath() => traversalStack;
 
     public bool HasOptions(SqlCompilerNamingOptions requiredOptions)
     {
@@ -92,15 +90,10 @@ namespace Xtensive.Sql.Compiler
       return OpenScope(ContextType.Collection, (ContainerNode) cycle.EmptyCase);
     }
 
-    private SqlCompilerOutputScope OpenScope(ContextType type)
+    private SqlCompilerOutputScope OpenScope(ContextType type, ContainerNode container = null)
     {
-      return OpenScope(type, Output);
-    }
-
-    private SqlCompilerOutputScope OpenScope(ContextType type, ContainerNode container)
-    {
-      traversalPath = null;
       var scope = new SqlCompilerOutputScope(this, type);
+      container ??= Output;
       if (Output != container) {
         Output = container;
       }
@@ -113,9 +106,8 @@ namespace Xtensive.Sql.Compiler
       return scope;
     }
 
-    internal void CloseScope(SqlCompilerOutputScope scope)
+    internal void CloseScope(in SqlCompilerOutputScope scope)
     {
-      traversalPath = null;
       if (Output != scope.ParentContainer) {
         Output.FlushBuffer();
         Output = scope.ParentContainer;

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerContext.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerContext.cs
@@ -18,9 +18,9 @@ namespace Xtensive.Sql.Compiler
 
     public bool ParametrizeSchemaNames { get; set; }
 
-    public SqlTableNameProvider TableNameProvider { get; private set; }
+    public SqlTableNameProvider TableNameProvider { get; }
 
-    public SqlParameterNameProvider ParameterNameProvider { get; private set; }
+    public SqlParameterNameProvider ParameterNameProvider { get; }
 
     public ContainerNode Output { get; private set; }
 
@@ -37,17 +37,15 @@ namespace Xtensive.Sql.Compiler
     public SqlCompilerNamingScope EnterScope(SqlCompilerNamingOptions options)
     {
       if (NamingOptions==options)
-        return null;
+        return new(null);
 
       var scope = new SqlCompilerNamingScope(this, NamingOptions);
       NamingOptions = options;
       return scope;
     }
 
-    internal void CloseScope(SqlCompilerNamingScope scope)
-    {
-      NamingOptions = scope.ParentOptions;
-    }
+    internal void CloseScope(SqlCompilerNamingOptions parentOptions) =>
+      NamingOptions = parentOptions;
 
     #region SqlCompilerOutputScope members
 

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerNamingScope.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilerNamingScope.cs
@@ -12,22 +12,9 @@ namespace Xtensive.Sql.Compiler
   /// SQL compiler naming scope.
   /// </summary>
   [Serializable]
-  public class SqlCompilerNamingScope : IDisposable
+  public readonly struct SqlCompilerNamingScope(SqlCompilerContext context, SqlCompilerNamingOptions parentOptions = default) : IDisposable
   {
-    private readonly SqlCompilerContext context;
-
-    internal SqlCompilerNamingOptions ParentOptions { get; private set; }
-
     /// <inheritdoc/>
-    public void Dispose()
-    {
-      context.CloseScope(this);
-    }
-
-    public SqlCompilerNamingScope(SqlCompilerContext context, SqlCompilerNamingOptions parentOptions)
-    {
-      this.context = context;
-      ParentOptions = parentOptions;
-    }
+    public void Dispose() => context?.CloseScope(parentOptions);
   }
 }

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlParameterNameProvider.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlParameterNameProvider.cs
@@ -13,13 +13,15 @@ namespace Xtensive.Sql.Compiler
   /// SQL parameter name provider.
   /// </summary>
   [Serializable]
-  public class SqlParameterNameProvider
+  public struct SqlParameterNameProvider(SqlCompilerConfiguration configuration)
   {
     private const string DefaultPrefix = "p";
     private int nextParameter;
-    private readonly string prefix;
-    
-    internal Dictionary<object, string> NameTable { get; private set; }
+    private readonly string prefix = string.IsNullOrEmpty(configuration.ParameterNamePrefix)
+      ? DefaultPrefix
+      : configuration.ParameterNamePrefix;
+
+    internal Dictionary<object, string> NameTable { get; } = new();
 
     /// <summary>
     /// Gets the name for the specified <paramref name="parameter"/>.
@@ -28,24 +30,11 @@ namespace Xtensive.Sql.Compiler
     /// <returns>Name for the specified parameter.</returns>
     public string GetName(object parameter)
     {
-      string result;
-      if (!NameTable.TryGetValue(parameter, out result)) {
+      if (!NameTable.TryGetValue(parameter, out var result)) {
         result = prefix + nextParameter++;
         NameTable.Add(parameter, result);
       }
       return result;
     }
-
-
-    // Constructor
-
-    /// <inheritdoc/>
-    public SqlParameterNameProvider(SqlCompilerConfiguration configuration)
-    {
-      NameTable = new Dictionary<object, string>();
-      prefix = string.IsNullOrEmpty(configuration.ParameterNamePrefix)
-        ? DefaultPrefix
-        : configuration.ParameterNamePrefix;
-    }
-  }
+ }
 }

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlTableNameProvider.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlTableNameProvider.cs
@@ -10,19 +10,17 @@ namespace Xtensive.Sql.Compiler
   /// <summary>
   /// Table name provider.
   /// </summary>
-  public class SqlTableNameProvider
+  public struct SqlTableNameProvider(SqlCompilerContext context)
   {
-    private readonly Dictionary<SqlTable, string> aliasMap = new Dictionary<SqlTable, string>(16);
-    private readonly HashSet<string> aliasIndex = new HashSet<string>();
+    private readonly Dictionary<SqlTable, string> aliasMap = new(16);
+    private readonly HashSet<string> aliasIndex = new();
     private byte prefixIndex;
     private byte suffix;
-    private readonly SqlCompilerContext context;
 
-    private static readonly string[] Prefixes =
-      new[] {
-        "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v",
-        "w", "x", "y", "z"
-      };
+    private static readonly string[] Prefixes = [
+      "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v",
+      "w", "x", "y", "z"
+    ];
 
     public string GetName(SqlTable table)
     {
@@ -32,13 +30,11 @@ namespace Xtensive.Sql.Compiler
         return table.Name;
       }
 
-      string result;
-      if (aliasMap.TryGetValue(table, out result))
+      if (aliasMap.TryGetValue(table, out var result))
         return result;
 
-      var tableRef = table as SqlTableRef;
       // Table reference
-      if (tableRef!=null) {
+      if (table is SqlTableRef tableRef) {
         // Alias
         if (tableRef.Name!=tableRef.DataTable.Name) {
           result = tableRef.Name;
@@ -89,14 +85,6 @@ namespace Xtensive.Sql.Compiler
 
       prefixIndex = 0;
       suffix++;
-    }
-
-
-    // Constructor
-
-    public SqlTableNameProvider(SqlCompilerContext context)
-    {
-      this.context = context;
     }
   }
 }


### PR DESCRIPTION
Also:
* Make `SqlTableNameProvider` struct
* Make `SqlCompilerNamingScope` struct
* Get rid of `SqlCompilerContext.traversalPath` - no need for intermediate array