### PR TITLE
Optmize `BuildFieldCheck`: avoid double-calculation of `field.ValueType.ToNullable()`

### DIFF
--- a/Orm/Xtensive.Orm/Core/Extensions/ExpressionExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/ExpressionExtensions.cs
@@ -86,12 +86,11 @@ namespace Xtensive.Core
         var expressionParameter = lambdaExpressionParameters[i];
         var parameter = parameters[i];
         var parameterType = parameter.Type;
-        if (expressionParameter.Type.IsAssignableFrom(parameterType)) {
-          var expressionParameterType = expressionParameter.Type;
+        var expressionParameterType = expressionParameter.Type;
+        if (expressionParameterType.IsAssignableFrom(parameterType))
           convertedParameters[i] = expressionParameterType == parameterType
             ? parameter
             : Expression.Convert(parameter, expressionParameterType);
-        }
         else
           throw new InvalidOperationException(String.Format(
             Strings.ExUnableToUseExpressionXAsXParameterOfLambdaXBecauseOfTypeMistmatch,

--- a/Orm/Xtensive.Orm/Core/Extensions/ExpressionExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/ExpressionExtensions.cs
@@ -22,7 +22,7 @@ namespace Xtensive.Core
   /// </summary>
   public static class ExpressionExtensions
   {
-    private readonly static ConcurrentDictionary<Type, ConstantExpression> StructDefaultValues = new();
+    private readonly static ConcurrentDictionary<Type, ConstantExpression> StructDefaultConstantExpressions = new();
 
     /// <summary>
     /// Formats the <paramref name="expression"/>.
@@ -124,7 +124,7 @@ namespace Xtensive.Core
     public static ConstantExpression ToConstantExpression(this DefaultExpression defaultExpression) =>
       defaultExpression.Type switch {
         var type => type.IsValueType
-          ? StructDefaultValues.GetOrAdd<DefaultExpression>(
+          ? StructDefaultConstantExpressions.GetOrAdd<DefaultExpression>(
             type,
             static (t, expr) => Expression.Constant(((Func<object>) Expression.Lambda(Expression.Convert(expr, WellKnownTypes.Object)).Compile()).Invoke(), t),
             defaultExpression)

--- a/Orm/Xtensive.Orm/Core/Extensions/ExpressionExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/ExpressionExtensions.cs
@@ -127,14 +127,14 @@ namespace Xtensive.Core
     /// <param name="defaultExpression">The expression to convert.</param>
     /// <returns>Result constant expression.</returns>
     public static ConstantExpression ToConstantExpression(this DefaultExpression defaultExpression) =>
-      defaultExpression.Type switch {
-        var type => type.IsValueType
-          ? StructDefaultConstantExpressions.GetOrAdd(
-            type,
-            static (t, expr) => Expression.Constant(((Func<object>) Expression.Lambda(Expression.Convert(expr, WellKnownTypes.Object)).Compile()).Invoke(), t),
-            defaultExpression)
-          : null
-      };
+      StructDefaultConstantExpressions.GetOrAdd(
+        defaultExpression.Type,
+        static (t, expr) => Expression.Constant(
+          t.IsValueType
+            ? ((Func<object>) Expression.Lambda(Expression.Convert(expr, WellKnownTypes.Object)).Compile()).Invoke()
+            : null,
+          t),
+        defaultExpression);
 
     /// <summary>
     /// Gets return type of <see cref="LambdaExpression"/>.

--- a/Orm/Xtensive.Orm/Core/Extensions/ExpressionExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/ExpressionExtensions.cs
@@ -129,7 +129,7 @@ namespace Xtensive.Core
     public static ConstantExpression ToConstantExpression(this DefaultExpression defaultExpression) =>
       defaultExpression.Type switch {
         var type => type.IsValueType
-          ? StructDefaultConstantExpressions.GetOrAdd<DefaultExpression>(
+          ? StructDefaultConstantExpressions.GetOrAdd(
             type,
             static (t, expr) => Expression.Constant(((Func<object>) Expression.Lambda(Expression.Convert(expr, WellKnownTypes.Object)).Compile()).Invoke(), t),
             defaultExpression)

--- a/Orm/Xtensive.Orm/Core/Extensions/ExpressionExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/ExpressionExtensions.cs
@@ -79,7 +79,7 @@ namespace Xtensive.Core
         throw new InvalidOperationException(String.Format(
           Strings.ExUnableToBindParametersToLambdaXParametersCountIsIncorrect,
           lambdaExpression.ToString(true)));
-      if (parameters.Length==0)
+      if (parameters.Length == 0)
         return lambdaExpression;
       var convertedParameters = new Expression[parameters.Length];
       for (int i = 0; i < lambdaExpressionParametersCount; i++) {
@@ -94,7 +94,7 @@ namespace Xtensive.Core
         else
           throw new InvalidOperationException(String.Format(
             Strings.ExUnableToUseExpressionXAsXParameterOfLambdaXBecauseOfTypeMistmatch,
-            parameters[i].ToString(true), i, lambdaExpressionParameters[i].ToString(true)));
+            parameters[i].ToString(true), i, expressionParameter.ToString(true)));
       }
       return ExpressionReplacer.ReplaceAll(
         lambdaExpression.Body, lambdaExpressionParameters, convertedParameters);

--- a/Orm/Xtensive.Orm/Core/Extensions/ExpressionExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/ExpressionExtensions.cs
@@ -73,26 +73,32 @@ namespace Xtensive.Core
     /// <exception cref="InvalidOperationException">Something went wrong :(.</exception>
     public static Expression BindParameters(this LambdaExpression lambdaExpression, params Expression[] parameters)
     {
-      if (lambdaExpression.Parameters.Count!=parameters.Length)
+      var lambdaExpressionParameters = lambdaExpression.Parameters;
+      var lambdaExpressionParametersCount = lambdaExpressionParameters.Count;
+      if (lambdaExpressionParametersCount != parameters.Length)
         throw new InvalidOperationException(String.Format(
           Strings.ExUnableToBindParametersToLambdaXParametersCountIsIncorrect,
           lambdaExpression.ToString(true)));
       if (parameters.Length==0)
         return lambdaExpression;
       var convertedParameters = new Expression[parameters.Length];
-      for (int i = 0; i < lambdaExpression.Parameters.Count; i++) {
-        var expressionParameter = lambdaExpression.Parameters[i];
-        if (expressionParameter.Type.IsAssignableFrom(parameters[i].Type))
-          convertedParameters[i] = expressionParameter.Type==parameters[i].Type
-            ? parameters[i]
-            : Expression.Convert(parameters[i], expressionParameter.Type);
+      for (int i = 0; i < lambdaExpressionParametersCount; i++) {
+        var expressionParameter = lambdaExpressionParameters[i];
+        var parameter = parameters[i];
+        var parameterType = parameter.Type;
+        if (expressionParameter.Type.IsAssignableFrom(parameterType)) {
+          var expressionParameterType = expressionParameter.Type;
+          convertedParameters[i] = expressionParameterType == parameterType
+            ? parameter
+            : Expression.Convert(parameter, expressionParameterType);
+        }
         else
           throw new InvalidOperationException(String.Format(
             Strings.ExUnableToUseExpressionXAsXParameterOfLambdaXBecauseOfTypeMistmatch,
-            parameters[i].ToString(true), i, lambdaExpression.Parameters[i].ToString(true)));
+            parameters[i].ToString(true), i, lambdaExpressionParameters[i].ToString(true)));
       }
       return ExpressionReplacer.ReplaceAll(
-        lambdaExpression.Body, lambdaExpression.Parameters, convertedParameters);
+        lambdaExpression.Body, lambdaExpressionParameters, convertedParameters);
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Linq/Internals/ExpressionHashCodeCalculator.cs
+++ b/Orm/Xtensive.Orm/Linq/Internals/ExpressionHashCodeCalculator.cs
@@ -64,7 +64,7 @@ namespace Xtensive.Linq
     protected override int VisitDefault(DefaultExpression d)
     {
       if (d.Type.IsValueType) {
-        return d.GetDefaultValue().GetHashCode();
+        return d.ToConstantExpression().Value.GetHashCode();
       }
       else {
         return NullHashCode;

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/PartialIndexFilterBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/PartialIndexFilterBuilder.cs
@@ -94,13 +94,9 @@ namespace Xtensive.Orm.Building.Builders
 
       return base.VisitBinary(b);
 
-      static bool EnumRewritableOperations(BinaryExpression b)
-      {
-        var nt = b.NodeType;
-        return nt == ExpressionType.Equal || nt == ExpressionType.NotEqual
-          || nt == ExpressionType.GreaterThan || nt == ExpressionType.GreaterThanOrEqual
-          || nt == ExpressionType.LessThan || nt == ExpressionType.LessThanOrEqual;
-      }
+      static bool EnumRewritableOperations(BinaryExpression b) =>
+        b.NodeType is ExpressionType.Equal or ExpressionType.NotEqual or ExpressionType.GreaterThan or ExpressionType.GreaterThanOrEqual
+          or ExpressionType.LessThan or ExpressionType.LessThanOrEqual;
     }
 
     protected override Expression VisitMember(MemberExpression originalMemberAccess)
@@ -142,7 +138,7 @@ namespace Xtensive.Orm.Building.Builders
       }
       if (field.IsPrimitive) {
         EnsureCanBeUsedInFilter(originalMemberAccess, field);
-        return BuildFieldAccess(field, false);
+        return BuildFieldAccess(field, field.ValueType);
       }
       throw UnableToTranslate(originalMemberAccess, Strings.OnlyPrimitiveAndReferenceFieldsAreSupported);
     }
@@ -156,10 +152,9 @@ namespace Xtensive.Orm.Building.Builders
         throw UnableToTranslate(expression, string.Format(Strings.FieldXDoesNotExistInTableForY, field.Name, field.ReflectedType));
     }
 
-    private Expression BuildFieldAccess(FieldInfo field, bool addNullability)
+    private Expression BuildFieldAccess(FieldInfo field, Type valueType)
     {
       var fieldIndex = usedFields.Count;
-      var valueType = addNullability ? field.ValueType.ToNullable() : field.ValueType;
       usedFields.Add(field);
       return Expression.Call(Parameter,
         WellKnownMembers.Tuple.GenericAccessor.CachedMakeGenericMethod(valueType),
@@ -168,18 +163,12 @@ namespace Xtensive.Orm.Building.Builders
 
     private Expression BuildFieldCheck(FieldInfo field, ExpressionType nodeType)
     {
-      return Expression.MakeBinary(nodeType, BuildFieldAccess(field, true), Expression.Constant(null, field.ValueType.ToNullable()));
+      var nullableValueType = field.ValueType.ToNullable();
+      return Expression.MakeBinary(nodeType, BuildFieldAccess(field, nullableValueType), Expression.Constant(null, nullableValueType));
     }
 
-    private Expression BuildEntityCheck(FieldInfo field, ExpressionType nodeType)
-    {
-      var fields = field.Fields.Where(f => f.Column!=null).ToList();
-      if (fields.Count==0)
-        throw new InvalidOperationException();
-      return fields
-        .Skip(1)
-        .Aggregate(BuildFieldCheck(fields[0], nodeType), (c, f) => Expression.AndAlso(c, BuildFieldCheck(f, nodeType)));
-    }
+    private Expression BuildEntityCheck(FieldInfo field, ExpressionType nodeType) =>
+      field.Fields.Where(f => f.Column != null).Select(f => BuildFieldCheck(f, nodeType)).Aggregate(Expression.AndAlso);
 
     private bool IsNull(Expression expression)
     {


### PR DESCRIPTION
Also:
* Avoid intermediate List in `BuildEntityCheck()`, as `.Aggregate()` detects case with empty `IEnumerable<>` and throws Exception
* Optimize `.ToConstantExpression()` extension: `ConstantExpression` is immutable, so we can memoize it in the static cache
* Optimize `.BindParameters()`