### PR TITLE
Optimize `SqlRow` - avoid intermediate allocations. Use `IReadOnlyList<>` instead

### DIFF
--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Compiler.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Compiler.cs
@@ -67,7 +67,7 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
           }
         }
         else {
-          var row = SqlDml.Row(right.GetValues().Select(value => SqlDml.Literal(value)).ToArray());
+          var row = SqlDml.Row(right.GetValues().Select(SqlDml.Literal).ToArray());
           base.Visit(node.NodeType == SqlNodeType.In ? SqlDml.In(node.Left, row) : SqlDml.NotIn(node.Left, row));
         }
         return;

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Extractor.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Extractor.cs
@@ -208,7 +208,7 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
       // Query OID of some system catalog tables for using them in pg_depend lookups
       var rel = PgClass;
       var q = SqlDml.Select(rel);
-      q.Where = SqlDml.In(rel["relname"], SqlDml.Row("pg_class"));
+      q.Where = SqlDml.In(rel["relname"], SqlDml.Row(["pg_class"]));
       q.Columns.Add(rel["oid"]);
       q.Columns.Add(rel["relname"]);
       return q;
@@ -577,7 +577,7 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
         tablespacesTable["oid"] == relationsTable["reltablespace"]);
       var select = SqlDml.Select(join);
       select.Where = relationsTable["relowner"] == context.CurrentUserIdentifier
-        && SqlDml.In(relationsTable["relkind"], SqlDml.Row('r', 'v', 'S'));
+        && SqlDml.In(relationsTable["relkind"], SqlDml.Row(['r', 'v', 'S']));
 
       var catalog = context.Catalog;
       var targetSchemes = context.TargetSchemes;
@@ -1372,18 +1372,14 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
 
     protected static SqlRow CreateOidRow(IEnumerable<long> oids)
     {
-      var result = SqlDml.Row();
-      foreach (var oid in oids) {
-        result.Add(oid);
-      }
+      var list = oids.Select(oid => (SqlExpression) oid).ToList();
 
       // make sure it is not empty, so that "IN" expression always works
       // add an invalid OID value 
-      if (result.Count == 0) {
-        result.Add(-1000);
+      if (list.Count == 0) {
+        list.Add(-1000);
       }
-
-      return result;
+      return SqlDml.Row(list);
     }
 
     protected static int[] ReadIntArray(object value)

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Translator.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Translator.cs
@@ -488,7 +488,7 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
                 break;
               }
             }
-            var newNode = SqlDml.Match(SqlDml.Row(), SqlDml.SubQuery(finalQuery).Query, node.Unique, node.MatchType);
+            var newNode = SqlDml.Match(SqlDml.Row([]), SqlDml.SubQuery(finalQuery).Query, node.Unique, node.MatchType);
             node.ReplaceWith(newNode);
             _ = context.Output.Append("EXISTS(SELECT '");
             break;

--- a/Orm/Xtensive.Orm.Tests.Sql/SqlServer/CompilerTests.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/SqlServer/CompilerTests.cs
@@ -161,9 +161,8 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
       var tableRef = SqlDml.TableRef(Catalog.Schemas["Person"].Tables["Contact"]);
       var select = SqlDml.Select(tableRef);
       select.Columns.Add(SqlDml.Count());
-      var filter = SqlDml.DynamicFilter(dynamicFilterId);
+      var filter = SqlDml.DynamicFilter(dynamicFilterId, [tableRef["LastName"]]);
       select.Where = filter;
