### PR TITLE
Make `ParameterExpressionRegistry` readonly struct

### DIFF
--- a/Orm/Xtensive.Orm/Linq/ExpressionExtensions.cs
+++ b/Orm/Xtensive.Orm/Linq/ExpressionExtensions.cs
@@ -70,7 +70,7 @@ namespace Xtensive.Linq
     /// </summary>
     /// <param name="expression">The expression to convert.</param>
     /// <returns>Expression tree that wraps <paramref name="expression"/>.</returns>
-    public static ExpressionTree ToExpressionTree(this Expression expression) => new ExpressionTree(expression);
+    internal static ExpressionTree ToExpressionTree(this Expression expression) => new(expression);
 
 
     // Type initializer

--- a/Orm/Xtensive.Orm/Linq/ExpressionTree.cs
+++ b/Orm/Xtensive.Orm/Linq/ExpressionTree.cs
@@ -4,7 +4,6 @@
 // Created by: Denis Krjuchkov
 // Created:    2009.05.06
 
-using System;
 using System.Diagnostics;
 using System.Linq.Expressions;
 using Xtensive.Core;
@@ -16,10 +15,10 @@ namespace Xtensive.Linq
   /// that can be used for comparing expression trees and calculating their hash codes.
   /// </summary>
   [DebuggerDisplay("{expression}")]
-  public readonly struct ExpressionTree : IEquatable<ExpressionTree>
+  internal readonly struct ExpressionTree(Expression expr) : IEquatable<ExpressionTree>
   {
-    private readonly int hashCode;
-    private readonly Expression expression;
+    private readonly Expression expression = expr;
+    private readonly int hashCode = new ExpressionHashCodeCalculator().CalculateHashCode(expr);
 
     /// <summary>
     /// Gets the underlying <see cref="Expression"/>.
@@ -49,7 +48,7 @@ namespace Xtensive.Linq
     /// <returns><see langword="true"/> if <paramref name="left"/> is equal to <paramref name="right"/>.
     /// Otherwise, <see langword="false"/>.
     /// </returns>
-    public static bool operator == (ExpressionTree left, ExpressionTree right) => Equals(left, right);
+    public static bool operator == (ExpressionTree left, ExpressionTree right) => left.Equals(right);
 
     /// <summary>
     /// Implements the operator !=.
@@ -59,7 +58,7 @@ namespace Xtensive.Linq
     /// <returns><see langword="true"/> if <paramref name="left"/> is not equal to <paramref name="right"/>.
     /// Otherwise, <see langword="false"/>.
     /// </returns>
-    public static bool operator != (ExpressionTree left, ExpressionTree right) => !Equals(left, right);
+    public static bool operator != (ExpressionTree left, ExpressionTree right) => !left.Equals(right);
 
     #endregion
 
@@ -78,14 +77,5 @@ namespace Xtensive.Linq
     /// <param name="expression">Expression to calculate hash code for.</param>
     /// <returns>Hash code for <paramref name="expression"/>.</returns>
     public static int GetHashCode(Expression expression) => new ExpressionHashCodeCalculator().CalculateHashCode(expression);
-
-
-    // Constructors
-
-    internal ExpressionTree(Expression expression)
-    {
-      this.expression = expression;
-      hashCode = new ExpressionHashCodeCalculator().CalculateHashCode(expression);
-    }
   }
 }

--- a/Orm/Xtensive.Orm/Linq/Internals/ExpressionComparer.cs
+++ b/Orm/Xtensive.Orm/Linq/Internals/ExpressionComparer.cs
@@ -13,8 +13,8 @@ namespace Xtensive.Linq
 {
   internal sealed class ExpressionComparer
   {
-    private readonly ParameterExpressionRegistry leftParameters = new ParameterExpressionRegistry();
-    private readonly ParameterExpressionRegistry rightParameters = new ParameterExpressionRegistry();
+    private readonly ParameterExpressionRegistry leftParameters = new();
+    private readonly ParameterExpressionRegistry rightParameters = new();
 
     public bool AreEqual(Expression x, Expression y)
     {

--- a/Orm/Xtensive.Orm/Linq/Internals/ExpressionHashCodeCalculator.cs
+++ b/Orm/Xtensive.Orm/Linq/Internals/ExpressionHashCodeCalculator.cs
@@ -4,10 +4,6 @@
 // Created by: Denis Krjuchkov
 // Created:    2009.05.06
 
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using Xtensive.Core;
 
@@ -16,7 +12,7 @@ namespace Xtensive.Linq
   internal sealed class ExpressionHashCodeCalculator : ExpressionVisitor<int>
   {
     private const int NullHashCode = 0x7abf3456;
-    private readonly ParameterExpressionRegistry parameters = new ParameterExpressionRegistry();
+    private readonly ParameterExpressionRegistry parameters = new();
 
     public int CalculateHashCode(Expression expression)
     {

--- a/Orm/Xtensive.Orm/Linq/Internals/ParameterExpressionRegistry.cs
+++ b/Orm/Xtensive.Orm/Linq/Internals/ParameterExpressionRegistry.cs
@@ -4,38 +4,26 @@
 // Created by: Denis Krjuchkov
 // Created:    2009.05.06
 
-using System.Collections.Generic;
 using System.Linq.Expressions;
 
-namespace Xtensive.Linq
+namespace Xtensive.Linq;
+
+internal readonly struct ParameterExpressionRegistry()
 {
-  internal sealed class ParameterExpressionRegistry
+  private readonly List<ParameterExpression> indexes = [];
+
+  public int GetIndex(ParameterExpression parameter)
   {
-    private readonly List<ParameterExpression> indexes = new List<ParameterExpression>();
-
-    public int GetIndex(ParameterExpression parameter)
-    {
-      int result = indexes.IndexOf(parameter);
-      if (result >= 0)
-        return result;
-      indexes.Add(parameter);
-      return indexes.Count - 1;
-    }
-    
-    public void Add(ParameterExpression parameter)
-    {
-      indexes.Add(parameter);
-    }
-
-    public void AddRange(IEnumerable<ParameterExpression> parameters)
-    {
-      foreach (var p in parameters)
-        Add(p);
-    }
-    
-    public void Reset()
-    {
-      indexes.Clear();
-    }
+    int result = indexes.IndexOf(parameter);
+    if (result >= 0)
+      return result;
+    indexes.Add(parameter);
+    return indexes.Count - 1;
   }
+
+  public void Add(ParameterExpression parameter) => indexes.Add(parameter);
+
+  public void AddRange(IEnumerable<ParameterExpression> parameters) => indexes.AddRange(parameters);
+
+  public void Reset() => indexes.Clear();
 }


### PR DESCRIPTION
Also:
* Avoid boxing in `ExpressionTree.operator==()`