### PR TITLE
Optimize `MakeDelegateType()`

### DIFF
--- a/Orm/Xtensive.Orm/Core/Extensions/ArrayExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/ArrayExtensions.cs
@@ -155,26 +155,6 @@ namespace Xtensive.Core
     }
 
     /// <summary>
-    /// Creates new array consisting of <paramref name="items"/>
-    /// and <paramref name="item"/> added before array elements.
-    /// If <paramref name="items"/> is <see langword="null"/>
-    /// returns array that contains just <paramref name="item"/>.
-    /// </summary>
-    /// <typeparam name="TItem">The type of the item.</typeparam>
-    /// <param name="items">The items.</param>
-    /// <param name="item">The prefix item.</param>
-    /// <returns>Result array.</returns>
-    public static TItem[] Prepend<TItem>(this TItem[] items, TItem item)
-    {
-      if (items == null || items.Length == 0)
-        return new [] {item};
-      var result = new TItem[items.Length + 1];
-      Array.Copy(items, 0, result, 1, items.Length);
-      result[0] = item;
-      return result;
-    }
-
-    /// <summary>
     /// Combines the specified source and target arrays into new one.
     /// </summary>
     /// <typeparam name="TItem">The type of the item.</typeparam>

--- a/Orm/Xtensive.Orm/Linq/ConstantExtractor.cs
+++ b/Orm/Xtensive.Orm/Linq/ConstantExtractor.cs
@@ -9,9 +9,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using Xtensive.Collections;
-using Xtensive.Core;
-
 using Xtensive.Reflection;
