### PR TITLE
Fix Race Condition with `TranslatorState.NonVisitableExpressions`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/LocalCollectionKeyTypeExtractor.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/LocalCollectionKeyTypeExtractor.cs
@@ -24,14 +24,14 @@ namespace Xtensive.Orm.Linq
         return key.EntityType.UnderlyingType;
       }
 
-      var expr = VisitBinaryExpession(expression);
+      var expr = VisitBinaryExpression(expression);
       if (expr.Type.IsSubclassOf(WellKnownOrmTypes.Entity)) {
         return expr.Type;
       }
       throw new NotSupportedException(string.Format(Strings.ExCurrentTypeXIsNotSupported, expr.Type));
     }
 
-    private static Expression VisitBinaryExpession(BinaryExpression binaryExpression)
+    private static Expression VisitBinaryExpression(BinaryExpression binaryExpression)
     {
       if (!(binaryExpression.Right is MemberExpression memberExpression)) {
         throw new InvalidOperationException(string.Format(Strings.ExCantConvertXToY, binaryExpression.Type, typeof(MemberExpression)));

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -44,7 +44,9 @@ namespace Xtensive.Orm.Linq
 
     private bool isAlreadyTagged;
 
-    internal TranslatorState State { get; private set; } = TranslatorState.InitState;
+    internal TranslatorState State { get; private set; } = new(TranslatorState.InitState) {
+      NonVisitableExpressions = new()
+    };
 
     protected override Expression VisitConstant(ConstantExpression c) =>
       c.Value is IQueryable rootPoint

--- a/Orm/Xtensive.Orm/Orm/Linq/TranslatorState.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/TranslatorState.cs
@@ -43,7 +43,6 @@ namespace Xtensive.Orm.Linq
       CurrentLambda = null,
       IncludeAlgorithm = IncludeAlgorithm.Auto,
       TypeOfEntityStoredInKey = null,
-      NonVisitableExpressions = new HashSet<Expression>(),
     };
 
     private readonly TranslatorStateFlags flags;
@@ -63,7 +62,7 @@ namespace Xtensive.Orm.Linq
 
 
     /// <summary>
-    /// Expessions that were constructed during original expression translation
+    /// Expressions that were constructed during original expression translation
     /// and aim to replace original parts so they are avoidable to visit by Linq translator.
     /// </summary>
     /// <remarks>


### PR DESCRIPTION
A mutable `HashSet` cannot be `static`

Also:
* Fix typo `Expession`