### PR TITLE
Optimize `propertyFilter` in `Translator` to avoid evaluating the same value multiple times

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Domain.cs
+++ b/Orm/Xtensive.Orm/Orm/Domain.cs
@@ -121,7 +121,7 @@ namespace Xtensive.Orm
 
     internal DomainHandler Handler { get { return Handlers.DomainHandler; } }
 
-    internal HandlerAccessor Handlers { get; private set; }
+    internal HandlerAccessor Handlers { get; }
 
     internal ConcurrentDictionary<TypeInfo, GenericKeyFactory> GenericKeyFactories { get; private set; }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -1352,10 +1352,10 @@ namespace Xtensive.Orm.Linq
       }
 
       Expression result = null;
-      bool propertyFilter(PersistentFieldExpression f)
-      {
-        return f.Name == context.Domain.Handlers.NameBuilder.BuildFieldName((PropertyInfo) member);
-      }
+
+      string builtFieldName = null;
+      bool propertyFilter(PersistentFieldExpression f) =>
+        f.Name == (builtFieldName ??= context.Domain.Handlers.NameBuilder.BuildFieldName((PropertyInfo) member));
 
       switch (extendedExpression.ExtendedType) {
         case ExtendedExpressionType.FullText:


### PR DESCRIPTION
`.BuildFieldName()` is implemented as memoization in `ConcurrentDictionary`, but profiling shows that is bottleneck anyway