+using Expr = Xtensive.Core.Expr;
+using Memoizer = Xtensive.Core.Memoizer;
 
 namespace Xtensive.Linq
 {

--- a/Orm/Xtensive.Orm/Linq/ConstantExtractor.cs
+++ b/Orm/Xtensive.Orm/Linq/ConstantExtractor.cs
@@ -76,7 +76,7 @@ namespace Xtensive.Linq
     private static Type FixDelegateType(Type delegateType) =>
       Memoizer.Get(delegateType, static t =>
         DelegateHelper.GetDelegateSignature(t) switch {
-          var signature => DelegateHelper.MakeDelegateType(signature.First, signature.Second.Prepend(ConstantParameter.Type))
+          var signature => DelegateHelper.MakeDelegateType(signature.First, signature.Second.Prepend(ConstantParameter.Type), signature.Second.Length + 1)
         });
 
     private static bool DefaultConstantFilter(ConstantExpression constant)

--- a/Orm/Xtensive.Orm/Linq/ConstantExtractor.cs
+++ b/Orm/Xtensive.Orm/Linq/ConstantExtractor.cs
@@ -9,9 +9,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using Xtensive.Collections;
+using Xtensive.Core;
 using Xtensive.Reflection;
-using Expr = Xtensive.Core.Expr;
-using Memoizer = Xtensive.Core.Memoizer;
 
 namespace Xtensive.Linq
 {

--- a/Orm/Xtensive.Orm/Linq/Internals/LambdaExpressionFactory.cs
+++ b/Orm/Xtensive.Orm/Linq/Internals/LambdaExpressionFactory.cs
@@ -59,7 +59,7 @@ namespace Xtensive.Linq
 
     public LambdaExpression CreateLambda(Expression body, IReadOnlyList<ParameterExpression> parameters)
     {
-      var delegateType = DelegateHelper.MakeDelegateType(body.Type, parameters.Select(p => p.Type));
+      var delegateType = DelegateHelper.MakeDelegateType(body.Type, parameters.Select(p => p.Type), parameters.Count);
       return CreateLambda(delegateType, body, parameters);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/MemberCompilerProviderBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/MemberCompilerProviderBuilder.cs
@@ -135,7 +135,7 @@ namespace Xtensive.Orm.Building.Builders
 
       if (isStatic)
         return (_, _this, parameters) => substitution.BindParameters(parameters);
-      return (_, _this, parameters) => substitution.BindParameters(parameters.Prepend(_this));
+      return (_, _this, parameters) => substitution.BindParameters(parameters.Prepend(_this).ToArray());
     }
 
 

--- a/Orm/Xtensive.Orm/Orm/Model/TypeIndexInfoCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeIndexInfoCollection.cs
@@ -53,8 +53,9 @@ namespace Xtensive.Orm.Model
       var names = (fieldNames ?? Array.Empty<string>()).Prepend(fieldName);
 
       var fields = new List<FieldInfo>();
+      var reflectedTypeFields = primaryIndex.ReflectedType.Fields;
       foreach (var name in names) {
-        if (primaryIndex.ReflectedType.Fields.TryGetValue(name, out var field)) {
+        if (reflectedTypeFields.TryGetValue(name, out var field)) {
           fields.Add(field);
         }
       }

--- a/Orm/Xtensive.Orm/Orm/Model/TypeIndexInfoCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeIndexInfoCollection.cs
@@ -80,17 +80,16 @@ namespace Xtensive.Orm.Model
 
     private IndexInfo GetIndex(IEnumerable<FieldInfo> fields)
     {
-      Action<IEnumerable<FieldInfo>, List<ColumnInfo>> columnsExtractor = null;
-      columnsExtractor = ((fieldsToExtract, extractedColumns) => {
+      void columnsExtractor(IEnumerable<FieldInfo> fieldsToExtract, List<ColumnInfo> extractedColumns) {
         foreach (var field in fieldsToExtract) {
-          if (field.Column==null) {
-            if (field.IsEntity || field.IsStructure)
-              columnsExtractor(field.Fields, extractedColumns);
-          }
-          else
+          if (field.Column != null) {
             extractedColumns.Add(field.Column);
+          }
+          else if (field.IsEntity || field.IsStructure) {
+            columnsExtractor(field.Fields, extractedColumns);
+          }
         }
-      });
+      }
 
       var columns = new List<ColumnInfo>();
       columnsExtractor(fields, columns);

--- a/Orm/Xtensive.Orm/Orm/Model/TypeIndexInfoCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeIndexInfoCollection.cs
@@ -84,8 +84,8 @@ namespace Xtensive.Orm.Model
 
       void columnsExtractor(IEnumerable<FieldInfo> fieldsToExtract) {
         foreach (var field in fieldsToExtract) {
-          if (field.Column != null) {
-            columns.Add(field.Column);
+          if (field.Column is { } column) {
+            columns.Add(column);
           }
           else if (field.IsEntity || field.IsStructure) {
             columnsExtractor(field.Fields);
@@ -97,9 +97,10 @@ namespace Xtensive.Orm.Model
       var columnNumber = columns.Count;
 
       var candidates = this
-        .Where(i => i.KeyColumns.Take(columnNumber)
-          .Select((pair, index) => (column: pair.Key, columnIndex: index))
-          .All(p => p.column == columns[p.columnIndex]))
+        .Where(i => i.KeyColumns
+          .Take(columnNumber)
+          .Select((pair, index) => pair.Key == columns[index])
+          .All(o => o))
         .OrderByDescending(i => i.Attributes).ToList();
 
       return candidates.Where(c => c.KeyColumns.Count == columnNumber).FirstOrDefault() ?? candidates.FirstOrDefault();

--- a/Orm/Xtensive.Orm/Orm/Model/TypeIndexInfoCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeIndexInfoCollection.cs
@@ -80,19 +80,20 @@ namespace Xtensive.Orm.Model
 
     private IndexInfo GetIndex(IEnumerable<FieldInfo> fields)
     {
-      void columnsExtractor(IEnumerable<FieldInfo> fieldsToExtract, List<ColumnInfo> extractedColumns) {
+      var columns = new List<ColumnInfo>();
+
+      void columnsExtractor(IEnumerable<FieldInfo> fieldsToExtract) {
         foreach (var field in fieldsToExtract) {
           if (field.Column != null) {
-            extractedColumns.Add(field.Column);
+            columns.Add(field.Column);
           }
           else if (field.IsEntity || field.IsStructure) {
-            columnsExtractor(field.Fields, extractedColumns);
+            columnsExtractor(field.Fields);
           }
         }
       }
 
-      var columns = new List<ColumnInfo>();
-      columnsExtractor(fields, columns);
+      columnsExtractor(fields);
       var columnNumber = columns.Count;
 
       var candidates = this
@@ -101,9 +102,7 @@ namespace Xtensive.Orm.Model
           .All(p => p.column == columns[p.columnIndex]))
         .OrderByDescending(i => i.Attributes).ToList();
 
-      var result = candidates.Where(c => c.KeyColumns.Count==columnNumber).FirstOrDefault();
-
-      return result ?? candidates.FirstOrDefault();
+      return candidates.Where(c => c.KeyColumns.Count == columnNumber).FirstOrDefault() ?? candidates.FirstOrDefault();
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Model/TypeIndexInfoCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeIndexInfoCollection.cs
@@ -66,12 +66,8 @@ namespace Xtensive.Orm.Model
       return GetIndex(fields);
     }
 
-    public IndexInfo GetIndex(FieldInfo field, params FieldInfo[] fields)
-    {
-      var fieldInfos = new List<FieldInfo> {field};
-      fieldInfos.AddRange(fields);
-      return GetIndex(fieldInfos);
-    }
+    public IndexInfo GetIndex(FieldInfo field, params FieldInfo[] fields) =>
+      GetIndex(fields.Prepend(field));
 
     /// <inheritdoc/>
     public override void UpdateState()

--- a/Orm/Xtensive.Orm/Orm/Model/TypeIndexInfoCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeIndexInfoCollection.cs
@@ -80,7 +80,7 @@ namespace Xtensive.Orm.Model
 
     private IndexInfo GetIndex(IEnumerable<FieldInfo> fields)
     {
-      Action<IEnumerable<FieldInfo>, IList<ColumnInfo>> columnsExtractor = null;
+      Action<IEnumerable<FieldInfo>, List<ColumnInfo>> columnsExtractor = null;
       columnsExtractor = ((fieldsToExtract, extractedColumns) => {
         foreach (var field in fieldsToExtract) {
           if (field.Column==null) {
@@ -97,10 +97,9 @@ namespace Xtensive.Orm.Model
       var columnNumber = columns.Count;
 
       var candidates = this
-        .Where(i => i.KeyColumns
-          .TakeWhile((_, index) => index < columns.Count)
+        .Where(i => i.KeyColumns.Take(columnNumber)
           .Select((pair, index) => (column: pair.Key, columnIndex: index))
-          .All(p => p.column==columns[p.columnIndex]))
+          .All(p => p.column == columns[p.columnIndex]))
         .OrderByDescending(i => i.Attributes).ToList();
 
       var result = candidates.Where(c => c.KeyColumns.Count==columnNumber).FirstOrDefault();

--- a/Orm/Xtensive.Orm/Reflection/DelegateHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/DelegateHelper.cs
@@ -472,29 +472,15 @@ namespace Xtensive.Reflection
     /// </summary>
     /// <param name="returnType">Type of return value.</param>
     /// <param name="parameterTypes">Types of parameters.</param>
+    /// /// <param name="n">Length of <paramref name="parameterTypes" />.</param>
     /// <returns>Created delegate type.</returns>
-    public static Type MakeDelegateType(Type returnType, params Type[] parameterTypes)
+    internal static Type MakeDelegateType(Type returnType, IEnumerable<Type> parameterTypes, int n)
     {
-      ArgumentNullException.ThrowIfNull(parameterTypes);
-      var n = parameterTypes.Length;
       ArgumentOutOfRangeException.ThrowIfGreaterThan(n, MaxNumberOfGenericDelegateParameters);
-      if (returnType == WellKnownTypes.Void || returnType == null) {
-        return n == 0 ? ActionTypes[0] : ActionTypes[n].MakeGenericType(parameterTypes);
-      }
-      var funcGenericParameters = parameterTypes.Append(returnType).ToArray();
-      return FuncTypes[funcGenericParameters.Length - 1].MakeGenericType(funcGenericParameters);
-    }
-
-    /// <summary>
-    /// Creates a delegate type that represents a delegate that calls a method with specified signature.
-    /// </summary>
-    /// <param name="returnType">Type of return value.</param>
-    /// <param name="parameterTypes">Types of parameters.</param>
-    /// <returns>Created delegate type.</returns>
-    public static Type MakeDelegateType(Type returnType, IEnumerable<Type> parameterTypes)
-    {
-      ArgumentNullException.ThrowIfNull(parameterTypes);
-      return MakeDelegateType(returnType, parameterTypes.ToArray());
+      return returnType != WellKnownTypes.Void && returnType != null
+        ? FuncTypes[n].MakeGenericType(parameterTypes.Append(returnType).ToArray())
+        : n == 0 ? ActionTypes[0]
+        : ActionTypes[n].MakeGenericType(parameterTypes.ToArray());
     }
 
     /// <summary>


### PR DESCRIPTION
* Avoid intermediate array allocation
* Make this function internal
* Remove unused overload with `params`
* Avoid redundant null-checking
* Use LINQ `.Prepend()` instead of `Xtensive.Core`'s
* Ret rid of `Xtensive.Core.Prepend()` to avoid confusion with LINQ. There was only one remaining usage 
* Optimize `TypeIndexInfoCollection.GetIndex()`: replace `.TakeWhile()` by `.Take()`
* Make `columnsExtractor()` a local function