### PR TITLE
Disable indentation in XML Serialization

### DIFF
--- a/Orm/Xtensive.Orm/Core/SimpleXmlSerializer.cs
+++ b/Orm/Xtensive.Orm/Core/SimpleXmlSerializer.cs
@@ -1,10 +1,12 @@
-﻿// Copyright (C) 2013 Xtensive LLC
+// Copyright (C) 2013 Xtensive LLC
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Denis Krjuchkov
 // Created:    2013.07.18
 
 using System.IO;
+using System.Text;
+using System.Xml;
 using System.Xml.Serialization;
 
 namespace Xtensive.Core
@@ -15,6 +17,12 @@ namespace Xtensive.Core
   public sealed class SimpleXmlSerializer<T>
     where T : class
   {
+    private static readonly XmlWriterSettings WriterSettings = new() {
+      Encoding = new UTF8Encoding(false),
+      Indent = false,
+      NewLineChars = "\n"
+    };
+
     private readonly XmlSerializer serializer = new XmlSerializer(typeof (T));
 
     /// <summary>
@@ -39,10 +47,11 @@ namespace Xtensive.Core
     {
       ArgumentNullException.ThrowIfNull(value);
 
-      using (var writer = new StringWriter()) {
-        serializer.Serialize(writer, value);
-        return writer.ToString();
+      using StringWriter stringWriter = new();
+      using (var xmlWriter = XmlWriter.Create(stringWriter, WriterSettings)) {
+        serializer.Serialize(xmlWriter, value);
       }
+      return stringWriter.ToString();
     }
   }
 }


### PR DESCRIPTION
`Metadata.Extensions` table contains mostly XML, and takes **14 MB** in our case.
Indentless will save some space

Also:
* Make `NewLineChars` be `LF` independently of Platform