### PR TITLE
Replace heavy `SqlExpression.operator==()`  by `is null`/`is not null`

### DIFF
--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/QueryOperation.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/QueryOperation.cs
@@ -170,13 +170,13 @@ namespace Xtensive.Orm.BulkOperations
         var rightColumn = sqlTableRef == null
           ? GetStatementTable(statement).Columns[columnInfo.Name]
           : sqlTableRef.Columns[columnInfo.Name];
-        if (leftColumn == null || rightColumn == null) {
+        if (leftColumn is null || rightColumn is null) {
           throw new InvalidOperationException("Source query doesn't contain one of key columns of updated table.");
         }
 
         var columnEqualityExpression =
           SqlDml.Equals(queryRef.Columns[columnInfo.Name], sqlTableRef.Columns[columnInfo.Name]);
-        whereExpression = whereExpression == null
+        whereExpression = whereExpression is null
           ? columnEqualityExpression
           : SqlDml.And(whereExpression, columnEqualityExpression);
       }

--- a/Orm/Xtensive.Orm.Firebird/Sql.Drivers.Firebird/v2_5/Extractor.cs
+++ b/Orm/Xtensive.Orm.Firebird/Sql.Drivers.Firebird/v2_5/Extractor.cs
@@ -470,7 +470,7 @@ namespace Xtensive.Sql.Drivers.Firebird.v2_5
         }
       }
 
