### PR TITLE
Refactor to `ArgumentException.ThrowIfNullOrEmpty() / .ThrowIfNullOrWhitespace()` usage

### DIFF
--- a/Orm/Xtensive.Orm.Tests.Framework/Measurement.cs
+++ b/Orm/Xtensive.Orm.Tests.Framework/Measurement.cs
@@ -34,7 +34,7 @@ namespace Xtensive.Orm.Tests
       get { return name; }
       [DebuggerStepThrough]
       set {
-        ArgumentValidator.EnsureArgumentNotNullOrEmpty(value, "value");
+        ArgumentException.ThrowIfNullOrEmpty(value);
         name = value;
         UpdateFullName();
       }

--- a/Orm/Xtensive.Orm.Tests.Framework/TestSqlDriver.cs
+++ b/Orm/Xtensive.Orm.Tests.Framework/TestSqlDriver.cs
@@ -24,14 +24,14 @@ namespace Xtensive.Orm.Tests
 
     public static SqlDriver Create(string connectionUrl)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(connectionUrl, "connectionUrl");
+      ArgumentException.ThrowIfNullOrEmpty(connectionUrl);
       return BuildDriver(new ConnectionInfo(connectionUrl));
     }
 
     public static SqlDriver Create(string provider, string connectionString)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(provider, "provider");
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(connectionString, "connectionString");
+      ArgumentException.ThrowIfNullOrEmpty(provider);
+      ArgumentException.ThrowIfNullOrEmpty(connectionString);
       return BuildDriver(new ConnectionInfo(provider, connectionString));
     }
 

--- a/Orm/Xtensive.Orm/Collections/TypeRegistry.cs
+++ b/Orm/Xtensive.Orm/Collections/TypeRegistry.cs
@@ -96,7 +96,7 @@ namespace Xtensive.Collections
     {
       EnsureNotLocked();
       ArgumentNullException.ThrowIfNull(assembly);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(@namespace, "@namespace");
+      ArgumentException.ThrowIfNullOrEmpty(@namespace);
       Register(new TypeRegistration(assembly, @namespace));
     }
 

--- a/Orm/Xtensive.Orm/Core/ArgumentValidator.cs
+++ b/Orm/Xtensive.Orm/Core/ArgumentValidator.cs
@@ -38,43 +38,6 @@ namespace Xtensive.Core
     }
 
     /// <summary>
-    /// Ensures argument (<paramref name="value"/>) is not
-    /// <see langoword="null"/> or <see cref="string.Empty"/> string.
-    /// </summary>
-    /// <param name="value">Value to check.</param>
-    /// <param name="parameterName">Name of the method parameter.</param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if NET7_0_OR_GREATER
-    [Obsolete("Use ArgumentException.ThrowIfNullOrEmpty()")]
-#endif
-    internal static void EnsureArgumentNotNullOrEmpty(string value, [InvokerParameterName] string parameterName)
-    {
-#if NET7_0_OR_GREATER
-      ArgumentException.ThrowIfNullOrEmpty(value, parameterName);
-#else
-      ArgumentNullException.ThrowIfNull(value, parameterName);
-      if (value.Length == 0) {
-        throw new ArgumentException(Strings.ExArgumentCannotBeEmptyString, parameterName);
-      }
-#endif
-    }
-
-    [Obsolete("Use CommunityToolkit.Diagnostics.Guard.IsNotNullOrWhiteSpace()")]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void EnsureArgumentNotNullOrEmptyOrWhiteSpace(string value, [InvokerParameterName] string parameterName)
-    {
-      ArgumentNullException.ThrowIfNull(value, parameterName);
-
-      if (value.Length==0) {
-        throw new ArgumentException(Strings.ExArgumentCannotBeEmptyString, parameterName);
-      }
-
-      if (value.Trim().Length==0) {
-        throw new ArgumentException(Strings.ExArgumentCannotBeWhiteSpacesOnlyString, parameterName);
-      }
-    }
-
-    /// <summary>
     /// Ensures argument (<paramref name="value"/>) is not <see langword="null"/>
     /// and of <typeparamref name="T"/> type.
     /// </summary>

--- a/Orm/Xtensive.Orm/Linq/SerializableExpressions/Internals/ReflectionExtensions.cs
+++ b/Orm/Xtensive.Orm/Linq/SerializableExpressions/Internals/ReflectionExtensions.cs
@@ -87,7 +87,7 @@ namespace Xtensive.Linq.SerializableExpressions.Internals
 
     public static void AddArray<T>(this SerializationInfo info, string key, T[] array)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(key, "key");
+      ArgumentException.ThrowIfNullOrEmpty(key);
       ArgumentNullException.ThrowIfNull(array);
 
       info.AddValue($"{key}Count", array.Length);
@@ -97,7 +97,7 @@ namespace Xtensive.Linq.SerializableExpressions.Internals
 
     public static T[] GetArrayFromSerializableForm<T>(this SerializationInfo info, string key)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(key, "key");
+      ArgumentException.ThrowIfNullOrEmpty(key);
 
       var count = info.GetInt32($"{key}Count");
       var array = new T[count];

