### PR TITLE
Implement `GetHashCode()` via `HashCode.Combine()`

### DIFF
--- a/Extensions/Xtensive.Orm.Security/Permission.cs
+++ b/Extensions/Xtensive.Orm.Security/Permission.cs
@@ -56,16 +56,7 @@ namespace Xtensive.Orm.Security
     }
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      unchecked {
-        int result = (Type != null ? Type.GetHashCode() : 0);
-        result = (result*397) ^ CanRead.GetHashCode();
-        result = (result*397) ^ CanWrite.GetHashCode();
-        result = (result*397) ^ (Query != null ? Query.GetHashCode() : 0);
-        return result;
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(Type, CanRead, CanWrite, Query);
 
     #endregion
 

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/CachePerformanceTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/CachePerformanceTest.cs
@@ -52,10 +52,7 @@ namespace Xtensive.Orm.Tests.Core.Caching
         return Equals(obj as Item);
       }
 
-      public override int GetHashCode()
-      {
-        return (Value!=null ? Value.GetHashCode() : 0);
-      }
+      public override int GetHashCode() => Value?.GetHashCode() ?? 0;
 
       public override string ToString()
       {

--- a/Orm/Xtensive.Orm.Tests.Core/Caching/WeakestCacheTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Caching/WeakestCacheTest.cs
@@ -36,10 +36,7 @@ namespace Xtensive.Orm.Tests.Core.Caching
         return Equals(obj as Item);
       }
 
-      public override int GetHashCode()
-      {
-        return (Value != null ? Value.GetHashCode() : 0);
-      }
+      public override int GetHashCode() => Value?.GetHashCode() ?? 0;
 
       public override string ToString()
       {

--- a/Orm/Xtensive.Orm.Tests.Core/Modelling/IndexingModel/TypeInfo.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Modelling/IndexingModel/TypeInfo.cs
@@ -100,19 +100,7 @@ namespace Xtensive.Orm.Tests.Core.Modelling.IndexingModel
     }
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      unchecked {
-        int result = (Type!=null ? Type.GetHashCode() : 0);
-        result = (result * 397) ^ (IsNullable ? 1 : 0);
-        result = (result * 397) ^ Length;
-        result = (result * 397) ^ Scale;
-        result = (result * 397) ^ Precision;
-        if (Culture!=null)
-          result = (result * 397) ^ Culture.GetHashCode();
-        return result;
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(Type, IsNullable, Length, Scale, Precision, Culture);
 
     /// <summary>
     /// Implements the operator ==.

--- a/Orm/Xtensive.Orm.Tests.Framework/Dynamic.cs
+++ b/Orm/Xtensive.Orm.Tests.Framework/Dynamic.cs
@@ -219,11 +219,13 @@ namespace System.Linq.Dynamic
     public Signature(IEnumerable<DynamicProperty> properties)
     {
       this.properties = properties.ToArray();
-      hashCode = 0;
+      HashCode hc = new();
       foreach (DynamicProperty p in properties)
       {
-        hashCode ^= p.Name.GetHashCode() ^ p.Type.GetHashCode();
+        hc.Add(p.Name);
+        hc.Add(p.Type);
       }
+      hashCode = hc.ToHashCode();
     }
 
     #region IEquatable<Signature> Members
@@ -241,10 +243,7 @@ namespace System.Linq.Dynamic
 
     #endregion
 
-    public override int GetHashCode()
-    {
-      return hashCode;
-    }
+    public override int GetHashCode() => hashCode;
 
     public override bool Equals(object obj)
     {

--- a/Orm/Xtensive.Orm.Tests/Linq/LocalCollectionsTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/LocalCollectionsTest.cs
@@ -54,10 +54,7 @@ namespace Xtensive.Orm.Tests.Linq.LocalCollectionsTest_Model
       return Equals((Poco<T>) obj);
     }
 
-    public override int GetHashCode()
-    {
-      return Value.GetHashCode();
-    }
+    public override int GetHashCode() => Value.GetHashCode();
   }
 
   public class Poco<T1, T2>