-      if (expression == null) {
+      if (expression is null) {
         var column = state.Table.TableColumns[reader.GetString(6).Trim()];
         var isDescending = ReadBool(reader, 4);
         _ = state.Index.CreateIndexColumn(column, !isDescending);

--- a/Orm/Xtensive.Orm.Firebird/Sql.Drivers.Firebird/v2_5/Translator.cs
+++ b/Orm/Xtensive.Orm.Firebird/Sql.Drivers.Firebird/v2_5/Translator.cs
@@ -270,7 +270,7 @@ namespace Xtensive.Sql.Drivers.Firebird.v2_5
           Translate(context, index.DataTable);
           return;
         case CreateIndexSection.ColumnsEnter:
-          if (node.Index.Columns[0].Expression != null) {
+          if (node.Index.Columns[0].Expression is not null) {
             if (node.Index.Columns.Count > 1) {
               _ = SqlHelper.NotSupported("expression index with multiple column");
             }

--- a/Orm/Xtensive.Orm.Firebird/Sql.Drivers.Firebird/v4_0/Extractor.cs
+++ b/Orm/Xtensive.Orm.Firebird/Sql.Drivers.Firebird/v4_0/Extractor.cs
@@ -469,7 +469,7 @@ namespace Xtensive.Sql.Drivers.Firebird.v4_0
         }
       }
 
-      if (expression == null) {
+      if (expression is null) {
         var column = state.Table.TableColumns[reader.GetString(6).Trim()];
         var isDescending = ReadBool(reader, 4);
         _ = state.Index.CreateIndexColumn(column, !isDescending);

--- a/Orm/Xtensive.Orm.Firebird/Sql.Drivers.Firebird/v4_0/Translator.cs
+++ b/Orm/Xtensive.Orm.Firebird/Sql.Drivers.Firebird/v4_0/Translator.cs
@@ -14,7 +14,7 @@ namespace Xtensive.Sql.Drivers.Firebird.v4_0
       var output = context.Output;
       switch (section) {
         case JoinSection.Specification:
-          if (node.Expression == null) {
+          if (node.Expression is null) {
             switch (node.JoinType) {
               case SqlJoinType.CrossApply:
                 _ = output.Append("CROSS JOIN LATERAL");

--- a/Orm/Xtensive.Orm.Manual/Concurrency/LockingTest.cs
+++ b/Orm/Xtensive.Orm.Manual/Concurrency/LockingTest.cs
@@ -77,7 +77,7 @@ namespace Xtensive.Orm.Manual.Concurrency.Locking
       using (var session = GetDomain().OpenSession())
       using (var tx = session.OpenTransaction()) {
         Counter counter;
-        if (counterKey==null) {
+        if (counterKey is null) {
           counter = new Counter(session, LockingTestName);
           counterKey = counter.Key;
         }

--- a/Orm/Xtensive.Orm.Manual/Prefetch/PrefetchTest.cs
+++ b/Orm/Xtensive.Orm.Manual/Prefetch/PrefetchTest.cs
@@ -128,7 +128,7 @@ namespace Xtensive.Orm.Manual.Prefetch
           var accessor = DirectStateAccessor.Get(person);
           Assert.That(accessor.GetFieldState("Photo"), Is.EqualTo(PersistentFieldState.Loaded));
           Assert.That(accessor.GetFieldState("Manager"), Is.EqualTo(PersistentFieldState.Loaded));
-          if (person.ManagerKey != null) {
+          if (person.ManagerKey is not null) {
             Assert.IsNotNull(DirectStateAccessor.Get(session)[person.ManagerKey]);
             Assert.That(DirectStateAccessor.Get(person.Manager).GetFieldState("Photo"), Is.EqualTo(PersistentFieldState.Loaded));
           }
@@ -325,7 +325,7 @@ namespace Xtensive.Orm.Manual.Prefetch
           var accessor = DirectStateAccessor.Get(person);
           Assert.That(accessor.GetFieldState("Photo"), Is.EqualTo(PersistentFieldState.Loaded));
           Assert.That(accessor.GetFieldState("Manager"), Is.EqualTo(PersistentFieldState.Loaded));
-          if (person.ManagerKey != null) {
+          if (person.ManagerKey is not null) {
             Assert.IsNotNull(DirectStateAccessor.Get(session)[person.ManagerKey]);
             Assert.That(DirectStateAccessor.Get(person.Manager).GetFieldState("Photo"), Is.EqualTo(PersistentFieldState.Loaded));
           }
@@ -457,7 +457,7 @@ namespace Xtensive.Orm.Manual.Prefetch
             var accessor = DirectStateAccessor.Get(person);
             Assert.That(accessor.GetFieldState("Photo"), Is.EqualTo(PersistentFieldState.Loaded));
             Assert.That(accessor.GetFieldState("Manager"), Is.EqualTo(PersistentFieldState.Loaded));
-            if (person.ManagerKey != null) {
+            if (person.ManagerKey is not null) {
               Assert.IsNotNull(DirectStateAccessor.Get(session)[person.ManagerKey]);
               Assert.That(DirectStateAccessor.Get(person.Manager).GetFieldState("Photo"), Is.EqualTo(PersistentFieldState.Loaded));
             }
@@ -505,7 +505,7 @@ namespace Xtensive.Orm.Manual.Prefetch
           var accessor = DirectStateAccessor.Get(person);
           Assert.That(accessor.GetFieldState("Photo"), Is.EqualTo(PersistentFieldState.Loaded));
           Assert.That(accessor.GetFieldState("Manager"), Is.EqualTo(PersistentFieldState.Loaded));
-          if (person.ManagerKey != null) {
+          if (person.ManagerKey is not null) {
             Assert.IsNotNull(DirectStateAccessor.Get(session)[person.ManagerKey]);
             Assert.That(DirectStateAccessor.Get(person.Manager).GetFieldState("Photo"), Is.EqualTo(PersistentFieldState.Loaded));
           }

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v10_0/Translator.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v10_0/Translator.cs
@@ -18,7 +18,7 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v10_0
       var output = context.Output;
       switch (section) {
         case JoinSection.Specification: {
-          if (node.Expression == null) {
+          if (node.Expression is null) {
             switch (node.JoinType) {
               case SqlJoinType.InnerJoin:
               case SqlJoinType.LeftOuterJoin:

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Compiler.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Compiler.cs
@@ -307,7 +307,7 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
     protected static SqlExpression NpgsqlTypeExtractPoint(SqlExpression expression, SqlExpression numberPoint)
     {
       var numberPointAsInt = numberPoint as SqlLiteral<int>;
-      var valueNumberPoint = numberPointAsInt != null ? numberPointAsInt.Value : 0;
+      var valueNumberPoint = numberPointAsInt is not null ? numberPointAsInt.Value : 0;
 
       return SqlDml.RawConcat(
         SqlDml.Native("("),
@@ -550,19 +550,19 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
     private bool TryDivideOffsetIntoParts(SqlExpression offsetInMinutes, ref int hours , ref int minutes)
     {
       var offsetToDouble = offsetInMinutes as SqlLiteral<double>;
-      if (offsetToDouble != null) {
+      if (offsetToDouble is not null) {
         hours = (int) offsetToDouble.Value / 60;
         minutes = Math.Abs((int) offsetToDouble.Value % 60);
         return true;
       }
       var offsetToInt = offsetInMinutes as SqlLiteral<int>;
-      if (offsetToInt != null) {
+      if (offsetToInt is not null) {
         hours = offsetToInt.Value / 60;
         minutes = Math.Abs(offsetToInt.Value % 60);
         return true;
       }
       var offsetToTimeSpan = offsetInMinutes as SqlLiteral<TimeSpan>;
-      if (offsetToTimeSpan != null) {
+      if (offsetToTimeSpan is not null) {
         var totalMinutes = offsetToTimeSpan.Value.TotalMinutes;
         hours = (int) totalMinutes / 60;
         minutes = Math.Abs((int)totalMinutes % 60);

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Translator.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_0/Translator.cs
@@ -540,7 +540,7 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
         }
         else { //(!whenNotNeeded)
                //Check if any row element is NULL
-          _ = @case.Add(when == null ? true : when, true);
+          _ = @case.Add(when is null ? true : when, true);
           subQueryNeeded = true;
         }
       }
@@ -569,7 +569,7 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
         //c.Add(Sql.Exists(q1), true);
         @case.Else = SqlDml.Exists(subquery);
       }
-      if (@case.Else == null) {
+      if (@case.Else is null) {
         @case.Else = false;
       }
       if (existsNull) {
@@ -714,7 +714,7 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
             _ = c3.Add(SqlDml.IsNull(row[i]), true);
             c3.Else = row[i] == columns[i];
 
-            where = where == null ? c3 : where && c3;
+            where = where is null ? c3 : where && c3;
           }
           if (node.Unique) {
             var c4 = SqlDml.Case();
@@ -729,7 +729,7 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_0
         }
         @case.Else = SqlDml.Exists(subQuery);
       }
-      if (@case.Else == null) {
+      if (@case.Else is null) {
         @case.Else = false;
       }
       if (allNull) {

--- a/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_3/Compiler.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Sql.Drivers.PostgreSql/v8_3/Compiler.cs
@@ -62,12 +62,12 @@ namespace Xtensive.Sql.Drivers.PostgreSql.v8_3
       var vector = ((Translator) translator).GetFulltextVector(context, fullTextIndex);
       var tableName = translator.QuoteIdentifier(node.TargetTable.Name);
       var internalColumnIndex = 0;
-      while (node.Columns["column" + internalColumnIndex] != null) {
+      while (node.Columns["column" + internalColumnIndex] is not null) {
         internalColumnIndex++;
       }
       var vectorName = translator.QuoteIdentifier("column" + internalColumnIndex);
       internalColumnIndex++;
-      while (node.Columns["column" + internalColumnIndex] != null) {
+      while (node.Columns["column" + internalColumnIndex] is not null) {
         internalColumnIndex++;
       }
 

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v09/Compiler.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v09/Compiler.cs
@@ -380,7 +380,7 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
 
       _ = output.Append(", ");
       node.SearchCondition.AcceptVisitor(this);
-      if (node.TopNByRank!=null) {
+      if (node.TopNByRank is not null) {
         _ = output.Append(", ");
         node.TopNByRank.AcceptVisitor(this);
       }
@@ -406,7 +406,7 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
 
       _ = output.Append(", ");
       node.FreeText.AcceptVisitor(this);
-      if (node.TopNByRank != null) {
+      if (node.TopNByRank is not null) {
         _ = context.Output.Append(", ");
         node.TopNByRank.AcceptVisitor(this);
       }

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v09/Translator.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v09/Translator.cs
@@ -252,7 +252,7 @@ namespace Xtensive.Sql.Drivers.SqlServer.v09
       var output = context.Output;
       switch (section) {
         case JoinSection.Specification:
-          if (node.Expression == null)
+          if (node.Expression is null)
             switch (node.JoinType) {
               case SqlJoinType.InnerJoin:
               case SqlJoinType.LeftOuterJoin:

--- a/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/v3/Compiler.cs
+++ b/Orm/Xtensive.Orm.Sqlite/Sql.Drivers.Sqlite/v3/Compiler.cs
@@ -460,13 +460,13 @@ namespace Xtensive.Sql.Drivers.Sqlite.v3
       var sign = '+';
       var offsetAsInt = offset as SqlLiteral<int>;
       var offsetAsDouble = offset as SqlLiteral<double>;
-      if (offsetAsInt != null) {
+      if (offsetAsInt is not null) {
         if (offsetAsInt.Value < 0) {
           sign = '-';
           offset = -offset;
         }
       }
-      else if (offsetAsDouble != null) {
+      else if (offsetAsDouble is not null) {
         if (offsetAsDouble.Value < 0) {
           sign = '-';
           offset = -offset;

--- a/Orm/Xtensive.Orm.Tests.Core/Modelling/IndexingModel/ColumnInfo.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Modelling/IndexingModel/ColumnInfo.cs
@@ -40,7 +40,7 @@ namespace Xtensive.Orm.Tests.Core.Modelling.IndexingModel
     {
       using (var ea = new ExceptionAggregator()) {
         ea.Execute(base.ValidateState);
-        if (Type==null) {
+        if (Type is null) {
           ea.Execute(() => {
             throw new ValidationException(
               string.Format(Strings.ExUndefinedTypeOfColumnX, Name),

--- a/Orm/Xtensive.Orm.Tests.Core/Modelling/IndexingModel/TypeInfo.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Modelling/IndexingModel/TypeInfo.cs
@@ -88,16 +88,7 @@ namespace Xtensive.Orm.Tests.Core.Modelling.IndexingModel
     }
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (obj is null)
-        return false;
-      if (ReferenceEquals(this, obj))
-        return true;
-      if (obj.GetType()!=typeof (TypeInfo))
-        return false;
-      return Equals((TypeInfo) obj);
-    }
+    public override bool Equals(object obj) => obj is TypeInfo other && Equals(other);
 
     /// <inheritdoc/>
     public override int GetHashCode() => HashCode.Combine(Type, IsNullable, Length, Scale, Precision, Culture);
@@ -108,10 +99,7 @@ namespace Xtensive.Orm.Tests.Core.Modelling.IndexingModel
     /// <param name="left">The left.</param>
     /// <param name="right">The right.</param>
     /// <returns>The result of the operator.</returns>
-    public static bool operator ==(TypeInfo left, TypeInfo right)
-    {
-      return Equals(left, right);
-    }
+    public static bool operator ==(TypeInfo left, TypeInfo right) => left?.Equals(right) ?? right is null;
 
     /// <summary>
     /// Implements the operator !=.
@@ -119,10 +107,7 @@ namespace Xtensive.Orm.Tests.Core.Modelling.IndexingModel
     /// <param name="left">The left.</param>
     /// <param name="right">The right.</param>
     /// <returns>The result of the operator.</returns>
-    public static bool operator !=(TypeInfo left, TypeInfo right)
-    {
-      return !Equals(left, right);
-    }
+    public static bool operator !=(TypeInfo left, TypeInfo right) => !(left == right);
 
     #endregion
 

--- a/Orm/Xtensive.Orm.Tests.Sql/CloneTests.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/CloneTests.cs
@@ -395,7 +395,7 @@ namespace Xtensive.Orm.Tests.Sql
       }
 
       Assert.AreEqual(s.Limit, sClone.Limit);
-      if (s.Where!=null) {
+      if (s.Where is not null) {
         Assert.AreNotEqual(s.Where, sClone.Where);
         Assert.AreEqual(s.Where.NodeType, sClone.Where.NodeType);
       }
@@ -421,7 +421,7 @@ namespace Xtensive.Orm.Tests.Sql
         Assert.AreNotEqual(s.From, sClone.From);
         Assert.AreEqual(s.From.NodeType, sClone.From.NodeType);
       }
-      if (s.Having!=null) {
+      if (s.Having is not null) {
         Assert.AreNotEqual(s.Having, sClone.Having);
         Assert.AreEqual(s.Having.NodeType, sClone.Having.NodeType);
       }
@@ -440,7 +440,7 @@ namespace Xtensive.Orm.Tests.Sql
       }
 
       Assert.AreEqual(s.Limit, sClone.Limit);
-      if (s.Where!=null) {
+      if (s.Where is not null) {
         Assert.AreNotEqual(s.Where, sClone.Where);
         Assert.AreEqual(s.Where.NodeType, sClone.Where.NodeType);
       }
@@ -634,7 +634,7 @@ namespace Xtensive.Orm.Tests.Sql
         Assert.IsFalse(uClone.Values.ContainsKey(p.Key));
         Assert.IsFalse(uClone.Values.ContainsValue(p.Value));
       }
-      if (u.Where!=null) {
+      if (u.Where is not null) {
         Assert.AreNotEqual(u.Where, uClone.Where);
         Assert.AreEqual(u.Where.NodeType, uClone.Where.NodeType);
       }

--- a/Orm/Xtensive.Orm.Tests/Issues/Issue0391_OnRemoveActionNone.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/Issue0391_OnRemoveActionNone.cs
@@ -33,7 +33,7 @@ namespace Xtensive.Orm.Tests.Issues.Issue0391_OnRemoveActionNone_Model
     public bool HasCustomerKey()
     {
       var field = GetTypeInfo().Fields["Customer"];
-      return GetReferenceKey(field)!=null;
+      return GetReferenceKey(field) is not null;
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0647_StoredDomainModelMappingsUpdateBug.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0647_StoredDomainModelMappingsUpdateBug.cs
@@ -565,7 +565,7 @@ namespace Xtensive.Orm.Tests.Issues
 
     private ConnectionInfo ComposeConnectionToMasterDatabase(ConnectionInfo baseConnectionInfo)
     {
-      if (baseConnectionInfo.ConnectionUrl == null) {
+      if (baseConnectionInfo.ConnectionUrl is null) {
         throw new InvalidOperationException("Can't convert connection string based ConnectionInfo");
       }
 

--- a/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/Prefetch/PrefetchTest.cs
@@ -786,7 +786,7 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
           var titleType = Domain.Model.Types[typeof(Model.Title)];
           await foreach (var book in prefetcher) {
             var titleKey = book.GetReferenceKey(titleField);
-            if (titleKey != null) {
+            if (titleKey is not null) {
               PrefetchTestHelper.AssertOnlyDefaultColumnsAreLoaded(titleKey, titleType, session);
             }
           }
@@ -813,7 +813,7 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
             count++;
             if (book != null) {
               var titleKey = book.GetReferenceKey(titleField);
-              if (titleKey != null) {
+              if (titleKey is not null) {
                 PrefetchTestHelper.AssertOnlyDefaultColumnsAreLoaded(titleKey, titleType, session);
               }
             }
@@ -843,7 +843,7 @@ namespace Xtensive.Orm.Tests.Storage.Prefetch
             count++;
             if (book != null) {
               var titleKey = book.GetReferenceKey(titleField);
-              if (titleKey != null) {
+              if (titleKey is not null) {
                 PrefetchTestHelper.AssertOnlyDefaultColumnsAreLoaded(titleKey, titleType, session);
               }
             }

--- a/Orm/Xtensive.Orm/Orm/ConnectionInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/ConnectionInfo.cs
@@ -37,7 +37,7 @@ namespace Xtensive.Orm
     /// <inheritdoc/>
     public override string ToString()
     {
-      return ConnectionUrl!=null
+      return ConnectionUrl is not null
         ? ConnectionUrl.ToString()
         : string.Format(ToStringFormat, Provider, ConnectionString);
     }

--- a/Orm/Xtensive.Orm/Orm/ConnectionInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/ConnectionInfo.cs
@@ -48,38 +48,22 @@ namespace Xtensive.Orm
     public override int GetHashCode() => HashCode.Combine(Provider, ConnectionString, ConnectionUrl);
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (obj is null)
-        return false;
-      if (ReferenceEquals(this, obj))
-        return true;
-      return Equals((ConnectionInfo) obj);
-    }
+    public override bool Equals(object obj) => obj is ConnectionInfo other && Equals(other);
 
     /// <inheritdoc/>
     public bool Equals(ConnectionInfo other)
     {
       if (other is null)
         return false;
-      if (ReferenceEquals(this, other))
-        return true;
-      return Equals(other.Provider, Provider)
-        && Equals(other.ConnectionString, ConnectionString)
-        && Equals(other.ConnectionUrl, ConnectionUrl);
+      return ReferenceEquals(this, other)
+             || Equals(other.Provider, Provider) && Equals(other.ConnectionString, ConnectionString) && Equals(other.ConnectionUrl, ConnectionUrl);
     }
 
     /// <inheritdoc/>
-    public static bool operator ==(ConnectionInfo left, ConnectionInfo right)
-    {
-      return Equals(left, right);
-    }
+    public static bool operator ==(ConnectionInfo left, ConnectionInfo right) => left?.Equals(right) ?? right is null;
 
     /// <inheritdoc/>
-    public static bool operator !=(ConnectionInfo left, ConnectionInfo right)
-    {
-      return !Equals(left, right);
-    }
+    public static bool operator !=(ConnectionInfo left, ConnectionInfo right) => !(left == right);
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
+++ b/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
@@ -436,7 +436,7 @@ namespace Xtensive.Orm
     protected Pair<Key, Delegate> GetSubscription(object eventKey)
     {
       var entityKey = GetOwnerKey(Owner);
-      if (entityKey != null) {
+      if (entityKey is not null) {
         return new Pair<Key, Delegate>(entityKey,
           Session.EntityEvents.GetSubscriber(entityKey, Field, eventKey));
       }

--- a/Orm/Xtensive.Orm/Orm/Internals/FieldAccessors/EntityFieldAccessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/FieldAccessors/EntityFieldAccessor.cs
@@ -49,7 +49,7 @@ namespace Xtensive.Orm.Internals.FieldAccessors
     {
       var field = Field;
       Key key = obj.GetReferenceKey(field);
-      if (key==null)
+      if (key is null)
         return default(T);
       return (T) (object) obj.Session.Query.SingleOrDefault(key);
     }

--- a/Orm/Xtensive.Orm/Orm/Internals/FieldAccessors/KeyFieldAccessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/FieldAccessors/KeyFieldAccessor.cs
@@ -38,7 +38,7 @@ namespace Xtensive.Orm.Internals.FieldAccessors
     {
       var field = Field;
       var key = (Key) (object) value;
-      obj.Tuple.SetValue(field.MappingInfo.Offset, key==null ? null : key.Format());
+      obj.Tuple.SetValue(field.MappingInfo.Offset, key is null ? null : key.Format());
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Internals/KeyFactory.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/KeyFactory.cs
@@ -83,7 +83,7 @@ namespace Xtensive.Orm.Internals
           value = entity.Key;
         }
         var key = value as Key;
-        if (key!=null) {
+        if (key is not null) {
           if (key.TypeReference.Type.Hierarchy==type.Hierarchy)
             typeIdIndex = -1; // Key must be fully copied in this case
           for (int keyIndex = 0; keyIndex < key.Value.Count; keyIndex++) {

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntitySetTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntitySetTask.cs
@@ -109,7 +109,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       foreach (var record in records) {
         for (var i = 0; i < record.Count; i++) {
           var key = record.GetKey(i);
-          if (key == null) {
+          if (key is null) {
             continue;
           }
           var tuple = record.GetTuple(i);

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/ReferenceNode.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/ReferenceNode.cs
@@ -25,7 +25,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 
       var entity = (Entity) target;
       var referenceKey = entity.GetReferenceKey(Field);
-      return referenceKey == null
+      return referenceKey is null
         ? Array.Empty<Key>()
         : new[] {referenceKey};
     }

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/ReferencedEntityContainer.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/ReferencedEntityContainer.cs
@@ -28,7 +28,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     public override EntityGroupTask GetTask()
     {
-      if (Key!=null && Task==null)
+      if (Key is not null && Task is null)
         return null;
 
       if (Task!=null)

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/RootEntityContainer.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/RootEntityContainer.cs
@@ -34,7 +34,7 @@ namespace Xtensive.Orm.Internals.Prefetch
 
     public void NotifyOwnerAboutKeyWithUnknownType()
     {
-      if (Task != null && ownerKey != null)
+      if (Task is not null && ownerKey is not null)
         referencingFieldDescriptor.NotifySubscriber(ownerKey, Key);
     }
     

--- a/Orm/Xtensive.Orm/Orm/Internals/RemapContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/RemapContext.cs
@@ -48,7 +48,7 @@ namespace Xtensive.Orm.Internals
     /// <returns>Real key</returns>
     public Key TryRemapKey(Key oldKey)
     {
-      if (oldKey==null)
+      if (oldKey is null)
         return oldKey;
       Key newKey;
       return keyMap.TryGetValue(oldKey, out newKey) ? newKey : oldKey;

--- a/Orm/Xtensive.Orm/Orm/Key.cs
+++ b/Orm/Xtensive.Orm/Orm/Key.cs
@@ -155,7 +155,7 @@ namespace Xtensive.Orm
     /// The result of the operator.
     /// </returns>
     [DebuggerStepThrough]
-    public static bool operator ==(Key left, Key right) => Equals(left, right);
+    public static bool operator ==(Key left, Key right) => left?.Equals(right) ?? right is null;
 
     /// <summary>
     /// Implements the operator !=.
@@ -166,7 +166,7 @@ namespace Xtensive.Orm
     /// The result of the operator.
     /// </returns>
     [DebuggerStepThrough]
-    public static bool operator !=(Key left, Key right) => !Equals(left, right);
+    public static bool operator !=(Key left, Key right) => !(left == right);
 
     /// <inheritdoc/>
     public override int GetHashCode() =>

--- a/Orm/Xtensive.Orm/Orm/KeyMapping.cs
+++ b/Orm/Xtensive.Orm/Orm/KeyMapping.cs
@@ -33,7 +33,7 @@ namespace Xtensive.Orm
     /// <param name="key">The key to remap.</param>
     /// <returns>The mapped storage <see cref="Key"/>.</returns>
     public Key TryRemapKey(Key key) =>
-      key!=null && Map.TryGetValue(key, out var remappedKey) ? remappedKey : key;
+      key is not null && Map.TryGetValue(key, out var remappedKey) ? remappedKey : key;
 
     /// <summary>
     /// Remaps the keys of cached entities

--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfoRef.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfoRef.cs
@@ -61,10 +61,7 @@ namespace Xtensive.Orm.Model
     /// <returns>
     /// The result of the operator.
     /// </returns>
-    public static bool operator !=(FieldInfoRef x, FieldInfoRef y)
-    {
-      return !Equals(x, y);
-    }
+    public static bool operator !=(FieldInfoRef x, FieldInfoRef y) => !(x == y);
 
     /// <summary>
     /// Implements the operator ==.
@@ -74,28 +71,14 @@ namespace Xtensive.Orm.Model
     /// <returns>
     /// The result of the operator.
     /// </returns>
-    public static bool operator ==(FieldInfoRef x, FieldInfoRef y)
-    {
-      return Equals(x, y);
-    }
+    public static bool operator ==(FieldInfoRef x, FieldInfoRef y) => x?.Equals(y) ?? y is null;
 
     /// <inheritdoc/>
-    public bool Equals(FieldInfoRef other)
-    {
-      if (other is null)
-        return false;
-      return 
-        TypeRef==other.TypeRef
-        && FieldName==other.FieldName;
-    }
+    public bool Equals(FieldInfoRef other) =>
+      other is not null && TypeRef==other.TypeRef && FieldName==other.FieldName;
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (ReferenceEquals(this, obj))
-        return true;
-      return Equals(obj as FieldInfoRef);
-    }
+    public override bool Equals(object obj) => obj is FieldInfoRef other && Equals(other);
 
     /// <inheritdoc/>
     public override int GetHashCode() => HashCode.Combine(FieldName, TypeRef);

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfoRef.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfoRef.cs
@@ -47,7 +47,7 @@ namespace Xtensive.Orm.Model
     /// <returns>
     /// The result of the operator.
     /// </returns>
-    public static bool operator !=(TypeInfoRef x, TypeInfoRef y) => !Equals(x, y);
+    public static bool operator !=(TypeInfoRef x, TypeInfoRef y) => !x.Equals(y);
 
     /// <summary>
     /// Implements the operator ==.
@@ -57,7 +57,7 @@ namespace Xtensive.Orm.Model
     /// <returns>
     /// The result of the operator.
     /// </returns>
-    public static bool operator ==(TypeInfoRef x, TypeInfoRef y) => Equals(x, y);
+    public static bool operator ==(TypeInfoRef x, TypeInfoRef y) => x.Equals(y);
 
     /// <inheritdoc/>
     public bool Equals(TypeInfoRef other) =>

--- a/Orm/Xtensive.Orm/Orm/OperationLog.cs
+++ b/Orm/Xtensive.Orm/Orm/OperationLog.cs
@@ -88,7 +88,7 @@ namespace Xtensive.Orm
               string identifier = pair.Key;
               var oldKey = pair.Value;
               var newKey = identifierToKey.GetValueOrDefault(identifier);
-              if (newKey!=null)
+              if (newKey is not null)
                 executionContext.AddKeyMapping(oldKey, newKey);
             }
           }

--- a/Orm/Xtensive.Orm/Orm/Operations/EntityFieldSetOperation.cs
+++ b/Orm/Xtensive.Orm/Orm/Operations/EntityFieldSetOperation.cs
@@ -148,7 +148,7 @@ namespace Xtensive.Orm.Operations
         else
           info.AddValue("value", string.Empty);
       }
-      else if (structureValue != null) {
+      else if (structureValue is not null) {
         // serializing structure value as tuple
         info.AddValue("value", structureValue.Tuple.ToRegular(), WellKnownOrmTypes.Tuple);
       }

--- a/Orm/Xtensive.Orm/Orm/Operations/EntityFieldSetOperation.cs
+++ b/Orm/Xtensive.Orm/Orm/Operations/EntityFieldSetOperation.cs
@@ -64,7 +64,7 @@ namespace Xtensive.Orm.Operations
       var key = context.TryRemapKey(Key);
       var valueKey = context.TryRemapKey(ValueKey);
       var entity = session.Query.Single(key);
-      var value = ValueKey != null ? session.Query.Single(valueKey) : Value;
+      var value = ValueKey is not null ? session.Query.Single(valueKey) : Value;
       entity.SetFieldValue(Field, value);
     }
 
@@ -143,7 +143,7 @@ namespace Xtensive.Orm.Operations
       var structureValue = Value as Structure;
       if (WellKnownOrmInterfaces.Entity.IsAssignableFrom(Field.ValueType)) {
         // serializing entity value as key
-        if (ValueKey != null)
+        if (ValueKey is not null)
           info.AddValue("value", ValueKey.Format());
         else
           info.AddValue("value", string.Empty);

--- a/Orm/Xtensive.Orm/Orm/Operations/Internals/OperationRegistrationScope.cs
+++ b/Orm/Xtensive.Orm/Orm/Operations/Internals/OperationRegistrationScope.cs
@@ -57,7 +57,7 @@ namespace Xtensive.Orm.Operations
         return;
 
       var existingKey = KeyByIdentifier.GetValueOrDefault(identifier);
-      if (existingKey != null) {
+      if (existingKey is not null) {
         KeyByIdentifier.Remove(identifier);
         IdentifierByKey.Remove(existingKey);
       }

--- a/Orm/Xtensive.Orm/Orm/Operations/OperationExecutionContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Operations/OperationExecutionContext.cs
@@ -42,7 +42,7 @@ namespace Xtensive.Orm.Operations
     /// <returns>Remapped key</returns>
     public Key TryRemapKey(Key key)
     {
-      if (key==null)
+      if (key is null)
         return key;
       Key remappedKey;
       return KeyMapping.TryGetValue(key, out remappedKey) ? remappedKey : key;

--- a/Orm/Xtensive.Orm/Orm/Persistent.cs
+++ b/Orm/Xtensive.Orm/Orm/Persistent.cs
@@ -425,7 +425,7 @@ namespace Xtensive.Orm
             var persistent = this;
             var currentField = field;
             var structure = persistent as Structure;
-            while (structure != null && structure.Owner != null) {
+            while (structure?.Owner != null) {
               currentField = structure.Owner.TypeInfo.StructureFieldMapping[(structure.Field, currentField)];
               persistent = structure.Owner;
               structure = persistent as Structure;

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
@@ -446,7 +446,7 @@ namespace Xtensive.Orm.Providers
       }
       var body = Visit(l.Body);
       var sqlContainer = body as SqlContainer;
-      if (sqlContainer!=null)
+      if (sqlContainer is not null)
         return TryUnwrapEnum(sqlContainer);
       return body;
     }

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/DateOnlyCompilers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/DateOnlyCompilers.cs
@@ -136,7 +136,7 @@ namespace Xtensive.Orm.Providers
     {
       var stringValue = value as SqlLiteral<string>;
 
-      if (stringValue == null || !stringValue.Value.Equals("o", StringComparison.OrdinalIgnoreCase))
+      if (stringValue is null || !stringValue.Value.Equals("o", StringComparison.OrdinalIgnoreCase))
         throw new NotSupportedException(Strings.ExTranslationOfDateOnlyToStringWithArbitraryArgumentIsNotSupported);
 
       return SqlDml.DateToString(_this);

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/DateTimeCompilers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/DateTimeCompilers.cs
@@ -439,7 +439,7 @@ namespace Xtensive.Orm.Providers
     {
       var stringValue = value as SqlLiteral<string>;
 
-      if (stringValue == null || !stringValue.Value.Equals("s"))
+      if (stringValue is null || !stringValue.Value.Equals("s"))
         throw new NotSupportedException(Strings.ExTranslationOfDateTimeToStringWithArbitraryArgumentIsNotSupported);
 
       return SqlDml.DateTimeToStringIso(_this);

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/EnumCompilers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/EnumCompilers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2003-2013 Xtensive LLC.
+// Copyright (C) 2003-2013 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Alexey Kulakov
@@ -25,7 +25,7 @@ namespace Xtensive.Orm.Providers
     private static SqlExpression GetSqlLiterExpression(SqlExpression expression)
     {
       var container = expression as SqlContainer;
-      if (container != null) {
+      if (container is not null) {
         var containeredValue = (container).Value as Enum;
         if (containeredValue!=null)
           return SqlDml.Literal(Convert.ChangeType(containeredValue,Enum.GetUnderlyingType(containeredValue.GetType())));

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/MathCompilers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/MathCompilers.cs
@@ -578,7 +578,7 @@ namespace Xtensive.Orm.Providers
       if (!isDecimal) {
         return SqlDml.Round(value, digits, TypeCode.Double, midpointRounding);
       }
-      if (digits == null) {
+      if (digits is null) {
         return TryCastToDecimalPS(SqlDml.Round(value, digits, TypeCode.Decimal, midpointRounding), 28, 0);
       }
       if (!(digits is SqlLiteral<int> scale)) {
@@ -592,7 +592,7 @@ namespace Xtensive.Orm.Providers
       if (!isDecimal) {
         return SqlDml.Round(value, digits, TypeCode.Double, MidpointRounding.ToEven);
       }
-      if (digits == null) {
+      if (digits is null) {
         return TryCastToDecimalPS(SqlDml.Round(value, digits, TypeCode.Decimal, MidpointRounding.ToEven), 28, 0);
       }
       if (!(digits is SqlLiteral<int> scale)) {

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/NullableCompilers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/NullableCompilers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2009-2020 Xtensive LLC.
+// Copyright (C) 2009-2020 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Denis Krjuchkov
@@ -50,11 +50,11 @@ namespace Xtensive.Orm.Providers
       var @this = _this;
       var @default = _default;
       SqlContainer container = @this as SqlContainer;
-      if (container != null)
+      if (container is not null)
         if (container.Value.GetType().IsEnum)
           @this = SqlDml.Literal(Convert.ChangeType(container.Value, Enum.GetUnderlyingType(container.Value.GetType())));
       container = @default as SqlContainer;
-      if (container != null)
+      if (container is not null)
         if (container.Value.GetType().IsEnum)
           @default = SqlDml.Literal(Convert.ChangeType(container.Value, Enum.GetUnderlyingType(container.Value.GetType())));
       if (!IsBooleanSpecialCase(context, memberInfo))

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/TimeOnlyCompilers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/MemberCompilers/TimeOnlyCompilers.cs
@@ -150,7 +150,7 @@ namespace Xtensive.Orm.Providers
     {
       var stringValue = value as SqlLiteral<string>;
 
-      if (stringValue == null || !stringValue.Value.Equals("o", StringComparison.OrdinalIgnoreCase))
+      if (stringValue is null || !stringValue.Value.Equals("o", StringComparison.OrdinalIgnoreCase))
         throw new NotSupportedException(Strings.ExTranslationOfTimeOnlyToStringWithArbitraryArgumentIsNotSupported);
 
       return SqlDml.TimeToString(_this);

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
@@ -29,7 +29,7 @@ namespace Xtensive.Orm.Providers
         throw new InvalidOperationException(Strings.ExCannotApplyNodeConfigurationSettingsConnectionIsInUse);
       }
 
-      if (nodeConfiguration.ConnectionInfo != null) {
+      if (nodeConfiguration.ConnectionInfo is not null) {
         connection.ConnectionInfo = nodeConfiguration.ConnectionInfo;
       }
 
@@ -60,7 +60,7 @@ namespace Xtensive.Orm.Providers
       var sessionConfiguration = GetConfiguration(session);
       connection.CommandTimeout = sessionConfiguration.DefaultCommandTimeout;
       var connectionInfo = GetConnectionInfo(session) ?? sessionConfiguration.ConnectionInfo;
-      if (connectionInfo != null) {
+      if (connectionInfo is not null) {
         connection.ConnectionInfo = connectionInfo;
       }
 

--- a/Orm/Xtensive.Orm/Orm/Ref.cs
+++ b/Orm/Xtensive.Orm/Orm/Ref.cs
@@ -82,7 +82,7 @@ namespace Xtensive.Orm
       };
 
     /// <inheritdoc/>
-    public override int GetHashCode() => Key!=null ? Key.GetHashCode() : 0;
+    public override int GetHashCode() => Key?.GetHashCode() ?? 0;
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Column.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Column.cs
@@ -41,7 +41,7 @@ namespace Xtensive.Orm.Rse
 
     /// <inheritdoc/>
     public bool Equals(Column other) =>
-      other != null && (ReferenceEquals(this, other) || Name == other.Name);
+      other is not null && (ReferenceEquals(this, other) || Name == other.Name);
 
     /// <inheritdoc/>
     public override bool Equals(object obj) => obj is Column other && Equals(other);

--- a/Orm/Xtensive.Orm/Orm/Rse/Column.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Column.cs
@@ -40,20 +40,11 @@ namespace Xtensive.Orm.Rse
     #region Equals, GetHashCode, ==, !=
 
     /// <inheritdoc/>
-    public bool Equals(Column other)
-    {
-      if (other==null)
-        return false;
-      return Name==other.Name;
-    }
+    public bool Equals(Column other) =>
+      other != null && (ReferenceEquals(this, other) || Name == other.Name);
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (ReferenceEquals(this, obj))
-        return true;
-      return Equals(obj as Column);
-    }
+    public override bool Equals(object obj) => obj is Column other && Equals(other);
 
     /// <inheritdoc/>
     public override int GetHashCode() => Name.GetHashCode();
@@ -66,10 +57,7 @@ namespace Xtensive.Orm.Rse
     /// <returns>
     /// The result of the operator.
     /// </returns>
-    public static bool operator ==(Column left, Column right)
-    {
-      return Equals(left, right);
-    }
+    public static bool operator ==(Column left, Column right) => left?.Equals(right) ?? right is null;
 
     /// <summary>
     /// Implements the operator !=.
@@ -79,10 +67,7 @@ namespace Xtensive.Orm.Rse
     /// <returns>
     /// The result of the operator.
     /// </returns>
-    public static bool operator !=(Column left, Column right)
-    {
-      return !Equals(left, right);
-    }
+    public static bool operator !=(Column left, Column right) => !(left == right);
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Column.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Column.cs
@@ -106,7 +106,7 @@ namespace Xtensive.Orm.Rse
       Name = name;
       Index = index;
       Type = type;
-      Origin = originalColumn==null ? this : originalColumn.Origin;
+      Origin = originalColumn is null ? this : originalColumn.Origin;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeaderExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeaderExtensions.cs
@@ -23,7 +23,7 @@ namespace Xtensive.Orm.Rse
     public static int IndexOf(this RecordSetHeader header, string columnName)
     {
       var column = (MappedColumn) header.Columns[columnName];
-      return column==null ? -1 : column.Index;
+      return column is null ? -1 : column.Index;
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Structure.cs
+++ b/Orm/Xtensive.Orm/Orm/Structure.cs
@@ -299,7 +299,7 @@ namespace Xtensive.Orm
 
     #region Equals & GetHashCode
 
-    public static bool operator==(Structure left, Structure right) => left is null ? right is null : left.Equals(right);
+    public static bool operator==(Structure left, Structure right) => left?.Equals(right) ?? right is null;
 
     public static bool operator !=(Structure left, Structure rigth) => !(left == rigth);
 

--- a/Orm/Xtensive.Orm/Orm/Structure.cs
+++ b/Orm/Xtensive.Orm/Orm/Structure.cs
@@ -289,7 +289,7 @@ namespace Xtensive.Orm
     protected override sealed Pair<Key, Delegate> GetSubscription(object eventKey)
     {
       var entityKey = GetOwnerEntityKey(Owner);
-      if (entityKey!=null)
+      if (entityKey is not null)
         return new Pair<Key, Delegate>(entityKey,
           Session.EntityEvents.GetSubscriber(entityKey, Field, eventKey));
       return new Pair<Key, Delegate>(null, null);

--- a/Orm/Xtensive.Orm/Orm/Structure.cs
+++ b/Orm/Xtensive.Orm/Orm/Structure.cs
@@ -299,17 +299,9 @@ namespace Xtensive.Orm
 
     #region Equals & GetHashCode
 
-    public static bool operator==(Structure left, Structure right)
-    {
-      if (left is not null)
-        return left.Equals(right);
-      return right is null;
-    }
+    public static bool operator==(Structure left, Structure right) => left is null ? right is null : left.Equals(right);
 
-    public static bool operator !=(Structure left, Structure rigth)
-    {
-      return !(left==rigth);
-    }
+    public static bool operator !=(Structure left, Structure rigth) => !(left == rigth);
 
     /// <inheritdoc/>
     public override bool Equals(object obj) =>
@@ -318,7 +310,7 @@ namespace Xtensive.Orm
     /// <inheritdoc/>
     public bool Equals(Structure other)
     {
-      if (other==null)
+      if (other is null)
         return false;
       if (ReferenceEquals(this, other))
         return true;

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/CatalogCloner.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/CatalogCloner.cs
@@ -113,7 +113,7 @@ namespace Xtensive.Orm.Upgrade.Internals
         CopyDbName(newDomain, sourceDomain);
         if (sourceDomain.Collation!=null)
           newDomain.Collation = collationsMap[sourceDomain.Collation];
-        if (sourceDomain.DefaultValue!=null)
+        if (sourceDomain.DefaultValue is not null)
           newDomain.DefaultValue = sourceDomain.DefaultValue.Clone();
         foreach (var domainConstraint in sourceDomain.DomainConstraints) {
           var newConstraint = newDomain.CreateConstraint(domainConstraint.Name, domainConstraint.Condition.Clone());
@@ -159,7 +159,7 @@ namespace Xtensive.Orm.Upgrade.Internals
         var newView = newSchema.CreateView(sourceView.Name);
         CopyDbName(newView, sourceView);
         newView.CheckOptions = sourceView.CheckOptions;
-        if (sourceView.Definition != null) {
+        if (sourceView.Definition is not null) {
           newView.Definition = sourceView.Definition.Clone();
         }
         CloneViewColumns(newView, sourceView);
@@ -181,7 +181,7 @@ namespace Xtensive.Orm.Upgrade.Internals
         var newColumn = newTable.CreateColumn(sourceTableColumn.Name, sourceTableColumn.DataType);
         CopyDbName(newColumn, sourceTableColumn);
 
-        if (sourceTableColumn.DefaultValue!=null)
+        if (sourceTableColumn.DefaultValue is not null)
           newColumn.DefaultValue = sourceTableColumn.DefaultValue.Clone();
 
         var schema = newTable.Schema;
@@ -196,7 +196,7 @@ namespace Xtensive.Orm.Upgrade.Internals
         }
         if (sourceTableColumn.Domain!=null)
           newColumn.Domain = schema.Domains[sourceTableColumn.Domain.Name];
-        if (sourceTableColumn.Expression!=null)
+        if (sourceTableColumn.Expression is not null)
           newColumn.Expression = sourceTableColumn.Expression.Clone();
         newColumn.IsNullable = sourceTableColumn.IsNullable;
         newColumn.IsPersisted = sourceTableColumn.IsPersisted;
@@ -251,7 +251,7 @@ namespace Xtensive.Orm.Upgrade.Internals
         ft.IsClustered = ftIndex.IsClustered;
         ft.IsUnique = ftIndex.IsUnique;
         ft.UnderlyingUniqueIndex = ftIndex.UnderlyingUniqueIndex;
-        if (ftIndex.Where!=null)
+        if (ftIndex.Where is not null)
           ft.Where = ftIndex.Where.Clone();
         ClonePartitionDescriptor(ft, sourceIndex);
         return;
@@ -269,7 +269,7 @@ namespace Xtensive.Orm.Upgrade.Internals
         spatial.IsBitmap = spatialIndex.IsBitmap;
         spatial.IsClustered = spatialIndex.IsClustered;
         spatial.IsUnique = spatialIndex.IsUnique;
-        if (spatialIndex.Where!=null)
+        if (spatialIndex.Where is not null)
           spatial.Where = spatialIndex.Where.Clone();
         ClonePartitionDescriptor(spatialIndex, sourceIndex);
         return;
@@ -283,7 +283,7 @@ namespace Xtensive.Orm.Upgrade.Internals
       index.FillFactor = sourceIndex.FillFactor;
       index.IsUnique = sourceIndex.IsUnique;
       index.IsClustered = sourceIndex.IsClustered;
-      if (sourceIndex.Where!=null)
+      if (sourceIndex.Where is not null)
         index.Where = sourceIndex.Where.Clone();
       index.NonkeyColumns.AddRange(GetNonKeyColumns(newTable, sourceIndex));
       index.IsBitmap = sourceIndex.IsBitmap;

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SchemaComparer.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SchemaComparer.cs
@@ -87,8 +87,8 @@ namespace Xtensive.Orm.Upgrade
           action => {
             var sourceType = action.Difference.Source as StorageTypeInfo;
             var targetType = action.Difference.Target as StorageTypeInfo;
-            return sourceType==null || targetType==null || sourceType.IsTypeUndefined
-                   || sourceType.Type.ToNullable()!=targetType.Type.ToNullable();
+            return sourceType is null || targetType is null || sourceType.IsTypeUndefined
+                   || sourceType.Type.ToNullable() != targetType.Type.ToNullable();
           })
         .ToList();
 

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SqlActionTranslator.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/SqlActionTranslator.cs
@@ -339,13 +339,13 @@ namespace Xtensive.Orm.Upgrade
         var newColumn = newTable.CreateColumn(oldColumn.Name, oldColumn.DataType);
         newColumn.DbName = oldColumn.DbName;
         newColumn.IsNullable = oldColumn.IsNullable;
-        if (oldColumn.DefaultValue!=null && (oldColumn.DefaultValue is SqlLiteral<string> || oldColumn.DefaultValue is SqlLiteral<char>)) {
+        if (oldColumn.DefaultValue is not null && (oldColumn.DefaultValue is SqlLiteral<string> || oldColumn.DefaultValue is SqlLiteral<char>)) {
           var stringLiteral = oldColumn.DefaultValue as SqlLiteral<string>;
-          if (stringLiteral!=null)
+          if (stringLiteral is not null)
             newColumn.DefaultValue = SqlDml.Literal(TryUnquoteLiteral(stringLiteral.GetValue().ToString()));
 
           var charLiteral = oldColumn.DefaultValue as SqlLiteral<char>;
-          if (charLiteral!=null) {
+          if (charLiteral is not null) {
             var unquotedLiteral = TryUnquoteLiteral(charLiteral.GetValue().ToString());
             newColumn.DefaultValue = SqlDml.Literal(string.IsNullOrEmpty(unquotedLiteral) ? '\0' : Convert.ToChar(unquotedLiteral, CultureInfo.InvariantCulture));
           }

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Model/ForeignKeyInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Model/ForeignKeyInfo.cs
@@ -146,7 +146,7 @@ namespace Xtensive.Orm.Upgrade.Model
 
     private static bool CompareTypes(StorageTypeInfo first, StorageTypeInfo second)
     {
-      if (first==null || second==null)
+      if (first is null || second is null)
         return false;
       if (first.IsTypeUndefined || second.IsTypeUndefined)
         return true;

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Model/PrimaryIndexInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Model/PrimaryIndexInfo.cs
@@ -53,7 +53,7 @@ namespace Xtensive.Orm.Upgrade.Model
           ea.Execute(() => {
             throw new ValidationException(Strings.ExEmptyKeyColumnsCollection, Path);
           });
-        if (keys.Where(ci => ci.Type == null || ci.Type.IsNullable).Count() > 0)
+        if (keys.Where(ci => ci.Type is null || ci.Type.IsNullable).Count() > 0)
           ea.Execute(() => {
             throw new ValidationException(Strings.ExPrimaryKeyColumnCanNotBeNullable, Path);
           });

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Model/StorageColumnInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Model/StorageColumnInfo.cs
@@ -76,7 +76,7 @@ namespace Xtensive.Orm.Upgrade.Model
     {
       using (var ea = new ExceptionAggregator()) {
         ea.Execute(base.ValidateState);
-        if (Type==null) {
+        if (Type is null) {
           ea.Execute(() => {
             throw new ValidationException(
               string.Format(Strings.ExUndefinedTypeOfColumnX, Name),

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Model/StorageSequenceInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Model/StorageSequenceInfo.cs
@@ -97,7 +97,7 @@ namespace Xtensive.Orm.Upgrade.Model
               Path);
           });
         }
-        if (Type==null) {
+        if (Type is null) {
           ea.Execute(() => {
             throw new ValidationException(
               string.Format(string.Format(Strings.ExUndefinedTypeOfSequenceX, Name)),

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Model/StorageTypeInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Model/StorageTypeInfo.cs
@@ -109,16 +109,7 @@ namespace Xtensive.Orm.Upgrade.Model
     }
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (IsTypeUndefined)
-        return false;
-      if (obj is null)
-        return false;
-      if (ReferenceEquals(this, obj))
-        return true;
-      return obj is StorageTypeInfo otherStorageTypeInfo && Equals(otherStorageTypeInfo);
-    }
+    public override bool Equals(object obj) => obj is StorageTypeInfo other && Equals(other);
 
     /// <inheritdoc/>
     public override int GetHashCode() => HashCode.Combine(Type, IsNullable, Length, Scale, Precision);
@@ -129,10 +120,7 @@ namespace Xtensive.Orm.Upgrade.Model
     /// <param name="left">The left.</param>
     /// <param name="right">The right.</param>
     /// <returns>The result of the operator.</returns>
-    public static bool operator ==(StorageTypeInfo left, StorageTypeInfo right)
-    {
-      return Equals(left, right);
-    }
+    public static bool operator ==(StorageTypeInfo left, StorageTypeInfo right) => left?.Equals(right) ?? right is null;
 
     /// <summary>
     /// Implements the operator !=.
@@ -140,10 +128,7 @@ namespace Xtensive.Orm.Upgrade.Model
     /// <param name="left">The left.</param>
     /// <param name="right">The right.</param>
     /// <returns>The result of the operator.</returns>
-    public static bool operator !=(StorageTypeInfo left, StorageTypeInfo right)
-    {
-      return !Equals(left, right);
-    }
+    public static bool operator !=(StorageTypeInfo left, StorageTypeInfo right) => !(left == right);
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Model/StorageTypeInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Model/StorageTypeInfo.cs
@@ -173,7 +173,7 @@ namespace Xtensive.Orm.Upgrade.Model
         sb.Append(string.Format(Strings.PropertyPairFormat, Strings.Precision, Precision));
       }
 
-      if (NativeType != null) {
+      if (NativeType is not null) {
         sb.Append(Strings.Comma);
         sb.Append(string.Format(Strings.PropertyPairFormat, Strings.NativeType, NativeType));
       }

--- a/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/UpgradingDomainBuilder.cs
@@ -48,7 +48,7 @@ namespace Xtensive.Orm.Upgrade
         throw new InvalidOperationException($"{nameof(configuration.ShareQueryCacheOverNodes)} options cannot be set without {nameof(configuration.ShareStorageSchemaOverNodes)} option");
       }
 
-      if (configuration.ConnectionInfo==null) {
+      if (configuration.ConnectionInfo is null) {
         throw new ArgumentException(Strings.ExConnectionInfoIsMissing, nameof(configuration));
       }
 
@@ -74,7 +74,7 @@ namespace Xtensive.Orm.Upgrade
     {
       ArgumentNullException.ThrowIfNull(configuration);
 
-      if (configuration.ConnectionInfo==null) {
+      if (configuration.ConnectionInfo is null) {
         throw new ArgumentException(Strings.ExConnectionInfoIsMissing, nameof(configuration));
       }
 

--- a/Orm/Xtensive.Orm/Orm/UrlInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/UrlInfo.cs
@@ -393,15 +393,7 @@ namespace Xtensive.Orm
     #region Equals, GetHashCode, ==, !=
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (obj is null)
-        return false;
-      if (ReferenceEquals(this, obj))
-        return true;
-
-      return obj is UrlInfo otherUrlInfo && Equals(otherUrlInfo);
-    }
+    public override bool Equals(object obj) => obj is UrlInfo other && Equals(other);
 
     /// <inheritdoc/>
     public override int GetHashCode() => url?.GetHashCode() ?? 0;
@@ -412,10 +404,7 @@ namespace Xtensive.Orm
     /// <param name="left"></param>
     /// <param name="right"></param>
     /// <returns></returns>
-    public static bool operator ==(UrlInfo left, UrlInfo right)
-    {
-      return Equals(left, right);
-    }
+    public static bool operator ==(UrlInfo left, UrlInfo right) => left?.Equals(right) ?? right is null;
 
     /// <summary>
     /// Checks specified objects for inequality.
@@ -423,10 +412,7 @@ namespace Xtensive.Orm
     /// <param name="left"></param>
     /// <param name="right"></param>
     /// <returns></returns>
-    public static bool operator !=(UrlInfo left, UrlInfo right)
-    {
-      return !Equals(left, right);
-    }
+    public static bool operator !=(UrlInfo left, UrlInfo right) => !(left == right);
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/VersionSet.cs
+++ b/Orm/Xtensive.Orm/Orm/VersionSet.cs
@@ -83,12 +83,7 @@ namespace Xtensive.Orm
     /// </summary>
     /// <param name="key">The key to check for containment.</param>
     /// <returns>Check result.</returns>
-    public bool Contains(Key key)
-    {
-      if (key==null)
-        return false;
-      return versions.ContainsKey(key);
-    }
+    public bool Contains(Key key) => key is not null && versions.ContainsKey(key);
 
     #region Validate methods
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlBinary.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlBinary.cs
@@ -25,61 +25,23 @@ namespace Xtensive.Sql.Dml
     /// <value>The right operand of the binary operator.</value>
     public SqlExpression Right { get; private set; }
 
-    public static bool operator true(SqlBinary operand)
-    {
-      switch (operand.NodeType) {
-        case SqlNodeType.Equals:
-          if (((object)operand.Right)==((object)operand.Left))
-            return true;
-          else
-            return false;
-        case SqlNodeType.NotEquals:
-          if (((object)operand.Right)!=((object)operand.Left))
-            return true;
-          else
-            return false;
-        case SqlNodeType.And:
-          if (((SqlBinary)operand.Left ? true : false) && ((SqlBinary)operand.Right ? true : false))
-            return true;
-          else
-            return false;
-        case SqlNodeType.Or:
-          if (((SqlBinary)operand.Left ? true : false) || ((SqlBinary)operand.Right ? true : false))
-            return true;
-          else
-            return false;
-        default:
-          return false;
-      }
-    }
+    public static bool operator true(SqlBinary operand) =>
+      operand.NodeType switch {
+        SqlNodeType.Equals => (object) operand.Right == (object) operand.Left,
+        SqlNodeType.NotEquals => (object) operand.Right != (object) operand.Left,
+        SqlNodeType.And => ((SqlBinary)operand.Left ? true : false) && ((SqlBinary)operand.Right ? true : false),
+        SqlNodeType.Or => ((SqlBinary)operand.Left ? true : false) || ((SqlBinary)operand.Right ? true : false),
+        _ =>  false
+      };
 
-    public static bool operator false(SqlBinary operand)
-    {
-      switch (operand.NodeType) {
-        case SqlNodeType.Equals:
-          if (((object)operand.Right)==((object)operand.Left))
-            return false;
-          else
-            return true;
-        case SqlNodeType.NotEquals:
-          if (((object)operand.Right)!=((object)operand.Left))
-            return false;
-          else
-            return true;
-        case SqlNodeType.And:
-          if (((SqlBinary)operand.Left ? true : false) && ((SqlBinary)operand.Right ? true : false))
-            return false;
-          else
-            return true;
-        case SqlNodeType.Or:
-          if (((SqlBinary)operand.Left ? true : false) || ((SqlBinary)operand.Right ? true : false))
-            return false;
-          else
-            return true;
-        default:
-          return false;
-      }
-    }
+    public static bool operator false(SqlBinary operand) =>
+      operand.NodeType switch {
+        SqlNodeType.Equals => (object) operand.Right != (object) operand.Left,
+        SqlNodeType.NotEquals => (object) operand.Right == (object) operand.Left,
+        SqlNodeType.And => !((SqlBinary) operand.Left ? true : false) && ((SqlBinary) operand.Right ? true : false),
+        SqlNodeType.Or => !((SqlBinary) operand.Left ? true : false) || ((SqlBinary) operand.Right ? true : false),
+        _ => false
+      };
 
     public override void ReplaceWith(SqlExpression expression)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlBinary.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlBinary.cs
@@ -27,8 +27,8 @@ namespace Xtensive.Sql.Dml
 
     public static bool operator true(SqlBinary operand) =>
       operand.NodeType switch {
-        SqlNodeType.Equals => (object) operand.Right == (object) operand.Left,
-        SqlNodeType.NotEquals => (object) operand.Right != (object) operand.Left,
+        SqlNodeType.Equals => ReferenceEquals(operand.Left, operand.Right),
+        SqlNodeType.NotEquals => !ReferenceEquals(operand.Left, operand.Right),
         SqlNodeType.And => ((SqlBinary)operand.Left ? true : false) && ((SqlBinary)operand.Right ? true : false),
         SqlNodeType.Or => ((SqlBinary)operand.Left ? true : false) || ((SqlBinary)operand.Right ? true : false),
         _ =>  false
@@ -36,8 +36,8 @@ namespace Xtensive.Sql.Dml
 
     public static bool operator false(SqlBinary operand) =>
       operand.NodeType switch {
-        SqlNodeType.Equals => (object) operand.Right != (object) operand.Left,
-        SqlNodeType.NotEquals => (object) operand.Right == (object) operand.Left,
+        SqlNodeType.Equals => !ReferenceEquals(operand.Left, operand.Right),
+        SqlNodeType.NotEquals => ReferenceEquals(operand.Left, operand.Right),
         SqlNodeType.And => !((SqlBinary) operand.Left ? true : false) && ((SqlBinary) operand.Right ? true : false),
         SqlNodeType.Or => !((SqlBinary) operand.Left ? true : false) || ((SqlBinary) operand.Right ? true : false),
         _ => false

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlComment.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlComment.cs
@@ -36,10 +36,10 @@ namespace Xtensive.Sql.Dml
       if (ReferenceEquals(comment1, comment2))
         return comment1;
 
-      if (comment1 == null && comment2 == null)
+      if (comment1 is null && comment2 is null)
         return null;
-      if (comment1 != null) {
-        if (comment2 != null)
+      if (comment1 is not null) {
+        if (comment2 is not null)
           comment1.Text += $" {comment2.Text}";
         return comment1;
       }

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlCustomFunctionType.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlCustomFunctionType.cs
@@ -22,35 +22,16 @@ namespace Xtensive.Sql.Dml
 
     #region Equality members
 
-    public bool Equals(SqlCustomFunctionType other)
-    {
-      if (other is null)
-        return false;
-      if (ReferenceEquals(this, other))
-        return true;
-      return string.Equals(Name, other.Name);
-    }
+    public bool Equals(SqlCustomFunctionType other) =>
+      (other is not null) && (ReferenceEquals(this, other) || string.Equals(Name, other.Name));
 
-    public override bool Equals(object obj)
-    {
-      if (obj is null)
-        return false;
-      if (ReferenceEquals(this, obj))
-        return true;
-      return Equals((SqlCustomFunctionType) obj);
-    }
+    public override bool Equals(object obj) => obj is SqlCustomFunctionType other && Equals(other);
 
     public override int GetHashCode() => Name.GetHashCode();
 
-    public static bool operator ==(SqlCustomFunctionType left, SqlCustomFunctionType right)
-    {
-      return Equals(left, right);
-    }
+    public static bool operator ==(SqlCustomFunctionType left, SqlCustomFunctionType right) => left?.Equals(right) ?? right is null;
 
-    public static bool operator !=(SqlCustomFunctionType left, SqlCustomFunctionType right)
-    {
-      return !Equals(left, right);
-    }
+    public static bool operator !=(SqlCustomFunctionType left, SqlCustomFunctionType right) => !(left == right);
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Sql/Internals/SqlValidator.cs
+++ b/Orm/Xtensive.Orm/Sql/Internals/SqlValidator.cs
@@ -84,7 +84,7 @@ namespace Xtensive.Sql
 
     public static bool IsBooleanExpression(SqlExpression node)
     {
-      if (node == null)
+      if (node is null)
         return true;
       switch (node.NodeType) {
         case SqlNodeType.And:
@@ -135,7 +135,7 @@ namespace Xtensive.Sql
 
     public static bool IsArithmeticExpression(SqlExpression node)
     {
-      if (node == null) {
+      if (node is null) {
         return true;
       }
 
@@ -190,7 +190,7 @@ namespace Xtensive.Sql
 
     public static bool IsCharacterExpression(SqlExpression node)
     {
-      if (node == null)
+      if (node is null)
         return true;
       if (node is SqlBinary)
         return true; // Allow easy operation for SQLite

--- a/Orm/Xtensive.Orm/Sql/SqlDml.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlDml.cs
@@ -1752,7 +1752,7 @@ namespace Xtensive.Sql
       ArgumentNullException.ThrowIfNull(start);
       SqlValidator.EnsureIsCharacterExpression(operand);
       SqlValidator.EnsureIsArithmeticExpression(start);
-      if (length != null) {
+      if (length is not null) {
         SqlValidator.EnsureIsArithmeticExpression(length);
         return new SqlFunctionCall(SqlFunctionType.Substring, operand, start, length);
       }

--- a/Orm/Xtensive.Orm/Sql/SqlValueType.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlValueType.cs
@@ -66,7 +66,7 @@ namespace Xtensive.Sql
 
     /// <inheritdoc/>
     public bool Equals(SqlValueType other) =>
-      other != null &&
+      other is not null &&
       other.Type == Type &&
       other.TypeName == TypeName &&
       other.Length == Length &&
@@ -82,8 +82,7 @@ namespace Xtensive.Sql
     /// <param name="left">The left.</param>
     /// <param name="right">The right.</param>
     /// <returns>The result of the operator.</returns>
-    public static bool operator ==(SqlValueType left, SqlValueType right) =>
-      ReferenceEquals(left, right) || left?.Equals(right) == true;
+    public static bool operator ==(SqlValueType left, SqlValueType right) => left?.Equals(right) ?? right is null;
 
     /// <summary>
     /// Implements the operator !=.


### PR DESCRIPTION
This overloaded `==` allocates `SqlBinary` and then calls its `operator true()`

For comparing with `null` it is semantically the same as `is null`
see https://github.com/servicetitan/dataobjects-net/blob/master-servicetitan/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlBinary.cs#L32

Also:
* Simplify `SqlBinary`
* Fix recursion in `Structure.Equals()`
* Improve `TypeInfo.Equals()` / `operator==`
* Improve `Column.Equals()` / `operator==`
* Improve `Key.operator==` usage
* Improve `SqlValueType.operator==`
* Improve `ConnectionInfo.operator==`
* Improve `StorageTypeInfo.operator==`
* Improve `FieldInfoRef.operator==`
* Improve `UrlInfo.operator==`
* Improve `SqlCustomFunctionType.operator==`