--- a/Orm/Xtensive.Orm/Modelling/Actions/CreateNodeAction.cs
+++ b/Orm/Xtensive.Orm/Modelling/Actions/CreateNodeAction.cs
@@ -43,7 +43,7 @@ namespace Xtensive.Modelling.Actions
     public string Name {
       get { return name; }
       set {
-        ArgumentValidator.EnsureArgumentNotNullOrEmpty(value, "value");
+        ArgumentException.ThrowIfNullOrEmpty(value);
         EnsureNotLocked();
         name = value;
       }

--- a/Orm/Xtensive.Orm/Modelling/Comparison/Hints/DataHint.cs
+++ b/Orm/Xtensive.Orm/Modelling/Comparison/Hints/DataHint.cs
@@ -49,7 +49,7 @@ namespace Xtensive.Modelling.Comparison.Hints
     /// </summary>
     protected DataHint(string sourceTablePath,  IReadOnlyList<IdentityPair> identities)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(sourceTablePath, "sourceTablePath");
+      ArgumentException.ThrowIfNullOrEmpty(sourceTablePath);
       ArgumentNullException.ThrowIfNull(identities, "pairs");
       
       SourceTablePath = sourceTablePath;

--- a/Orm/Xtensive.Orm/Modelling/Comparison/Hints/IgnoreHint.cs
+++ b/Orm/Xtensive.Orm/Modelling/Comparison/Hints/IgnoreHint.cs
@@ -44,7 +44,7 @@ namespace Xtensive.Modelling.Comparison.Hints
     /// <param name="path">The ignored node path.</param>
     public IgnoreHint(string path)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(path, "path");
+      ArgumentException.ThrowIfNullOrEmpty(path);
       Path = path;
     }
   }

--- a/Orm/Xtensive.Orm/Modelling/Nesting.cs
+++ b/Orm/Xtensive.Orm/Modelling/Nesting.cs
@@ -73,7 +73,7 @@ namespace Xtensive.Modelling
     internal Nesting(Node node, string propertyName)
     {
       ArgumentNullException.ThrowIfNull(node);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(propertyName, "propertyName");
+      ArgumentException.ThrowIfNullOrEmpty(propertyName);
       Node = node;
       PropertyName = propertyName;
       Initialize();

--- a/Orm/Xtensive.Orm/Modelling/Node.cs
+++ b/Orm/Xtensive.Orm/Modelling/Node.cs
@@ -428,7 +428,7 @@ namespace Xtensive.Modelling
     /// <exception cref="InvalidOperationException">newName!=newIndex for <see cref="IUnnamedNode"/>.</exception>
     protected virtual void ValidateMove(Node newParent, string newName, int newIndex)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(newName, nameof(newName));
+      ArgumentException.ThrowIfNullOrEmpty(newName);
       if (this is IModel) {
         ArgumentValidator.EnsureArgumentIsInRange(newIndex, 0, 0, nameof(newIndex));
         return;
@@ -1012,7 +1012,7 @@ namespace Xtensive.Modelling
       }
 
       if (!(this is IUnnamedNode)) {
-        ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, nameof(name));
+        ArgumentException.ThrowIfNullOrEmpty(name);
       }
 
       Initialize();

--- a/Orm/Xtensive.Orm/Modelling/NodeCollection.cs
+++ b/Orm/Xtensive.Orm/Modelling/NodeCollection.cs
@@ -372,7 +372,7 @@ namespace Xtensive.Modelling
     protected NodeCollection(Node parent, string name)
     {
       ArgumentNullException.ThrowIfNull(parent);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
       this.name = name;
       this.parent = parent;
       Initialize();
@@ -394,4 +394,3 @@ namespace Xtensive.Modelling
     }
   }
 }
-

--- a/Orm/Xtensive.Orm/Orm/Building/Definitions/TypeDef.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Definitions/TypeDef.cs
@@ -171,7 +171,7 @@ namespace Xtensive.Orm.Building.Definitions
     /// <returns></returns>
     public FieldDef DefineField(string name, Type valueType)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, nameof(name));
+      ArgumentException.ThrowIfNullOrEmpty(name);
       ArgumentNullException.ThrowIfNull(valueType);
 
       var field = builder.DefineField(UnderlyingType, name, valueType);

--- a/Orm/Xtensive.Orm/Orm/Configuration/DatabaseConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/DatabaseConfiguration.cs
@@ -28,7 +28,7 @@ namespace Xtensive.Orm.Configuration
       get { return name; }
       set
       {
-        ArgumentValidator.EnsureArgumentNotNullOrEmpty(value, "value");
+        ArgumentException.ThrowIfNullOrEmpty(value);
         EnsureNotLocked();
         name = value;
       }
@@ -109,7 +109,7 @@ namespace Xtensive.Orm.Configuration
     /// <param name="name">Database name.</param>
     public DatabaseConfiguration(string name)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
       Name = name;
       minTypeId = TypeInfo.MinTypeId;
       maxTypeId = int.MaxValue;

