### PR TITLE
 Use LINQ `.Append()` instead of custom array-copying implementation            

### DIFF
--- a/Orm/Xtensive.Orm.Tests.Core/Collections/EnumerableExtensionsTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Collections/EnumerableExtensionsTest.cs
@@ -112,7 +112,7 @@ namespace Xtensive.Orm.Tests.Core.Collections
 
     private static IEnumerable<Node> Flatten(Node root, bool rootFirst, Action<Node> exitAction)
     {
-      return EnumerableUtils.One(root).Flatten(n => n != null ? n.Children : null, exitAction, rootFirst);
+      return new[] { root }.Flatten(n => n != null ? n.Children : null, exitAction, rootFirst);
     }
 
     [Test]

--- a/Orm/Xtensive.Orm.Tests.Core/Collections/TopologicalSorterTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Collections/TopologicalSorterTest.cs
@@ -70,7 +70,7 @@ namespace Xtensive.Orm.Tests.Core.Collections
         {
             var node = new Node<int>(1);
             var edge = new Edge<int>(node, node, 1);
-            var graph = new Graph<Node<int>, Edge<int>>(EnumerableUtils.One(node));
+            var graph = new Graph<Node<int>, Edge<int>>([node]);
 
             var result = TopologicalSorter.Sort(graph, e => e.Source==e.Target);
             Assert.AreEqual(1, result.SortedNodes.Count);

--- a/Orm/Xtensive.Orm.Tests.Core/Helpers/TopologicalSorterTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Helpers/TopologicalSorterTest.cs
@@ -132,7 +132,7 @@ namespace Xtensive.Orm.Tests.Core.Helpers
       Assert.AreEqual(1, removedEdges1.Count);
       Assert.AreEqual(connection1, removedEdges1[0]);
 
-      result = TopologicalSorter.Sort([node2], out var removedEdges2).ToList(1);
+      result = TopologicalSorter.Sort((IEnumerable<Node<int, string>>) [node2], out var removedEdges2).ToList(1);
       Assert.AreEqual(1, result.Count);
       Assert.AreEqual(node2.Item, result[0]);
       Assert.AreEqual(1, removedEdges2.Count);

--- a/Orm/Xtensive.Orm.Tests.Core/Helpers/TopologicalSorterTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Helpers/TopologicalSorterTest.cs
@@ -126,7 +126,7 @@ namespace Xtensive.Orm.Tests.Core.Helpers
       var connection2 = new NodeConnection<int, string>(node2, node2, "ConnectionItem");
       connection2.BindToNodes();
 
-      var result = TopologicalSorter.SortToList([node1], out var removedEdges1);
+      var result = TopologicalSorter.SortToList((IEnumerable<Node<int, string>>)[node1], out var removedEdges1);
       Assert.AreEqual(1, result.Count);
       Assert.AreEqual(node1.Item, result[0]);
       Assert.AreEqual(1, removedEdges1.Count);

--- a/Orm/Xtensive.Orm.Tests.Core/Helpers/TopologicalSorterTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Helpers/TopologicalSorterTest.cs
@@ -126,13 +126,13 @@ namespace Xtensive.Orm.Tests.Core.Helpers
       var connection2 = new NodeConnection<int, string>(node2, node2, "ConnectionItem");
       connection2.BindToNodes();
 
-      var result = TopologicalSorter.SortToList(EnumerableUtils.One(node1), out var removedEdges1);
+      var result = TopologicalSorter.SortToList([node1], out var removedEdges1);
       Assert.AreEqual(1, result.Count);
       Assert.AreEqual(node1.Item, result[0]);
       Assert.AreEqual(1, removedEdges1.Count);
       Assert.AreEqual(connection1, removedEdges1[0]);
 
-      result = TopologicalSorter.Sort(EnumerableUtils.One(node2), out var removedEdges2).ToList(1);
+      result = TopologicalSorter.Sort([node2], out var removedEdges2).ToList(1);
       Assert.AreEqual(1, result.Count);
       Assert.AreEqual(node2.Item, result[0]);
       Assert.AreEqual(1, removedEdges2.Count);

--- a/Orm/Xtensive.Orm.Tests.Sql/MySQL/MiscTests.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/MySQL/MiscTests.cs
@@ -353,7 +353,7 @@ namespace Xtensive.Orm.Tests.Sql.MySQL
     {
       SqlSelect select = SqlDml.Select();
       var table = Catalog.DefaultSchema.Tables["Address"];
-      select.From = SqlDml.QueryRef(SqlDml.FreeTextTable(table, "How can I make my own beers and ales?", EnumerableUtils.One(table.Columns[0].Name).ToList(), EnumerableUtils.One(table.Columns[0].Name).ToList()));
+      select.From = SqlDml.QueryRef(SqlDml.FreeTextTable(table, "How can I make my own beers and ales?", [table.Columns[0].Name], [table.Columns[0].Name]));
       select.Columns.Add(select.From.Asterisk);
       Console.WriteLine(SqlDriver.Compile(select).GetCommandText());
     }

--- a/Orm/Xtensive.Orm.Tests.Sql/SqlServer/MiscTests.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/SqlServer/MiscTests.cs
@@ -364,7 +364,7 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
     {
       SqlSelect select = SqlDml.Select();
       var table = Catalog.Schemas["Person"].Tables["Address"];
-      select.From = SqlDml.QueryRef(SqlDml.FreeTextTable(table, "How can I make my own beers and ales?", EnumerableUtils.One(table.Columns[0].Name).ToList(), EnumerableUtils.One(table.Columns[0].Name).ToList()));
+      select.From = SqlDml.QueryRef(SqlDml.FreeTextTable(table, "How can I make my own beers and ales?", [table.Columns[0].Name], [table.Columns[0].Name]));
       select.Columns.Add(select.From.Asterisk);
       Console.WriteLine(sqlDriver.Compile(select).GetCommandText());
     }
@@ -376,7 +376,7 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
       var table = Catalog.Schemas["Person"].Tables["Address"];
       select.From = SqlDml.QueryRef( SqlDml.FreeTextTable(table,
         "How can I make my own beers",
-        EnumerableUtils.One(table.Columns[0].Name).ToList(),
+        [table.Columns[0].Name],
         (SqlLiteral)5));
       Console.WriteLine(sqlDriver.Compile(select).GetCommandText());
     }

