### PR TITLE
Make `FieldInfo` more compact

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -152,5 +152,6 @@
     <DefineConstants Condition="'$(DO_SAFE_COLLECTION_WRAPPER)'=='true'">$(DefineConstants);DO_SAFE_COLLECTION_WRAPPER</DefineConstants>
     <DefineConstants Condition="'$(DO_CONFIGURE_AWAIT_FALSE)'=='true'">$(DefineConstants);DO_CONFIGURE_AWAIT_FALSE</DefineConstants>
     <DefineConstants Condition="'$(DO_MAX_1000_COLUMNS)'!='false'">$(DefineConstants);DO_MAX_1000_COLUMNS</DefineConstants>
+    <DefineConstants Condition="'$(DO_MAX_255_FIELDS)'!='false'">$(DefineConstants);DO_MAX_255_FIELDS</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/Orm/Xtensive.Orm.Tests.Sql/SqlServer/SqlDecimalTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/SqlServer/SqlDecimalTest.cs
@@ -234,7 +234,7 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
 
     private static List<byte[]> GetTestCases(bool forFast)
     {
-      byte basePresicion = 38;
+      byte basePrecision = 38;
       byte maxScale = 28;
       byte basePrecisionZeros = 0;
 
@@ -243,12 +243,12 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
       for (byte scale = 0; scale < maxScale; scale++) {
         for (byte zerosInScale = 0; zerosInScale < scale; zerosInScale += 3) {
           if (!forFast) {
-            for (byte precisionZeros = 0; precisionZeros < basePresicion - scale - 1; precisionZeros += 3) {
-              list.Add(new[] { basePresicion, scale, precisionZeros, zerosInScale });
+            for (byte precisionZeros = 0; precisionZeros < basePrecision - scale - 1; precisionZeros += 3) {
+              list.Add(new[] { basePrecision, scale, precisionZeros, zerosInScale });
             }
           }
           else {
-            list.Add(new[] { basePresicion, scale, basePrecisionZeros, zerosInScale });
+            list.Add(new[] { basePrecision, scale, basePrecisionZeros, zerosInScale });
           }
         }
       }

--- a/Orm/Xtensive.Orm.Tests/Storage/CommandProcessing/BatchingCommandProcessorParametersManagement.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/CommandProcessing/BatchingCommandProcessorParametersManagement.cs
@@ -867,7 +867,11 @@ namespace Xtensive.Orm.Tests.Storage.CommandProcessing
           Assert.That(session.Query.All<ALotOfFieldsEntityValid>().Count(), Is.EqualTo(countBefore + 3));
         }
 
+#if DO_MAX_255_FIELDS
+        Assert.That(counter.Count, Is.EqualTo(1));
+#else
         Assert.That(counter.Count, Is.EqualTo(2));
+#endif
       }
     }
 

--- a/Orm/Xtensive.Orm.Tests/Storage/CommandProcessing/BatchingCommandProcessorParametersManagement.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/CommandProcessing/BatchingCommandProcessorParametersManagement.cs
@@ -895,8 +895,11 @@ namespace Xtensive.Orm.Tests.Storage.CommandProcessing
           var result = (await session.Query.All<ALotOfFieldsEntityValid>().ExecuteAsync()).ToArray().Length;
           Assert.That(result, Is.EqualTo(countBefore + 3));
         }
-
+#if DO_MAX_255_FIELDS
+        Assert.That(counter.Count, Is.EqualTo(1));
+#else
         Assert.That(counter.Count, Is.EqualTo(2));
+#endif
       }
     }
 
@@ -1049,7 +1052,11 @@ namespace Xtensive.Orm.Tests.Storage.CommandProcessing
           var result = session.Query.All<ALotOfFieldsEntityValid>().ToArray();
           Assert.That(result.Length, Is.EqualTo(countBefore + batchSize + 1));
         }
+#if DO_MAX_255_FIELDS
+        Assert.That(counter.Count, Is.EqualTo(4));
+#else
         Assert.That(counter.Count, Is.EqualTo(13));
+#endif
       }
     }
 
@@ -1119,7 +1126,11 @@ namespace Xtensive.Orm.Tests.Storage.CommandProcessing
           session.SaveChanges();
         }
 
+#if DO_MAX_255_FIELDS
+        Assert.That(counter.Count, Is.EqualTo(1));
+#else
         Assert.That(counter.Count, Is.EqualTo(2));
+#endif
       }
     }
   }

