### PR TITLE
Optimize `AsTupleAccess()`

### DIFF
--- a/Orm/Xtensive.Orm/Linq/ExpressionVisitor.cs
+++ b/Orm/Xtensive.Orm/Linq/ExpressionVisitor.cs
@@ -183,9 +183,10 @@ namespace Xtensive.Linq
       IEnumerable<Expression> initializers = VisitExpressionList(naExpressions);
       if (initializers == naExpressions)
         return na;
-      if (na.NodeType == ExpressionType.NewArrayInit)
-        return Expression.NewArrayInit(na.Type.GetElementType(), initializers);
-      return Expression.NewArrayBounds(na.Type.GetElementType(), initializers);
+      var elementType = na.Type.GetElementType();
+      return na.NodeType == ExpressionType.NewArrayInit
+        ? Expression.NewArrayInit(elementType, initializers)
+        : Expression.NewArrayBounds(elementType, initializers);
     }
 
     /// <inheritdoc/>

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/IncludeFilterMappingGatherer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/IncludeFilterMappingGatherer.cs
@@ -4,8 +4,6 @@
 // Created by: Alexey Gamzov
 // Created:    2009.11.16
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using Xtensive.Core;
 using Xtensive.Linq;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/IncludeFilterMappingGatherer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/IncludeFilterMappingGatherer.cs