--- a/Orm/Xtensive.Orm.Tests/Linq/QueryMethodTests.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/QueryMethodTests.cs
@@ -190,9 +190,9 @@ namespace Xtensive.Orm.Tests.Linq
     private IEnumerable<Customer> GetExpectedCustomerAsSequence()
     {
       if (StorageProviderInfo.Instance.CheckProviderIs(StorageProvider.Firebird)) {
-        return EnumerableUtils.One(Session.Query.All<Customer>().OrderBy(c => c.CustomerId).AsEnumerable().First());
+        return [Session.Query.All<Customer>().OrderBy(c => c.CustomerId).AsEnumerable().First()];
       }
-      return EnumerableUtils.One(Customers.First());
+      return [Customers.First()];
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Storage/Multinode/QueryCachingTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Multinode/QueryCachingTest.cs
@@ -426,7 +426,7 @@ namespace Xtensive.Orm.Tests.Storage.Multinode
       return (nodeId == WellKnown.DefaultNodeId)
         ? CustomUpgradeHandler.TypeIdPerNode.Values.ToArray()
         : CustomUpgradeHandler.TypeIdPerNode.Where(i => i.Key != nodeId)
-            .Select(i => i.Value).Union(EnumerableUtils.One(100)).ToArray();
+            .Select(i => i.Value).Union([100]).ToArray();
     }
 
     private List<BaseTestEntity> ExecuteSimpleQueryCaching(Session session) =>

--- a/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchManagerBasicTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchManagerBasicTest.cs
@@ -949,9 +949,9 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
           var newOrder = new Order();
           var orderDetail = new OrderDetail {Product = new Product()};
           session.SaveChanges();
-          var order = EnumerableUtils.One(newOrder).Prefetch(o => o.Details).First();
+          var order = new[] { newOrder }.Prefetch(o => o.Details).First();
           Assert.That(order, Is.Not.Null);
-          var product = EnumerableUtils.One(orderDetail).Prefetch(d => d.Product).First();
+          var product = new[] { orderDetail }.Prefetch(d => d.Product).First();
           Assert.That(product, Is.Not.Null);
           //Query.All<Order>().Prefetch(o => o.Details).First();
           t.Complete();

--- a/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchTest.cs
@@ -619,7 +619,7 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
         AssertEx.Throws<KeyNotFoundException>(() => session.Query.All<Track>()
           .Prefetch(t => t.PersistenceState)
           .ToList());