-      filter.Expressions.Add(tableRef["LastName"]);
       var result = sqlConnection.Driver.Compile(select);
       using (var command = sqlConnection.CreateCommand()) {
         var values = new List<string[]> {new[] {"'Achong'"}, new[] {"'Abel'"}};
@@ -181,10 +180,8 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
       var tableRef = SqlDml.TableRef(Catalog.Schemas["Person"].Tables["Contact"]);
       var select = SqlDml.Select(tableRef);
       select.Columns.Add(SqlDml.Count());
-      var filter = SqlDml.DynamicFilter(dynamicFilterId);
+      var filter = SqlDml.DynamicFilter(dynamicFilterId, [tableRef["FirstName"], tableRef["LastName"]]);
       select.Where = filter;
-      filter.Expressions.Add(tableRef["FirstName"]);
-      filter.Expressions.Add(tableRef["LastName"]);
       var result = sqlConnection.Driver.Compile(select);
       using (var command = sqlConnection.CreateCommand()) {
         var values = new List<string[]> {new[] {"'Gustavo'", "'Achong'"}, new[] {"'Catherine'", "'Abel'"}};

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Include.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Include.cs
@@ -80,9 +80,7 @@ namespace Xtensive.Orm.Providers
       var filterTupleDescriptor = provider.FilteredColumnsExtractionTransform.Descriptor;
       var mappings = filterTupleDescriptor.Select(type => Driver.GetTypeMapping(type)).ToArray(filterTupleDescriptor.Count).AsSafeWrapper();
       binding = new QueryRowFilterParameterBinding(mappings, valueAccessor);
-      var resultExpression = SqlDml.DynamicFilter(binding);
-      resultExpression.Expressions.AddRange(provider.FilteredColumns.Select(index => sourceColumns[index]));
-      return resultExpression;
+      return SqlDml.DynamicFilter(binding, provider.FilteredColumns.Select(index => sourceColumns[index]).ToArray());
     }
 
     protected SqlExpression CreateIncludeViaTemporaryTableExpression(

--- a/Orm/Xtensive.Orm/Sql/Dml/Collections/SqlInsertValuesCollection.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Collections/SqlInsertValuesCollection.cs
@@ -53,28 +53,21 @@ namespace Xtensive.Sql.Dml.Collections
       if (rows.Count == 0) {
         // save columns order as header for further rows to match;
         columns = row.Keys.ToList();
-        rows.Add(SqlDml.Row(row.Values.ToList()));
+        rows.Add(SqlDml.Row(row.Values.ToArray()));
       }
       else {
         if (columns.Count != row.Count)
           throw new ArgumentException("Inconsistent row length.");
         if (row.Keys.SequenceEqual(columns)) {
           //fast addition
-          rows.Add(SqlDml.Row(row.Values.ToList()));
+          rows.Add(SqlDml.Row(row.Values.ToArray()));
         }
         else {
           //re-arrange values to be the same order
           //and also make sure all columns exist
-          var rowList = new List<SqlExpression>();
-          foreach (var column in columns) {
-            if (row.TryGetValue(column, out var value)) {
-              rowList.Add(value);
-            }
-            else {
-              throw new ArgumentException(string.Format("There is no mentioning of column '{0}' in previously added rows.", column.Name));
-            }
-          }
-
+          var rowList = columns.Select(column =>
+            row.GetValueOrDefault(column) ??
+            throw new ArgumentException($"There is no mentioning of column '{column.Name}' in previously added rows.")).ToArray();
           rows.Add(SqlDml.Row(rowList));
         }
       }

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlConcat.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlConcat.cs
@@ -31,10 +31,7 @@ namespace Xtensive.Sql.Dml
 
     public override void ReplaceWith(SqlExpression expression)
     {
-      var replacingExpression = ArgumentValidator.EnsureArgumentIs<SqlConcat>(expression);
-      expressions.Clear();
-      foreach (var e in replacingExpression)
-        expressions.Add(e);
+      expressions = ArgumentValidator.EnsureArgumentIs<SqlConcat>(expression).expressions;
     }
     
     public override void AcceptVisitor(ISqlVisitor visitor)
@@ -45,7 +42,7 @@ namespace Xtensive.Sql.Dml
 
     // Constructors
 
-    internal SqlConcat(IList<SqlExpression> expressions)
+    internal SqlConcat(IReadOnlyList<SqlExpression> expressions)
       : base(SqlNodeType.Concat, expressions)
     {
     }

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlDynamicFilter.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlDynamicFilter.cs
@@ -14,7 +14,7 @@ namespace Xtensive.Sql.Dml
   {
     public object Id { get; private set; }
 
-    public IReadOnlyList<SqlExpression> Expressions { get; set; }
+    public IReadOnlyList<SqlExpression> Expressions { get; private set; }
 
     internal override SqlDynamicFilter Clone(SqlNodeCloneContext? context = null) =>
       context.GetOrAdd(this, static (t, c) => new(t.Id, t.Expressions.Select(e => e.Clone(c)).ToArray()));

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlDynamicFilter.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlDynamicFilter.cs
@@ -5,6 +5,7 @@
 // Created:    2009.11.06
 
 using System.Collections.Generic;
+using System.Linq;
 using Xtensive.Core;
 
 namespace Xtensive.Sql.Dml
@@ -13,39 +14,27 @@ namespace Xtensive.Sql.Dml
   {
     public object Id { get; private set; }
 
-    public List<SqlExpression> Expressions { get; private set; }
+    public IReadOnlyList<SqlExpression> Expressions { get; set; }
 
     internal override SqlDynamicFilter Clone(SqlNodeCloneContext? context = null) =>
-      context.GetOrAdd(this, static (t, c) => {
-        var clone = new SqlDynamicFilter(t.Id);
-        foreach (var expression in t.Expressions) {
-          clone.Expressions.Add(expression.Clone(c));
-        }
+      context.GetOrAdd(this, static (t, c) => new(t.Id, t.Expressions.Select(e => e.Clone(c)).ToArray()));
 
-        return clone;
-      });
-
-    public override void AcceptVisitor(ISqlVisitor visitor)
-    {
-      visitor.Visit(this); 
-    }
+    public override void AcceptVisitor(ISqlVisitor visitor) => visitor.Visit(this);
 
     public override void ReplaceWith(SqlExpression expression)
     {
       var replacingExpression = ArgumentValidator.EnsureArgumentIs<SqlDynamicFilter>(expression);
       Id = replacingExpression.Id;
-      Expressions.Clear();
-      Expressions.AddRange(replacingExpression.Expressions);
+      Expressions = replacingExpression.Expressions;
     }
-
 
     // Constructors
 
-    internal SqlDynamicFilter(object id)
+    internal SqlDynamicFilter(object id, IReadOnlyList<SqlExpression> expressions)
       : base(SqlNodeType.DynamicFilter)
     {
       Id = id;
-      Expressions = new List<SqlExpression>();
+      Expressions = expressions;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlExpressionList.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlExpressionList.cs
@@ -10,101 +10,29 @@ using Xtensive.Core;
 
 namespace Xtensive.Sql.Dml
 {
-  public abstract class SqlExpressionList : SqlExpression, IList<SqlExpression>
+  public abstract class SqlExpressionList : SqlExpression, IReadOnlyList<SqlExpression>
   {
-    protected IList<SqlExpression> expressions;
+    protected IReadOnlyList<SqlExpression> expressions;
 
     /// <inheritdoc/>
-    public SqlExpression this[int index]
-    {
-      get { return expressions[index]; }
-      set
-      {
-        ArgumentValidator.EnsureArgumentNotNull(value, "value");
-        expressions[index] = value;
-      }
-    }
+    public SqlExpression this[int index] => expressions[index];
 
     /// <inheritdoc/>
-    public int Count
-    {
-      get { return expressions.Count; }
-    }
+    public int Count => expressions.Count;
 
     /// <inheritdoc/>
-    public bool IsReadOnly
-    {
-      get { return false; }
-    }
+    public IEnumerator<SqlExpression> GetEnumerator() => expressions.GetEnumerator();
 
     /// <inheritdoc/>
-    public void Add(SqlExpression item)
-    {
-      ArgumentValidator.EnsureArgumentNotNull(item, "item");
-      expressions.Add(item);
-    }
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     /// <inheritdoc/>
-    public void Clear()
-    {
-      expressions.Clear();
-    }
+    public int IndexOf(SqlExpression item) => expressions.IndexOf(item);
 
-    /// <inheritdoc/>
-    public bool Contains(SqlExpression item)
-    {
-      return expressions.Contains(item);
-    }
-
-    /// <inheritdoc/>
-    public void CopyTo(SqlExpression[] array, int index)
-    {
-      expressions.CopyTo(array, index);
-    }
-
-    /// <inheritdoc/>
-    public IEnumerator<SqlExpression> GetEnumerator()
-    {
-      return expressions.GetEnumerator();
-    }
-
-    /// <inheritdoc/>
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-      return expressions.GetEnumerator();
-    }
-
-    /// <inheritdoc/>
-    public int IndexOf(SqlExpression item)
-    {
-      return expressions.IndexOf(item);
-    }
-
-    /// <inheritdoc/>
-    public void Insert(int index, SqlExpression item)
-    {
-      expressions.Insert(index, item);
-    }
-
-    /// <inheritdoc/>
-    public bool Remove(SqlExpression item)
-    {
-      return expressions.Remove(item);
-    }
-
-    /// <inheritdoc/>
-    public void RemoveAt(int index)
-    {
-      expressions.RemoveAt(index);
-    }
-
-
-    // Constructor
-
-    protected SqlExpressionList(SqlNodeType nodeType, IList<SqlExpression> list)
+    protected SqlExpressionList(SqlNodeType nodeType, IReadOnlyList<SqlExpression> expressions)
       : base(nodeType)
     {
-      expressions = list;
+      this.expressions = expressions;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Sql/Internals/SqlValidator.cs
+++ b/Orm/Xtensive.Orm/Sql/Internals/SqlValidator.cs
@@ -39,11 +39,11 @@ namespace Xtensive.Sql
         WellKnownOrmTypes.TypeInfo
     };
 
-    public static void EnsureAreSqlRowArguments(IEnumerable<SqlExpression> nodes)
+    public static void EnsureAreSqlRowArguments(IReadOnlyList<SqlExpression> nodes)
     {
-      ArgumentValidator.EnsureArgumentNotNull(nodes, "expressions");
-      foreach (SqlExpression expression in nodes)
-        ArgumentValidator.EnsureArgumentNotNull(expression, "expression");
+      ArgumentNullException.ThrowIfNull(nodes);
+      foreach (var expression in nodes)
+        ArgumentNullException.ThrowIfNull(expression);
     }
 
     public static void EnsureIsBooleanExpression(SqlExpression node)

--- a/Orm/Xtensive.Orm/Sql/SqlDml.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlDml.cs
@@ -1509,10 +1509,10 @@ namespace Xtensive.Sql
       return new SqlPlaceholder(id);
     }
 
-    public static SqlDynamicFilter DynamicFilter(object id)
+    public static SqlDynamicFilter DynamicFilter(object id, IReadOnlyList<SqlExpression> expressions)
     {
       ArgumentValidator.EnsureArgumentNotNull(id, "id");
-      return new SqlDynamicFilter(id);
+      return new SqlDynamicFilter(id, expressions);
     }
 
     public static SqlContainer Container(object value)
@@ -1562,23 +1562,13 @@ namespace Xtensive.Sql
 
     #region Row
 
-    public static SqlRow Row(IList<SqlExpression> expressions)
+    public static SqlRow Row(IReadOnlyList<SqlExpression> expressions)
     {
       SqlValidator.EnsureAreSqlRowArguments(expressions);
       return new SqlRow(expressions);
     }
 
-    public static SqlRow Row(params SqlExpression[] expressions)
-    {
-      var collection = new List<SqlExpression>(expressions.Length);
-      collection.AddRange(expressions);
-      return Row(collection);
-    }
-
-    public static SqlRow Row()
-    {
-      return Row(new List<SqlExpression>());
-    }
+    public static SqlRow Row(params SqlExpression[] expressions) => Row((IReadOnlyList<SqlExpression>)expressions);
 
     #endregion
 
@@ -1837,15 +1827,11 @@ namespace Xtensive.Sql
       return NotLike(expression, new SqlLiteral<string>(pattern), new SqlLiteral<char>(escape));
     }
 
-    public static SqlBinary Overlaps(DateTime from1, TimeSpan span1, DateTime from2, TimeSpan span2)
-    {
-      return new SqlBinary(SqlNodeType.Overlaps, Row(from1, span1), Row(from2, span2));
-    }
+    public static SqlBinary Overlaps(DateTime from1, TimeSpan span1, DateTime from2, TimeSpan span2) =>
+      new(SqlNodeType.Overlaps, Row([from1, span1]), Row([from2, span2]));
 
-    public static SqlBinary Overlaps(DateTime from1, DateTime to1, DateTime from2, DateTime to2)
-    {
-      return new SqlBinary(SqlNodeType.Overlaps, Row(from1, to1), Row(from2, to2));
-    }
+    public static SqlBinary Overlaps(DateTime from1, DateTime to1, DateTime from2, DateTime to2) =>
+      new(SqlNodeType.Overlaps, Row([from1, to1]), Row([from2, to2]));
 
     public static SqlBinary Overlaps(SqlExpression from1, SqlExpression toOrSpan1, SqlExpression from2, SqlExpression toOrSpan2)
     {
@@ -1853,7 +1839,7 @@ namespace Xtensive.Sql
       ArgumentValidator.EnsureArgumentNotNull(toOrSpan1, "toOrSpan1");
       ArgumentValidator.EnsureArgumentNotNull(from2, "from2");
       ArgumentValidator.EnsureArgumentNotNull(toOrSpan2, "toOrSpan2");
-      return new SqlBinary(SqlNodeType.Overlaps, Row(from1, toOrSpan1), Row(from2, toOrSpan2));
+      return new(SqlNodeType.Overlaps, Row([from1, toOrSpan1]), Row([from2, toOrSpan2]));
     }
 
     public static SqlBinary Overlaps(SqlRow left, SqlRow right)


### PR DESCRIPTION
Also:
* Make `SqlExpressionList` to implement `IReadOnlyList<>` instead of `IList<>` (that was unused functionality)