--- a/Orm/Xtensive.Orm.Tests/Storage/CommandProcessing/ParametersManagementModel.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/CommandProcessing/ParametersManagementModel.cs
@@ -163,8 +163,8 @@ namespace Xtensive.Orm.Tests.Storage.CommandProcessing
       var maxcount = originalCount;
 
 #if DO_MAX_1000_COLUMNS
-      if (maxcount > 989) {
-        maxcount = 989;
+      if (maxcount > Math.Min((int)FieldInfo.MaxFieldId, 989)) {
+        maxcount = Math.Min((int) FieldInfo.MaxFieldId, 989);
       }
 #else
       if (maxcount > 1024) {

--- a/Orm/Xtensive.Orm.Tests/Storage/CommandProcessing/ParametersManagementModel.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/CommandProcessing/ParametersManagementModel.cs
@@ -163,7 +163,7 @@ namespace Xtensive.Orm.Tests.Storage.CommandProcessing
       var maxcount = originalCount;
 
 #if DO_MAX_1000_COLUMNS
-      maxcount = Math.Clamp(maxcount, 1, Math.Min((int) FieldInfo.MaxFieldId, 989));
+      maxcount = Math.Clamp(maxcount, 1, Math.Min((int) FieldInfo.MaxFieldId - 1, 989));
 #else
       if (maxcount > 1024) {
         maxcount = 1000;

--- a/Orm/Xtensive.Orm.Tests/Storage/CommandProcessing/ParametersManagementModel.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/CommandProcessing/ParametersManagementModel.cs
@@ -163,7 +163,7 @@ namespace Xtensive.Orm.Tests.Storage.CommandProcessing
       var maxcount = originalCount;
 
 #if DO_MAX_1000_COLUMNS
-      if (maxcount > Math.Min((int)FieldInfo.MaxFieldId, 989)) {
+      if (maxcount > Math.Min((int) FieldInfo.MaxFieldId, 989)) {
         maxcount = Math.Min((int) FieldInfo.MaxFieldId, 989);
       }
 #else

--- a/Orm/Xtensive.Orm.Tests/Storage/CommandProcessing/ParametersManagementModel.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/CommandProcessing/ParametersManagementModel.cs
@@ -163,7 +163,7 @@ namespace Xtensive.Orm.Tests.Storage.CommandProcessing
       var maxcount = originalCount;
 
 #if DO_MAX_1000_COLUMNS
-      maxcount = Math.Clamp(maxcount, 1, Math.Min((int) FieldInfo.MaxFieldId - 1, 989));
+      maxcount = Math.Clamp(maxcount, 1, Math.Min((int) FieldInfo.MaxFieldId - 11, 989));
 #else
       if (maxcount > 1024) {
         maxcount = 1000;
@@ -191,7 +191,7 @@ namespace Xtensive.Orm.Tests.Storage.CommandProcessing
         _ = t.DefineField(fieldName, typeof(int));
       }
 
-      // each entitity field count is valid
+      // each entity field count is valid
       // overall entity field count is valid
       var types = new TypeDef[] {
         model.Types[typeof(SeveralPersistActionsEntityValidA)],
@@ -224,7 +224,7 @@ namespace Xtensive.Orm.Tests.Storage.CommandProcessing
       currentFieldCount = 0;
       var fieldsCount = 2100;
 #if DO_MAX_1000_COLUMNS
-      fieldsCount = 990;
+      fieldsCount = Math.Min(990, FieldInfo.MaxFieldId - 11);
 #endif
       foreach (var fieldName in GetFieldNames(fieldsCount)) {
         _ = types[indexToWrite].DefineField(fieldName, typeof(int));

--- a/Orm/Xtensive.Orm.Tests/Storage/CommandProcessing/ParametersManagementModel.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/CommandProcessing/ParametersManagementModel.cs
@@ -163,9 +163,7 @@ namespace Xtensive.Orm.Tests.Storage.CommandProcessing
       var maxcount = originalCount;
 
 #if DO_MAX_1000_COLUMNS
-      if (maxcount > Math.Min((int) FieldInfo.MaxFieldId, 989)) {
-        maxcount = Math.Min((int) FieldInfo.MaxFieldId, 989);
-      }
+      maxcount = Math.Clamp(maxcount, 1, Math.Min((int) FieldInfo.MaxFieldId, 989));
 #else
       if (maxcount > 1024) {
         maxcount = 1000;

--- a/Orm/Xtensive.Orm.Tests/Upgrade/ColumnTypeTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Upgrade/ColumnTypeTest.cs
@@ -492,18 +492,18 @@ namespace Xtensive.Orm.Tests.Upgrade
 
     private void ChangeFieldTypeTest(
       string fieldName, Type newColumnType, object expectedValue,
-      DomainUpgradeMode mode, int? newLength, int? newPresicion, int? newScale) =>
-      ChangeFieldTypeTest(fieldName, newColumnType, expectedValue, mode, newLength, newPresicion, newScale, null);
+      DomainUpgradeMode mode, int? newLength, sbyte? newPrecision, sbyte? newScale) =>
+      ChangeFieldTypeTest(fieldName, newColumnType, expectedValue, mode, newLength, newPrecision, newScale, null);
 
     private Task ChangeFieldTypeAsyncTest(string fieldName,
       Type newColumnType,
       object expectedValue,
       DomainUpgradeMode mode,
       int? newLength,
-      int? newPresicion,
-      int? newScale)
+      sbyte? newPrecision,
+      sbyte? newScale)
     {
-      return ChangeFieldTypeAsyncTest(fieldName, newColumnType, expectedValue, mode, newLength, newPresicion, newScale, null);
+      return ChangeFieldTypeAsyncTest(fieldName, newColumnType, expectedValue, mode, newLength, newPrecision, newScale, null);
     }
 
     private void ChangeFieldTypeTest(string fieldName,
@@ -511,8 +511,8 @@ namespace Xtensive.Orm.Tests.Upgrade
       object expectedValue,
       DomainUpgradeMode mode,
       int? newLength,
-      int? newPrecision,
-      int? newScale,
+      sbyte? newPrecision,
+      sbyte? newScale,
       bool? isNullable)
     {
       using (FieldTypeChanger.Enable(newColumnType, fieldName, newLength, newPrecision, newScale, isNullable)) {
@@ -531,8 +531,8 @@ namespace Xtensive.Orm.Tests.Upgrade
       object expectedValue,
       DomainUpgradeMode mode,
       int? newLength,
-      int? newPrecision,
-      int? newScale,
+      sbyte? newPrecision,
+      sbyte? newScale,
       bool? isNullable)
     {
       using (FieldTypeChanger.Enable(newColumnType, fieldName, newLength, newPrecision, newScale, isNullable)) {
@@ -633,13 +633,13 @@ namespace Xtensive.Orm.Tests.Upgrade
     private static Type ColumnType { get; set; }
     private static string ColumnName { get; set; }
     private static int? ColumnLength { get; set; }
-    private static int? ColumnScale { get; set; }
-    private static int? ColumnPrecision { get; set; }
+    private static sbyte? ColumnScale { get; set; }
+    private static sbyte? ColumnPrecision { get; set; }
     private static bool? ColumnNullable { get; set; }
     private static bool isEnabled;
 
     /// <exception cref="InvalidOperationException">Handler is already enabled.</exception>
-    public static IDisposable Enable(Type newType, string fieldName, int? length, int? precision, int? scale, bool? isNullable)
+    public static IDisposable Enable(Type newType, string fieldName, int? length, sbyte? precision, sbyte? scale, bool? isNullable)
     {
       if (isEnabled) {
         throw new InvalidOperationException();

--- a/Orm/Xtensive.Orm/Orm/Attributes/FieldAttribute.cs
+++ b/Orm/Xtensive.Orm/Orm/Attributes/FieldAttribute.cs
@@ -17,8 +17,8 @@ namespace Xtensive.Orm
   public sealed class FieldAttribute : StorageAttribute
   {
     internal int? length;
-    internal int? scale;
-    internal int? precision;
+    internal sbyte? scale;
+    internal sbyte? precision;
     internal bool? nullable;
     internal bool? nullableOnUpgrade;
     internal bool? indexed;
@@ -51,10 +51,10 @@ namespace Xtensive.Orm
     /// <remarks>
     /// This property can be specified for <see cref="decimal"/> type.
     /// </remarks>
-    public int Scale
+    public sbyte Scale
     {
-      get { return scale ?? 0; }
-      set { scale = value; }
+      get => scale ?? 0;
+      set => scale = value;
     }
 
     /// <summary>
@@ -63,10 +63,10 @@ namespace Xtensive.Orm
     /// <remarks>
     /// This property can be specified for <see cref="decimal"/> type.
     /// </remarks>
-    public int Precision
+    public sbyte Precision
     {
-      get { return precision ?? 0; }
-      set { precision = value; }
+      get => precision ?? 0;
+      set => precision = value;
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Building/Definitions/FieldDef.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Definitions/FieldDef.cs
@@ -30,8 +30,8 @@ namespace Xtensive.Orm.Building.Definitions
     private OnRemoveAction?                 onOwnerRemove;
     private string                          pairTo;
     private int?                            length;
-    private int?                            scale;
-    private int?                            precision;
+    private sbyte?                          scale;
+    private sbyte?                          precision;
     private object                          defaultValue;
     private string                          defaultSqlExpression;
     private Validator                       validator;
@@ -53,9 +53,9 @@ namespace Xtensive.Orm.Building.Definitions
     /// <summary>
     /// Gets or sets the scale of the field.
     /// </summary>
-    public int? Scale
+    public sbyte? Scale
     {
-      get { return scale; }
+      get => scale;
       set
       {
         if (value.HasValue)
@@ -67,9 +67,9 @@ namespace Xtensive.Orm.Building.Definitions
     /// <summary>
     /// Gets or sets the precision of the field.
     /// </summary>
-    public int? Precision
+    public sbyte? Precision
     {
-      get { return precision; }
+      get => precision;
       set
       {
         if (value.HasValue)

--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
@@ -67,8 +67,8 @@ namespace Xtensive.Orm.Model
     private byte fieldId;
     private byte adapterIndex = 255;
 #else
-    public const byte MaxFieldId = 32767;
-    public const byte NoAdapterIndex = -1;
+    public const short MaxFieldId = 32767;
+    public const short NoAdapterIndex = -1;
     private short fieldId;
     private short adapterIndex = -1;
 #endif

--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
@@ -40,13 +40,15 @@ namespace Xtensive.Orm.Model
     /// Minimal possible <see cref="FieldId"/> value.
     /// Value is <see langword="100" />.
     /// </summary>
-    public const byte MinFieldId = 1;    
+    public const byte MinFieldId = 1;
+
+    public const sbyte NoScalePrecision = -128;
 
     private PropertyInfo underlyingProperty;
     private Type valueType;
     private int? length;
-    private sbyte? scale;
-    private sbyte? precision;
+    private sbyte scale = NoScalePrecision;
+    private sbyte precision = NoScalePrecision;
     private object defaultValue;
     private string defaultSqlExpression;
     private TypeInfo reflectedType;
@@ -400,11 +402,11 @@ namespace Xtensive.Orm.Model
     public sbyte? Scale
     {
       [DebuggerStepThrough]
-      get => scale;
+      get => scale == NoScalePrecision ? null : scale;
       [DebuggerStepThrough]
       set {
         EnsureNotLocked();
-        scale = value;
+        scale = value ?? NoScalePrecision;
       }
     }
 
@@ -414,11 +416,11 @@ namespace Xtensive.Orm.Model
     public sbyte? Precision
     {
       [DebuggerStepThrough]
-      get => precision;
+      get => precision == NoScalePrecision ? null : precision;
       [DebuggerStepThrough]
       set {
         EnsureNotLocked();
-        precision = value;
+        precision = value ?? NoScalePrecision;
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
@@ -41,7 +41,6 @@ namespace Xtensive.Orm.Model
     /// Value is <see langword="100" />.
     /// </summary>
     public const byte MinFieldId = 1;    
-    public const byte MaxFieldId = 255;
 
     private PropertyInfo underlyingProperty;
     private Type valueType;
@@ -58,12 +57,22 @@ namespace Xtensive.Orm.Model
     private Type itemType;
     private string originalName;
     internal SegmentTransform valueExtractor;
-    private byte adapterIndex = 255;
     private ColumnInfoCollection columns;
-    private byte fieldId;
     private long cachedHashCode;
-
     private Segment<ColNum> mappingInfo;
+
+#if DO_MAX_255_FIELDS
+    public const byte MaxFieldId = 255;
+    public const byte NoAdapterIndex = 255;
+    private byte fieldId;
+    private byte adapterIndex = 255;
+#else
+    public const byte MaxFieldId = 32767;
+    public const byte NoAdapterIndex = -1;
+    private short fieldId;
+    private short adapterIndex = -1;
+#endif
+
 
     #region IsXxx properties
 
@@ -72,7 +81,11 @@ namespace Xtensive.Orm.Model
     /// in <see cref="TypeInfo.Fields"/> collection of <see cref="ReflectedType"/>.
     /// </summary>
     /// <exception cref="NotSupportedException">Property is already initialized.</exception>
+#if DO_MAX_255_FIELDS
     public byte FieldId
+#else
+    public short FieldId
+#endif
     {
       [DebuggerStepThrough]
       get => fieldId;
@@ -587,7 +600,7 @@ namespace Xtensive.Orm.Model
     public int AdapterIndex
     {
       [DebuggerStepThrough]
-      get => adapterIndex == 255 ? -1 : adapterIndex;
+      get => adapterIndex == NoAdapterIndex ? -1 : adapterIndex;
       [DebuggerStepThrough]
       internal set {
         EnsureNotLocked();

--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
@@ -34,19 +34,20 @@ namespace Xtensive.Orm.Model
     /// "No <see cref="NoFieldId"/>" value (<see cref="NoFieldId"/> is unknown or undefined).
     /// Value is <see langword="0" />.
     /// </summary>
-    public const int NoFieldId = 0;
+    public const byte NoFieldId = 0;
 
     /// <summary>
     /// Minimal possible <see cref="FieldId"/> value.
     /// Value is <see langword="100" />.
     /// </summary>
-    public const int MinFieldId = 1;
+    public const byte MinFieldId = 1;    
+    public const byte MaxFieldId = 255;
 
     private PropertyInfo underlyingProperty;
     private Type valueType;
     private int? length;
-    private int? scale;
-    private int? precision;
+    private sbyte? scale;
+    private sbyte? precision;
     private object defaultValue;
     private string defaultSqlExpression;
     private TypeInfo reflectedType;
@@ -57,9 +58,9 @@ namespace Xtensive.Orm.Model
     private Type itemType;
     private string originalName;
     internal SegmentTransform valueExtractor;
-    private int adapterIndex = -1;
+    private byte adapterIndex = 255;
     private ColumnInfoCollection columns;
-    private int fieldId;
+    private byte fieldId;
     private long cachedHashCode;
 
     private Segment<ColNum> mappingInfo;
@@ -71,10 +72,10 @@ namespace Xtensive.Orm.Model
     /// in <see cref="TypeInfo.Fields"/> collection of <see cref="ReflectedType"/>.
     /// </summary>
     /// <exception cref="NotSupportedException">Property is already initialized.</exception>
-    public int FieldId
+    public byte FieldId
     {
       [DebuggerStepThrough]
-      get { return fieldId; }
+      get => fieldId;
       set {
         if (fieldId != NoFieldId)
           throw Exceptions.AlreadyInitialized("FieldId");
@@ -383,10 +384,10 @@ namespace Xtensive.Orm.Model
     /// <summary>
     /// Gets or sets the scale of the field.
     /// </summary>
-    public int? Scale
+    public sbyte? Scale
     {
       [DebuggerStepThrough]
-      get { return scale; }
+      get => scale;
       [DebuggerStepThrough]
       set {
         EnsureNotLocked();
@@ -397,10 +398,10 @@ namespace Xtensive.Orm.Model
     /// <summary>
     /// Gets or sets the precision of the field.
     /// </summary>
-    public int? Precision
+    public sbyte? Precision
     {
       [DebuggerStepThrough]
-      get { return precision; }
+      get => precision;
       [DebuggerStepThrough]
       set {
         EnsureNotLocked();
@@ -586,11 +587,11 @@ namespace Xtensive.Orm.Model
     public int AdapterIndex
     {
       [DebuggerStepThrough]
-      get { return adapterIndex; }
+      get => adapterIndex == 255 ? -1 : adapterIndex;
       [DebuggerStepThrough]
-      set {
+      internal set {
         EnsureNotLocked();
-        adapterIndex = value;
+        adapterIndex = (byte)value;
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
@@ -638,7 +638,9 @@ namespace Xtensive.Orm.Model
     {
       base.UpdateState();
 
-      var adapterIndex = 0;
+      if (Fields.Count > FieldInfo.MaxFieldId)
+        throw new NotSupportedException($"Max number of supported fields is {FieldInfo.MaxFieldId}");
+      byte adapterIndex = 0;
       foreach (var field in Fields) {
         if (field.IsStructure || field.IsEntitySet) {
           field.AdapterIndex = adapterIndex++;
@@ -757,7 +759,9 @@ namespace Xtensive.Orm.Model
     {
       base.Lock(recursive);
 
-      int currentFieldId = FieldInfo.MinFieldId;
+      if (fields.Count > FieldInfo.MaxFieldId)
+        throw new NotSupportedException($"Max number of supported fields is {FieldInfo.MaxFieldId}");
+      byte currentFieldId = FieldInfo.MinFieldId;
       foreach (var field in fields)
         field.FieldId = currentFieldId++;
       isLeaf = GetIsLeaf();


### PR DESCRIPTION
Instances of `FieldInfo` are accessed very frequently
More compact representation will have more chances to be in CPU cache

* `Precision` & `Scale` are tiny numbers (< 20)
* Limit number of `[Field]`s in class by 255. It seems to be enough for our purposes
* Add `DO_MAX_255_FIELDS` preprocessor constant for easy switching back
* Fix typo