### PR TITLE
Replace slow `Enum.TryParse()` by dictionary lookup

### DIFF
--- a/Orm/Xtensive.Orm/Linq/QueryableVisitor.cs
+++ b/Orm/Xtensive.Orm/Linq/QueryableVisitor.cs
@@ -66,14 +66,12 @@ public abstract class QueryableVisitor : ExpressionVisitor
   };
 
   /// <inheritdoc/>
-  protected override Expression VisitMethodCall(MethodCallExpression mc)
-  {
-    var mcArguments = mc.Arguments;
-    return (mcArguments.Count > 0 && mcArguments[0].Type == WellKnownTypes.String)
-           || !(GetQueryableMethod(mc) is { } method)
+  protected override Expression VisitMethodCall(MethodCallExpression mc) =>
+    mc.Arguments is var mcArguments
+    && (mcArguments.Count > 0 && mcArguments[0].Type == WellKnownTypes.String)
+    || !(GetQueryableMethod(mc) is { } method)
       ? base.VisitMethodCall(mc)
       : VisitQueryableMethod(mc, method);
-  }
 
   /// <summary>
   /// Visits method of <see cref="IQueryable"/> or <see cref="IEnumerable{T}"/>.

--- a/Orm/Xtensive.Orm/Linq/QueryableVisitor.cs
+++ b/Orm/Xtensive.Orm/Linq/QueryableVisitor.cs
@@ -89,21 +89,10 @@ namespace Xtensive.Linq
     /// <param name="call">A call to process.</param>
     /// <returns><see cref="QueryableMethodKind"/> for the specified expression,
     /// or null if method is not a LINQ method.</returns>
-    public static QueryableMethodKind? GetQueryableMethod(MethodCallExpression call)
-    {
-      if (call == null) {
-        return null;
-      }
-
-      var declaringType = call.Method.DeclaringType;
-      if (declaringType == WellKnownTypes.Queryable || declaringType == WellKnownTypes.Enumerable) {
-        return ParseQueryableMethodKind(call.Method.Name);
-      }
-
-      return null;
-    }
-
-    private static QueryableMethodKind? ParseQueryableMethodKind(string methodName) =>
-      QueryableMethodKindFromName.GetValueOrDefault(methodName);
+    public static QueryableMethodKind? GetQueryableMethod(MethodCallExpression call) =>
+      call?.Method.DeclaringType is { } declaringType
+      && (declaringType == WellKnownTypes.Queryable || declaringType == WellKnownTypes.Enumerable)
+        ? QueryableMethodKindFromName.GetValueOrDefault(call.Method.Name)
+        : null;
   }
 }

--- a/Orm/Xtensive.Orm/Linq/QueryableVisitor.cs
+++ b/Orm/Xtensive.Orm/Linq/QueryableVisitor.cs
@@ -5,94 +5,92 @@
 // Created:    2009.02.25
 
 using System.Linq.Expressions;
-using Xtensive.Orm;
 using Xtensive.Reflection;
 
