### PR TITLE
Optimize: `ExpressionComparer` 

### DIFF
--- a/Orm/Xtensive.Orm/Linq/Internals/ExpressionComparer.cs
+++ b/Orm/Xtensive.Orm/Linq/Internals/ExpressionComparer.cs
@@ -109,7 +109,7 @@ namespace Xtensive.Linq
       return VisitNew(x.NewExpression, y.NewExpression)
         && x.Initializers.Count==y.Initializers.Count
         && x.Initializers
-          .Zip(y.Initializers, (first, second) => new Pair<ElementInit>(first, second))
+          .Zip(y.Initializers)
           .All(p => self.VisitElementInit(p.First, p.Second));
     }
 
@@ -125,7 +125,7 @@ namespace Xtensive.Linq
       return VisitNew(x.NewExpression, y.NewExpression)
         && x.Bindings.Count==y.Bindings.Count
         && x.Bindings
-          .Zip(y.Bindings, (first, second) => new Pair<MemberBinding>(first, second))
+          .Zip(y.Bindings)
           .All(p => self.VisitMemberBinding(p.First, p.Second));
     }
 
@@ -145,14 +145,14 @@ namespace Xtensive.Linq
           var mby = (MemberMemberBinding)y;
           return mbx.Bindings.Count==mby.Bindings.Count
                  && mbx.Bindings
-                    .Zip(mby.Bindings, (first, second) => new Pair<MemberBinding>(first, second))
+                    .Zip(mby.Bindings)
                     .All(p => self.VisitMemberBinding(p.First, p.Second));
         case MemberBindingType.ListBinding:
           var mlx = (MemberListBinding)x;
           var mly = (MemberListBinding)y;
           return mlx.Initializers.Count==mly.Initializers.Count
                  && mlx.Initializers
-                    .Zip(mly.Initializers, (first, second) => new Pair<ElementInit>(first, second))
+                    .Zip(mly.Initializers)
                     .All(p => self.VisitElementInit(p.First, p.Second));
         default:
           throw new ArgumentOutOfRangeException();

--- a/Orm/Xtensive.Orm/Linq/Internals/ExpressionComparer.cs
+++ b/Orm/Xtensive.Orm/Linq/Internals/ExpressionComparer.cs
@@ -4,12 +4,14 @@
 // Created by: Denis Krjuchkov
 // Created:    2009.05.06
 