@@ -85,12 +82,7 @@ namespace Xtensive.Orm.Tests.Linq.LocalCollectionsTest_Model
       return Equals((Poco<T1, T2>) obj);
     }
 
-    public override int GetHashCode()
-    {
-      unchecked {
-        return (Value1.GetHashCode() * 397) ^ Value2.GetHashCode();
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(Value1, Value2);
 
     public Poco(T1 Value1, T2 Value2)
     {
@@ -137,15 +129,7 @@ namespace Xtensive.Orm.Tests.Linq.LocalCollectionsTest_Model
       return Equals((Poco<T1, T2, T3>) obj);
     }
 
-    public override int GetHashCode()
-    {
-      unchecked {
-        int result = Value1.GetHashCode();
-        result = (result * 397) ^ Value2.GetHashCode();
-        result = (result * 397) ^ Value3.GetHashCode();
-        return result;
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(Value1, Value2, Value3);
 
     public Poco()
     {

--- a/Orm/Xtensive.Orm/Annotations.cs
+++ b/Orm/Xtensive.Orm/Annotations.cs
@@ -75,10 +75,7 @@ namespace JetBrains.Annotations
     /// Returns the hash code for this instance.
     /// </summary>
     /// <returns>A hash code for the current <see cref="LocalizationRequiredAttribute"/>.</returns>
-    public override int GetHashCode()
-    {
-      return base.GetHashCode();
-    }
+    public override int GetHashCode() => base.GetHashCode();
   }
 
   /// <summary>

--- a/Orm/Xtensive.Orm/Arithmetic/ArithmeticRules.cs
+++ b/Orm/Xtensive.Orm/Arithmetic/ArithmeticRules.cs
@@ -45,10 +45,7 @@ namespace Xtensive.Arithmetic
       obj is ArithmeticRules other && Equals(other);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      return ((byte)overflowBehavior << 8) | (byte)nullBehavior;
-    }
+    public override int GetHashCode() => ((byte) overflowBehavior << 8) | (byte) nullBehavior;
 
 
     // Constructors

--- a/Orm/Xtensive.Orm/Caching/WeakestCache.cs
+++ b/Orm/Xtensive.Orm/Caching/WeakestCache.cs
@@ -101,10 +101,7 @@ namespace Xtensive.Caching
         return Equals((WeakEntry) obj);
       }
 
-      public override int GetHashCode()
-      {
-        return hashCode;
-      }
+      public override int GetHashCode() => hashCode;
 
       #endregion
 

--- a/Orm/Xtensive.Orm/Collections/FlagCollection.cs
+++ b/Orm/Xtensive.Orm/Collections/FlagCollection.cs
@@ -333,12 +333,7 @@ namespace Xtensive.Collections
     }
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      int result = keys.GetHashCode();
-      result = 29*result + flags.GetHashCode();
-      return result;
-    }
+    public override int GetHashCode() => HashCode.Combine(keys, flags);
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Collections/TypeRegistration.cs
+++ b/Orm/Xtensive.Orm/Collections/TypeRegistration.cs
@@ -69,15 +69,7 @@ namespace Xtensive.Collections
     }
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      unchecked {
-        int result = (type!=null ? type.GetHashCode() : 0);
-        result = (result * 397) ^ (assembly!=null ? assembly.GetHashCode() : 0);
-        result = (result * 397) ^ (@namespace!=null ? @namespace.GetHashCode() : 0);
-        return result;
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(type, assembly, @namespace);
 
     /// <inheritdoc/>
     public static bool operator ==(TypeRegistration left, TypeRegistration right)

--- a/Orm/Xtensive.Orm/Comparison/ComparisonRule.cs
+++ b/Orm/Xtensive.Orm/Comparison/ComparisonRule.cs
@@ -83,13 +83,7 @@ namespace Xtensive.Comparison
       obj is ComparisonRule other && Equals(other);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      int result = (int)Direction;
-      if (Culture != null)
-        result ^= Culture.GetHashCode();
-      return result;
-    }
+    public override int GetHashCode() => HashCode.Combine(Direction, Culture);
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Comparison/Internals/NoSystemComparerHandler.cs
+++ b/Orm/Xtensive.Orm/Comparison/Internals/NoSystemComparerHandler.cs
@@ -36,13 +36,11 @@ namespace Xtensive.Comparison
     }
 
     /// <exception cref="NotSupportedException"><c>NotSupportedException</c>.</exception>