-namespace Xtensive.Linq
+namespace Xtensive.Linq;
+
+/// <summary>
+/// Abstract base visitor that handles methods of <see cref="IQueryable"/> and <see cref="IEnumerable{T}"/> by calling <see cref="VisitQueryableMethod"/>.
+/// </summary>
+[Serializable]
+public abstract class QueryableVisitor : ExpressionVisitor
 {
-  /// <summary>
-  /// Abstract base visitor that handles methods of <see cref="IQueryable"/> and <see cref="IEnumerable{T}"/> by calling <see cref="VisitQueryableMethod"/>.
-  /// </summary>
-  [Serializable]
-  public abstract class QueryableVisitor : ExpressionVisitor
+  private static readonly Dictionary<string, QueryableMethodKind> QueryableMethodKindFromName = new() {
+    [nameof(Queryable.Aggregate)] = QueryableMethodKind.Aggregate,
+    [nameof(Queryable.All)] = QueryableMethodKind.All,
+    [nameof(Queryable.Any)] = QueryableMethodKind.Any,
+    ["AsEnumerable"] = QueryableMethodKind.AsEnumerable,
+    ["AsQueryable"] = QueryableMethodKind.AsQueryable,
+    [nameof(Queryable.Average)] = QueryableMethodKind.Average,
+    [nameof(Queryable.Cast)] = QueryableMethodKind.Cast,
+    [nameof(Queryable.Concat)] = QueryableMethodKind.Concat,
+    [nameof(Queryable.Contains)] = QueryableMethodKind.Contains,
+    [nameof(Queryable.Count)] = QueryableMethodKind.Count,
+    [nameof(Queryable.DefaultIfEmpty)] = QueryableMethodKind.DefaultIfEmpty,
+    [nameof(Queryable.Distinct)] = QueryableMethodKind.Distinct,
+    [nameof(Queryable.DistinctBy)] = QueryableMethodKind.DistinctBy,
+    [nameof(Queryable.ElementAt)] = QueryableMethodKind.ElementAt,
+    [nameof(Queryable.ElementAtOrDefault)] = QueryableMethodKind.ElementAtOrDefault,
+    [nameof(Queryable.Except)] = QueryableMethodKind.Except,
+    [nameof(Queryable.First)] = QueryableMethodKind.First,
+    [nameof(Queryable.FirstOrDefault)] = QueryableMethodKind.FirstOrDefault,
+    [nameof(Queryable.GroupBy)] = QueryableMethodKind.GroupBy,
+    [nameof(Queryable.GroupJoin)] = QueryableMethodKind.GroupJoin,
+    [nameof(Queryable.Intersect)] = QueryableMethodKind.Intersect,
+    [nameof(Queryable.Join)] = QueryableMethodKind.Join,
+    [nameof(Queryable.Last)] = QueryableMethodKind.Last,
+    [nameof(Queryable.LastOrDefault)] = QueryableMethodKind.LastOrDefault,
+    [nameof(Queryable.LongCount)] = QueryableMethodKind.LongCount,
+    [nameof(Queryable.Max)] = QueryableMethodKind.Max,
+    [nameof(Queryable.Min)] = QueryableMethodKind.Min,
+    [nameof(Queryable.OfType)] = QueryableMethodKind.OfType,
+    [nameof(Queryable.OrderBy)] = QueryableMethodKind.OrderBy,
+    [nameof(Queryable.OrderByDescending)] = QueryableMethodKind.OrderByDescending,
+    [nameof(Queryable.Reverse)] = QueryableMethodKind.Reverse,
+    [nameof(Queryable.Select)] = QueryableMethodKind.Select,
+    [nameof(Queryable.SelectMany)] = QueryableMethodKind.SelectMany,
+    [nameof(Queryable.SequenceEqual)] = QueryableMethodKind.SequenceEqual,
+    [nameof(Queryable.Single)] = QueryableMethodKind.Single,
+    [nameof(Queryable.SingleOrDefault)] = QueryableMethodKind.SingleOrDefault,
+    [nameof(Queryable.Skip)] = QueryableMethodKind.Skip,
+    [nameof(Queryable.SkipWhile)] = QueryableMethodKind.SkipWhile,
+    [nameof(Queryable.Sum)] = QueryableMethodKind.Sum,
+    [nameof(Queryable.Take)] = QueryableMethodKind.Take,
+    [nameof(Queryable.TakeWhile)] = QueryableMethodKind.TakeWhile,
+    [nameof(Queryable.ThenBy)] = QueryableMethodKind.ThenBy,
+    [nameof(Queryable.ThenByDescending)] = QueryableMethodKind.ThenByDescending,
+    ["ToArray"] = QueryableMethodKind.ToArray,
+    ["ToList"] = QueryableMethodKind.ToList,
+    [nameof(Queryable.Union)] = QueryableMethodKind.Union,
+    [nameof(Queryable.Where)] = QueryableMethodKind.Where
+  };
+
+  /// <inheritdoc/>
+  protected override Expression VisitMethodCall(MethodCallExpression mc)
   {
-    private static readonly Dictionary<string, QueryableMethodKind> QueryableMethodKindFromName = new() {
-      [nameof(Queryable.Aggregate)] = QueryableMethodKind.Aggregate,
-      [nameof(Queryable.All)] = QueryableMethodKind.All,
-      [nameof(Queryable.Any)] = QueryableMethodKind.Any,
-      ["AsEnumerable"] = QueryableMethodKind.AsEnumerable,
-      ["AsQueryable"] = QueryableMethodKind.AsQueryable,
-      [nameof(Queryable.Average)] = QueryableMethodKind.Average,
-      [nameof(Queryable.Cast)] = QueryableMethodKind.Cast,
-      [nameof(Queryable.Concat)] = QueryableMethodKind.Concat,
-      [nameof(Queryable.Contains)] = QueryableMethodKind.Contains,
-      [nameof(Queryable.Count)] = QueryableMethodKind.Count,
-      [nameof(Queryable.DefaultIfEmpty)] = QueryableMethodKind.DefaultIfEmpty,
-      [nameof(Queryable.Distinct)] = QueryableMethodKind.Distinct,
-      [nameof(Queryable.DistinctBy)] = QueryableMethodKind.DistinctBy,
-      [nameof(Queryable.ElementAt)] = QueryableMethodKind.ElementAt,
-      [nameof(Queryable.ElementAtOrDefault)] = QueryableMethodKind.ElementAtOrDefault,
-      [nameof(Queryable.Except)] = QueryableMethodKind.Except,
-      [nameof(Queryable.First)] = QueryableMethodKind.First,
-      [nameof(Queryable.FirstOrDefault)] = QueryableMethodKind.FirstOrDefault,
-      [nameof(Queryable.GroupBy)] = QueryableMethodKind.GroupBy,
-      [nameof(Queryable.GroupJoin)] = QueryableMethodKind.GroupJoin,
-      [nameof(Queryable.Intersect)] = QueryableMethodKind.Intersect,
-      [nameof(Queryable.Join)] = QueryableMethodKind.Join,
-      [nameof(Queryable.Last)] = QueryableMethodKind.Last,
-      [nameof(Queryable.LastOrDefault)] = QueryableMethodKind.LastOrDefault,
-      [nameof(Queryable.LongCount)] = QueryableMethodKind.LongCount,
-      [nameof(Queryable.Max)] = QueryableMethodKind.Max,
-      [nameof(Queryable.Min)] = QueryableMethodKind.Min,
-      [nameof(Queryable.OfType)] = QueryableMethodKind.OfType,
-      [nameof(Queryable.OrderBy)] = QueryableMethodKind.OrderBy,
-      [nameof(Queryable.OrderByDescending)] = QueryableMethodKind.OrderByDescending,
-      [nameof(Queryable.Reverse)] = QueryableMethodKind.Reverse,
-      [nameof(Queryable.Select)] = QueryableMethodKind.Select,
-      [nameof(Queryable.SelectMany)] = QueryableMethodKind.SelectMany,
-      [nameof(Queryable.SequenceEqual)] = QueryableMethodKind.SequenceEqual,
-      [nameof(Queryable.Single)] = QueryableMethodKind.Single,
-      [nameof(Queryable.SingleOrDefault)] = QueryableMethodKind.SingleOrDefault,
-      [nameof(Queryable.Skip)] = QueryableMethodKind.Skip,
-      [nameof(Queryable.SkipWhile)] = QueryableMethodKind.SkipWhile,
-      [nameof(Queryable.Sum)] = QueryableMethodKind.Sum,
-      [nameof(Queryable.Take)] = QueryableMethodKind.Take,
-      [nameof(Queryable.TakeWhile)] = QueryableMethodKind.TakeWhile,
-      [nameof(Queryable.ThenBy)] = QueryableMethodKind.ThenBy,
-      [nameof(Queryable.ThenByDescending)] = QueryableMethodKind.ThenByDescending,
-      ["ToArray"] = QueryableMethodKind.ToArray,
-      ["ToList"] = QueryableMethodKind.ToList,
-      [nameof(Queryable.Union)] = QueryableMethodKind.Union,
-      [nameof(Queryable.Where)] = QueryableMethodKind.Where
-    };
-
-    /// <inheritdoc/>
-    protected override Expression VisitMethodCall(MethodCallExpression mc)
-    {
-      var mcArguments = mc.Arguments;
-      return (mcArguments.Count > 0 && mcArguments[0].Type == WellKnownTypes.String)
-             || !(GetQueryableMethod(mc) is { } method)
-        ? base.VisitMethodCall(mc)
-        : VisitQueryableMethod(mc, method);
-    }
-
-    /// <summary>
-    /// Visits method of <see cref="IQueryable"/> or <see cref="IEnumerable{T}"/>.
-    /// </summary>
-    /// <param name="mc">The method call expression.</param>
-    /// <param name="methodKind">Kind of the method.</param>
-    protected abstract Expression VisitQueryableMethod(MethodCallExpression mc, QueryableMethodKind methodKind);
-
-    /// <summary>
-    /// Parses <see cref="QueryableMethodKind"/> for the specified expression.
-    /// </summary>
-    /// <param name="call">A call to process.</param>
-    /// <returns><see cref="QueryableMethodKind"/> for the specified expression,
-    /// or null if method is not a LINQ method.</returns>
-    public static QueryableMethodKind? GetQueryableMethod(MethodCallExpression call) =>
-      call?.Method.DeclaringType is { } declaringType
-      && (declaringType == WellKnownTypes.Queryable || declaringType == WellKnownTypes.Enumerable)
-        ? QueryableMethodKindFromName.GetValueOrDefault(call.Method.Name)
-        : null;
+    var mcArguments = mc.Arguments;
+    return (mcArguments.Count > 0 && mcArguments[0].Type == WellKnownTypes.String)
+           || !(GetQueryableMethod(mc) is { } method)
+      ? base.VisitMethodCall(mc)
+      : VisitQueryableMethod(mc, method);
   }
+
+  /// <summary>
+  /// Visits method of <see cref="IQueryable"/> or <see cref="IEnumerable{T}"/>.
+  /// </summary>
+  /// <param name="mc">The method call expression.</param>
+  /// <param name="methodKind">Kind of the method.</param>
+  protected abstract Expression VisitQueryableMethod(MethodCallExpression mc, QueryableMethodKind methodKind);
+
+  /// <summary>
+  /// Parses <see cref="QueryableMethodKind"/> for the specified expression.
+  /// </summary>
+  /// <param name="call">A call to process.</param>
+  /// <returns><see cref="QueryableMethodKind"/> for the specified expression,
+  /// or null if method is not a LINQ method.</returns>
+  public static QueryableMethodKind? GetQueryableMethod(MethodCallExpression call) =>
+    call?.Method.DeclaringType is { } declaringType
+    && (declaringType == WellKnownTypes.Queryable || declaringType == WellKnownTypes.Enumerable)
+      ? QueryableMethodKindFromName.GetValueOrDefault(call.Method.Name)
+      : null;
 }

