### PR TITLE
Use `Module` instead of `ModuleHandle`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Providers/NameBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/NameBuilder.cs
@@ -21,6 +21,7 @@ using Xtensive.Orm.Internals;
 using Xtensive.Orm.Model;
 using Xtensive.Orm.Weaving;
 using Xtensive.Reflection;
+using Module = System.Reflection.Module;
 using FieldInfo = Xtensive.Orm.Model.FieldInfo;
 using TypeInfo = Xtensive.Orm.Model.TypeInfo;
 
@@ -39,14 +40,14 @@ namespace Xtensive.Orm.Providers
     private const string ReferenceForeignKeyFormat = "FK_{0}_{1}_{2}";
     private const string HierarchyForeignKeyFormat = "FK_{0}_{1}";
 
-    private static readonly Func<(int, ModuleHandle), PropertyInfo, string> fieldNameCacheValueFactory =
+    private static readonly Func<(int, Module), PropertyInfo, string> fieldNameCacheValueFactory =
       (key, prop) => prop.GetAttribute<OverrideFieldNameAttribute>()?.Name ?? prop.Name;
 
     private readonly int maxIdentifierLength;
     private readonly NamingConvention namingConvention;
     private readonly bool isMultidatabase;
     private readonly string defaultDatabase;
-    private readonly ConcurrentDictionary<(int, ModuleHandle), string> fieldNameCache = new();
+    private readonly ConcurrentDictionary<(int, Module), string> fieldNameCache = new();
 
     /// <summary>
     /// Gets the <see cref="Entity.TypeId"/> column name.
@@ -194,7 +195,7 @@ namespace Xtensive.Orm.Providers
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private string BuildFieldNameInternal(PropertyInfo propertyInfo)
-      => fieldNameCache.GetOrAdd((propertyInfo.MetadataToken, propertyInfo.Module.ModuleHandle), fieldNameCacheValueFactory, propertyInfo);
+      => fieldNameCache.GetOrAdd((propertyInfo.MetadataToken, propertyInfo.Module), fieldNameCacheValueFactory, propertyInfo);
 
     /// <summary>
     /// Builds the name of the field.

--- a/Orm/Xtensive.Orm/Reflection/AttributeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/AttributeHelper.cs
@@ -8,7 +8,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
-using PerAttributeKey = System.ValueTuple<int, System.ModuleHandle, Xtensive.Reflection.AttributeSearchOptions>;
+using PerAttributeKey = System.ValueTuple<int, System.Reflection.Module, Xtensive.Reflection.AttributeSearchOptions>;
 
 namespace Xtensive.Reflection
 {
@@ -69,7 +69,7 @@ namespace Xtensive.Reflection
       }
 
       public static TAttribute[] Get(MemberInfo member, AttributeSearchOptions options) =>
-        Dictionary.GetOrAdd(new PerAttributeKey(member.MetadataToken, member.Module.ModuleHandle, options), ExtractAttributesByKey, member);
+        Dictionary.GetOrAdd(new PerAttributeKey(member.MetadataToken, member.Module, options), ExtractAttributesByKey, member);
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -50,7 +50,7 @@ namespace Xtensive.Reflection
     private static readonly int NullableTypeMetadataToken = WellKnownTypes.NullableOfT.MetadataToken;
     private static readonly int ValueTuple1MetadataToken = typeof(ValueTuple<>).MetadataToken;
     private static readonly int ValueTuple8MetadataToken = typeof(ValueTuple<,,,,,,,>).MetadataToken;
-    private static readonly ModuleHandle SystemCoreLibModuleHandle = WellKnownTypes.NullableOfT.Module.ModuleHandle;
+    private static readonly Module SystemCoreLibModule = WellKnownTypes.NullableOfT.Module;
     private static readonly Type CompilerGeneratedAttributeType = typeof(CompilerGeneratedAttribute);
     private static readonly string TypeHelperNamespace = typeof(TypeHelper).Namespace;
 
@@ -70,14 +70,14 @@ namespace Xtensive.Reflection
 
     private static readonly ConcurrentDictionary<(Type, Type), InterfaceMapping> interfaceMaps = new();
 