-    public override int GetHashCode()
-    {
+    public override int GetHashCode() =>
       throw new NotSupportedException(string.Format(
         Strings.ExTypeXMustImplementY,
         typeof(T).GetShortName(),
         typeof(IEquatable<T>).GetShortName()));
-    }
 
 
     // Constructors

--- a/Orm/Xtensive.Orm/Conversion/Biconverter.cs
+++ b/Orm/Xtensive.Orm/Conversion/Biconverter.cs
@@ -57,12 +57,7 @@ namespace Xtensive.Conversion
       obj is Biconverter<TFrom, TTo> other && Equals(other);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      unchecked {
-        return ((ConvertForward!=null ? ConvertForward.GetHashCode() : 0) * 397) ^ (ConvertBackward!=null ? ConvertBackward.GetHashCode() : 0);
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(ConvertForward, ConvertBackward);
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Core/HasVersion{TValue,TVersion}.cs
+++ b/Orm/Xtensive.Orm/Core/HasVersion{TValue,TVersion}.cs
@@ -61,14 +61,7 @@ namespace Xtensive.Core
       obj is HasVersion<TValue, TVersion> other && Equals(other);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      unchecked {
-        return 
-          ((Value!=null ? Value.GetHashCode() : 0) * 397) ^ 
-          (Version!=null ? Version.GetHashCode() : 0);
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(Value, Version);
 
     /// <summary>
     /// Checks specified objects for equality.

--- a/Orm/Xtensive.Orm/Core/Pair{TFirst,TSecond}.cs
+++ b/Orm/Xtensive.Orm/Core/Pair{TFirst,TSecond}.cs
@@ -57,12 +57,7 @@ namespace Xtensive.Core
       obj is Pair<TFirst, TSecond> other && Equals(other);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      unchecked {
-        return ((First?.GetHashCode() ?? 0) * 397) ^ (Second?.GetHashCode() ?? 0);
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(First, Second);
 
     /// <summary>
     /// Checks specified objects for equality.

--- a/Orm/Xtensive.Orm/Core/Pair{T}.cs
+++ b/Orm/Xtensive.Orm/Core/Pair{T}.cs
@@ -58,14 +58,7 @@ namespace Xtensive.Core
       obj is Pair<T> other && Equals(other);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      unchecked {
-        int result = (First!=null ? First.GetHashCode() : 0);
-        result = (result * 397) ^ (Second!=null ? Second.GetHashCode() : 0);
-        return result;
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(First, Second);
 
     /// <summary>
     /// Checks specified objects for equality.

--- a/Orm/Xtensive.Orm/Core/Segment.cs
+++ b/Orm/Xtensive.Orm/Core/Segment.cs
@@ -66,12 +66,7 @@ namespace Xtensive.Core
       obj is Pair<T> other && Equals(other);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      int firstHash = Offset == null ? 0 : Offset.GetHashCode();
-      int secondHash = Length == null ? 0 : Length.GetHashCode();
-      return firstHash ^ 29 * secondHash;
-    }
+    public override int GetHashCode() => HashCode.Combine(Offset, Length);
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Linq/Internals/ExpressionHashCodeCalculator.cs
+++ b/Orm/Xtensive.Orm/Linq/Internals/ExpressionHashCodeCalculator.cs
@@ -86,10 +86,7 @@ namespace Xtensive.Linq
       return Visit(m.Expression) ^ m.Member.GetHashCode();
     }
 
-    protected override int VisitMethodCall(MethodCallExpression mc)
-    {
-      return Visit(mc.Object) ^ mc.Method.GetHashCode() ^ HashExpressionSequence(mc.Arguments);
-    }
+    protected override int VisitMethodCall(MethodCallExpression mc) => HashCode.Combine(Visit(mc.Object), mc.Method, HashExpressionSequence(mc.Arguments));
 
     protected override int VisitLambda(LambdaExpression l)
     {
@@ -108,18 +105,24 @@ namespace Xtensive.Linq
 
     protected override int VisitMemberInit(MemberInitExpression mi)
     {
-      var result = Visit(mi.NewExpression);
-      foreach (var b in mi.Bindings)
-        result ^= b.BindingType.GetHashCode() ^ b.Member.GetHashCode();
-      return result;
+      HashCode hashCode = new();
+      hashCode.Add(Visit(mi.NewExpression));
+      foreach (var b in mi.Bindings) {
+        hashCode.Add(b.BindingType);
+        hashCode.Add(b.Member);
+      }
+      return hashCode.ToHashCode();
     }
 
     protected override int VisitListInit(ListInitExpression li)
     {
-      var result = VisitNew(li.NewExpression);
-      foreach (var e in li.Initializers)
-        result ^= e.AddMethod.GetHashCode() ^ HashExpressionSequence(e.Arguments);
-      return result;
+      HashCode hashCode = new();
+      hashCode.Add(VisitNew(li.NewExpression));
+      foreach (var e in li.Initializers) {
+        hashCode.Add(e.AddMethod);
+        hashCode.Add(HashExpressionSequence(e.Arguments));
+      }
+      return hashCode.ToHashCode();
     }
 
     protected override int VisitNewArray(NewArrayExpression na)

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/DatabaseDependencyBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/DatabaseDependencyBuilder.cs
@@ -31,12 +31,7 @@ namespace Xtensive.Orm.Building.Builders
       public override bool Equals(object obj) =>
         obj is DatabaseReference other && Equals(other);
 
-      public override int GetHashCode()
-      {
-        unchecked {
-          return (TargetDatabase.GetHashCode() * 397) ^ OwnerDatabase.GetHashCode();
-        }
-      }
+      public override int GetHashCode() => HashCode.Combine(TargetDatabase, OwnerDatabase);
 
       public static bool operator ==(DatabaseReference left, DatabaseReference right)
       {

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/StorageMappingBuilder.cs
@@ -31,12 +31,7 @@ namespace Xtensive.Orm.Building.Builders
       public override bool Equals(object obj) =>
         obj is MappingRequest other && Equals(other);
 
-      public override int GetHashCode()
-      {
-        unchecked {
-          return (Assembly.GetHashCode() * 397) ^ Namespace.GetHashCode();
-        }
-      }
+      public override int GetHashCode() => HashCode.Combine(Assembly, Namespace);
 
       public static bool operator ==(MappingRequest left, MappingRequest right)
       {

--- a/Orm/Xtensive.Orm/Orm/Building/DependencyGraph/Edge.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/DependencyGraph/Edge.cs
@@ -20,12 +20,7 @@ namespace Xtensive.Orm.Building.DependencyGraph
     public EdgeWeight Weight { get; }
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      unchecked {
-        return (Tail.GetHashCode() * 397) ^ Head.GetHashCode();
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(Tail, Head);
 
     /// <inheritdoc/>
     public bool Equals(Edge<TValue> obj) =>

--- a/Orm/Xtensive.Orm/Orm/Configuration/SessionConfigurationCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/SessionConfigurationCollection.cs
@@ -124,16 +124,7 @@ namespace Xtensive.Orm.Configuration
     }
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      unchecked {
-        int result = (Default!=null ? Default.GetHashCode() : 0);
-        result = (result * 397) ^ (System!=null ? System.GetHashCode() : 0);
-        result = (result * 397) ^ (Service!=null ? Service.GetHashCode() : 0);
-        result = (result * 397) ^ (KeyGenerator!=null ? KeyGenerator.GetHashCode() : 0);
-        return result;
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(Default, System, Service, KeyGenerator);
  
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/ConnectionInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/ConnectionInfo.cs
@@ -45,15 +45,7 @@ namespace Xtensive.Orm
     #region GetHashCode, Equals, ==, !=
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      unchecked {
-        int result = (Provider!=null ? Provider.GetHashCode() : 0);
-        result = (result * 397) ^ (ConnectionString!=null ? ConnectionString.GetHashCode() : 0);
-        result = (result * 397) ^ (ConnectionUrl!=null ? ConnectionUrl.GetHashCode() : 0);
-        return result;
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(Provider, ConnectionString, ConnectionUrl);
 
     /// <inheritdoc/>
     public override bool Equals(object obj)

--- a/Orm/Xtensive.Orm/Orm/EntityState.cs
+++ b/Orm/Xtensive.Orm/Orm/EntityState.cs
@@ -304,10 +304,7 @@ namespace Xtensive.Orm
     }
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      return Key.GetHashCode();
-    }
+    public override int GetHashCode() => Key.GetHashCode();
 
     /// <inheritdoc/>
     public bool Equals(EntityState other)

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntitySetTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntitySetTask.cs
@@ -42,10 +42,7 @@ namespace Xtensive.Orm.Internals.Prefetch
     {
       ReferencingField = referencingField;
       ItemCountLimit = itemCountLimit;
-      unchecked {
-        cachedHashCode = (ReferencingField.GetHashCode() * 397)
-                         ^ (ItemCountLimit.HasValue ? 1 : 0);
-      }
+      cachedHashCode = HashCode.Combine(ReferencingField, ItemCountLimit.HasValue);
     }
   }
 

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/GraphContainer.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/GraphContainer.cs
@@ -115,10 +115,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     public override int GetHashCode()
     {
-      if (cachedHashCode == null)
-        unchecked {
-          cachedHashCode = (Key.GetHashCode() * 397) ^ Type.GetHashCode();
-        }
+      cachedHashCode ??= HashCode.Combine(Key, Type);
       return cachedHashCode.Value;
     }
 

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/Node.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/Node.cs
@@ -35,10 +35,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       return Equals(obj as Node);
     }
 
-    public override int GetHashCode()
-    {
-      return Path.GetHashCode();
-    }
+    public override int GetHashCode() => Path.GetHashCode();
 
     public override string ToString()
     {

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchManager.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/PrefetchManager.cs
@@ -45,7 +45,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       {
         this.descriptors = descriptors;
         this.type = type;
-        hashCode = unchecked ((type.GetHashCode() * 397) ^ descriptors.GetHashCode());
+        hashCode = HashCode.Combine(type, descriptors);
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/MemberCompilation/MemberCompilerProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/MemberCompilation/MemberCompilerProvider.cs
@@ -27,12 +27,8 @@ namespace Xtensive.Orm.Linq.MemberCompilation
 
       public override bool Equals(object obj) => obj is CompilerKey other && Equals(other);
 
-      public override int GetHashCode()
-      {
-        unchecked {
-          return module == null ? metadataToken : (module.GetHashCode() * 397) ^ metadataToken;
-        }
-      }
+      public override int GetHashCode() =>
+          module == null ? metadataToken : HashCode.Combine(module, metadataToken);
 
       public CompilerKey(MemberInfo memberInfo)
       {

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnInfo.cs
@@ -236,10 +236,7 @@ namespace Xtensive.Orm.Model
       || obj is ColumnInfo other && Equals(other);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      return field.GetHashCode();
-    }
+    public override int GetHashCode() => field.GetHashCode();
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/Model/IndexInfoRef.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/IndexInfoRef.cs
@@ -86,14 +86,7 @@ namespace Xtensive.Orm.Model
     }
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      unchecked {
-        return 
-          ((IndexName!=null ? IndexName.GetHashCode() : 0) * 397) ^ 
-          (TypeName!=null ? TypeName.GetHashCode() : 0);
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(IndexName, TypeName);
 
     /// <summary>
     /// Implements the operator ==.

--- a/Orm/Xtensive.Orm/Orm/Model/KeyField.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/KeyField.cs
@@ -22,10 +22,7 @@ namespace Xtensive.Orm.Model
     public Direction Direction { get; private set; }
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      return Name.GetHashCode() ^ Direction.GetHashCode();
-    }
+    public override int GetHashCode() => HashCode.Combine(Name, Direction);
 
     /// <inheritdoc/>
     public override bool Equals(object obj) =>

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/QueryParameterIdentity.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/QueryParameterIdentity.cs
@@ -32,16 +32,7 @@ namespace Xtensive.Orm.Providers
         && Mapping.Equals(other.Mapping);
     }
 
-    public override int GetHashCode()
-    {
-      unchecked {
-        var hashCode = FieldName.GetHashCode();
-        hashCode = (hashCode * 397) ^ ClosureObject.GetHashCode();
-        hashCode = (hashCode * 397) ^ (int) BindingType;
-        hashCode = (hashCode * 397) ^ Mapping.GetHashCode();
-        return hashCode;
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(FieldName, ClosureObject, BindingType, Mapping);
 
     public static bool operator ==(QueryParameterIdentity left, QueryParameterIdentity right)
     {

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilderTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilderTask.cs
@@ -61,16 +61,9 @@ namespace Xtensive.Orm.Providers
     }
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      return hashCode;
-    }
+    public override int GetHashCode() => hashCode;
 
-    private int CalculateHashCode()
-    {
-      return Type.GetHashCode() ^ Kind.GetHashCode() ^ ValidateVersion.GetHashCode()
-        ^ HashBits(AvailableFields) ^ HashBits(ChangedFields);
-    }
+    private int CalculateHashCode() => HashCode.Combine(Type, Kind, ValidateVersion, HashBits(AvailableFields), HashBits(ChangedFields));
 
     private int HashBits(BitArray bits)
     {

--- a/Orm/Xtensive.Orm/Orm/Rse/Column.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Column.cs
@@ -56,10 +56,7 @@ namespace Xtensive.Orm.Rse
     }
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      return Name.GetHashCode();
-    }
+    public override int GetHashCode() => Name.GetHashCode();
 
     /// <summary>
     /// Implements the operator ==.

--- a/Orm/Xtensive.Orm/Orm/Structure.cs
+++ b/Orm/Xtensive.Orm/Orm/Structure.cs
@@ -345,10 +345,7 @@ namespace Xtensive.Orm
     }
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      return Tuple.GetHashCode();
-    }
+    public override int GetHashCode() => Tuple.GetHashCode();
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Hints/ChangeFieldTypeHint.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Hints/ChangeFieldTypeHint.cs
@@ -51,15 +51,7 @@ namespace Xtensive.Orm.Upgrade
     public override bool Equals(UpgradeHint other) => Equals(other as ChangeFieldTypeHint);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      unchecked {
-        int result = base.GetHashCode();
-        result = (result * 397) ^ (Type != null ? Type.GetHashCode() : 0);
-        result = (result * 397) ^ (FieldName != null ? FieldName.GetHashCode() : 0);
-        return result;
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Type, FieldName);
 
     /// <inheritdoc/>
     public override string ToString() => $"Change type of field: {Type}.{FieldName}";

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Hints/CopyFieldHint.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Hints/CopyFieldHint.cs
@@ -57,17 +57,7 @@ namespace Xtensive.Orm.Upgrade
     public override bool Equals(UpgradeHint other) => Equals(other as CopyFieldHint);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      unchecked {
-        int result = base.GetHashCode();
-        result = (result * 397) ^ (SourceType != null ? SourceType.GetHashCode() : 0);
-        result = (result * 397) ^ (SourceField != null ? SourceField.GetHashCode() : 0);
-        result = (result * 397) ^ (TargetType != null ? TargetType.GetHashCode() : 0);
-        result = (result * 397) ^ (TargetField != null ? TargetField.GetHashCode() : 0);
-        return result;
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), SourceType, SourceField, TargetType, TargetField);
 
     /// <inheritdoc/>
     public override string ToString() =>

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Hints/MergeTypeHint.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Hints/MergeTypeHint.cs
@@ -46,15 +46,7 @@ namespace Xtensive.Orm.Upgrade
     public override bool Equals(UpgradeHint other) => Equals(other as MergeTypeHint);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      unchecked {
-        int result = base.GetHashCode();
-        result = (result * 397) ^ (NewType != null ? NewType.GetHashCode() : 0);
-        result = (result * 397) ^ (OldType != null ? OldType.GetHashCode() : 0);
-        return result;
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), NewType, OldType);
 
     /// <inheritdoc/>
     public override string ToString() =>

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Hints/MoveFieldHint.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Hints/MoveFieldHint.cs
@@ -58,17 +58,7 @@ namespace Xtensive.Orm.Upgrade
     public override bool Equals(UpgradeHint other) => Equals(other as MoveFieldHint);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      unchecked {
-        int result = base.GetHashCode();
-        result = (result * 397) ^ (SourceType != null ? SourceType.GetHashCode() : 0);
-        result = (result * 397) ^ (SourceField != null ? SourceField.GetHashCode() : 0);
-        result = (result * 397) ^ (TargetType != null ? TargetType.GetHashCode() : 0);
-        result = (result * 397) ^ (TargetField != null ? TargetField.GetHashCode() : 0);
-        return result;
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), SourceType, SourceField, TargetType, TargetField);
 
     /// <inheritdoc/>
     public override string ToString() =>

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Hints/RecycledTypeHint.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Hints/RecycledTypeHint.cs
@@ -40,14 +40,7 @@ namespace Xtensive.Orm.Upgrade
     public override bool Equals(UpgradeHint other) => Equals(other as RecycledTypeHint);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      unchecked {
-        int result = base.GetHashCode();
-        result = (result * 397) ^ (Type != null ? Type.GetHashCode() : 0);
-        return result;
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Type);
 
     /// <inheritdoc/>
     public override string ToString() => $"Recycled type: {Type}";

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Hints/RemoveFieldHint.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Hints/RemoveFieldHint.cs
@@ -55,15 +55,7 @@ namespace Xtensive.Orm.Upgrade
     public override bool Equals(UpgradeHint other) => Equals(other as RemoveFieldHint);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      unchecked {
-        int result = base.GetHashCode();
-        result = (result * 397) ^ (Type != null ? Type.GetHashCode() : 0);
-        result = (result * 397) ^ (Field != null ? Field.GetHashCode() : 0);
-        return result;
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Type, Field);
 
     /// <inheritdoc/>
     public override string ToString() => $"Remove field: {Type}.{Field}";

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Hints/RemoveTypeHint.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Hints/RemoveTypeHint.cs
@@ -43,14 +43,7 @@ namespace Xtensive.Orm.Upgrade
     public override bool Equals(UpgradeHint other) => Equals(other as RemoveTypeHint);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      unchecked {
-        int result = base.GetHashCode();
-        result = (result * 397) ^ (Type != null ? Type.GetHashCode() : 0);
-        return result;
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Type);
 
     /// <inheritdoc/>
     public override string ToString() => $"Remove type: {Type}";

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Hints/RenameFieldHint.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Hints/RenameFieldHint.cs
@@ -50,16 +50,7 @@ namespace Xtensive.Orm.Upgrade
     public override bool Equals(UpgradeHint other) => Equals(other as RenameFieldHint);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      unchecked {
-        int result = base.GetHashCode();
-        result = (result * 397) ^ (TargetType != null ? TargetType.GetHashCode() : 0);
-        result = (result * 397) ^ (OldFieldName != null ? OldFieldName.GetHashCode() : 0);
-        result = (result * 397) ^ (NewFieldName != null ? NewFieldName.GetHashCode() : 0);
-        return result;
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), TargetType, OldFieldName, NewFieldName); 
 
     /// <inheritdoc/>
     public override string ToString() =>

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Hints/RenameTypeHint.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Hints/RenameTypeHint.cs
@@ -46,15 +46,7 @@ namespace Xtensive.Orm.Upgrade
     public override bool Equals(UpgradeHint other) => Equals(other as RenameTypeHint);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      unchecked {
-        int result = base.GetHashCode();
-        result = (result * 397) ^ (NewType != null ? NewType.GetHashCode() : 0);
-        result = (result * 397) ^ (OldType != null ? OldType.GetHashCode() : 0);
-        return result;
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), NewType, OldType);
 
     /// <inheritdoc/>
     public override string ToString() =>

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Hints/UpgradeHint.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Hints/UpgradeHint.cs
@@ -27,10 +27,7 @@ namespace Xtensive.Orm.Upgrade
         || obj is UpgradeHint other && Equals(other);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      return base.GetHashCode();