+using System;
+using System.Linq;
 using System.Linq.Expressions;
 using Xtensive.Core;
 
 namespace Xtensive.Linq
 {
-  internal readonly struct ExpressionComparer()
+  internal sealed class ExpressionComparer
   {
     private readonly ParameterExpressionRegistry leftParameters = new();
     private readonly ParameterExpressionRegistry rightParameters = new();
@@ -33,13 +35,14 @@ namespace Xtensive.Linq
     {
       if (ReferenceEquals(x, y))
         return true;
-      if (x == null || y == null)
+      if (x==null || y==null)
         return false;
-      var nodeType = x.NodeType;
-      if (nodeType != y.NodeType || x.Type != y.Type)
+      if (x.NodeType!=y.NodeType)
+        return false;
+      if (x.Type!=y.Type)
         return false;
 
-      switch (nodeType) {
+      switch (x.NodeType) {
       case ExpressionType.Negate:
       case ExpressionType.NegateChecked:
       case ExpressionType.Not:
@@ -105,12 +108,11 @@ namespace Xtensive.Linq
 
     private bool VisitListInit(ListInitExpression x, ListInitExpression y)
     {
-      var self = this;    // To allow struct's methods inside closures
       return VisitNew(x.NewExpression, y.NewExpression)
         && x.Initializers.Count==y.Initializers.Count
         && x.Initializers
           .Zip(y.Initializers, (first, second) => new Pair<ElementInit>(first, second))
-          .All(p => self.VisitElementInit(p.First, p.Second));
+          .All(p => VisitElementInit(p.First, p.Second));
     }
 
     /// <summary>
@@ -121,21 +123,19 @@ namespace Xtensive.Linq
     /// <returns></returns>
     private bool VisitMemberInit(MemberInitExpression x, MemberInitExpression y)
     {
-      var self = this;    // To allow struct's methods inside closures
       return VisitNew(x.NewExpression, y.NewExpression)
         && x.Bindings.Count==y.Bindings.Count
         && x.Bindings
           .Zip(y.Bindings, (first, second) => new Pair<MemberBinding>(first, second))
-          .All(p => self.VisitMemberBinding(p.First, p.Second));
+          .All(p => VisitMemberBinding(p.First, p.Second));
     }
 
     private bool VisitMemberBinding(MemberBinding x, MemberBinding y)
     {
-      var bindingType = x.BindingType;
-      if (bindingType != y.BindingType || x.Member != y.Member)
+      var result = x.BindingType==y.BindingType && x.Member==y.Member;
+      if (!result)
         return false;
-      var self = this;    // To allow struct's methods inside closures
-      switch (bindingType) {
+      switch (x.BindingType) {
         case MemberBindingType.Assignment:
           var ax = (MemberAssignment)x;
           var ay = (MemberAssignment)y;
@@ -146,14 +146,14 @@ namespace Xtensive.Linq
           return mbx.Bindings.Count==mby.Bindings.Count
                  && mbx.Bindings
                     .Zip(mby.Bindings, (first, second) => new Pair<MemberBinding>(first, second))
-                    .All(p => self.VisitMemberBinding(p.First, p.Second));
+                    .All(p => VisitMemberBinding(p.First, p.Second));
         case MemberBindingType.ListBinding:
           var mlx = (MemberListBinding)x;
           var mly = (MemberListBinding)y;
           return mlx.Initializers.Count==mly.Initializers.Count
                  && mlx.Initializers
                     .Zip(mly.Initializers, (first, second) => new Pair<ElementInit>(first, second))
-                    .All(p => self.VisitElementInit(p.First, p.Second));
+                    .All(p => VisitElementInit(p.First, p.Second));
         default:
           throw new ArgumentOutOfRangeException();
       }
@@ -164,38 +164,42 @@ namespace Xtensive.Linq
       return x.AddMethod==y.AddMethod && CompareExpressionSequences(x.Arguments, y.Arguments);
     }
 
-    private bool VisitInvocation(InvocationExpression x, InvocationExpression y) =>
-      Visit(x.Expression, y.Expression) && CompareExpressionSequences(x.Arguments, y.Arguments);
+    private bool VisitInvocation(InvocationExpression x, InvocationExpression y)
+    {
+      return Visit(x.Expression, y.Expression) && CompareExpressionSequences(x.Arguments, y.Arguments);
+    }
 
-    private bool VisitNewArray(NewArrayExpression x, NewArrayExpression y) =>
-      CompareExpressionSequences(x.Expressions, y.Expressions);
+    private bool VisitNewArray(NewArrayExpression x, NewArrayExpression y)
+    {
+      return CompareExpressionSequences(x.Expressions, y.Expressions);
+    }
 
     private bool VisitNew(NewExpression x, NewExpression y)
     {
-      if (x.Constructor!=y.Constructor || !CompareExpressionSequences(x.Arguments, y.Arguments))
+      if (x.Constructor!=y.Constructor)
         return false;
-      var xMembers = x.Members;
-      var yMembers = y.Members;
-      if (xMembers == null)
-        return yMembers == null;
-      if (yMembers == null)
+      if (!CompareExpressionSequences(x.Arguments, y.Arguments))
         return false;
-      var count = xMembers.Count;
-      if (count != yMembers.Count)
+      if (x.Members == null)
+        if (y.Members == null)
+          return true;
+        else
+          return false;
+      if (y.Members == null)
         return false;
-      for (int i = 0; i < count; i++)
-        if (xMembers[i] != yMembers[i])
+      if (x.Members.Count != y.Members.Count)
+        return false;
+      for (int i = 0; i < x.Members.Count; i++)
+        if (x.Members[i] != y.Members[i])
           return false;
       return true;
     }
 
     private bool VisitLambda(LambdaExpression x, LambdaExpression y)
     {
-      var xParameters = x.Parameters;
-      var yParameters = y.Parameters;
-      leftParameters.AddRange(xParameters);
-      rightParameters.AddRange(yParameters);
-      return CompareExpressionSequences(xParameters, yParameters) && Visit(x.Body, y.Body);
+      leftParameters.AddRange(x.Parameters);
+      rightParameters.AddRange(y.Parameters);
+      return CompareExpressionSequences(x.Parameters, y.Parameters) && Visit(x.Body, y.Body);
     }
 
     private bool VisitMethodCall(MethodCallExpression x, MethodCallExpression y)
@@ -215,10 +219,11 @@ namespace Xtensive.Linq
 
     private bool VisitConstant(ConstantExpression x, ConstantExpression y)
     {
-      var xValue = x.Value;
-      var yValue = y.Value;
-      return ReferenceEquals(xValue, yValue)
-             || xValue != null && yValue != null && xValue.Equals(yValue);
+      if (ReferenceEquals(x.Value, y.Value))
+        return true;
+      if (x.Value == null || y.Value == null)
+        return false;
+      return x.Value.Equals(y.Value);
     }
 
     private bool VisitConditional(ConditionalExpression x, ConditionalExpression y)
@@ -246,10 +251,9 @@ namespace Xtensive.Linq
       System.Collections.ObjectModel.ReadOnlyCollection<T> y)
       where T : Expression
     {
-      var count = x.Count;
-      if (count != y.Count)
+      if (x.Count != y.Count)
         return false;
-      for (int i = 0; i < count; i++)
+      for (int i = 0; i < x.Count; i++)
         if (!Visit(x[i], y[i]))
           return false;
       return true;

--- a/Orm/Xtensive.Orm/Linq/Internals/ExpressionHashCodeCalculator.cs
+++ b/Orm/Xtensive.Orm/Linq/Internals/ExpressionHashCodeCalculator.cs
@@ -27,44 +27,77 @@ namespace Xtensive.Linq
 
     #region ExpressionVisitor<int> implementation
 
-    protected override int Visit(Expression e) =>
-      e == null ? NullHashCode : HashCode.Combine(base.Visit(e), e.NodeType, e.Type);
+    protected override int Visit(Expression e)
+    {
+      if (e==null)
+        return NullHashCode;
+      var hash = (uint) (base.Visit(e) ^ (int) e.NodeType ^ e.Type.GetHashCode());
+      // transform bytes 0123 -> 1302
+      hash = (hash & 0xFF00) >> 8 | (hash & 0xFF000000) >> 16 | (hash & 0xFF) << 16 | (hash & 0xFF0000) << 8;
+      return (int) hash;
+    }
 
-    protected override int VisitUnary(UnaryExpression u) =>
-      HashCode.Combine(Visit(u.Operand), u.Method);
+    protected override int VisitUnary(UnaryExpression u)
+    {
+      return Visit(u.Operand) ^ (u.Method == null ? 0 : u.Method.GetHashCode());
+    }
 
-    protected override int VisitBinary(BinaryExpression b) =>
-      HashCode.Combine(Visit(b.Left), Visit(b.Right), b.Method);
+    protected override int VisitBinary(BinaryExpression b)
+    {
+      return Visit(b.Left) ^ Visit(b.Right) ^ (b.Method == null ? 0 : b.Method.GetHashCode());
+    }
 
-    protected override int VisitTypeIs(TypeBinaryExpression tb) =>
-      HashCode.Combine(Visit(tb.Expression), tb.TypeOperand);
+    protected override int VisitTypeIs(TypeBinaryExpression tb)
+    {
+      return Visit(tb.Expression) ^ tb.TypeOperand.GetHashCode();
+    }
 
-    protected override int VisitConstant(ConstantExpression c) =>
-      c.Value?.GetHashCode() ?? NullHashCode;
+    protected override int VisitConstant(ConstantExpression c)
+    {
+      return c.Value != null ? c.Value.GetHashCode() : NullHashCode;
+    }
 
-    protected override int VisitDefault(DefaultExpression d) =>
-      d.Type.IsValueType
-        ? d.ToConstantExpression().Value.GetHashCode()
-        : NullHashCode;
+    protected override int VisitDefault(DefaultExpression d)
+    {
+      if (d.Type.IsValueType) {
+        return d.ToConstantExpression().Value.GetHashCode();
+      }
+      else {
+        return NullHashCode;
+      }
+    }
 
-    protected override int VisitConditional(ConditionalExpression c) =>
-      HashCode.Combine(Visit(c.Test), Visit(c.IfTrue), Visit(c.IfFalse));
+    protected override int VisitConditional(ConditionalExpression c)
+    {
+      return Visit(c.Test) ^ Visit(c.IfTrue) ^ Visit(c.IfFalse);
+    }
 
-    protected override int VisitParameter(ParameterExpression p) => parameters.GetIndex(p);
+    protected override int VisitParameter(ParameterExpression p)
+    {
+      return parameters.GetIndex(p);
+    }
 
-    protected override int VisitMemberAccess(MemberExpression m) =>
-      HashCode.Combine(Visit(m.Expression), m.Member);
+    protected override int VisitMemberAccess(MemberExpression m)
+    {
+      return Visit(m.Expression) ^ m.Member.GetHashCode();
+    }
 
     protected override int VisitMethodCall(MethodCallExpression mc) => HashCode.Combine(Visit(mc.Object), mc.Method, HashExpressionSequence(mc.Arguments));
 
     protected override int VisitLambda(LambdaExpression l)
     {
       parameters.AddRange(l.Parameters);
-      return HashCode.Combine(HashExpressionSequence(l.Parameters.Cast<Expression>()), Visit(l.Body));
+      return HashExpressionSequence(l.Parameters.Cast<Expression>()) ^ Visit(l.Body);
     }
 
-    protected override int VisitNew(NewExpression n) =>
-      HashCode.Combine(n.Constructor, n.Members.CalculateHashCode(), HashExpressionSequence(n.Arguments));
+    protected override int VisitNew(NewExpression n)
+    {
+      int result = 0;
+      result ^= n.Constructor!=null ? n.Constructor.GetHashCode() : NullHashCode;
+      result ^= n.Members != null ? n.Members.CalculateHashCode() : NullHashCode;
+      result ^= HashExpressionSequence(n.Arguments);
+      return result;
+    }
 
     protected override int VisitMemberInit(MemberInitExpression mi)
     {
@@ -88,13 +121,20 @@ namespace Xtensive.Linq
       return hashCode.ToHashCode();
     }
 
-    protected override int VisitNewArray(NewArrayExpression na) =>
-      HashExpressionSequence(na.Expressions);
+    protected override int VisitNewArray(NewArrayExpression na)
+    {
+      return HashExpressionSequence(na.Expressions);
+    }
 
-    protected override int VisitInvocation(InvocationExpression i) =>
-      HashCode.Combine(HashExpressionSequence(i.Arguments), Visit(i.Expression));
+    protected override int VisitInvocation(InvocationExpression i)
+    {
+      return HashExpressionSequence(i.Arguments) ^ Visit(i.Expression);
+    }
 
-    protected override int VisitUnknown(Expression e) => e.GetHashCode();
+    protected override int VisitUnknown(Expression e)
+    {
+      return e.GetHashCode();
+    }
 
     #endregion
 
@@ -102,10 +142,10 @@ namespace Xtensive.Linq
 
     private int HashExpressionSequence(IEnumerable<Expression> expressions)
     {
-      HashCode hashCode = new();
+      int result = 0;
       foreach (var e in expressions)
-        hashCode.Add(Visit(e));
-      return hashCode.ToHashCode();
+        result ^= Visit(e);
+      return result;
     }
 
     #endregion

--- a/Orm/Xtensive.Orm/Modelling/Comparison/Comparer.cs
+++ b/Orm/Xtensive.Orm/Modelling/Comparison/Comparer.cs
@@ -484,7 +484,7 @@ namespace Xtensive.Modelling.Comparison
         EnumerableUtils.Unfold(difference, d => d.Parent).Reverse();
       var currentDiffs =
         EnumerableUtils.Unfold(Context.Difference, d => d.Parent).Reverse();
-      var commonDiffs = diffs.Zip(currentDiffs, (first, second) => new Pair<Difference>(first, second)).Where(p => p.First==p.Second).Select(p => p.First);
+      var commonDiffs = diffs.Zip(currentDiffs).Where(p => p.First==p.Second).Select(p => p.First);
       var newDiffs = diffs.Except(commonDiffs);
       var query =
         from diff in newDiffs

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/OwnerRemover.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/OwnerRemover.cs
@@ -62,11 +62,11 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
         return expression;
 
       var bindings = expression.Bindings
-        .Zip(newBindings, (first, second) => (first, second))
-        .ToDictionary(item => item.first.Key, item => item.second);
+        .Zip(newBindings)
+        .ToDictionary(item => item.First.Key, item => item.Second);
       var nativeBingings = expression.NativeBindings
-        .Zip(newNativeBindings, (first, second) => (first, second))
-        .ToDictionary(item => item.first.Key, item => item.second);
+        .Zip(newNativeBindings)
+        .ToDictionary(item => item.First.Key, item => item.Second);
       return new ConstructorExpression(expression.Type, bindings, nativeBingings, expression.Constructor, newConstructorArguments);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
@@ -888,8 +888,8 @@ namespace Xtensive.Orm.Model
       var structureFields = Fields.Where(f => f.IsStructure && f.Parent == null);
       foreach (var structureField in structureFields) {
         var structureTypeInfo = Model.Types[structureField.ValueType];
-        foreach (var pair in structureTypeInfo.Fields.Zip(structureField.Fields, (first, second) => (first, second)))
-          result.Add((structureField, pair.first), pair.second);
+        foreach (var pair in structureTypeInfo.Fields.Zip(structureField.Fields))
+          result.Add((structureField, pair.First), pair.Second);
       }
       return result.AsSafeWrapper();
     }


### PR DESCRIPTION
Also:
* Make `ExpressionComparer`  `readonly struct`
* Use `HashCode.Combine()` instead of custom implementation in `ExpressionHashCodeCalculator`
* Simplify `.Zip()` usage (avoid `Pair<>`)