-    private static readonly ConcurrentDictionary<(int, ModuleHandle, Type), MethodInfo> GenericMethodInstances1 = new();
+    private static readonly ConcurrentDictionary<(int, Module, Type), MethodInfo> GenericMethodInstances1 = new();
 
-    private static readonly ConcurrentDictionary<(int, ModuleHandle, Type, Type), MethodInfo> GenericMethodInstances2 = new();
+    private static readonly ConcurrentDictionary<(int, Module, Type, Type), MethodInfo> GenericMethodInstances2 = new();
 #if NET8_0_OR_GREATER
 
-    private static readonly ConcurrentDictionary<(int, ModuleHandle, Type), MethodInvoker> GenericMethodInvokers1 = new();
+    private static readonly ConcurrentDictionary<(int, Module, Type), MethodInvoker> GenericMethodInvokers1 = new();
 
-    private static readonly ConcurrentDictionary<(int, ModuleHandle, Type, Type), MethodInvoker> GenericMethodInvokers2 = new();
+    private static readonly ConcurrentDictionary<(int, Module, Type, Type), MethodInvoker> GenericMethodInvokers2 = new();
 #endif
 
     // .NET8+ caches GenericTypeDefinition
@@ -87,10 +87,10 @@ namespace Xtensive.Reflection
 
     private static readonly ConcurrentDictionary<(Type, Type, Type), Type> GenericTypeInstances2 = new();
 
-    private static readonly Func<(int token, ModuleHandle module, Type typeArgument), MethodInfo, MethodInfo> GenericMethodFactory1 =
+    private static readonly Func<(int token, Module module, Type typeArgument), MethodInfo, MethodInfo> GenericMethodFactory1 =
       (key, genericDefinition) => genericDefinition.MakeGenericMethod(key.typeArgument);
 
-    private static readonly Func<(int token, ModuleHandle module, Type typeArgument1, Type typeArgument2), MethodInfo, MethodInfo> GenericMethodFactory2 =
+    private static readonly Func<(int token, Module module, Type typeArgument1, Type typeArgument2), MethodInfo, MethodInfo> GenericMethodFactory2 =
       (key, genericDefinition) => genericDefinition.MakeGenericMethod(key.typeArgument1, key.typeArgument2);
 
     private static readonly Func<(Type genericDefinition, Type typeArgument), Type> GenericTypeFactory1 =
@@ -100,10 +100,10 @@ namespace Xtensive.Reflection
       key => key.genericDefinition.MakeGenericType(key.typeArgument1, key.typeArgument2);
 #if NET8_0_OR_GREATER
 
-    private static readonly Func<(int token, ModuleHandle module, Type typeArgument), MethodInfo, MethodInvoker> GenericMethodInvokerFactory1 =
+    private static readonly Func<(int token, Module module, Type typeArgument), MethodInfo, MethodInvoker> GenericMethodInvokerFactory1 =
       (key, genericDefinition) => MethodInvoker.Create(genericDefinition.MakeGenericMethod(key.typeArgument));
 
-    private static readonly Func<(int token, ModuleHandle module, Type typeArgument1, Type typeArgument2), MethodInfo, MethodInvoker> GenericMethodInvokerFactory2 =
+    private static readonly Func<(int token, Module module, Type typeArgument1, Type typeArgument2), MethodInfo, MethodInvoker> GenericMethodInvokerFactory2 =
       (key, genericDefinition) => MethodInvoker.Create(genericDefinition.MakeGenericMethod(key.typeArgument1, key.typeArgument2));
 #endif
 
@@ -936,7 +936,7 @@ namespace Xtensive.Reflection
     /// <returns><see langword="True"/> if type is nullable type;
     /// otherwise, <see langword="false"/>.</returns>
     public static bool IsNullable(this Type type) =>
-      (type.MetadataToken ^ NullableTypeMetadataToken) == 0 && type.Module.ModuleHandle == SystemCoreLibModuleHandle;
+      (type.MetadataToken ^ NullableTypeMetadataToken) == 0 && type.Module == SystemCoreLibModule;
 
     /// <summary>
     /// Indicates whether <typeparamref name="T"/> type is a <see cref="Nullable{T}"/> type.