@@ -12,7 +12,7 @@ using Xtensive.Orm.Rse;
 
 namespace Xtensive.Orm.Linq.Expressions.Visitors
 {
-  internal sealed class IncludeFilterMappingGatherer(Expression filterDataTuple, ApplyParameter filteredTuple, ArraySegment<IncludeFilterMappingGatherer.MappingEntry> resultMapping)
+  internal sealed class IncludeFilterMappingGatherer(Expression filterDataTuple, ApplyParameter filteredTuple, ArraySegment<IncludeFilterMappingGatherer.MappingEntry?> resultMapping)
     : ExtendedExpressionVisitor
   {
     public readonly struct MappingEntry
@@ -36,11 +36,11 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
     private static readonly ParameterExpression CalculatedColumnParameter = Expression.Parameter(WellKnownOrmTypes.Tuple, "filteredRow");
     private static readonly IReadOnlyList<ParameterExpression> CalculatedColumnParameters = [CalculatedColumnParameter];
 
-    public static void Gather(Expression filterExpression, Expression filterDataTuple, ApplyParameter filteredTuple, ArraySegment<MappingEntry> mapping)
+    public static void Gather(Expression filterExpression, Expression filterDataTuple, ApplyParameter filteredTuple, ArraySegment<MappingEntry?> mapping)
     {
       var visitor = new IncludeFilterMappingGatherer(filterDataTuple, filteredTuple, mapping);
       _ = visitor.Visit(filterExpression);
-      if (mapping.Contains(default))
+      if (mapping.Contains(null))
         throw Exceptions.InternalError("Failed to gather mappings for IncludeProvider", OrmLog.Instance);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -1539,14 +1539,10 @@ namespace Xtensive.Orm.Linq
           // Mapping from filter data column to filtered column
           for (var i = 0; i < filterColumnCount; i++) {
             var mapping = filteredColumnMappings[i];
-            if (mapping.ColumnIndex >= 0) {
-              filteredColumns[i] = mapping.ColumnIndex;
-            }
-            else {
-              var descriptor = CreateCalculatedColumnDescriptor(mapping.CalculatedColumn);
-              var column = AddCalculatedColumn(outerParameter, descriptor, mapping.CalculatedColumn.Body.Type);
-              filteredColumns[i] = column.Mapping.Offset;
-            }
+            filteredColumns[i] = mapping.ColumnIndex >= 0
+              ? mapping.ColumnIndex
+              : AddCalculatedColumn(outerParameter, CreateCalculatedColumnDescriptor(mapping.CalculatedColumn), mapping.CalculatedColumn.Body.Type)
+                  .Mapping.Offset;
           }
         }
         finally {

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -4,9 +4,7 @@
 // Created by: Alexis Kochetov
 // Created:    2009.02.27
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.Buffers;
 using System.Linq.Expressions;
 using System.Reflection;
 using Xtensive.Collections;
@@ -1523,50 +1521,53 @@ namespace Xtensive.Orm.Linq
 
         var predicateLambda = predicateExpression.ToLambda(context);
 
-        RawProvider rawProvider;
-        if (visitedSource.ItemProjector.DataSource is StoreProvider storeProvider) {
-          rawProvider = (RawProvider) storeProvider.Source;
-        }
-        else {
-          var joinProvider = (JoinProvider) visitedSource.ItemProjector.DataSource;
-          rawProvider = (RawProvider) ((StoreProvider) joinProvider.Left).Source;
-        }
+        var rawProvider = (RawProvider)
+          (visitedSource.ItemProjector.DataSource as StoreProvider
+            ?? (StoreProvider) ((JoinProvider) visitedSource.ItemProjector.DataSource).Left
+          ).Source;
 
         var filterColumnCount = rawProvider.Header.Length;
         var filteredTuple = context.GetApplyParameter(context.Bindings[outerParameter]);
 
-        // Mapping from filter data column to expression that requires filtering
-        var filteredColumnMappings = IncludeFilterMappingGatherer.Gather(
-          predicateLambda.Body, predicateLambda.Parameters[0], filteredTuple, filterColumnCount);
-
-        // Mapping from filter data column to filtered column
         var filteredColumns = new ColNum[filterColumnCount];
-        for (var i = 0; i < filterColumnCount; i++) {
-          var mapping = filteredColumnMappings[i];
-          if (mapping.ColumnIndex >= 0) {
-            filteredColumns[i] = mapping.ColumnIndex;
-          }
-          else {
-            var descriptor = CreateCalculatedColumnDescriptor(mapping.CalculatedColumn);
-            var column = AddCalculatedColumn(outerParameter, descriptor, mapping.CalculatedColumn.Body.Type);
-            filteredColumns[i] = column.Mapping.Offset;
+
+        // Mapping from filter data column to expression that requires filtering
+        var filteredColumnMappings = ArrayPool<IncludeFilterMappingGatherer.MappingEntry>.Shared.Rent(filterColumnCount);
+        try {
+          IncludeFilterMappingGatherer.Gather(predicateLambda.Body, predicateLambda.Parameters[0], filteredTuple, new(filteredColumnMappings, 0, filterColumnCount));
+
+          // Mapping from filter data column to filtered column
+          for (var i = 0; i < filterColumnCount; i++) {
+            var mapping = filteredColumnMappings[i];
+            if (mapping.ColumnIndex >= 0) {
+              filteredColumns[i] = mapping.ColumnIndex;
+            }
+            else {
+              var descriptor = CreateCalculatedColumnDescriptor(mapping.CalculatedColumn);
+              var column = AddCalculatedColumn(outerParameter, descriptor, mapping.CalculatedColumn.Body.Type);
+              filteredColumns[i] = column.Mapping.Offset;
+            }
           }
         }
+        finally {
+          ArrayPool<IncludeFilterMappingGatherer.MappingEntry>.Shared.Return(filteredColumnMappings, true);
+        }
 
-        var outerResult = context.Bindings[outerParameter];
-        var columnIndex = outerResult.ItemProjector.DataSource.Header.Length;
-        var newDataSource = outerResult.ItemProjector.DataSource
+        var contextBindings = context.Bindings;
+        var outerResult = contextBindings[outerParameter];
+        var outerResultItemProjector = outerResult.ItemProjector;
+        var outerResultItemProjectorDataSource = outerResultItemProjector.DataSource;
+        var columnIndex = outerResultItemProjectorDataSource.Header.Length;
+        var newDataSource = outerResultItemProjectorDataSource
           .Include(State.IncludeAlgorithm, true, rawProvider.Source, context.GetNextAlias(), filteredColumns);
 
-        var newItemProjector = outerResult.ItemProjector.Remap(newDataSource, 0);
+        var newItemProjector = outerResultItemProjector.Remap(newDataSource, 0);
         var newOuterResult = outerResult.Apply(newItemProjector);
-        context.Bindings.ReplaceBound(outerParameter, newOuterResult);
+        contextBindings.ReplaceBound(outerParameter, newOuterResult);
         Expression resultExpression = ColumnExpression.Create(WellKnownTypes.Bool, columnIndex);
-        if (notExists) {
-          resultExpression = Expression.Not(resultExpression);
-        }
-
-        return resultExpression;
+        return notExists
+          ? Expression.Not(resultExpression)
+          : resultExpression;
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -1532,13 +1532,13 @@ namespace Xtensive.Orm.Linq
         var filteredColumns = new ColNum[filterColumnCount];
 
         // Mapping from filter data column to expression that requires filtering
-        var filteredColumnMappings = ArrayPool<IncludeFilterMappingGatherer.MappingEntry>.Shared.Rent(filterColumnCount);
+        var filteredColumnMappings = ArrayPool<IncludeFilterMappingGatherer.MappingEntry?>.Shared.Rent(filterColumnCount);
         try {
           IncludeFilterMappingGatherer.Gather(predicateLambda.Body, predicateLambda.Parameters[0], filteredTuple, new(filteredColumnMappings, 0, filterColumnCount));
 
           // Mapping from filter data column to filtered column
           for (var i = 0; i < filterColumnCount; i++) {
-            var mapping = filteredColumnMappings[i];
+            var mapping = filteredColumnMappings[i].Value;
             filteredColumns[i] = mapping.ColumnIndex >= 0
               ? mapping.ColumnIndex
               : AddCalculatedColumn(outerParameter, CreateCalculatedColumnDescriptor(mapping.CalculatedColumn), mapping.CalculatedColumn.Body.Type)
@@ -1546,7 +1546,7 @@ namespace Xtensive.Orm.Linq
           }
         }
         finally {
-          ArrayPool<IncludeFilterMappingGatherer.MappingEntry>.Shared.Return(filteredColumnMappings, true);
+          ArrayPool<IncludeFilterMappingGatherer.MappingEntry?>.Shared.Return(filteredColumnMappings, true);
         }
 
         var contextBindings = context.Bindings;

--- a/Orm/Xtensive.Orm/Orm/Linq/TranslatorState.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/TranslatorState.cs
@@ -28,18 +28,11 @@ namespace Xtensive.Orm.Linq
       SkipNullableColumnsDetectionInGroupBy = 1 << 9
     }
 
-    internal readonly struct TranslatorScope : IDisposable
+    internal readonly struct TranslatorScope(Translator translator) : IDisposable
     {
-      private readonly TranslatorState previousState;
-      private readonly Translator translator;
+      private readonly TranslatorState previousState = translator.State;
 
       public void Dispose() => translator.RestoreState(previousState);
-
-      public TranslatorScope(Translator translator)
-      {
-        this.translator = translator;
-        previousState = translator.State;
-      }
     }
 
     public static readonly TranslatorState InitState = new TranslatorState {

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.Helpers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.Helpers.cs
@@ -255,7 +255,7 @@ namespace Xtensive.Orm.Providers
     private static SqlExpression ConvertIntConstantToSingleCharString(Expression expression)
     {
       var value = (int) ((ConstantExpression) expression).Value;
-      return SqlDml.Literal(new string(new[] {(char) value}));
+      return SqlDml.Literal(((char) value).ToString());
     }
 
     private static Expression GetOperand(Expression expression)


### PR DESCRIPTION
Also:
* Make `IncludeFilterMappingGatherer.MappingEntry` readonly struct
* Rent temporary array of `MappingEntry` from pool
* Avoif double-dereferencing the same properties
* Avoid intermediate array in `ConvertIntConstantToSingleCharString()`