### PR TITLE
Optimize `PrefetchActionContainer`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Building/Builders/ModelBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/ModelBuilder.cs
@@ -173,8 +173,7 @@ namespace Xtensive.Orm.Building.Builders
       foreach (var type in context.Model.Types.Entities) {
         var associations = type.GetOwnerAssociations()
           .Where(static a => a.OnOwnerRemove is OnRemoveAction.Cascade or OnRemoveAction.Clear);
-        var action = new PrefetchActionContainer(type).BuildPrefetchAction(associations);
-        if (action != null) {
+        if (PrefetchActionContainer.BuildPrefetchAction(type, associations) is { } action) {
           domain.PrefetchActionMap.Add(type, action);
         }
       }

--- a/Orm/Xtensive.Orm/Orm/Building/PrefetchActionContainer.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/PrefetchActionContainer.cs
@@ -4,41 +4,27 @@
 // Created by: Alexis Kochetov
 // Created:    2010.01.27
 
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
-using Xtensive.Core;
 using Xtensive.Orm.Internals.Prefetch;
 using Xtensive.Orm.Model;
 using Xtensive.Orm.Providers;
 
-namespace Xtensive.Orm.Building
+namespace Xtensive.Orm.Building;
+
+[Serializable]
+internal static class PrefetchActionContainer
 {
-  [Serializable]
-  internal sealed class PrefetchActionContainer
+  // Returns null if associations is empty
+  public static Action<SessionHandler, IEnumerable<Key>> BuildPrefetchAction(TypeInfo type, IEnumerable<AssociationInfo> associations)
   {
-    private readonly TypeInfo type;
-    private IReadOnlyList<PrefetchFieldDescriptor> fields;
+    var fields = associations.Select(static association => new PrefetchFieldDescriptor(association.OwnerField, true, false)).ToArray();
+    return fields.Length > 0
+      ? Prefetch
+      : null;
 
-    // Returns null if associations is empty
-    public Action<SessionHandler, IEnumerable<Key>> BuildPrefetchAction(IEnumerable<AssociationInfo> associations)
-    {
-      fields = associations.Select(static association => new PrefetchFieldDescriptor(association.OwnerField, true, false))
-        .ToList();
-      return fields.Count > 0 ? Prefetch : null;
-    }
-
-    private void Prefetch(SessionHandler sh, IEnumerable<Key> keys)
+    void Prefetch(SessionHandler sh, IEnumerable<Key> keys)
     {
       foreach (var key in keys)
         sh.Prefetch(key, type, fields);
-    }
-
-    public PrefetchActionContainer(TypeInfo type)
-    {
-      this.type = type;
-      fields = Array.Empty<PrefetchFieldDescriptor>();
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Domain.cs
+++ b/Orm/Xtensive.Orm/Orm/Domain.cs
@@ -117,7 +117,7 @@ namespace Xtensive.Orm
 
     internal EntityDataReader EntityDataReader { get; private set; }
 
-    internal Dictionary<TypeInfo, Action<SessionHandler, IEnumerable<Key>>> PrefetchActionMap { get; private set; }
+    internal Dictionary<TypeInfo, Action<SessionHandler, IEnumerable<Key>>> PrefetchActionMap { get; } = new();
 
     internal DomainHandler Handler { get { return Handlers.DomainHandler; } }
 
@@ -413,7 +413,6 @@ namespace Xtensive.Orm
       EntityDataReader = new EntityDataReader(this);
       KeyGenerators = new KeyGeneratorRegistry();
       QueryCache = new FastConcurrentLruCache<object, Pair<object, ParameterizedQuery>>(Configuration.QueryCacheSize, k => k.First);
-      PrefetchActionMap = new Dictionary<TypeInfo, Action<SessionHandler, IEnumerable<Key>>>();
       Extensions = new ExtensionCollection();
       UpgradeContextCookie = upgradeContextCookie;
       SingleConnection = singleConnection;


### PR DESCRIPTION
* Use array instead of `List` because the result is stored in Domain's model. Its lifetime is long
* Avoid instantiation of `PrefetchActionContainer`