-    }
+    public override int GetHashCode() => base.GetHashCode();
 
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Model/PartialIndexFilterInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Model/PartialIndexFilterInfo.cs
@@ -36,10 +36,7 @@ namespace Xtensive.Orm.Upgrade.Model
       return Equals((PartialIndexFilterInfo)obj);
     }
 
-    public override int GetHashCode()
-    {
-      return Expression.GetHashCode();
-    }
+    public override int GetHashCode() => Expression.GetHashCode();
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Model/StorageTypeInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Model/StorageTypeInfo.cs
@@ -121,20 +121,7 @@ namespace Xtensive.Orm.Upgrade.Model
     }
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      unchecked {
-        int result = (Type != null ? Type.GetHashCode() : 0);
-        result = (result * 397) ^ (IsNullable ? 1 : 0);
-        if (Length.HasValue)
-          result = (result * 397) ^ Length.Value;
-        if (Scale.HasValue)
-          result = (result * 397) ^ Scale.Value;
-        if (Precision.HasValue)
-          result = (result * 397) ^ Precision.Value;
-        return result;
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(Type, IsNullable, Length, Scale, Precision);
 
     /// <summary>
     /// Implements the operator ==.

--- a/Orm/Xtensive.Orm/Orm/UrlInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/UrlInfo.cs
@@ -404,10 +404,7 @@ namespace Xtensive.Orm
     }
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-      return (url!=null ? url.GetHashCode() : 0);
-    }
+    public override int GetHashCode() => url?.GetHashCode() ?? 0;
 
     /// <summary>
     /// Checks specified objects for equality.

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlCustomFunctionType.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlCustomFunctionType.cs
@@ -40,10 +40,7 @@ namespace Xtensive.Sql.Dml
       return Equals((SqlCustomFunctionType) obj);
     }
 