--- a/Orm/Xtensive.Orm/Linq/QueryableVisitor.cs
+++ b/Orm/Xtensive.Orm/Linq/QueryableVisitor.cs
@@ -89,6 +89,7 @@ public abstract class QueryableVisitor : ExpressionVisitor
   public static QueryableMethodKind? GetQueryableMethod(MethodCallExpression call) =>
     call?.Method.DeclaringType is { } declaringType
     && (declaringType == WellKnownTypes.Queryable || declaringType == WellKnownTypes.Enumerable)
-      ? QueryableMethodKindFromName.GetValueOrDefault(call.Method.Name)
+    && QueryableMethodKindFromName.TryGetValue(call.Method.Name, out var v)
+      ? v
       : null;
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -51,54 +51,34 @@ namespace Xtensive.Orm.Linq
 
     protected override Expression VisitQueryableMethod(MethodCallExpression mc, QueryableMethodKind methodKind)
     {
+      var mcArguments = mc.Arguments;
+      var argsCount = mcArguments.Count;
       using (CreateScope(new TranslatorState(State))) {
         switch (methodKind) {
           case QueryableMethodKind.Cast:
-            return VisitCast(mc.Arguments[0], mc.Method.GetGenericArguments()[0],
-              mc.Arguments[0].Type.GetGenericArguments()[0]);
+            return VisitCast(mcArguments[0], mc.Method.GetGenericArguments()[0],
+              mcArguments[0].Type.GetGenericArguments()[0]);
           case QueryableMethodKind.AsQueryable:
-            return VisitAsQueryable(mc.Arguments[0]);
-          case QueryableMethodKind.AsEnumerable:
-            break;
-          case QueryableMethodKind.ToArray:
-            break;
-          case QueryableMethodKind.ToList:
-            break;
-          case QueryableMethodKind.Aggregate:
-            break;
+            return VisitAsQueryable(mcArguments[0]);
           case QueryableMethodKind.ElementAt:
-            return VisitElementAt(mc.Arguments[0], mc.Arguments[1], context.IsRoot(mc), mc.Method.ReturnType, false);
+            return VisitElementAt(mcArguments[0], mcArguments[1], context.IsRoot(mc), mc.Method.ReturnType, false);
           case QueryableMethodKind.ElementAtOrDefault:
-            return VisitElementAt(mc.Arguments[0], mc.Arguments[1], context.IsRoot(mc), mc.Method.ReturnType, true);
-          case QueryableMethodKind.Last:
-            break;
-          case QueryableMethodKind.LastOrDefault:
-            break;
+            return VisitElementAt(mcArguments[0], mcArguments[1], context.IsRoot(mc), mc.Method.ReturnType, true);
           case QueryableMethodKind.Except:
           case QueryableMethodKind.Intersect:
           case QueryableMethodKind.Concat:
           case QueryableMethodKind.Union:
             using (CreateScope(new TranslatorState(State) { BuildingProjection = false })) {
-              return VisitSetOperations(mc.Arguments[0], mc.Arguments[1], methodKind, mc.Method.GetGenericArguments()[0]);
+              return VisitSetOperations(mcArguments[0], mcArguments[1], methodKind, mc.Method.GetGenericArguments()[0]);
             }
-          case QueryableMethodKind.Reverse:
-            break;
-          case QueryableMethodKind.SequenceEqual:
-            break;
-          case QueryableMethodKind.DefaultIfEmpty:
-            break;
-          case QueryableMethodKind.SkipWhile:
-            break;
-          case QueryableMethodKind.TakeWhile:
-            break;
           case QueryableMethodKind.All:
-            if (mc.Arguments.Count == 2) {
-              return VisitAll(mc.Arguments[0], mc.Arguments[1].StripQuotes(), context.IsRoot(mc));
+            if (argsCount == 2) {
+              return VisitAll(mcArguments[0], mcArguments[1].StripQuotes(), context.IsRoot(mc));
             }
 
             break;
           case QueryableMethodKind.OfType:
-            var source = mc.Arguments[0];
+            var source = mcArguments[0];
             var targetType = mc.Method.GetGenericArguments()[0];
             var sourceType = source.Type;
             if (sourceType.IsGenericType) {
@@ -112,24 +92,24 @@ namespace Xtensive.Orm.Linq
               throw new NotSupportedException();
             }
           case QueryableMethodKind.Any:
-            if (mc.Arguments.Count == 1) {
-              return VisitAny(mc.Arguments[0], null, context.IsRoot(mc));
+            if (argsCount == 1) {
+              return VisitAny(mcArguments[0], null, context.IsRoot(mc));
             }
 
-            if (mc.Arguments.Count == 2) {
-              return VisitAny(mc.Arguments[0], mc.Arguments[1].StripQuotes(), context.IsRoot(mc));
+            if (argsCount == 2) {
+              return VisitAny(mcArguments[0], mcArguments[1].StripQuotes(), context.IsRoot(mc));
             }
 
             break;
           case QueryableMethodKind.Contains:
-            if (mc.Arguments.Count == 2) {
-              return VisitContains(mc.Arguments[0], mc.Arguments[1], context.IsRoot(mc));
+            if (argsCount == 2) {
+              return VisitContains(mcArguments[0], mcArguments[1], context.IsRoot(mc));
             }
 
             break;
           case QueryableMethodKind.Distinct:
-            if (mc.Arguments.Count == 1) {
-              return VisitDistinct(mc.Arguments[0]);
+            if (argsCount == 1) {
+              return VisitDistinct(mcArguments[0]);
             }
 
             break;
@@ -139,13 +119,13 @@ namespace Xtensive.Orm.Linq
           case QueryableMethodKind.FirstOrDefault:
           case QueryableMethodKind.Single:
           case QueryableMethodKind.SingleOrDefault:
-            if (mc.Arguments.Count == 1) {
-              return VisitFirstSingle(mc.Arguments[0], null, mc.Method, context.IsRoot(mc));
+            if (argsCount == 1) {
+              return VisitFirstSingle(mcArguments[0], null, mc.Method, context.IsRoot(mc));
             }
 
-            if (mc.Arguments.Count == 2) {
-              var predicate = (mc.Arguments[1].StripQuotes());
-              return VisitFirstSingle(mc.Arguments[0], predicate, mc.Method, context.IsRoot(mc));
+            if (argsCount == 2) {
+              var predicate = (mcArguments[1].StripQuotes());
+              return VisitFirstSingle(mcArguments[0], predicate, mc.Method, context.IsRoot(mc));
             }
 
             break;
@@ -160,21 +140,21 @@ namespace Xtensive.Orm.Linq
             }
           case QueryableMethodKind.GroupJoin:
             using (CreateScope(new TranslatorState(State) { BuildingProjection = false })) {
-              return VisitGroupJoin(mc.Arguments[0],
-                mc.Arguments[1],
-                mc.Arguments[2].StripQuotes(),
-                mc.Arguments[3].StripQuotes(),
-                mc.Arguments[4].StripQuotes(),
-                mc.Arguments.Count > 5 ? mc.Arguments[5] : null,
+              return VisitGroupJoin(mcArguments[0],
+                mcArguments[1],
+                mcArguments[2].StripQuotes(),
+                mcArguments[3].StripQuotes(),
+                mcArguments[4].StripQuotes(),
+                argsCount > 5 ? mcArguments[5] : null,
                 mc);
             }
           case QueryableMethodKind.Join:
             using (CreateScope(new TranslatorState(State) { BuildingProjection = false })) {
-              return VisitJoin(mc.Arguments[0],
-                mc.Arguments[1],
-                mc.Arguments[2].StripQuotes(),
-                mc.Arguments[3].StripQuotes(),
-                mc.Arguments[4].StripQuotes(),
+              return VisitJoin(mcArguments[0],
+                mcArguments[1],
+                mcArguments[2].StripQuotes(),
+                mcArguments[3].StripQuotes(),
+                mcArguments[4].StripQuotes(),
                 false,
                 mc);
             }
@@ -184,19 +164,19 @@ namespace Xtensive.Orm.Linq
               return VisitSort(mc);
             }
           case QueryableMethodKind.Select:
-            return VisitSelect(mc.Arguments[0], mc.Arguments[1].StripQuotes());
+            return VisitSelect(mcArguments[0], mcArguments[1].StripQuotes());
           case QueryableMethodKind.SelectMany:
-            if (mc.Arguments.Count == 2) {
-              return VisitSelectMany(mc.Arguments[0],
-                mc.Arguments[1].StripQuotes(),
+            if (argsCount == 2) {
+              return VisitSelectMany(mcArguments[0],
+                mcArguments[1].StripQuotes(),
                 null,
                 mc);
             }
 
-            if (mc.Arguments.Count == 3) {
-              return VisitSelectMany(mc.Arguments[0],
-                mc.Arguments[1].StripQuotes(),
-                mc.Arguments[2].StripQuotes(),
+            if (argsCount == 3) {
+              return VisitSelectMany(mcArguments[0],
+                mcArguments[1].StripQuotes(),
+                mcArguments[2].StripQuotes(),
                 mc);
             }
 
@@ -207,24 +187,24 @@ namespace Xtensive.Orm.Linq
           case QueryableMethodKind.Min:
           case QueryableMethodKind.Sum:
           case QueryableMethodKind.Average:
-            if (mc.Arguments.Count == 1) {
-              return VisitAggregate(mc.Arguments[0], mc.Method, null, context.IsRoot(mc), mc);
+            if (argsCount == 1) {
+              return VisitAggregate(mcArguments[0], mc.Method, null, context.IsRoot(mc), mc);
             }
 
-            if (mc.Arguments.Count == 2) {
-              return VisitAggregate(mc.Arguments[0], mc.Method, mc.Arguments[1].StripQuotes(), context.IsRoot(mc), mc);
+            if (argsCount == 2) {
+              return VisitAggregate(mcArguments[0], mc.Method, mcArguments[1].StripQuotes(), context.IsRoot(mc), mc);
             }
 
             break;
           case QueryableMethodKind.Skip:
-            if (mc.Arguments.Count == 2) {
-              return VisitSkip(mc.Arguments[0], mc.Arguments[1]);
+            if (argsCount == 2) {
+              return VisitSkip(mcArguments[0], mcArguments[1]);
             }
 
             break;
           case QueryableMethodKind.Take:
-            if (mc.Arguments.Count == 2) {
-              return VisitTake(mc.Arguments[0], mc.Arguments[1]);
+            if (argsCount == 2) {
+              return VisitTake(mcArguments[0], mcArguments[1]);
             }
 
             break;
@@ -235,8 +215,20 @@ namespace Xtensive.Orm.Linq
             }
           case QueryableMethodKind.Where:
             using (CreateScope(new TranslatorState(State) { BuildingProjection = false })) {
-              return VisitWhere(mc.Arguments[0], mc.Arguments[1].StripQuotes());
+              return VisitWhere(mcArguments[0], mcArguments[1].StripQuotes());
             }
+          case QueryableMethodKind.AsEnumerable
+            or QueryableMethodKind.ToArray
+            or QueryableMethodKind.ToList
+            or QueryableMethodKind.Aggregate
+            or QueryableMethodKind.Last
+            or QueryableMethodKind.LastOrDefault
+            or QueryableMethodKind.Reverse
+            or QueryableMethodKind.SequenceEqual
+            or QueryableMethodKind.DefaultIfEmpty
+            or QueryableMethodKind.SkipWhile
+            or QueryableMethodKind.TakeWhile:
+            break;
           default:
             throw new ArgumentOutOfRangeException(nameof(methodKind));
         }
@@ -247,14 +239,17 @@ namespace Xtensive.Orm.Linq
 
     private Expression VisitAsQueryable(Expression source) => VisitSequence(source);
 
-    private Expression VisitLeftJoin(MethodCallExpression mc) =>
-      VisitJoin(mc.Arguments[0],
-        mc.Arguments[1],
-        mc.Arguments[2].StripQuotes(),
-        mc.Arguments[3].StripQuotes(),
-        mc.Arguments[4].StripQuotes(),
+    private Expression VisitLeftJoin(MethodCallExpression mc)
+    {
+      var mcArguments = mc.Arguments;
+      return VisitJoin(mcArguments[0],
+        mcArguments[1],
+        mcArguments[2].StripQuotes(),
+        mcArguments[3].StripQuotes(),
+        mcArguments[4].StripQuotes(),
         true,
         mc);
+    }
 
     private Expression VisitLock(MethodCallExpression expression)
     {


### PR DESCRIPTION
Also:
* Optimize `VisitQueryableMethod()`:  pre-store `mc.Arguments` to avoid multiple dereference