-        var d = session.Query.Many<Model.OfferContainer>(EnumerableUtils.One(Key.Create<Model.OfferContainer>(Domain, 1)))
+        var d = session.Query.Many<Model.OfferContainer>([Key.Create<Model.OfferContainer>(Domain, 1)])
           .Prefetch(oc => oc.IntermediateOffer.AnotherContainer.RealOffer.Book)
           .ToList();
       }
@@ -639,7 +639,7 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
         _ = Assert.ThrowsAsync<KeyNotFoundException>(async () => (await session.Query.All<Track>()
           .Prefetch(t => t.PersistenceState).ExecuteAsync())
           .ToList());
-        var d = (await session.Query.Many<Model.OfferContainer>(EnumerableUtils.One(Key.Create<Model.OfferContainer>(Domain, 1)))
+        var d = (await session.Query.Many<Model.OfferContainer>([Key.Create<Model.OfferContainer>(Domain, 1)])
           .Prefetch(oc => oc.IntermediateOffer.AnotherContainer.RealOffer.Book).ExecuteAsync())
           .ToList();
       }
@@ -699,7 +699,7 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
         }
         using (var tx = session.OpenTransaction()) {
           var books = session.Query.All<Model.Book>().AsEnumerable()
-            .Concat(EnumerableUtils.One<Model.Book>(null)).Prefetch(b => b.Title);
+            .Concat([null]).Prefetch(b => b.Title);
           var titleField = Domain.Model.Types[typeof(Model.Book)].Fields[nameof(Model.Book.Title)];
           var titleType = Domain.Model.Types[typeof(Model.Title)];
           var count = 0;
@@ -727,7 +727,7 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
 
         await using (var tx = session.OpenTransaction()) {
           var books = session.Query.All<Model.Book>().AsEnumerable()
-            .Concat(EnumerableUtils.One<Model.Book>(null)).Prefetch(b => b.Title).AsAsyncEnumerable();
+            .Concat([null]).Prefetch(b => b.Title).AsAsyncEnumerable();
           var titleField = Domain.Model.Types[typeof(Model.Book)].Fields[nameof(Model.Book.Title)];
           var titleType = Domain.Model.Types[typeof(Model.Title)];
           var count = 0;
@@ -804,7 +804,7 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
           tx.Complete();
         }
         using (var tx = session.OpenTransaction()) {
-          var books = session.Query.All<Model.Book>().AsEnumerable().Concat(EnumerableUtils.One<Model.Book>(null))
+          var books = session.Query.All<Model.Book>().AsEnumerable().Concat([null])
             .Prefetch(b => b.Title.Book);
           var titleField = Domain.Model.Types[typeof (Model.Book)].Fields["Title"];
           var titleType = Domain.Model.Types[typeof (Model.Title)];
@@ -834,7 +834,7 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
         }
 
         await using (var tx = session.OpenTransaction()) {
-          var books = session.Query.All<Model.Book>().AsEnumerable().Concat(EnumerableUtils.One<Model.Book>(null))
+          var books = session.Query.All<Model.Book>().AsEnumerable().Concat([null])
             .Prefetch(b => b.Title.Book).AsAsyncEnumerable();
           var titleField = Domain.Model.Types[typeof(Model.Book)].Fields[nameof(Model.Book.Title)];
           var titleType = Domain.Model.Types[typeof(Model.Title)];
@@ -861,7 +861,7 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
 
       using (var session = Domain.OpenSession())
       using (var tx = session.OpenTransaction()) {
-        var containers = session.Query.Many<Model.OfferContainer>(EnumerableUtils.One(containerKey))
+        var containers = session.Query.Many<Model.OfferContainer>([containerKey])
           .Prefetch(oc => oc.RealOffer.Book)
           .Prefetch(oc => oc.IntermediateOffer.RealOffer.BookShop);
         foreach (var key in containers) {
@@ -879,7 +879,7 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
 
       await using (var session = await Domain.OpenSessionAsync())
       await using (var tx = session.OpenTransaction()) {
-        var containers = session.Query.Many<Model.OfferContainer>(EnumerableUtils.One(containerKey))
+        var containers = session.Query.Many<Model.OfferContainer>([containerKey])
           .Prefetch(oc => oc.RealOffer.Book)
           .Prefetch(oc => oc.IntermediateOffer.RealOffer.BookShop).AsAsyncEnumerable();
         await foreach (var key in containers) {
@@ -897,7 +897,7 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
 
       using (var session = Domain.OpenSession())
       using (var tx = session.OpenTransaction()) {
-        var containers = session.Query.Many<Model.OfferContainer>(EnumerableUtils.One(containerKey))
+        var containers = session.Query.Many<Model.OfferContainer>([containerKey])
           .Prefetch(oc => oc.IntermediateOffer);
         foreach (var key in containers) {
           PrefetchTestHelper.AssertOnlySpecifiedColumnsAreLoaded(containerKey, containerKey.TypeInfo, session,
@@ -914,7 +914,7 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
 
       await using (var session = await Domain.OpenSessionAsync())
       await using (var tx = session.OpenTransaction()) {
-        var containers = session.Query.Many<Model.OfferContainer>(EnumerableUtils.One(containerKey))
+        var containers = session.Query.Many<Model.OfferContainer>([containerKey])
           .Prefetch(oc => oc.IntermediateOffer).AsAsyncEnumerable();
         await foreach (var key in containers) {
           PrefetchTestHelper.AssertOnlySpecifiedColumnsAreLoaded(containerKey, containerKey.TypeInfo, session,

--- a/Orm/Xtensive.Orm.Tests/Storage/Randomized/Tree.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Randomized/Tree.cs
@@ -33,7 +33,7 @@ namespace Xtensive.Orm.Tests.Storage.Randomized
     /// <inheritdoc/>
     public IEnumerator<TreeNode> GetEnumerator()
     {
-      return EnumerableUtils.One(Root).Flatten(node => node.Children, null, true).GetEnumerator();
+      return new[] { Root }.Flatten(node => node.Children, null, true).GetEnumerator();
     }
 
     /// <inheritdoc/>

--- a/Orm/Xtensive.Orm.Tests/Storage/VersionRootTests.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/VersionRootTests.cs
@@ -60,7 +60,7 @@ namespace Xtensive.Orm.Tests.Storage.VersionRootModel
       if (Order==null)
         return Enumerable.Empty<Entity>();
       else 
-        return EnumerableUtils.One((Entity) Order);
+        return [(Entity) Order];
     }
   }
 

--- a/Orm/Xtensive.Orm/Collections/EnumerableUtils.cs
+++ b/Orm/Xtensive.Orm/Collections/EnumerableUtils.cs
@@ -17,16 +17,6 @@ namespace Xtensive.Collections
   public static class EnumerableUtils
   {
     /// <summary>
-    /// Gets the enumerable with one element.
-    /// </summary>
-    /// <typeparam name="TItem">The type of enumerated item.</typeparam>
-    /// <returns>Sequence with value inside.</returns>
-    public static IEnumerable<TItem> One<TItem>(TItem value)
-    {
-      yield return value;
-    }
-
-    /// <summary>
     /// Unfolds the whole sequence from its <paramref name="first"/> item.
     /// If <paramref name="first"/> is <see langword="null" />,
     /// an empty sequence is returned.

--- a/Orm/Xtensive.Orm/Collections/TypeRegistrationProcessorBase.cs
+++ b/Orm/Xtensive.Orm/Collections/TypeRegistrationProcessorBase.cs
@@ -34,7 +34,7 @@ namespace Xtensive.Collections
       var types =
         registration.Type==null
           ? FindTypes(registration.Assembly, BaseType, (type, typeFilter) => IsAcceptable(registration, type))
-          : EnumerableUtils.One(registration.Type).Where(t => IsAcceptable(registration, t));
+          : IsAcceptable(registration, registration.Type) ? [registration.Type] : [];
       foreach (var type in types)
         Process(registry, registration, type);
     }

--- a/Orm/Xtensive.Orm/Core/Extensions/ArrayExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/ArrayExtensions.cs
@@ -175,26 +175,6 @@ namespace Xtensive.Core
     }
 
     /// <summary>
-    /// Creates new array consisting of <paramref name="items"/>
-    /// and <paramref name="item"/> added after array elements.
-    /// If <paramref name="items"/> is <see langword="null"/>
-    /// returns array that contains just <paramref name="item"/>.
-    /// </summary>
-    /// <typeparam name="TItem">The type of the item.</typeparam>
-    /// <param name="items">The items.</param>
-    /// <param name="item">The prefix item.</param>
-    /// <returns>Result array.</returns>
-    public static TItem[] Append<TItem>(this TItem[] items, TItem item)
-    {
-      if (items == null || items.Length == 0)
-        return new [] {item};
-      var result = new TItem[items.Length + 1];
-      Array.Copy(items, result, items.Length);
-      result[items.Length] = item;
-      return result;
-    }
-
-    /// <summary>
     /// Combines the specified source and target arrays into new one.
     /// </summary>
     /// <typeparam name="TItem">The type of the item.</typeparam>

--- a/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
@@ -429,7 +429,7 @@ namespace Xtensive.Core
       using var enumerator = source.GetEnumerator();
       while (currentCount < firstFastCount && enumerator.MoveNext()) {
         currentCount++;
-        yield return EnumerableUtils.One(enumerator.Current);
+        yield return [enumerator.Current];
       }
       while (enumerator.MoveNext()) {
         currentCount = 0;

--- a/Orm/Xtensive.Orm/Core/Extensions/StringExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/StringExtensions.cs
@@ -5,6 +5,7 @@
 // Created:    2008.07.18
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
@@ -415,7 +416,7 @@ namespace Xtensive.Core
     {
       ArgumentNullException.ThrowIfNull(source);
       ArgumentNullException.ThrowIfNull(escapedChars);
-      var chars = escapedChars.Append(escape);
+      var chars = escapedChars.Append(escape).ToArray();
       var sb = new ValueStringBuilder(stackalloc char[4096]);
       foreach (var c in source) {
         var found = false;

--- a/Orm/Xtensive.Orm/Orm/Entity.cs
+++ b/Orm/Xtensive.Orm/Orm/Entity.cs
@@ -397,12 +397,12 @@ namespace Xtensive.Orm
 
     internal void RemoveLaterInternal(EntityRemoveReason reason)
     {
-      Session.RemovalProcessor.EnqueueForRemoval(EnumerableUtils.One(this), reason);
+      Session.RemovalProcessor.EnqueueForRemoval([this], reason);
     }
 
     internal void RemoveInternal(EntityRemoveReason reason)
     {
-      Session.RemovalProcessor.Remove(EnumerableUtils.One(this), reason);
+      Session.RemovalProcessor.Remove([this], reason);
     }
 
     /// <exception cref="InvalidOperationException">Entity is removed.</exception>

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/LocalCollectionExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/LocalCollectionExpression.cs
@@ -28,7 +28,7 @@ namespace Xtensive.Orm.Linq.Expressions
     public IEnumerable<ColumnExpression> Columns =>
       Fields
         .SelectMany(field => field.Value is ColumnExpression
-          ? EnumerableUtils.One(field.Value)
+          ? [field.Value]
           : ((LocalCollectionExpression) field.Value).Columns.Cast<IMappedExpression>())
         .Cast<ColumnExpression>();
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/LocalCollectionExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/LocalCollectionExpression.cs
@@ -28,7 +28,7 @@ namespace Xtensive.Orm.Linq.Expressions
     public IEnumerable<ColumnExpression> Columns =>
       Fields
         .SelectMany(field => field.Value is ColumnExpression
-          ? [field.Value]
+          ? new[] { field.Value }
           : ((LocalCollectionExpression) field.Value).Columns.Cast<IMappedExpression>())
         .Cast<ColumnExpression>();
 

--- a/Orm/Xtensive.Orm/Orm/Linq/ItemToTupleConverter{TItem}.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ItemToTupleConverter{TItem}.cs
@@ -44,7 +44,7 @@ namespace Xtensive.Orm.Linq
       public void Add(Type type)
       {
         count++;
-        types = types==null ? EnumerableUtils.One(type) : types.Concat(EnumerableUtils.One(type));
+        types = types==null ? [type] : types.Concat([type]);
       }
 
       public void AddRange(IReadOnlyCollection<Type> newTypes)

--- a/Orm/Xtensive.Orm/Orm/Operations/KeySetOperation.cs
+++ b/Orm/Xtensive.Orm/Orm/Operations/KeySetOperation.cs
@@ -49,7 +49,7 @@ namespace Xtensive.Orm.Operations
 
     /// <inheritdoc/>
     public KeySetOperation(Key key)
-      : this(EnumerableUtils.One(key))
+      : this([key])
     {
     }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/SqlPersistTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/SqlPersistTask.cs
@@ -58,13 +58,13 @@ namespace Xtensive.Orm.Providers
 
     public SqlPersistTask(PersistRequest request, Tuple tuple = null)
     {
-      RequestSequence = EnumerableUtils.One(request);
+      RequestSequence = [request];
       Tuple = tuple;
     }
 
     public SqlPersistTask(PersistRequest request, IReadOnlyList<Tuple> tuples)
     {
-      RequestSequence = EnumerableUtils.One(request);
+      RequestSequence = [request];
       Tuples = tuples;
     }
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
@@ -318,7 +318,7 @@ namespace Xtensive.Orm.Rse.Transformation
       var newSource = VisitCompilable(provider.Source);
       var currentMapping = mappings[provider.Source];
       var rowNumberColumn = provider.Header.Columns.Last();
-      mappings[provider] = Merge(currentMapping, EnumerableUtils.One(rowNumberColumn.Index));
+      mappings[provider] = Merge(currentMapping, [rowNumberColumn.Index]);
       return newSource == provider.Source
         ? provider
         : new RowNumberProvider(newSource, rowNumberColumn.Name);

--- a/Orm/Xtensive.Orm/Orm/Transaction.cs
+++ b/Orm/Xtensive.Orm/Orm/Transaction.cs
@@ -276,7 +276,7 @@ namespace Xtensive.Orm
     private void PromoteLifetimeTokensToSession()
     {
       if (Outer == null
-          && Session.TryPromoteTokens(EnumerableUtils.One(LifetimeToken).Union(lifetimeTokens))) {
+          && Session.TryPromoteTokens(new[] { LifetimeToken }.Union(lifetimeTokens))) {
         ClearLifetimeTokens();
       }
     }

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/HintGenerator.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/HintGenerator.cs
@@ -839,7 +839,7 @@ namespace Xtensive.Orm.Upgrade
 
     private static IEnumerable<StoredTypeInfo> GetAffectedMappedTypes(StoredTypeInfo type, bool includeInheritors)
     {
-      var result = EnumerableUtils.One(type);
+      IEnumerable<StoredTypeInfo> result = [type];
       if (includeInheritors) {
         result = result.Concat(type.AllDescendants);
       }
@@ -852,7 +852,7 @@ namespace Xtensive.Orm.Upgrade
     private static StoredTypeInfo[] GetAffectedMappedTypesAsArray(StoredTypeInfo type, bool includeInheritors)
     {
       var count = 1;
-      var result = EnumerableUtils.One(type);
+      IEnumerable<StoredTypeInfo> result = [type];
       if (includeInheritors) {
         result = result.Concat(type.AllDescendants);
         count += type.AllDescendants.Length;
@@ -860,7 +860,6 @@ namespace Xtensive.Orm.Upgrade
       return type.Hierarchy.InheritanceSchema == InheritanceSchema.ConcreteTable
         ? result.Where(t => !t.IsAbstract).ToArray()
         : result.ToArray(count);
-
     }
 
     private IdentityPair CreateIdentityPair(StoredTypeInfo removedType, StoredTypeInfo updatedType, int? typeIdOverride = null)

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/HintGenerator.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/HintGenerator.cs
@@ -351,10 +351,7 @@ namespace Xtensive.Orm.Upgrade
 
     private void GenerateCleanupByForeignKeyHints(StoredTypeInfo removedType, CleanupInfo cleanupInfo)
     {
-      var removedTypeAndAncestors = new HashSet<StoredTypeInfo>(removedType.AllAncestors.Length + 1);
-      foreach (var t in removedType.AllAncestors.Append(removedType)) {
-        removedTypeAndAncestors.Add(t);
-      }
+      var removedTypeAndAncestors = removedType.AllAncestors.Append(removedType).ToHashSet();
 
       var descendantsToHash = (cleanupInfo & CleanupInfo.ConflictByTable) != 0
         ? removedType.AllDescendants

--- a/Orm/Xtensive.Orm/Reflection/DelegateHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/DelegateHelper.cs
@@ -481,7 +481,7 @@ namespace Xtensive.Reflection
       if (returnType == WellKnownTypes.Void || returnType == null) {
         return n == 0 ? ActionTypes[0] : ActionTypes[n].MakeGenericType(parameterTypes);
       }
-      var funcGenericParameters = parameterTypes.Append(returnType);
+      var funcGenericParameters = parameterTypes.Append(returnType).ToArray();
       return FuncTypes[funcGenericParameters.Length - 1].MakeGenericType(funcGenericParameters);
     }
 


### PR DESCRIPTION
Also:
* Get rid of `EnumerableUtils.One(x)`.  Replace it by `[x]`.  Simple array are more efficient than Enumerator object with `yield` statement