--- a/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
@@ -170,7 +170,7 @@ namespace Xtensive.Orm.Configuration
     {
       get => sectionName;
       set {
-        ArgumentValidator.EnsureArgumentNotNullOrEmpty(value, "value");
+        ArgumentException.ThrowIfNullOrEmpty(value);
         if (sectionNameIsDefined) {
           throw Exceptions.AlreadyInitialized(nameof(SectionName));
         }

--- a/Orm/Xtensive.Orm/Orm/Configuration/KeyGeneratorConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/KeyGeneratorConfiguration.cs
@@ -26,7 +26,7 @@ namespace Xtensive.Orm.Configuration
       get { return name; }
       set
       {
-        ArgumentValidator.EnsureArgumentNotNullOrEmpty(value, "value");
+        ArgumentException.ThrowIfNullOrEmpty(value);
         EnsureNotLocked();
         name = value;
       }

--- a/Orm/Xtensive.Orm/Orm/Configuration/LoggingConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/LoggingConfiguration.cs
@@ -43,7 +43,7 @@ namespace Xtensive.Orm.Configuration
     /// <returns>Loaded configuration.</returns>
     public static LoggingConfiguration Load(string sectionName)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(sectionName, "sectionName");
+      ArgumentException.ThrowIfNullOrEmpty(sectionName);
 
       var section = (ConfigurationSection)ConfigurationManager.GetSection(sectionName);
       if (section==null)
@@ -71,7 +71,7 @@ namespace Xtensive.Orm.Configuration
     public static LoggingConfiguration Load(System.Configuration.Configuration configuration, string sectionName)
     {
       ArgumentNullException.ThrowIfNull(configuration);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(sectionName, "sectionName");
+      ArgumentException.ThrowIfNullOrEmpty(sectionName);
 
       var section = (ConfigurationSection) configuration.GetSection(sectionName);
       if (section==null)

--- a/Orm/Xtensive.Orm/Orm/Configuration/NameMappingCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/NameMappingCollection.cs
@@ -38,8 +38,8 @@ namespace Xtensive.Orm.Configuration
     /// <param name="mappedName"></param>
     public void Add([NotNull] string originalName, [NotNull] string mappedName)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(originalName, "originalName");
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(mappedName, "mappedName");
+      ArgumentException.ThrowIfNullOrEmpty(originalName);
+      ArgumentException.ThrowIfNullOrEmpty(mappedName);
       EnsureNotLocked();
       items[originalName] = mappedName;
     }
@@ -50,7 +50,7 @@ namespace Xtensive.Orm.Configuration
     /// <param name="originalName"></param>
     public bool Remove([NotNull] string originalName)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(originalName, "originalName");
+      ArgumentException.ThrowIfNullOrEmpty(originalName);
       EnsureNotLocked();
       return items.Remove(originalName);
     }
@@ -61,7 +61,7 @@ namespace Xtensive.Orm.Configuration
     /// <param name="name">Mapped name for <paramref name="name"/>.</param>
     public string Apply([NotNull] string name)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
       string result;
       if (items.TryGetValue(name, out result))
         return result;

--- a/Orm/Xtensive.Orm/Orm/Configuration/SessionConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/SessionConfiguration.cs
@@ -305,7 +305,7 @@ namespace Xtensive.Orm.Configuration
     /// <param name="name">Value for <see cref="Name"/>.</param>
     public SessionConfiguration(string name, SessionOptions sessionOptions)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
 
       Name = name;
       Options = sessionOptions;

--- a/Orm/Xtensive.Orm/Orm/Configuration/SessionConfigurationCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/SessionConfigurationCollection.cs
@@ -91,7 +91,7 @@ namespace Xtensive.Orm.Configuration
 
     private void EnsureItemIsValid(SessionConfiguration item)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(item.Name, "SessionConfiguration.Name");
+      ArgumentException.ThrowIfNullOrEmpty(item.Name, "SessionConfiguration.Name");
       var current = this[item.Name];
       if (current != null)
         throw new InvalidOperationException(string.Format(Strings.ExConfigurationWithXNameAlreadyRegistered, current.Name));

--- a/Orm/Xtensive.Orm/Orm/ConnectionInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/ConnectionInfo.cs
@@ -93,8 +93,8 @@ namespace Xtensive.Orm
     /// <param name="connectionString">A value for <see cref="ConnectionString"/>.</param>
     public ConnectionInfo(string provider, string connectionString)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(provider, "provider");
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(connectionString, "connectionString");
+      ArgumentException.ThrowIfNullOrEmpty(provider);
+      ArgumentException.ThrowIfNullOrEmpty(connectionString);
 
       ConnectionString = connectionString;
       Provider = provider.ToLowerInvariant();

--- a/Orm/Xtensive.Orm/Orm/ConnectionInitEventData.cs
+++ b/Orm/Xtensive.Orm/Orm/ConnectionInitEventData.cs
@@ -20,7 +20,7 @@ namespace Xtensive.Orm
     public ConnectionInitEventData(string initializationScript, DbConnection connection, bool reconnect = false)
       : base(connection, reconnect)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(initializationScript, nameof(initializationScript));
+      ArgumentException.ThrowIfNullOrEmpty(initializationScript);
       InitializationScript = initializationScript;
     }
   }

--- a/Orm/Xtensive.Orm/Orm/FullTextSearchCondition/Nodes/PrefixTerm.cs
+++ b/Orm/Xtensive.Orm/Orm/FullTextSearchCondition/Nodes/PrefixTerm.cs
@@ -30,7 +30,7 @@ namespace Xtensive.Orm.FullTextSearchCondition.Nodes
     internal PrefixTerm(IOperator source, string prefix)
       : base(SearchConditionNodeType.Prefix, source)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmptyOrWhiteSpace(prefix, "prefix");
+      ArgumentException.ThrowIfNullOrWhiteSpace(prefix);
       Prefix = prefix;
     }
   }

--- a/Orm/Xtensive.Orm/Orm/FullTextSearchCondition/Nodes/SimpleTerm.cs
+++ b/Orm/Xtensive.Orm/Orm/FullTextSearchCondition/Nodes/SimpleTerm.cs
@@ -30,7 +30,7 @@ namespace Xtensive.Orm.FullTextSearchCondition.Nodes
     internal SimpleTerm(IOperator source, string term)
       : base(SearchConditionNodeType.SimpleTerm, source)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmptyOrWhiteSpace(term, "term");