@@ -1000,7 +1000,7 @@ namespace Xtensive.Reflection
     /// <param name="typeArgument">Type argument for final generic method.</param>
     /// <returns>Newly created instance or already existing one.</returns>
     public static MethodInfo CachedMakeGenericMethod(this MethodInfo genericDefinition, Type typeArgument) =>
-      GenericMethodInstances1.GetOrAdd((genericDefinition.MetadataToken, genericDefinition.Module.ModuleHandle, typeArgument), GenericMethodFactory1, genericDefinition);
+      GenericMethodInstances1.GetOrAdd((genericDefinition.MetadataToken, genericDefinition.Module, typeArgument), GenericMethodFactory1, genericDefinition);
 
     /// <summary>
     /// Makes generic <see cref="MethodInfo"/> for given definition and type arguments
@@ -1011,7 +1011,7 @@ namespace Xtensive.Reflection
     /// <param name="typeArgument2">Second type argument for final generic method.</param>
     /// <returns>Newly created instance or already existing one.</returns>
     public static MethodInfo CachedMakeGenericMethod(this MethodInfo genericDefinition, Type typeArgument1, Type typeArgument2) =>
-      GenericMethodInstances2.GetOrAdd((genericDefinition.MetadataToken, genericDefinition.Module.ModuleHandle, typeArgument1, typeArgument2), GenericMethodFactory2, genericDefinition);
+      GenericMethodInstances2.GetOrAdd((genericDefinition.MetadataToken, genericDefinition.Module, typeArgument1, typeArgument2), GenericMethodFactory2, genericDefinition);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -1022,7 +1022,7 @@ namespace Xtensive.Reflection
     /// <param name="typeArgument">Type argument for final generic method.</param>
     /// <returns>Newly created instance or already existing one.</returns>
     public static MethodInvoker CachedMakeGenericMethodInvoker(this MethodInfo genericDefinition, Type typeArgument) =>
-      GenericMethodInvokers1.GetOrAdd((genericDefinition.MetadataToken, genericDefinition.Module.ModuleHandle, typeArgument), GenericMethodInvokerFactory1, genericDefinition);
+      GenericMethodInvokers1.GetOrAdd((genericDefinition.MetadataToken, genericDefinition.Module, typeArgument), GenericMethodInvokerFactory1, genericDefinition);
 
     /// <summary>
     /// Makes <see cref="MethodInvoker"/> for generic <see cref="MethodInfo"/> for given definition and type arguments
@@ -1033,7 +1033,7 @@ namespace Xtensive.Reflection
     /// <param name="typeArgument2">Second type argument for final generic method.</param>
     /// <returns>Newly created instance or already existing one.</returns>
     public static MethodInvoker CachedMakeGenericMethodInvoker(this MethodInfo genericDefinition, Type typeArgument1, Type typeArgument2) =>
-      GenericMethodInvokers2.GetOrAdd((genericDefinition.MetadataToken, genericDefinition.Module.ModuleHandle, typeArgument1, typeArgument2), GenericMethodInvokerFactory2, genericDefinition);
+      GenericMethodInvokers2.GetOrAdd((genericDefinition.MetadataToken, genericDefinition.Module, typeArgument1, typeArgument2), GenericMethodInvokerFactory2, genericDefinition);
 #endif
 
     /// <summary>
@@ -1277,7 +1277,7 @@ namespace Xtensive.Reflection
       // go one after another.
       var currentToken = type.MetadataToken;
       return ((currentToken >= ValueTuple1MetadataToken) && currentToken <= ValueTuple8MetadataToken)
-        && type.Module.ModuleHandle == SystemCoreLibModuleHandle;
+        && type.Module == SystemCoreLibModule;
     }
 
     #region Private \ internal methods


### PR DESCRIPTION
`ModuleHandle` is a wrapper over `Module` (`RuntimeModule`) with additional nul-checking
Why to use it?