### PR TITLE
Avoid array allocation in `AliasGenerator columnAliasGenerator` constructing

### DIFF
--- a/Orm/Xtensive.Orm/Core/AliasGenerator.cs
+++ b/Orm/Xtensive.Orm/Core/AliasGenerator.cs
@@ -4,8 +4,6 @@
 // Created by: Alexis Kochetov
 // Created:    2009.02.10
 
-using System;
-
 namespace Xtensive.Core
 {
   /// <summary>
@@ -57,19 +55,13 @@ namespace Xtensive.Core
     /// Creates generator with default settings.
     /// </summary>
     /// <returns></returns>
-    public static AliasGenerator Create()
-    {
-      return new AliasGenerator();
-    }
+    public static AliasGenerator Create() => new();
 
     /// <summary>
     /// Creates generator using specified alias template.
     /// </summary>
     /// <param name="aliasTemplate">Alias template. Could use two template parameters: {0} - for prefix and {1} for suffix.</param>
-    public static AliasGenerator Create(string aliasTemplate)
-    {
-      return new AliasGenerator(aliasTemplate);
-    }
+    public static AliasGenerator Create(string aliasTemplate) => new(DefaultPrefixSequence, aliasTemplate);
 
     /// <summary>
     /// Creates generator using specified prefix sequence.
@@ -88,18 +80,10 @@ namespace Xtensive.Core
     // Constructors
 
     public AliasGenerator()
-      : this (DefaultAliasTemplate)
+      : this (DefaultPrefixSequence, DefaultAliasTemplate)
     {}
 
-    private AliasGenerator(string aliasTemplate)
-      : this (DefaultPrefixSequence, aliasTemplate)
-    {}
-
-    private AliasGenerator(IReadOnlyList<string> prefixes)
-      : this (prefixes, DefaultAliasTemplate)
-    {}
-
-    private AliasGenerator(IReadOnlyList<string> prefixes, string aliasTemplate)
+    private AliasGenerator(IReadOnlyList<string> prefixes, string aliasTemplate = DefaultAliasTemplate)
     {
       prefixSequence = prefixes;
       this.aliasTemplate = aliasTemplate;

--- a/Orm/Xtensive.Orm/Core/AliasGenerator.cs
+++ b/Orm/Xtensive.Orm/Core/AliasGenerator.cs
@@ -28,7 +28,7 @@ namespace Xtensive.Core
         "w", "x", "y", "z"
       };
 
-    private readonly string[] prefixSequence;
+    private readonly IReadOnlyList<string> prefixSequence;
     private readonly string aliasTemplate;
     private byte prefixIndex;
     private int suffixNumber;
@@ -47,7 +47,7 @@ namespace Xtensive.Core
 
     private void VerifyState()
     {
-      if (prefixIndex >= prefixSequence.Length) {
+      if (prefixIndex >= prefixSequence.Count) {
         prefixIndex = 0;
         suffixNumber++;
       }
@@ -75,20 +75,14 @@ namespace Xtensive.Core
     /// Creates generator using specified prefix sequence.
     /// </summary>
     /// <param name="overriddenPrefixes">The overridden prefix sequence.</param>
-    public static AliasGenerator Create(string [] overriddenPrefixes)
-    {
-      return new AliasGenerator(overriddenPrefixes);
-    }
+    public static AliasGenerator Create(IReadOnlyList<string> overriddenPrefixes) => new(overriddenPrefixes);
 
     /// <summary>
     /// Creates generator using specified <paramref name="overriddenPrefixes"/> and <paramref name="aliasTemplate"/>.
     /// </summary>
     /// <param name="overriddenPrefixes">The overridden prefix sequence.</param>
     /// <param name="aliasTemplate">The alias template.</param>
-    public static AliasGenerator Create(string[] overriddenPrefixes, string aliasTemplate)
-    {
-      return new AliasGenerator(overriddenPrefixes, aliasTemplate);
-    }
+    public static AliasGenerator Create(IReadOnlyList<string> overriddenPrefixes, string aliasTemplate) => new(overriddenPrefixes, aliasTemplate);
 
 
     // Constructors
@@ -101,11 +95,11 @@ namespace Xtensive.Core
       : this (DefaultPrefixSequence, aliasTemplate)
     {}
 
-    private AliasGenerator(string[] prefixes)
+    private AliasGenerator(IReadOnlyList<string> prefixes)
       : this (prefixes, DefaultAliasTemplate)
     {}
 
-    private AliasGenerator(string[] prefixes, string aliasTemplate)
+    private AliasGenerator(IReadOnlyList<string> prefixes, string aliasTemplate)
     {
       prefixSequence = prefixes;
       this.aliasTemplate = aliasTemplate;

--- a/Orm/Xtensive.Orm/Core/AliasGenerator.cs
+++ b/Orm/Xtensive.Orm/Core/AliasGenerator.cs
@@ -67,7 +67,7 @@ namespace Xtensive.Core
     /// Creates generator using specified prefix sequence.
     /// </summary>
     /// <param name="overriddenPrefixes">The overridden prefix sequence.</param>
-    public static AliasGenerator Create(IReadOnlyList<string> overriddenPrefixes) => new(overriddenPrefixes);
+    public static AliasGenerator Create(IReadOnlyList<string> overriddenPrefixes) => new(overriddenPrefixes, DefaultAliasTemplate);
 
     /// <summary>
     /// Creates generator using specified <paramref name="overriddenPrefixes"/> and <paramref name="aliasTemplate"/>.
@@ -83,7 +83,7 @@ namespace Xtensive.Core
       : this (DefaultPrefixSequence, DefaultAliasTemplate)
     {}
 
-    private AliasGenerator(IReadOnlyList<string> prefixes, string aliasTemplate = DefaultAliasTemplate)
+    private AliasGenerator(IReadOnlyList<string> prefixes, string aliasTemplate)
     {
       prefixSequence = prefixes;
       this.aliasTemplate = aliasTemplate;

--- a/Orm/Xtensive.Orm/Orm/Linq/TranslatorContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/TranslatorContext.cs
@@ -25,12 +25,14 @@ namespace Xtensive.Orm.Linq
 {
   internal sealed class TranslatorContext
   {
+    private static readonly IReadOnlyList<string> ColumnAliasPrefixes = ["c01umn"];
+
     private AliasGenerator resultAliasGenerator = AliasGenerator.Create("#{0}{1}");
-    private AliasGenerator columnAliasGenerator = AliasGenerator.Create(new[] {"c01umn"});
-    private readonly Dictionary<ParameterExpression, Parameter<Tuple>> tupleParameters;
-    private readonly Dictionary<CompilableProvider, ApplyParameter> applyParameters;
-    private readonly Dictionary<ParameterExpression, ItemProjectorExpression> boundItemProjectors;
-    private readonly Dictionary<MemberInfo, int> queryReuses;
+    private AliasGenerator columnAliasGenerator = AliasGenerator.Create(ColumnAliasPrefixes);
+    private readonly Dictionary<ParameterExpression, Parameter<Tuple>> tupleParameters = new();
+    private readonly Dictionary<CompilableProvider, ApplyParameter> applyParameters = new();
+    private readonly Dictionary<ParameterExpression, ItemProjectorExpression> boundItemProjectors = new();
+    private readonly Dictionary<MemberInfo, int> queryReuses = new();
 
     public readonly CompilerConfiguration RseCompilerConfiguration;
 
@@ -52,7 +54,7 @@ namespace Xtensive.Orm.Linq
 
     public ParameterExtractor ParameterExtractor { get; }
 
-    public LinqBindingCollection Bindings { get; }
+    public LinqBindingCollection Bindings { get; } = new();
 
     public IReadOnlyList<string> SessionTags { get; private set; }
 
@@ -177,11 +179,6 @@ namespace Xtensive.Orm.Linq
       ProviderInfo = Domain.Handlers.ProviderInfo;
       Translator = new Translator(this, compiledQueryScope);
       ParameterExtractor = new ParameterExtractor(Evaluator);
-      Bindings = new LinqBindingCollection();
-      applyParameters = new Dictionary<CompilableProvider, ApplyParameter>();
-      tupleParameters = new Dictionary<ParameterExpression, Parameter<Tuple>>();
-      boundItemProjectors = new Dictionary<ParameterExpression, ItemProjectorExpression>();
-      queryReuses = new Dictionary<MemberInfo, int>();
     }
   }
 }


### PR DESCRIPTION
We can use static immutable array

Also:
* some refactoring
* Reduce number of `AliasGenerator` constructors. They all are `private`, so it is not a breaking change