+      ArgumentException.ThrowIfNullOrWhiteSpace(term);
       Term = term;
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Logging/LogManager.cs
+++ b/Orm/Xtensive.Orm/Orm/Logging/LogManager.cs
@@ -96,7 +96,7 @@ namespace Xtensive.Orm.Logging
     /// <returns>Founded log or default.</returns>
     public BaseLog GetLog(string logName)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(logName, "logName");
+      ArgumentException.ThrowIfNullOrEmpty(logName);
 
       lock (syncObj) {
         if (provider==null)

--- a/Orm/Xtensive.Orm/Orm/Model/Node.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/Node.cs
@@ -107,7 +107,7 @@ namespace Xtensive.Orm.Model
     /// </summary>
     protected Node(string name)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
       Name = name;
     }
 

--- a/Orm/Xtensive.Orm/Orm/Model/NodeCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/NodeCollection.cs
@@ -227,7 +227,7 @@ namespace Xtensive.Orm.Model
 
     protected NodeCollection(Node owner, string name, Dictionary<string, TNode> nameIndex)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
       NameIndex = nameIndex;
       Owner = owner;
       Name = name;

--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/CommandFactory.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/CommandFactory.cs
@@ -45,7 +45,7 @@ namespace Xtensive.Orm.Providers
     public virtual IEnumerable<CommandPart> CreatePersistParts(SqlPersistTask task, string parameterNamePrefix)
     {
       ArgumentNullException.ThrowIfNull(task);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(parameterNamePrefix, "parameterNamePrefix");
+      ArgumentException.ThrowIfNullOrEmpty(parameterNamePrefix);
 
       var nodeConfiguration = Session.StorageNode.Configuration;
       var shareStorageNodesOverNodes = Session.Domain.Configuration.ShareStorageSchemaOverNodes;
@@ -95,7 +95,7 @@ namespace Xtensive.Orm.Providers
     public virtual CommandPart CreateQueryPart(IQueryRequest request, string parameterNamePrefix, ParameterContext parameterContext)
     {
       ArgumentNullException.ThrowIfNull(request);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(parameterNamePrefix, "parameterNamePrefix");
+      ArgumentException.ThrowIfNullOrEmpty(parameterNamePrefix);
 
       int parameterIndex = 0;
       var compilationResult = request.GetCompiledStatement();

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/QueryParameterIdentity.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/QueryParameterIdentity.cs
@@ -54,7 +54,7 @@ namespace Xtensive.Orm.Providers
     {
       ArgumentNullException.ThrowIfNull(mapping);
       ArgumentNullException.ThrowIfNull(closureObject);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(fieldName, "fieldName");
+      ArgumentException.ThrowIfNullOrEmpty(fieldName);
 
       Mapping = mapping;
       ClosureObject = closureObject;

--- a/Orm/Xtensive.Orm/Orm/Providers/SequenceQuery.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SequenceQuery.cs
@@ -33,8 +33,8 @@ namespace Xtensive.Orm.Providers
     public SequenceQuery(string deleteQuery, string insertQuery, string selectQuery, SequenceQueryCompartment compartment)
     {
       ArgumentNullException.ThrowIfNull(deleteQuery);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(insertQuery, "insertQuery");
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(selectQuery, "selectQuery");
+      ArgumentException.ThrowIfNullOrEmpty(insertQuery);
+      ArgumentException.ThrowIfNullOrEmpty(selectQuery);
 
       DeleteQuery = deleteQuery;
       InsertQuery = insertQuery;
@@ -44,8 +44,8 @@ namespace Xtensive.Orm.Providers
 
     public SequenceQuery(string insertQuery, string selectQuery, SequenceQueryCompartment compartment)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(insertQuery, "insertQuery");
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(selectQuery, "selectQuery");
+      ArgumentException.ThrowIfNullOrEmpty(insertQuery);
+      ArgumentException.ThrowIfNullOrEmpty(selectQuery);
 
       InsertQuery = insertQuery;
       SelectQuery = selectQuery;
@@ -54,7 +54,7 @@ namespace Xtensive.Orm.Providers
 
     public SequenceQuery(string selectQuery, SequenceQueryCompartment compartment)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(selectQuery, "selectQuery");
+      ArgumentException.ThrowIfNullOrEmpty(selectQuery);
       SelectQuery = selectQuery;
       Compartment = compartment;
     }

--- a/Orm/Xtensive.Orm/Orm/Providers/TemporaryTables/TemporaryTableDescriptor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/TemporaryTables/TemporaryTableDescriptor.cs
@@ -84,7 +84,7 @@ namespace Xtensive.Orm.Providers
     /// <param name="name">A value for <see cref="Name"/>.</param>
     public TemporaryTableDescriptor(string name)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
       Name = name;
     }
   }

--- a/Orm/Xtensive.Orm/Orm/RecycledFieldDefinition.cs
+++ b/Orm/Xtensive.Orm/Orm/RecycledFieldDefinition.cs
@@ -55,7 +55,7 @@ namespace Xtensive.Orm
     public RecycledFieldDefinition(Type ownerType, string fieldName, Type fieldType, string originalFieldName)
     {
       Initialize(ownerType, fieldName, fieldType);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(originalFieldName, "originalFieldName");
+      ArgumentException.ThrowIfNullOrEmpty(originalFieldName);
 
       OriginalFieldName = originalFieldName;
     }
@@ -63,7 +63,7 @@ namespace Xtensive.Orm
     private void Initialize(Type ownerType, string fieldName, Type fieldType)
     {
       ArgumentNullException.ThrowIfNull(ownerType);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(fieldName, "fieldName");
+      ArgumentException.ThrowIfNullOrEmpty(fieldName);
       ArgumentNullException.ThrowIfNull(fieldType);
 
       OwnerType = ownerType;

--- a/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
@@ -101,7 +101,7 @@ namespace Xtensive.Orm.Rse
     /// <returns>Aliased collection of columns.</returns>
     public ColumnCollection Alias(string alias)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(alias, "alias");
+      ArgumentException.ThrowIfNullOrEmpty(alias);
       return new ColumnCollection(this.Select(column => column.Clone(alias + "." + column.Name)).ToArray(Count));
     }
 

--- a/Orm/Xtensive.Orm/Orm/Rse/CompilableProviderExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/CompilableProviderExtensions.cs
@@ -72,7 +72,7 @@ namespace Xtensive.Orm.Rse
 
     public static CompilableProvider Alias(this CompilableProvider source, string alias)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(alias, "alias");
+      ArgumentException.ThrowIfNullOrEmpty(alias);
       return new AliasProvider(source, alias);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/IncludeProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/IncludeProvider.cs
@@ -91,7 +91,7 @@ namespace Xtensive.Orm.Rse.Providers
       : base(ProviderType.Include, source)
     {
       ArgumentNullException.ThrowIfNull(filterDataSource);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(resultColumnName, "resultColumnName");
+      ArgumentException.ThrowIfNullOrEmpty(resultColumnName);
       ArgumentNullException.ThrowIfNull(filteredColumns);
       Algorithm = algorithm;
       IsInlined = isInlined;

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/StoreProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/StoreProvider.cs
@@ -53,7 +53,7 @@ namespace Xtensive.Orm.Rse.Providers
       : base (ProviderType.Store)
     {
       ArgumentNullException.ThrowIfNull(header);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
 
       Name = name;
 
@@ -71,7 +71,7 @@ namespace Xtensive.Orm.Rse.Providers
       : base(ProviderType.Store, source)
     {
       ArgumentNullException.ThrowIfNull(source);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
 
       Name = name;
       Source = source;

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/TagProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/TagProvider.cs
@@ -25,7 +25,7 @@ namespace Xtensive.Orm.Rse.Providers
     public TagProvider(CompilableProvider source, string tag)
       : base(ProviderType.Tag, source)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmptyOrWhiteSpace(tag, "tag");
+      ArgumentException.ThrowIfNullOrWhiteSpace(tag);
       Tag = tag;
       Initialize();
     }

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Hints/ChangeFieldTypeHint.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Hints/ChangeFieldTypeHint.cs
@@ -67,7 +67,7 @@ namespace Xtensive.Orm.Upgrade
     public ChangeFieldTypeHint(Type type, string fieldName)
     {
       ArgumentNullException.ThrowIfNull(type);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(fieldName, nameof(fieldName));
+      ArgumentException.ThrowIfNullOrEmpty(fieldName);
 
       Type = type;
       FieldName = fieldName;

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Hints/CopyFieldHint.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Hints/CopyFieldHint.cs
@@ -75,10 +75,10 @@ namespace Xtensive.Orm.Upgrade
     /// <param name="targetFieldName">Name of target field.</param>
     public CopyFieldHint(string sourceTypeName, string sourceFieldName, Type targetType, string targetFieldName)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(sourceTypeName, nameof(sourceTypeName));
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(sourceFieldName, nameof(sourceFieldName));
+      ArgumentException.ThrowIfNullOrEmpty(sourceTypeName);
+      ArgumentException.ThrowIfNullOrEmpty(sourceFieldName);
       ArgumentNullException.ThrowIfNull(targetType);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(targetFieldName, nameof(targetFieldName));
+      ArgumentException.ThrowIfNullOrEmpty(targetFieldName);
       SourceType = sourceTypeName;
       SourceField = sourceFieldName;
       TargetType = targetType;
@@ -106,9 +106,9 @@ namespace Xtensive.Orm.Upgrade
     public CopyFieldHint(Type sourceType, string sourceFieldName, Type targetType, string targetFieldName)
     {
       ArgumentNullException.ThrowIfNull(sourceType);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(sourceFieldName, nameof(sourceFieldName));
+      ArgumentException.ThrowIfNullOrEmpty(sourceFieldName);
       ArgumentNullException.ThrowIfNull(targetType);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(targetFieldName, nameof(targetFieldName));
+      ArgumentException.ThrowIfNullOrEmpty(targetFieldName);
       
       SourceType = sourceType.FullName;
       SourceField = sourceFieldName;

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Hints/MoveFieldHint.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Hints/MoveFieldHint.cs
@@ -76,10 +76,10 @@ namespace Xtensive.Orm.Upgrade
     /// <param name="targetFieldName">The target field name.</param>
     public MoveFieldHint(string sourceTypeName, string sourceFieldName, Type targetType, string targetFieldName)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(sourceTypeName, nameof(sourceTypeName));
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(sourceFieldName, nameof(sourceFieldName));
+      ArgumentException.ThrowIfNullOrEmpty(sourceTypeName);
+      ArgumentException.ThrowIfNullOrEmpty(sourceFieldName);
       ArgumentNullException.ThrowIfNull(targetType);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(targetFieldName, nameof(targetFieldName));
+      ArgumentException.ThrowIfNullOrEmpty(targetFieldName);
       SourceType = sourceTypeName;
       SourceField = sourceFieldName;
       TargetType = targetType;
@@ -107,9 +107,9 @@ namespace Xtensive.Orm.Upgrade
     public MoveFieldHint(Type sourceType, string sourceFieldName, Type targetType, string targetFieldName)
     {
       ArgumentNullException.ThrowIfNull(sourceType);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(sourceFieldName, nameof(sourceFieldName));
+      ArgumentException.ThrowIfNullOrEmpty(sourceFieldName);
       ArgumentNullException.ThrowIfNull(targetType);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(targetFieldName, nameof(targetFieldName));
+      ArgumentException.ThrowIfNullOrEmpty(targetFieldName);
 
       SourceType = sourceType.FullName;
       SourceField = sourceFieldName;

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Hints/RemoveFieldHint.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Hints/RemoveFieldHint.cs
@@ -70,8 +70,8 @@ namespace Xtensive.Orm.Upgrade
     /// <param name="fieldName">Removing field name.</param>
     public RemoveFieldHint(string typeName, string fieldName)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(typeName, nameof(typeName));
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(fieldName, nameof(fieldName));
+      ArgumentException.ThrowIfNullOrEmpty(typeName);
+      ArgumentException.ThrowIfNullOrEmpty(fieldName);
       Type = typeName;
       Field = fieldName;
       AffectedColumns = Array.Empty<string>();
@@ -85,7 +85,7 @@ namespace Xtensive.Orm.Upgrade
     public RemoveFieldHint(Type type, string fieldName)
     {
       ArgumentNullException.ThrowIfNull(type);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(fieldName, nameof(fieldName));
+      ArgumentException.ThrowIfNullOrEmpty(fieldName);
 
       Type = type.FullName;
       Field = fieldName;

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Hints/RemoveTypeHint.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Hints/RemoveTypeHint.cs
@@ -57,7 +57,7 @@ namespace Xtensive.Orm.Upgrade
     /// <param name="typeName">Full name of type.</param>
     public RemoveTypeHint(string typeName)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(typeName, nameof(typeName));
+      ArgumentException.ThrowIfNullOrEmpty(typeName);
       Type = typeName;
       AffectedTables = Array.Empty<string>();
     }

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Hints/RenameFieldHint.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Hints/RenameFieldHint.cs
@@ -68,7 +68,7 @@ namespace Xtensive.Orm.Upgrade
     public RenameFieldHint(Type targetType, string oldFieldName, string newFieldName)
     {
       ArgumentNullException.ThrowIfNull(targetType);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(oldFieldName, "oldFieldName");
+      ArgumentException.ThrowIfNullOrEmpty(oldFieldName);
       ArgumentNullException.ThrowIfNull(newFieldName);
 
       TargetType = targetType;

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Hints/RenameTypeHint.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Hints/RenameTypeHint.cs
@@ -63,7 +63,7 @@ namespace Xtensive.Orm.Upgrade
     public RenameTypeHint(string oldType, Type newType)
     {
       ArgumentNullException.ThrowIfNull(newType);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(oldType, nameof(oldType));
+      ArgumentException.ThrowIfNullOrEmpty(oldType);
 
       if (!oldType.Contains(".", StringComparison.Ordinal))
         oldType = newType.Namespace + "." + oldType;

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/AssemblyMetadata.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/AssemblyMetadata.cs
@@ -23,7 +23,7 @@ namespace Xtensive.Orm.Upgrade
 
     public AssemblyMetadata(string name, string version)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
       Name = name;
       Version = version;
     }

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Model/PartialIndexFilterInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Model/PartialIndexFilterInfo.cs
@@ -50,7 +50,7 @@ namespace Xtensive.Orm.Upgrade.Model
 
     public PartialIndexFilterInfo(string expression)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(expression, "expression");
+      ArgumentException.ThrowIfNullOrEmpty(expression);
       Expression = expression;
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Validation/ObjectValidator.cs
+++ b/Orm/Xtensive.Orm/Orm/Validation/ObjectValidator.cs
@@ -88,7 +88,7 @@ namespace Xtensive.Orm.Validation
     /// <param name="innerException">An <see cref="Exception"/> instance to be used as inner exception.</param>
     protected void ThrowConfigurationError(string message, Exception innerException = null)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(message, "message");
+      ArgumentException.ThrowIfNullOrEmpty(message);
 
       var exceptionMessage = string.Format(
         Strings.ExValidatorXConfigurationFailedOnTypeYWithMessageZ,

--- a/Orm/Xtensive.Orm/Orm/Validation/PropertyValidator.cs
+++ b/Orm/Xtensive.Orm/Orm/Validation/PropertyValidator.cs
@@ -113,7 +113,7 @@ namespace Xtensive.Orm.Validation
     /// <param name="innerException">An <see cref="Exception"/> instance to be used as inner exception.</param>
     protected void ThrowConfigurationError(string message, Exception innerException = null)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(message, "message");
+      ArgumentException.ThrowIfNullOrEmpty(message);
 
       var exceptionMessage = string.Format(
         Strings.ExValidatorXConfigurationFailedOnTypeYFieldZWithMessageA,

--- a/Orm/Xtensive.Orm/Orm/Validation/ValidationResult.cs
+++ b/Orm/Xtensive.Orm/Orm/Validation/ValidationResult.cs
@@ -60,7 +60,7 @@ namespace Xtensive.Orm.Validation
     public ValidationResult(IValidator source, string errorMessage, FieldInfo field = null, object value = null)
     {
       ArgumentNullException.ThrowIfNull(source);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(errorMessage, "errorMessage");
+      ArgumentException.ThrowIfNullOrEmpty(errorMessage);
 
       isError = true;
 

--- a/Orm/Xtensive.Orm/Reflection/DelegateHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/DelegateHelper.cs
@@ -352,7 +352,7 @@ namespace Xtensive.Reflection
       where TDelegate : class
     {
       ArgumentNullException.ThrowIfNull(type);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(methodName, "methodName");
+      ArgumentException.ThrowIfNullOrEmpty(methodName);
       ArgumentNullException.ThrowIfNull(genericArgumentTypes);
       Type delegateType = typeof (TDelegate);
       if (!WellKnownTypes.Delegate.IsAssignableFrom(delegateType))
@@ -399,7 +399,7 @@ namespace Xtensive.Reflection
       where TDelegate : class
     {
       ArgumentNullException.ThrowIfNull(type);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(methodName, "methodName");
+      ArgumentException.ThrowIfNullOrEmpty(methodName);
       ArgumentNullException.ThrowIfNull(genericArgumentVariants);
       Type delegateType = typeof (TDelegate);
       if (!WellKnownTypes.Delegate.IsAssignableFrom(delegateType))

--- a/Orm/Xtensive.Orm/Reflection/MethodHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/MethodHelper.cs
@@ -45,7 +45,7 @@ namespace Xtensive.Reflection
     public static MethodInfo GetMethodEx(this Type type, string name, BindingFlags bindingFlags, string[] genericArgumentNames, object[] parameterTypes)
     {
       ArgumentNullException.ThrowIfNull(type);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
 
       if (genericArgumentNames == null) {
         genericArgumentNames = Array.Empty<string>();

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -427,7 +427,7 @@ namespace Xtensive.Reflection
     /// <returns><see cref="Type"/> object of newly created type.</returns>
     public static Type CreateDummyType(string namePrefix, Type inheritFrom, bool implementProtectedConstructorAccessor)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(namePrefix, nameof(namePrefix));
+      ArgumentException.ThrowIfNullOrEmpty(namePrefix);
       ArgumentNullException.ThrowIfNull(inheritFrom);
 
 
@@ -448,7 +448,7 @@ namespace Xtensive.Reflection
     public static Type CreateInheritedDummyType(string typeName, Type inheritFrom,
       bool implementProtectedConstructorAccessor)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(typeName, nameof(typeName));
+      ArgumentException.ThrowIfNullOrEmpty(typeName);
       ArgumentNullException.ThrowIfNull(inheritFrom);
       EnsureEmitInitialized();
       lock (EmitLock) {
@@ -556,7 +556,7 @@ namespace Xtensive.Reflection
       params object[] arguments)
     {
       ArgumentNullException.ThrowIfNull(assembly);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(typeName, nameof(typeName));
+      ArgumentException.ThrowIfNullOrEmpty(typeName);
       var type = assembly.GetType(typeName, false);
       return type == null ? null : Activate(type, genericArguments, arguments);
     }

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlUserFunctionCall.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlUserFunctionCall.cs
@@ -32,14 +32,14 @@ namespace Xtensive.Sql.Dml
     internal SqlUserFunctionCall(string name, IReadOnlyList<SqlExpression> arguments)
       : base(SqlFunctionType.UserDefined, arguments)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
       Name = name;
     }
 
     internal SqlUserFunctionCall(string name, params SqlExpression[] arguments)
       : base(SqlFunctionType.UserDefined, arguments)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
       Name = name;
     }
 

--- a/Orm/Xtensive.Orm/Sql/Model/PairedNodeCollection.cs
+++ b/Orm/Xtensive.Orm/Sql/Model/PairedNodeCollection.cs
@@ -87,7 +87,7 @@ namespace Xtensive.Sql.Model
       : base(capacity)
     {
       ArgumentNullException.ThrowIfNull(owner);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(property, "property");
+      ArgumentException.ThrowIfNullOrEmpty(property);
       this.owner = owner;
       this.property = property;
     }
@@ -103,7 +103,7 @@ namespace Xtensive.Sql.Model
       : base(capacity, equalityComparer)
     {
       ArgumentNullException.ThrowIfNull(owner);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(property, nameof(property));
+      ArgumentException.ThrowIfNullOrEmpty(property);
       ArgumentNullException.ThrowIfNull(equalityComparer);
 
       this.owner = owner;

--- a/Orm/Xtensive.Orm/Sql/SqlConnection.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlConnection.cs
@@ -121,7 +121,7 @@ namespace Xtensive.Sql
     /// <returns>Created command.</returns>
     public DbCommand CreateCommand(string commandText)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(commandText, nameof(commandText));
+      ArgumentException.ThrowIfNullOrEmpty(commandText);
       var command = CreateCommand();
       command.CommandText = commandText;
       return command;

--- a/Orm/Xtensive.Orm/Sql/SqlDdl.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlDdl.cs
@@ -302,7 +302,7 @@ namespace Xtensive.Sql
     public static SqlRenameTable Rename(Table table, string newName)
     {
       ArgumentNullException.ThrowIfNull(table);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(newName, "newName");
+      ArgumentException.ThrowIfNullOrEmpty(newName);
       if (table.Name==newName)
         throw new ArgumentException(Strings.ExTableAlreadyHasSpecifiedName);
       return new SqlRenameTable(table, newName);
@@ -311,7 +311,7 @@ namespace Xtensive.Sql
     public static SqlAlterTable Rename(TableColumn column, string newName)
     {
       ArgumentNullException.ThrowIfNull(column, "table");
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(newName, "newName");
+      ArgumentException.ThrowIfNullOrEmpty(newName);
       if (column.Name==newName)
         throw new ArgumentException(Strings.ExColumnAlreadyHasSpecifiedName);
       return Alter(column.Table, new SqlRenameColumn(column, newName));

--- a/Orm/Xtensive.Orm/Sql/SqlDml.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlDml.cs
@@ -1429,7 +1429,7 @@ namespace Xtensive.Sql
 
     public static SqlNative Native(string value)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(value, "value");
+      ArgumentException.ThrowIfNullOrEmpty(value);
       return new SqlNative(value);
     }
 
@@ -1452,7 +1452,7 @@ namespace Xtensive.Sql
 
     public static SqlCursor Cursor(string name, ISqlQueryExpression query)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
       return new SqlCursor(name, query);
     }
 
@@ -1464,7 +1464,7 @@ namespace Xtensive.Sql
 
     public static SqlParameterRef ParameterRef(string name)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
       return new SqlParameterRef(name);
     }
 
@@ -1962,7 +1962,7 @@ namespace Xtensive.Sql
     public static SqlTableColumn TableColumn(SqlTable sqlTable, string name)
     {
       ArgumentNullException.ThrowIfNull(sqlTable, "table");
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
       return new SqlTableColumn(sqlTable, name);
     }
 
@@ -2069,14 +2069,14 @@ namespace Xtensive.Sql
     public static SqlTableRef TableRef(DataTable dataTable, string name)
     {
       ArgumentNullException.ThrowIfNull(dataTable);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
       return new SqlTableRef(dataTable, name);
     }
 
     public static SqlTableRef TableRef(DataTable dataTable, string name, IEnumerable<string> columnNames)
     {
       ArgumentNullException.ThrowIfNull(dataTable);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
       ArgumentNullException.ThrowIfNull(columnNames);
       return new SqlTableRef(dataTable, name, columnNames.ToArray());
     }
@@ -2090,7 +2090,7 @@ namespace Xtensive.Sql
     public static SqlQueryRef QueryRef(ISqlQueryExpression query, string alias)
     {
       ArgumentNullException.ThrowIfNull(query);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(alias, "alias");
+      ArgumentException.ThrowIfNullOrEmpty(alias);
       return new SqlQueryRef(query, alias);
     }
 
@@ -2172,25 +2172,25 @@ namespace Xtensive.Sql
 
     public static SqlVariable Variable(string name, SqlValueType type)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
       return new SqlVariable(name, type);
     }
 
     public static SqlVariable Variable(string name, SqlType type)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
       return new SqlVariable(name, new SqlValueType(type));
     }
 
     public static SqlVariable Variable(string name, SqlType type, int size)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
       return new SqlVariable(name, new SqlValueType(type, size));
     }
 
     public static SqlVariable Variable(string name, SqlType type, short precision, short scale)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(name, "name");
+      ArgumentException.ThrowIfNullOrEmpty(name);
       return new SqlVariable(name, new SqlValueType(type, precision, scale));
     }
 
@@ -2228,7 +2228,7 @@ namespace Xtensive.Sql
 
     public static SqlNativeHint NativeHint(string hintText)
     {
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(hintText, "hintText");
+      ArgumentException.ThrowIfNullOrEmpty(hintText);
       return new SqlNativeHint(hintText);
     }
 

--- a/Orm/Xtensive.Orm/Sql/SqlHelper.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlHelper.cs
@@ -365,7 +365,7 @@ namespace Xtensive.Sql
       DbConnection connection, DbTransaction transaction)
     {
       ArgumentNullException.ThrowIfNull(connection);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(queryText, nameof(queryText));
+      ArgumentException.ThrowIfNullOrEmpty(queryText);
 
       using var command = connection.CreateCommand();
       command.CommandText = queryText;
@@ -393,7 +393,7 @@ namespace Xtensive.Sql
       DbConnection connection, DbTransaction transaction, CancellationToken token)
     {
       ArgumentNullException.ThrowIfNull(connection);
-      ArgumentValidator.EnsureArgumentNotNullOrEmpty(queryText, nameof(queryText));
+      ArgumentException.ThrowIfNullOrEmpty(queryText);
 
       var command = connection.CreateCommand();
       await using (command.ConfigureAwaitFalse()) {

--- a/Orm/Xtensive.Orm/Sql/SqlValueType.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlValueType.cs
@@ -220,7 +220,7 @@ namespace Xtensive.Sql
       if (precision.HasValue!=scale.HasValue)
         throw new ArgumentException(Strings.ExInvalidArgumentsScaleAndPrecisionShouldBeUsedTogether);
       if (typeName!=null)
-        ArgumentValidator.EnsureArgumentNotNullOrEmpty(typeName, "typeName");
+        ArgumentException.ThrowIfNullOrEmpty(typeName);
       if (length!=null)
         ArgumentValidator.EnsureArgumentIsGreaterThan(length.Value, 0, "length");
       if (precision!=null)


### PR DESCRIPTION
Get rid of obsolete `ArgumentValidator` helpers