-    public override int GetHashCode()
-    {
-      return Name.GetHashCode();
-    }
+    public override int GetHashCode() => Name.GetHashCode();
 
     public static bool operator ==(SqlCustomFunctionType left, SqlCustomFunctionType right)
     {

--- a/Orm/Xtensive.Orm/Tuples/Transform/WrappingTransformTupleBase.cs
+++ b/Orm/Xtensive.Orm/Tuples/Transform/WrappingTransformTupleBase.cs
@@ -68,10 +68,7 @@ namespace Xtensive.Tuples.Transform
     }
 
     /// <inheritdoc/>
-    public sealed override int GetHashCode()
-    {
-      return origin.GetHashCode();
-    }
+    public sealed override int GetHashCode() => origin.GetHashCode();
 
 
     // Constructors

--- a/Weaver/Xtensive.Orm.Weaver/TypeIdentity.cs
+++ b/Weaver/Xtensive.Orm.Weaver/TypeIdentity.cs
@@ -37,14 +37,9 @@ namespace Xtensive.Orm.Weaver
         && WeavingHelper.TypeNameComparer.Equals(TypeName, other.TypeName);
     }
 
-    public override int GetHashCode()
-    {
-      unchecked {
-        var typeNameHash = TypeName!=null ? WeavingHelper.TypeNameComparer.GetHashCode(TypeName) : 0;
-        var assemblyNameHash = AssemblyName!=null ? WeavingHelper.AssemblyNameComparer.GetHashCode(AssemblyName) : 0;
-        return assemblyNameHash * 397 ^ typeNameHash;
-      }
-    }
+    public override int GetHashCode() => HashCode.Combine(
+      TypeName != null ? WeavingHelper.TypeNameComparer.GetHashCode(TypeName) : 0,
+      AssemblyName != null ? WeavingHelper.AssemblyNameComparer.GetHashCode(AssemblyName) : 0);
 
     public static bool operator ==(TypeIdentity left, TypeIdentity right)
     {


### PR DESCRIPTION
Unified `HashCode.Combine()` implementations may share compiled code (at least for reference-type arguments)