### PR TITLE
Optimize `IsGenericMethodSpecificationOf`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/MemberCompilation/MemberCompilerProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/MemberCompilation/MemberCompilerProvider.cs
@@ -111,9 +111,10 @@ namespace Xtensive.Orm.Linq.MemberCompilation
 
     private static MethodBase GetCanonicalMethod(MethodBase inputMethod, MethodBase[] possibleCanonicalMethods)
     {
+      var metadataToken = inputMethod.MetadataToken;
+      var module = inputMethod.Module;
       foreach (var candidate in possibleCanonicalMethods) {
-        if (inputMethod.MetadataToken == candidate.MetadataToken
-          && (ReferenceEquals(inputMethod.Module, candidate.Module) || inputMethod.Module == candidate.Module)) {
+        if (metadataToken == candidate.MetadataToken && module == candidate.Module) {
           return candidate;
         }
       }

--- a/Orm/Xtensive.Orm/Orm/Linq/Model/QueryParser.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Model/QueryParser.cs
@@ -4,7 +4,6 @@
 // Created by: Denis Krjuchkov
 // Created:    2013.12.11
 
-using System;
 using System.Linq.Expressions;
 using Xtensive.Core;
 using Xtensive.Reflection;
@@ -17,28 +16,29 @@ namespace Xtensive.Orm.Linq.Model
     {
       var method = mc.Method;
       var mcArguments = mc.Arguments;
+      MethodInfoParams methodInfoParams = new(method, false);
 
-      if (method.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByParams))
+      if (methodInfoParams.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByParams))
         return new GroupByQuery {
           Source = mcArguments[0],
           KeySelector = mcArguments[1].StripQuotes(),
         };
 
-      if (method.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByWithElementSelectorParams))
+      if (methodInfoParams.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByWithElementSelectorParams))
         return new GroupByQuery {
           Source = mcArguments[0],
           KeySelector = mcArguments[1].StripQuotes(),
           ElementSelector = mcArguments[2].StripQuotes(),
         };
 
-      if (method.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByWithResultSelectorParams))
+      if (methodInfoParams.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByWithResultSelectorParams))
         return new GroupByQuery {
             Source = mcArguments[0],
             KeySelector = mcArguments[1].StripQuotes(),
             ResultSelector = mcArguments[2].StripQuotes(),
           };
 
-      if (method.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByWithElementAndResultSelectorsParams))
+      if (methodInfoParams.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByWithElementAndResultSelectorsParams))
         return new GroupByQuery {
           Source = mcArguments[0],
           KeySelector = mcArguments[1].StripQuotes(),

--- a/Orm/Xtensive.Orm/Orm/Linq/Model/QueryParser.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Model/QueryParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2013 Xtensive LLC.
+// Copyright (C) 2013 Xtensive LLC.
 // All rights reserved.
 // For conditions of distribution and use, see license.
 // Created by: Denis Krjuchkov
@@ -16,29 +16,29 @@ namespace Xtensive.Orm.Linq.Model
     {
       var method = mc.Method;
       var mcArguments = mc.Arguments;
-      MethodInfoParams methodInfoParams = new(method, false);
+      GenericMethodHandle methodInfoHandle = new(method);
 
-      if (methodInfoParams.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByParams))
+      if (methodInfoHandle.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByHandle))
         return new GroupByQuery {
           Source = mcArguments[0],
           KeySelector = mcArguments[1].StripQuotes(),
         };
 
-      if (methodInfoParams.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByWithElementSelectorParams))
+      if (methodInfoHandle.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByWithElementSelectorHandle))
         return new GroupByQuery {
           Source = mcArguments[0],
           KeySelector = mcArguments[1].StripQuotes(),
           ElementSelector = mcArguments[2].StripQuotes(),
         };
 
-      if (methodInfoParams.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByWithResultSelectorParams))
+      if (methodInfoHandle.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByWithResultSelectorHandle))
         return new GroupByQuery {
             Source = mcArguments[0],
             KeySelector = mcArguments[1].StripQuotes(),
             ResultSelector = mcArguments[2].StripQuotes(),
           };
 
-      if (methodInfoParams.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByWithElementAndResultSelectorsParams))
+      if (methodInfoHandle.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByWithElementAndResultSelectorsHandle))
         return new GroupByQuery {
           Source = mcArguments[0],
           KeySelector = mcArguments[1].StripQuotes(),

--- a/Orm/Xtensive.Orm/Orm/Linq/Model/QueryParser.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Model/QueryParser.cs
@@ -17,27 +17,27 @@ namespace Xtensive.Orm.Linq.Model
     {
       var method = mc.Method;
 
-      if (method.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupBy))
+      if (method.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByParams))
         return new GroupByQuery {
           Source = mc.Arguments[0],
           KeySelector = mc.Arguments[1].StripQuotes(),
         };
 
-      if (method.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByWithElementSelector))
+      if (method.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByWithElementSelectorParams))
         return new GroupByQuery {
           Source = mc.Arguments[0],
           KeySelector = mc.Arguments[1].StripQuotes(),
           ElementSelector = mc.Arguments[2].StripQuotes(),
         };
 
-      if (method.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByWithResultSelector))
+      if (method.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByWithResultSelectorParams))
         return new GroupByQuery {
             Source = mc.Arguments[0],
             KeySelector = mc.Arguments[1].StripQuotes(),
             ResultSelector = mc.Arguments[2].StripQuotes(),
           };
 
-      if (method.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByWithElementAndResultSelectors))
+      if (method.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByWithElementAndResultSelectorsParams))
         return new GroupByQuery {
           Source = mc.Arguments[0],
           KeySelector = mc.Arguments[1].StripQuotes(),

--- a/Orm/Xtensive.Orm/Orm/Linq/Model/QueryParser.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Model/QueryParser.cs
@@ -16,33 +16,34 @@ namespace Xtensive.Orm.Linq.Model
     public static GroupByQuery ParseGroupBy(MethodCallExpression mc)
     {
       var method = mc.Method;
+      var mcArguments = mc.Arguments;
 
       if (method.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByParams))
         return new GroupByQuery {
-          Source = mc.Arguments[0],
-          KeySelector = mc.Arguments[1].StripQuotes(),
+          Source = mcArguments[0],
+          KeySelector = mcArguments[1].StripQuotes(),
         };
 
       if (method.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByWithElementSelectorParams))
         return new GroupByQuery {
-          Source = mc.Arguments[0],
-          KeySelector = mc.Arguments[1].StripQuotes(),
-          ElementSelector = mc.Arguments[2].StripQuotes(),
+          Source = mcArguments[0],
+          KeySelector = mcArguments[1].StripQuotes(),
+          ElementSelector = mcArguments[2].StripQuotes(),
         };
 
       if (method.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByWithResultSelectorParams))
         return new GroupByQuery {
-            Source = mc.Arguments[0],
-            KeySelector = mc.Arguments[1].StripQuotes(),
-            ResultSelector = mc.Arguments[2].StripQuotes(),
+            Source = mcArguments[0],
+            KeySelector = mcArguments[1].StripQuotes(),
+            ResultSelector = mcArguments[2].StripQuotes(),
           };
 
       if (method.IsGenericMethodSpecificationOf(QueryableMethodInfo.GroupByWithElementAndResultSelectorsParams))
         return new GroupByQuery {
-          Source = mc.Arguments[0],
-          KeySelector = mc.Arguments[1].StripQuotes(),
-          ElementSelector = mc.Arguments[2].StripQuotes(),
-          ResultSelector = mc.Arguments[3].StripQuotes()
+          Source = mcArguments[0],
+          KeySelector = mcArguments[1].StripQuotes(),
+          ElementSelector = mcArguments[2].StripQuotes(),
+          ResultSelector = mcArguments[3].StripQuotes()
         };
 
       throw new NotSupportedException(string.Format(

--- a/Orm/Xtensive.Orm/Orm/Linq/Model/QueryableMethodInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Model/QueryableMethodInfo.cs
@@ -11,16 +11,16 @@ namespace Xtensive.Orm.Linq.Model
     public static readonly MethodInfo Select = MethodOf(q => q.Select(o => o));
 
     public static readonly MethodInfo GroupBy = MethodOf(q => q.GroupBy(o => o));
-    internal static readonly MethodInfoParams GroupByParams = new(GroupBy);
+    internal static readonly GenericMethodDefinitionHandle GroupByHandle = new(GroupBy);
 
     public static readonly MethodInfo GroupByWithElementSelector = MethodOf(q => q.GroupBy(o => o, o => o.ToString()));
-    internal static readonly MethodInfoParams GroupByWithElementSelectorParams = new(GroupByWithElementSelector);
+    internal static readonly GenericMethodDefinitionHandle GroupByWithElementSelectorHandle = new(GroupByWithElementSelector);
 
     public static readonly MethodInfo GroupByWithResultSelector = MethodOf(q => q.GroupBy(o => o, (key, items) => items.Count()));
-    internal static readonly MethodInfoParams GroupByWithResultSelectorParams = new(GroupByWithResultSelector);
+    internal static readonly GenericMethodDefinitionHandle GroupByWithResultSelectorHandle = new(GroupByWithResultSelector);
 
     public static readonly MethodInfo GroupByWithElementAndResultSelectors = MethodOf(q => q.GroupBy(o => o, o => o.ToString(), (key, items) => items.Count()));
-    internal static readonly MethodInfoParams GroupByWithElementAndResultSelectorsParams = new(GroupByWithElementAndResultSelectors);
+    internal static readonly GenericMethodDefinitionHandle GroupByWithElementAndResultSelectorsHandle = new(GroupByWithElementAndResultSelectors);
 
     private static MethodInfo MethodOf<T>(Expression<Func<IQueryable<object>, IQueryable<T>>> methodExpression)
     {

--- a/Orm/Xtensive.Orm/Orm/Linq/Model/QueryableMethodInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Model/QueryableMethodInfo.cs
@@ -9,10 +9,18 @@ namespace Xtensive.Orm.Linq.Model
   internal static class QueryableMethodInfo
   {
     public static readonly MethodInfo Select = MethodOf(q => q.Select(o => o));
+
     public static readonly MethodInfo GroupBy = MethodOf(q => q.GroupBy(o => o));
+    internal static readonly MethodInfoParams GroupByParams = new(GroupBy);
+
     public static readonly MethodInfo GroupByWithElementSelector = MethodOf(q => q.GroupBy(o => o, o => o.ToString()));
+    internal static readonly MethodInfoParams GroupByWithElementSelectorParams = new(GroupByWithElementSelector);
+
     public static readonly MethodInfo GroupByWithResultSelector = MethodOf(q => q.GroupBy(o => o, (key, items) => items.Count()));
+    internal static readonly MethodInfoParams GroupByWithResultSelectorParams = new(GroupByWithResultSelector);
+
     public static readonly MethodInfo GroupByWithElementAndResultSelectors = MethodOf(q => q.GroupBy(o => o, o => o.ToString(), (key, items) => items.Count()));
+    internal static readonly MethodInfoParams GroupByWithElementAndResultSelectorsParams = new(GroupByWithElementAndResultSelectors);
 
     private static MethodInfo MethodOf<T>(Expression<Func<IQueryable<object>, IQueryable<T>>> methodExpression)
     {

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -461,15 +461,15 @@ namespace Xtensive.Orm.Linq
 
           // Query.ContainsTable<T>
           if (methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprHandle)
-              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprWithColumnsParams)
-              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprTopNByRankParams)
-              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprWithColumnsTopNByRankParams)) {
+              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprWithColumnsHandle)
+              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprTopNByRankHandle)
+              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprWithColumnsTopNByRankHandle)) {
             return ConstructContainsTableQueryRoot(method.GetGenericArguments()[0], mc.Arguments);
           }
 
           // Query.Single<T> & Query.SingleOrDefault<T>
-          if (methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.SingleKeyParams)
-              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.SingleOrDefaultKeyParams)) {
+          if (methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.SingleKeyHandle)
+              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.SingleOrDefaultKeyHandle)) {
             return VisitQuerySingle(mc);
           }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -446,29 +446,29 @@ namespace Xtensive.Orm.Linq
 #pragma warning disable 612,618
         if (methodDeclaringType == WellKnownOrmTypes.Query) {
           // Query.All<T>
-          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.All)) {
+          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.AllParams)) {
             return ConstructQueryable(mc);
           }
 
           // Query.FreeText<T>
-          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextString)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextExpression)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextExpressionTopNByRank)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextStringTopNByRank)) {
+          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextStringParams)
+            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextExpressionParams)
+            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextExpressionTopNByRankParams)
+            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextStringTopNByRankParams)) {
             return ConstructFreeTextQueryRoot(method.GetGenericArguments()[0], mc.Arguments);
           }
 
           // Query.ContainsTable<T>
-          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExpr)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprWithColumns)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprTopNByRank)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprWithColumnsTopNByRank)) {
+          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprParams)
+            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprWithColumnsParams)
+            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprTopNByRankParams)
+            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprWithColumnsTopNByRankParams)) {
             return ConstructContainsTableQueryRoot(method.GetGenericArguments()[0], mc.Arguments);
           }
 
           // Query.Single<T> & Query.SingleOrDefault<T>
-          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.SingleKey)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.SingleOrDefaultKey)) {
+          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.SingleKeyParams)
+            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.SingleOrDefaultKeyParams)) {
             return VisitQuerySingle(mc);
           }
 
@@ -477,33 +477,33 @@ namespace Xtensive.Orm.Linq
         // Visit QueryEndpoint.
         if (methodDeclaringType == WellKnownOrmTypes.QueryEndpoint) {
           // Query.All<T>
-          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.All)) {
+          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.AllParams)) {
             return ConstructQueryable(mc);
           }
 
           // Query.FreeText<T>
-          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextString)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextExpression)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextExpressionTopNByRank)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextStringTopNByRank)) {
+          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextStringParams)
+            || method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextExpressionParams)
+            || method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextExpressionTopNByRankParams)
+            || method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextStringTopNByRankParams)) {
             return ConstructFreeTextQueryRoot(method.GetGenericArguments()[0], mc.Arguments);
           }
 
           // Query.ContainsTable<T>
-          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExpr)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprWithColumns)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprTopNByRank)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprWithColumnsTopNByRank)) {
+          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprParams)
+            || method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprWithColumnsParams)
+            || method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprTopNByRankParams)
+            || method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprWithColumnsTopNByRankParams)) {
             return ConstructContainsTableQueryRoot(method.GetGenericArguments()[0], mc.Arguments);
           }
 
           // Query.Single<T> & Query.SingleOrDefault<T>
-          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.SingleKey)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.SingleOrDefaultKey)) {
+          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.SingleKeyParams)
+            || method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.SingleOrDefaultKeyParams)) {
             return VisitQuerySingle(mc);
           }
 
-          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.Items)) {
+          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ItemsParams)) {
             return VisitSequence(mc.Arguments[0].StripQuotes().Body, mc);
           }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -441,11 +441,11 @@ namespace Xtensive.Orm.Linq
 
         var methodDeclaringType = method.DeclaringType;
         var methodName = method.Name;
-        GenericMethodHandle methodInfoHandle = new(method);
 
         // Visit Query. Deprecated.
 #pragma warning disable 612,618
         if (methodDeclaringType == WellKnownOrmTypes.Query) {
+          GenericMethodHandle methodInfoHandle = new(method);
           // Query.All<T>
           if (methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.AllHandle)) {
             return ConstructQueryable(mc);
@@ -477,6 +477,7 @@ namespace Xtensive.Orm.Linq
         }
         // Visit QueryEndpoint.
         if (methodDeclaringType == WellKnownOrmTypes.QueryEndpoint) {
+          GenericMethodHandle methodInfoHandle = new(method);
           // Query.All<T>
           if (methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.AllHandle)) {
             return ConstructQueryable(mc);

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -441,35 +441,35 @@ namespace Xtensive.Orm.Linq
 
         var methodDeclaringType = method.DeclaringType;
         var methodName = method.Name;
-        MethodInfoParams methodInfoParams = new(method, false);
+        GenericMethodHandle methodInfoHandle = new(method);
 
         // Visit Query. Deprecated.
 #pragma warning disable 612,618
         if (methodDeclaringType == WellKnownOrmTypes.Query) {
           // Query.All<T>
-          if (methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.AllParams)) {
+          if (methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.AllHandle)) {
             return ConstructQueryable(mc);
           }
 
           // Query.FreeText<T>
-          if (methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextStringParams)
-              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextExpressionParams)
-              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextExpressionTopNByRankParams)
-              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextStringTopNByRankParams)) {
+          if (methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextStringHandle)
+              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextExpressionHandle)
+              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextExpressionTopNByRankHandle)
+              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextStringTopNByRankHandle)) {
             return ConstructFreeTextQueryRoot(method.GetGenericArguments()[0], mc.Arguments);
           }
 
           // Query.ContainsTable<T>
-          if (methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprParams)
-              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprWithColumnsParams)
-              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprTopNByRankParams)
-              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprWithColumnsTopNByRankParams)) {
+          if (methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprHandle)
+              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprWithColumnsParams)
+              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprTopNByRankParams)
+              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprWithColumnsTopNByRankParams)) {
             return ConstructContainsTableQueryRoot(method.GetGenericArguments()[0], mc.Arguments);
           }
 
           // Query.Single<T> & Query.SingleOrDefault<T>
-          if (methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.SingleKeyParams)
-              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.SingleOrDefaultKeyParams)) {
+          if (methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.SingleKeyParams)
+              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Query.SingleOrDefaultKeyParams)) {
             return VisitQuerySingle(mc);
           }
 
@@ -478,33 +478,33 @@ namespace Xtensive.Orm.Linq
         // Visit QueryEndpoint.
         if (methodDeclaringType == WellKnownOrmTypes.QueryEndpoint) {
           // Query.All<T>
-          if (methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.AllParams)) {
+          if (methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.AllHandle)) {
             return ConstructQueryable(mc);
           }
 
           // Query.FreeText<T>
-          if (methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextStringParams)
-              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextExpressionParams)
-              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextExpressionTopNByRankParams)
-              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextStringTopNByRankParams)) {
+          if (methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextStringHandle)
+              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextExpressionHandle)
+              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextExpressionTopNByRankHandle)
+              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextStringTopNByRankHandle)) {
             return ConstructFreeTextQueryRoot(method.GetGenericArguments()[0], mc.Arguments);
           }
 
           // Query.ContainsTable<T>
-          if (methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprParams)
-              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprWithColumnsParams)
-              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprTopNByRankParams)
-              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprWithColumnsTopNByRankParams)) {
+          if (methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprHandle)
+              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprWithColumnsHandle)
+              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprTopNByRankParams)
+              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprWithColumnsTopNByRankHandle)) {
             return ConstructContainsTableQueryRoot(method.GetGenericArguments()[0], mc.Arguments);
           }
 
           // Query.Single<T> & Query.SingleOrDefault<T>
-          if (methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.SingleKeyParams)
-              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.SingleOrDefaultKeyParams)) {
+          if (methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.SingleKeyHandle)
+              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.SingleOrDefaultKeyHandle)) {
             return VisitQuerySingle(mc);
           }
 
-          if (methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ItemsParams)) {
+          if (methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ItemsHandle)) {
             return VisitSequence(mc.Arguments[0].StripQuotes().Body, mc);
           }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -441,34 +441,35 @@ namespace Xtensive.Orm.Linq
 
         var methodDeclaringType = method.DeclaringType;
         var methodName = method.Name;
+        MethodInfoParams methodInfoParams = new(method, false);
 
         // Visit Query. Deprecated.
 #pragma warning disable 612,618
         if (methodDeclaringType == WellKnownOrmTypes.Query) {
           // Query.All<T>
-          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.AllParams)) {
+          if (methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.AllParams)) {
             return ConstructQueryable(mc);
           }
 
           // Query.FreeText<T>
-          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextStringParams)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextExpressionParams)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextExpressionTopNByRankParams)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextStringTopNByRankParams)) {
+          if (methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextStringParams)
+              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextExpressionParams)
+              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextExpressionTopNByRankParams)
+              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.FreeTextStringTopNByRankParams)) {
             return ConstructFreeTextQueryRoot(method.GetGenericArguments()[0], mc.Arguments);
           }
 
           // Query.ContainsTable<T>
-          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprParams)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprWithColumnsParams)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprTopNByRankParams)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprWithColumnsTopNByRankParams)) {
+          if (methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprParams)
+              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprWithColumnsParams)
+              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprTopNByRankParams)
+              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.ContainsTableExprWithColumnsTopNByRankParams)) {
             return ConstructContainsTableQueryRoot(method.GetGenericArguments()[0], mc.Arguments);
           }
 
           // Query.Single<T> & Query.SingleOrDefault<T>
-          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.SingleKeyParams)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Query.SingleOrDefaultKeyParams)) {
+          if (methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.SingleKeyParams)
+              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Query.SingleOrDefaultKeyParams)) {
             return VisitQuerySingle(mc);
           }
 
@@ -477,33 +478,33 @@ namespace Xtensive.Orm.Linq
         // Visit QueryEndpoint.
         if (methodDeclaringType == WellKnownOrmTypes.QueryEndpoint) {
           // Query.All<T>
-          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.AllParams)) {
+          if (methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.AllParams)) {
             return ConstructQueryable(mc);
           }
 
           // Query.FreeText<T>
-          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextStringParams)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextExpressionParams)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextExpressionTopNByRankParams)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextStringTopNByRankParams)) {
+          if (methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextStringParams)
+              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextExpressionParams)
+              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextExpressionTopNByRankParams)
+              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.FreeTextStringTopNByRankParams)) {
             return ConstructFreeTextQueryRoot(method.GetGenericArguments()[0], mc.Arguments);
           }
 
           // Query.ContainsTable<T>
-          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprParams)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprWithColumnsParams)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprTopNByRankParams)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprWithColumnsTopNByRankParams)) {
+          if (methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprParams)
+              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprWithColumnsParams)
+              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprTopNByRankParams)
+              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprWithColumnsTopNByRankParams)) {
             return ConstructContainsTableQueryRoot(method.GetGenericArguments()[0], mc.Arguments);
           }
 
           // Query.Single<T> & Query.SingleOrDefault<T>
-          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.SingleKeyParams)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.SingleOrDefaultKeyParams)) {
+          if (methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.SingleKeyParams)
+              || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.SingleOrDefaultKeyParams)) {
             return VisitQuerySingle(mc);
           }
 
-          if (method.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ItemsParams)) {
+          if (methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ItemsParams)) {
             return VisitSequence(mc.Arguments[0].StripQuotes().Body, mc);
           }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -493,7 +493,7 @@ namespace Xtensive.Orm.Linq
           // Query.ContainsTable<T>
           if (methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprHandle)
               || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprWithColumnsHandle)
-              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprTopNByRankParams)
+              || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprTopNByRankHandle)
               || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.QueryEndpoint.ContainsTableExprWithColumnsTopNByRankHandle)) {
             return ConstructContainsTableQueryRoot(method.GetGenericArguments()[0], mc.Arguments);
           }

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -1330,9 +1330,9 @@ namespace Xtensive.Orm.Linq
         var isOuter = false;
         if (collectionSelector.Body.NodeType == ExpressionType.Call) {
           var call = (MethodCallExpression) collectionSelector.Body;
-          MethodInfoParams methodInfoParams = new(call.Method, false);
-          isOuter = methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Queryable.DefaultIfEmptyParams)
-                    || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Enumerable.DefaultIfEmptyParams);
+          GenericMethodHandle methodInfoHandle = new(call.Method);
+          isOuter = methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Queryable.DefaultIfEmptyHandle)
+                    || methodInfoHandle.IsGenericMethodSpecificationOf(WellKnownMembers.Enumerable.DefaultIfEmptyHandle);
           if (isOuter) {
             collectionSelector = FastExpression.Lambda(call.Arguments[0], outerParameter);
           }

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -1331,8 +1331,8 @@ namespace Xtensive.Orm.Linq
         if (collectionSelector.Body.NodeType == ExpressionType.Call) {
           var call = (MethodCallExpression) collectionSelector.Body;
           var method = call.Method;
-          isOuter = method.IsGenericMethodSpecificationOf(WellKnownMembers.Queryable.DefaultIfEmpty)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Enumerable.DefaultIfEmpty);
+          isOuter = method.IsGenericMethodSpecificationOf(WellKnownMembers.Queryable.DefaultIfEmptyParams)
+            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Enumerable.DefaultIfEmptyParams);
           if (isOuter) {
             collectionSelector = FastExpression.Lambda(call.Arguments[0], outerParameter);
           }

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -1330,9 +1330,9 @@ namespace Xtensive.Orm.Linq
         var isOuter = false;
         if (collectionSelector.Body.NodeType == ExpressionType.Call) {
           var call = (MethodCallExpression) collectionSelector.Body;
-          var method = call.Method;
-          isOuter = method.IsGenericMethodSpecificationOf(WellKnownMembers.Queryable.DefaultIfEmptyParams)
-            || method.IsGenericMethodSpecificationOf(WellKnownMembers.Enumerable.DefaultIfEmptyParams);
+          MethodInfoParams methodInfoParams = new(call.Method, false);
+          isOuter = methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Queryable.DefaultIfEmptyParams)
+                    || methodInfoParams.IsGenericMethodSpecificationOf(WellKnownMembers.Enumerable.DefaultIfEmptyParams);
           if (isOuter) {
             collectionSelector = FastExpression.Lambda(call.Arguments[0], outerParameter);
           }

--- a/Orm/Xtensive.Orm/Orm/Linq/WellKnownMembers.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/WellKnownMembers.cs
@@ -16,9 +16,10 @@ using TypeInfo = Xtensive.Orm.Model.TypeInfo;
 
 namespace Xtensive.Orm.Linq
 {
-  public readonly record struct MethodInfoParams(int MetadataToken, Module Module, bool IsGenericMethodDefinition)
+  public readonly record struct MethodInfoParams(int MetadataToken, Module Module, bool IsGeneric)
   {
-    public MethodInfoParams(MethodInfo mi) : this(mi.MetadataToken, mi.Module, mi.IsGenericMethodDefinition) { }
+    public MethodInfoParams(MethodInfo mi, bool fromDefinition = true)
+      : this(mi.MetadataToken, mi.Module, fromDefinition ? mi.IsGenericMethodDefinition : mi.IsGenericMethod) { }
   }
 
   internal static partial class WellKnownMembers

--- a/Orm/Xtensive.Orm/Orm/Linq/WellKnownMembers.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/WellKnownMembers.cs
@@ -4,13 +4,8 @@
 // Created by: Denis Krjuchkov
 // Created:    2009.03.24
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using Xtensive.Collections;
-using Xtensive.Core;
 using Xtensive.Orm.FullTextSearchCondition.Interfaces;
 using Xtensive.Orm.FullTextSearchCondition.Nodes;
 using Xtensive.Orm.Internals;
@@ -21,6 +16,11 @@ using TypeInfo = Xtensive.Orm.Model.TypeInfo;
 
 namespace Xtensive.Orm.Linq
 {
+  public readonly record struct MethodInfoParams(int MetadataToken, Module Module, bool IsGenericMethodDefinition)
+  {
+    public MethodInfoParams(MethodInfo mi) : this(mi.MetadataToken, mi.Module, mi.IsGenericMethodDefinition) { }
+  }
+
   internal static partial class WellKnownMembers
   {
 #pragma warning disable 612,618
@@ -35,40 +35,56 @@ namespace Xtensive.Orm.Linq
       private static readonly MethodInfo[] SingleOrDefaultMethods = typeof(Orm.Query).GetMethods().Where(m => m.Name == nameof(Orm.Query.SingleOrDefault) && m.IsGenericMethod).ToArray();
 
       public static readonly MethodInfo All = typeof(Orm.Query).GetMethod(nameof(Orm.Query.All), Array.Empty<Type>());
+      internal static readonly MethodInfoParams AllParams = new(All);
 
       public static readonly MethodInfo FreeTextString = FreetextMethods
           .Single(ft => ft.GetParameters().Length == 1 && ft.GetParameterTypes()[0] == WellKnownTypes.String);
+      internal static readonly MethodInfoParams FreeTextStringParams = new(FreeTextString);
 
       public static readonly MethodInfo FreeTextStringTopNByRank = FreetextMethods
           .Single(ft => ft.GetParameters().Length == 2 && ft.GetParameterTypes()[0] == WellKnownTypes.String && ft.GetParameterTypes()[1] == WellKnownTypes.Int32);
+      internal static readonly MethodInfoParams FreeTextStringTopNByRankParams = new(FreeTextStringTopNByRank);
 
       public static readonly MethodInfo FreeTextExpression = FreetextMethods
           .Single(ft => ft.GetParameters().Length == 1 && ft.GetParameterTypes()[0] == typeof(Expression<Func<string>>));
+      internal static readonly MethodInfoParams FreeTextExpressionParams = new(FreeTextExpression);
 
       public static readonly MethodInfo FreeTextExpressionTopNByRank = FreetextMethods
           .Single(ft => ft.GetParameters().Length == 2 && ft.GetParameterTypes()[0] == typeof(Expression<Func<string>>) && ft.GetParameterTypes()[1] == WellKnownTypes.Int32);
+      internal static readonly MethodInfoParams FreeTextExpressionTopNByRankParams = new(FreeTextExpressionTopNByRank);
 
       public static readonly MethodInfo ContainsTableExpr = containsTableMethods
           .Single(g => g.ParameterTypes.Length == 1 && g.ParameterTypes[0] == typeof(Expression<Func<ConditionEndpoint, IOperand>>)).Method;
+      internal static readonly MethodInfoParams ContainsTableExprParams = new(ContainsTableExpr);
 
       public static readonly MethodInfo ContainsTableExprWithColumns = containsTableMethods
           .Single(g => g.ParameterTypes.Length == 2 &&
                        g.ParameterTypes[0] == typeof(Expression<Func<ConditionEndpoint, IOperand>>) &&
                        g.ParameterTypes[1].IsArray).Method;
+      internal static readonly MethodInfoParams ContainsTableExprWithColumnsParams = new(ContainsTableExprWithColumns);
 
       public static readonly MethodInfo ContainsTableExprTopNByRank = containsTableMethods
           .Single(g => g.ParameterTypes.Length == 2 && g.ParameterTypes[0] == typeof(Expression<Func<ConditionEndpoint, IOperand>>) && g.ParameterTypes[1] == WellKnownTypes.Int32).Method;
+      internal static readonly MethodInfoParams ContainsTableExprTopNByRankParams = new(ContainsTableExprTopNByRank);
 
       public static readonly MethodInfo ContainsTableExprWithColumnsTopNByRank = containsTableMethods
           .Single(g => g.ParameterTypes.Length == 3 &&
                        g.ParameterTypes[0] == typeof(Expression<Func<ConditionEndpoint, IOperand>>) &&
                        g.ParameterTypes[1].IsArray &&
                        g.ParameterTypes[2] == WellKnownTypes.Int32).Method;
+      internal static readonly MethodInfoParams ContainsTableExprWithColumnsTopNByRankParams = new(ContainsTableExprWithColumnsTopNByRank);
 
       public static readonly MethodInfo SingleKey = SingleMethods.Single(ft => ft.GetParameterTypes()[0] == typeof(Orm.Key));
+      internal static readonly MethodInfoParams SingleKeyParams = new(SingleKey);
+
       public static readonly MethodInfo SingleArray = SingleMethods.Single(ft => ft.GetParameterTypes()[0] == WellKnownTypes.ObjectArray);
+      internal static readonly MethodInfoParams SingleArrayParams = new(SingleArray);
+
       public static readonly MethodInfo SingleOrDefaultKey = SingleOrDefaultMethods.Single(ft => ft.GetParameterTypes()[0] == typeof(Orm.Key));
+      internal static readonly MethodInfoParams SingleOrDefaultKeyParams = new(SingleOrDefaultKey);
+
       public static readonly MethodInfo SingleOrDefaultArray = SingleOrDefaultMethods.Single(ft => ft.GetParameterTypes()[0] == WellKnownTypes.ObjectArray);
+      internal static readonly MethodInfoParams SingleOrDefaultArrayParams = new(SingleOrDefaultArray);
     }
 
     public static class QueryEndpoint
@@ -82,41 +98,59 @@ namespace Xtensive.Orm.Linq
       private static readonly MethodInfo[] SingleOrDefaultMethods = typeof(Orm.QueryEndpoint).GetMethods().Where(m => m.Name == nameof(Orm.QueryEndpoint.SingleOrDefault) && m.IsGenericMethod).ToArray();
 
       public static readonly MethodInfo All = typeof(Orm.QueryEndpoint).GetMethod(nameof(Orm.QueryEndpoint.All), Array.Empty<Type>());
+      internal static readonly MethodInfoParams AllParams = new(All);
 
       public static readonly MethodInfo FreeTextString = FreetextMethods
           .Single(ft => ft.GetParameters().Length == 1 && ft.GetParameterTypes()[0] == WellKnownTypes.String);
+      internal static readonly MethodInfoParams FreeTextStringParams = new(FreeTextString);
 
       public static readonly MethodInfo FreeTextStringTopNByRank = FreetextMethods
           .Single(ft => ft.GetParameters().Length == 2 && ft.GetParameterTypes()[0] == WellKnownTypes.String && ft.GetParameterTypes()[1] == WellKnownTypes.Int32);
+      internal static readonly MethodInfoParams FreeTextStringTopNByRankParams = new(FreeTextStringTopNByRank);
 
       public static readonly MethodInfo FreeTextExpression = FreetextMethods
           .Single(ft => ft.GetParameters().Length == 1 && ft.GetParameterTypes()[0] == typeof(Expression<Func<string>>));
+      internal static readonly MethodInfoParams FreeTextExpressionParams = new(FreeTextExpression);
 
       public static readonly MethodInfo FreeTextExpressionTopNByRank = FreetextMethods
           .Single(ft => ft.GetParameters().Length == 2 && ft.GetParameterTypes()[0] == typeof(Expression<Func<string>>) && ft.GetParameterTypes()[1] == WellKnownTypes.Int32);
+      internal static readonly MethodInfoParams FreeTextExpressionTopNByRankParams = new(FreeTextExpressionTopNByRank);
 
       public static readonly MethodInfo ContainsTableExpr = containsTableMethods
           .Single(g => g.ParameterTypes.Length == 1 && g.ParameterTypes[0] == typeof(Expression<Func<ConditionEndpoint, IOperand>>)).Method;
+      internal static readonly MethodInfoParams ContainsTableExprParams = new(ContainsTableExpr);
 
       public static readonly MethodInfo ContainsTableExprWithColumns = containsTableMethods
           .Single(g => g.ParameterTypes.Length == 2 &&
                        g.ParameterTypes[0] == typeof(Expression<Func<ConditionEndpoint, IOperand>>) &&
                        g.ParameterTypes[1].IsArray).Method;
+      internal static readonly MethodInfoParams ContainsTableExprWithColumnsParams = new(ContainsTableExprWithColumns);
 
       public static readonly MethodInfo ContainsTableExprTopNByRank = containsTableMethods
           .Single(g => g.ParameterTypes.Length == 2 && g.ParameterTypes[0] == typeof(Expression<Func<ConditionEndpoint, IOperand>>) && g.ParameterTypes[1] == WellKnownTypes.Int32).Method;
+      internal static readonly MethodInfoParams ContainsTableExprTopNByRankParams = new(ContainsTableExprTopNByRank);
 
       public static readonly MethodInfo ContainsTableExprWithColumnsTopNByRank = containsTableMethods
           .Single(g => g.ParameterTypes.Length == 3 &&
                        g.ParameterTypes[0] == typeof(Expression<Func<ConditionEndpoint, IOperand>>) &&
                        g.ParameterTypes[1].IsArray &&
                        g.ParameterTypes[2] == WellKnownTypes.Int32).Method;
+      internal static readonly MethodInfoParams ContainsTableExprWithColumnsTopNByRankParams = new(ContainsTableExprWithColumnsTopNByRank);
 
       public static readonly MethodInfo SingleKey = SingleMethods.Single(ft => ft.GetParameterTypes()[0] == typeof(Orm.Key));
+      internal static readonly MethodInfoParams SingleKeyParams = new(SingleKey);
+
       public static readonly MethodInfo SingleArray = SingleMethods.Single(ft => ft.GetParameterTypes()[0] == WellKnownTypes.ObjectArray);
+      internal static readonly MethodInfoParams SingleArrayParams = new(SingleArray);
+
       public static readonly MethodInfo SingleOrDefaultKey = SingleOrDefaultMethods.Single(ft => ft.GetParameterTypes()[0] == typeof(Orm.Key));
+      internal static readonly MethodInfoParams SingleOrDefaultKeyParams = new(SingleOrDefaultKey);
+
       public static readonly MethodInfo SingleOrDefaultArray = SingleOrDefaultMethods.Single(ft => ft.GetParameterTypes()[0] == WellKnownTypes.ObjectArray);
+      internal static readonly MethodInfoParams SingleOrDefaultArrayParams = new(SingleOrDefaultArray);
+
       public static readonly MethodInfo Items = typeof(Orm.QueryEndpoint).GetMethod(nameof(Orm.QueryEndpoint.Items));
+      internal static readonly MethodInfoParams ItemsParams = new(Items);
     }
 #pragma warning restore 612,618
 
@@ -193,7 +227,7 @@ namespace Xtensive.Orm.Linq
           .First(m => m.Name == nameof(System.Linq.Enumerable.SingleOrDefault) && m.GetParameters().Length == 1);
 
       public static readonly Type OfTuple = WellKnownInterfaces.EnumerableOfT.CachedMakeGenericType(typeof(Xtensive.Tuples.Tuple));
-      public static readonly MethodInfo DefaultIfEmpty = typeof(System.Linq.Enumerable).GetMethods().First(m => m.Name == nameof(System.Linq.Enumerable.DefaultIfEmpty));
+      public static readonly MethodInfoParams DefaultIfEmptyParams = new(typeof(System.Linq.Enumerable).GetMethods().First(m => m.Name == nameof(System.Linq.Enumerable.DefaultIfEmpty)));
       public static readonly MethodInfo Contains = GetMethod(typeof(System.Linq.Enumerable), nameof(System.Linq.Enumerable.Contains), 1, 2);
       public static readonly MethodInfo Cast = GetMethod(typeof(System.Linq.Enumerable), nameof(System.Linq.Enumerable.Cast), 1, 1);
     }

--- a/Orm/Xtensive.Orm/Orm/Linq/WellKnownMembers.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/WellKnownMembers.cs
@@ -145,7 +145,7 @@ namespace Xtensive.Orm.Linq
 
       public static readonly MethodInfo ContainsTableExprTopNByRank = containsTableMethods
           .Single(g => g.ParameterTypes.Length == 2 && g.ParameterTypes[0] == typeof(Expression<Func<ConditionEndpoint, IOperand>>) && g.ParameterTypes[1] == WellKnownTypes.Int32).Method;
-      internal static readonly GenericMethodDefinitionHandle ContainsTableExprTopNByRankParams = new(ContainsTableExprTopNByRank);
+      internal static readonly GenericMethodDefinitionHandle ContainsTableExprTopNByRankHandle = new(ContainsTableExprTopNByRank);
 
       public static readonly MethodInfo ContainsTableExprWithColumnsTopNByRank = containsTableMethods
           .Single(g => g.ParameterTypes.Length == 3 &&

--- a/Orm/Xtensive.Orm/Orm/Linq/WellKnownMembers.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/WellKnownMembers.cs
@@ -16,10 +16,26 @@ using TypeInfo = Xtensive.Orm.Model.TypeInfo;
 
 namespace Xtensive.Orm.Linq
 {
-  public readonly record struct MethodInfoParams(int MetadataToken, Module Module, bool IsGeneric)
+  public readonly record struct GenericMethodHandle(int MetadataToken, ModuleHandle ModuleHandle)
   {
-    public MethodInfoParams(MethodInfo mi, bool fromDefinition = true)
-      : this(mi.MetadataToken, mi.Module, fromDefinition ? mi.IsGenericMethodDefinition : mi.IsGenericMethod) { }
+    public GenericMethodHandle(MethodInfo mi)
+      : this(mi.MetadataToken, mi.Module.ModuleHandle)
+    {
+      if (!mi.IsGenericMethod) {
+        throw new ArgumentException($"{mi} must be Generic method");
+      }
+    }
+  }
+
+  public readonly record struct GenericMethodDefinitionHandle(int MetadataToken, ModuleHandle ModuleHandle)
+  {
+    public GenericMethodDefinitionHandle(MethodInfo mi)
+      : this(mi.MetadataToken, mi.Module.ModuleHandle)
+    {
+      if (!mi.IsGenericMethodDefinition) {
+        throw new ArgumentException($"{mi} must be Generic method definition");
+      }
+    }
   }
 
   internal static partial class WellKnownMembers
@@ -36,56 +52,56 @@ namespace Xtensive.Orm.Linq
       private static readonly MethodInfo[] SingleOrDefaultMethods = typeof(Orm.Query).GetMethods().Where(m => m.Name == nameof(Orm.Query.SingleOrDefault) && m.IsGenericMethod).ToArray();
 
       public static readonly MethodInfo All = typeof(Orm.Query).GetMethod(nameof(Orm.Query.All), Array.Empty<Type>());
-      internal static readonly MethodInfoParams AllParams = new(All);
+      internal static readonly GenericMethodDefinitionHandle AllHandle = new(All);
 
       public static readonly MethodInfo FreeTextString = FreetextMethods
           .Single(ft => ft.GetParameters().Length == 1 && ft.GetParameterTypes()[0] == WellKnownTypes.String);
-      internal static readonly MethodInfoParams FreeTextStringParams = new(FreeTextString);
+      internal static readonly GenericMethodDefinitionHandle FreeTextStringHandle = new(FreeTextString);
 
       public static readonly MethodInfo FreeTextStringTopNByRank = FreetextMethods
           .Single(ft => ft.GetParameters().Length == 2 && ft.GetParameterTypes()[0] == WellKnownTypes.String && ft.GetParameterTypes()[1] == WellKnownTypes.Int32);
-      internal static readonly MethodInfoParams FreeTextStringTopNByRankParams = new(FreeTextStringTopNByRank);
+      internal static readonly GenericMethodDefinitionHandle FreeTextStringTopNByRankHandle = new(FreeTextStringTopNByRank);
 
       public static readonly MethodInfo FreeTextExpression = FreetextMethods
           .Single(ft => ft.GetParameters().Length == 1 && ft.GetParameterTypes()[0] == typeof(Expression<Func<string>>));
-      internal static readonly MethodInfoParams FreeTextExpressionParams = new(FreeTextExpression);
+      internal static readonly GenericMethodDefinitionHandle FreeTextExpressionHandle = new(FreeTextExpression);
 
       public static readonly MethodInfo FreeTextExpressionTopNByRank = FreetextMethods
           .Single(ft => ft.GetParameters().Length == 2 && ft.GetParameterTypes()[0] == typeof(Expression<Func<string>>) && ft.GetParameterTypes()[1] == WellKnownTypes.Int32);
-      internal static readonly MethodInfoParams FreeTextExpressionTopNByRankParams = new(FreeTextExpressionTopNByRank);
+      internal static readonly GenericMethodDefinitionHandle FreeTextExpressionTopNByRankHandle = new(FreeTextExpressionTopNByRank);
 
       public static readonly MethodInfo ContainsTableExpr = containsTableMethods
           .Single(g => g.ParameterTypes.Length == 1 && g.ParameterTypes[0] == typeof(Expression<Func<ConditionEndpoint, IOperand>>)).Method;
-      internal static readonly MethodInfoParams ContainsTableExprParams = new(ContainsTableExpr);
+      internal static readonly GenericMethodDefinitionHandle ContainsTableExprHandle = new(ContainsTableExpr);
 
       public static readonly MethodInfo ContainsTableExprWithColumns = containsTableMethods
           .Single(g => g.ParameterTypes.Length == 2 &&
                        g.ParameterTypes[0] == typeof(Expression<Func<ConditionEndpoint, IOperand>>) &&
                        g.ParameterTypes[1].IsArray).Method;
-      internal static readonly MethodInfoParams ContainsTableExprWithColumnsParams = new(ContainsTableExprWithColumns);
+      internal static readonly GenericMethodDefinitionHandle ContainsTableExprWithColumnsParams = new(ContainsTableExprWithColumns);
 
       public static readonly MethodInfo ContainsTableExprTopNByRank = containsTableMethods
           .Single(g => g.ParameterTypes.Length == 2 && g.ParameterTypes[0] == typeof(Expression<Func<ConditionEndpoint, IOperand>>) && g.ParameterTypes[1] == WellKnownTypes.Int32).Method;
-      internal static readonly MethodInfoParams ContainsTableExprTopNByRankParams = new(ContainsTableExprTopNByRank);
+      internal static readonly GenericMethodDefinitionHandle ContainsTableExprTopNByRankParams = new(ContainsTableExprTopNByRank);
 
       public static readonly MethodInfo ContainsTableExprWithColumnsTopNByRank = containsTableMethods
           .Single(g => g.ParameterTypes.Length == 3 &&
                        g.ParameterTypes[0] == typeof(Expression<Func<ConditionEndpoint, IOperand>>) &&
                        g.ParameterTypes[1].IsArray &&
                        g.ParameterTypes[2] == WellKnownTypes.Int32).Method;
-      internal static readonly MethodInfoParams ContainsTableExprWithColumnsTopNByRankParams = new(ContainsTableExprWithColumnsTopNByRank);
+      internal static readonly GenericMethodDefinitionHandle ContainsTableExprWithColumnsTopNByRankParams = new(ContainsTableExprWithColumnsTopNByRank);
 
       public static readonly MethodInfo SingleKey = SingleMethods.Single(ft => ft.GetParameterTypes()[0] == typeof(Orm.Key));
-      internal static readonly MethodInfoParams SingleKeyParams = new(SingleKey);
+      internal static readonly GenericMethodDefinitionHandle SingleKeyParams = new(SingleKey);
 
       public static readonly MethodInfo SingleArray = SingleMethods.Single(ft => ft.GetParameterTypes()[0] == WellKnownTypes.ObjectArray);
-      internal static readonly MethodInfoParams SingleArrayParams = new(SingleArray);
+      internal static readonly GenericMethodDefinitionHandle SingleArrayParams = new(SingleArray);
 
       public static readonly MethodInfo SingleOrDefaultKey = SingleOrDefaultMethods.Single(ft => ft.GetParameterTypes()[0] == typeof(Orm.Key));
-      internal static readonly MethodInfoParams SingleOrDefaultKeyParams = new(SingleOrDefaultKey);
+      internal static readonly GenericMethodDefinitionHandle SingleOrDefaultKeyParams = new(SingleOrDefaultKey);
 
       public static readonly MethodInfo SingleOrDefaultArray = SingleOrDefaultMethods.Single(ft => ft.GetParameterTypes()[0] == WellKnownTypes.ObjectArray);
-      internal static readonly MethodInfoParams SingleOrDefaultArrayParams = new(SingleOrDefaultArray);
+      internal static readonly GenericMethodDefinitionHandle SingleOrDefaultArrayParams = new(SingleOrDefaultArray);
     }
 
     public static class QueryEndpoint
@@ -99,59 +115,59 @@ namespace Xtensive.Orm.Linq
       private static readonly MethodInfo[] SingleOrDefaultMethods = typeof(Orm.QueryEndpoint).GetMethods().Where(m => m.Name == nameof(Orm.QueryEndpoint.SingleOrDefault) && m.IsGenericMethod).ToArray();
 
       public static readonly MethodInfo All = typeof(Orm.QueryEndpoint).GetMethod(nameof(Orm.QueryEndpoint.All), Array.Empty<Type>());
-      internal static readonly MethodInfoParams AllParams = new(All);
+      internal static readonly GenericMethodDefinitionHandle AllHandle = new(All);
 
       public static readonly MethodInfo FreeTextString = FreetextMethods
           .Single(ft => ft.GetParameters().Length == 1 && ft.GetParameterTypes()[0] == WellKnownTypes.String);
-      internal static readonly MethodInfoParams FreeTextStringParams = new(FreeTextString);
+      internal static readonly GenericMethodDefinitionHandle FreeTextStringHandle = new(FreeTextString);
 
       public static readonly MethodInfo FreeTextStringTopNByRank = FreetextMethods
           .Single(ft => ft.GetParameters().Length == 2 && ft.GetParameterTypes()[0] == WellKnownTypes.String && ft.GetParameterTypes()[1] == WellKnownTypes.Int32);
-      internal static readonly MethodInfoParams FreeTextStringTopNByRankParams = new(FreeTextStringTopNByRank);
+      internal static readonly GenericMethodDefinitionHandle FreeTextStringTopNByRankHandle = new(FreeTextStringTopNByRank);
 
       public static readonly MethodInfo FreeTextExpression = FreetextMethods
           .Single(ft => ft.GetParameters().Length == 1 && ft.GetParameterTypes()[0] == typeof(Expression<Func<string>>));
-      internal static readonly MethodInfoParams FreeTextExpressionParams = new(FreeTextExpression);
+      internal static readonly GenericMethodDefinitionHandle FreeTextExpressionHandle = new(FreeTextExpression);
 
       public static readonly MethodInfo FreeTextExpressionTopNByRank = FreetextMethods
           .Single(ft => ft.GetParameters().Length == 2 && ft.GetParameterTypes()[0] == typeof(Expression<Func<string>>) && ft.GetParameterTypes()[1] == WellKnownTypes.Int32);
-      internal static readonly MethodInfoParams FreeTextExpressionTopNByRankParams = new(FreeTextExpressionTopNByRank);
+      internal static readonly GenericMethodDefinitionHandle FreeTextExpressionTopNByRankHandle = new(FreeTextExpressionTopNByRank);
 
       public static readonly MethodInfo ContainsTableExpr = containsTableMethods
           .Single(g => g.ParameterTypes.Length == 1 && g.ParameterTypes[0] == typeof(Expression<Func<ConditionEndpoint, IOperand>>)).Method;
-      internal static readonly MethodInfoParams ContainsTableExprParams = new(ContainsTableExpr);
+      internal static readonly GenericMethodDefinitionHandle ContainsTableExprHandle = new(ContainsTableExpr);
 
       public static readonly MethodInfo ContainsTableExprWithColumns = containsTableMethods
           .Single(g => g.ParameterTypes.Length == 2 &&
                        g.ParameterTypes[0] == typeof(Expression<Func<ConditionEndpoint, IOperand>>) &&
                        g.ParameterTypes[1].IsArray).Method;
-      internal static readonly MethodInfoParams ContainsTableExprWithColumnsParams = new(ContainsTableExprWithColumns);
+      internal static readonly GenericMethodDefinitionHandle ContainsTableExprWithColumnsHandle = new(ContainsTableExprWithColumns);
 
       public static readonly MethodInfo ContainsTableExprTopNByRank = containsTableMethods
           .Single(g => g.ParameterTypes.Length == 2 && g.ParameterTypes[0] == typeof(Expression<Func<ConditionEndpoint, IOperand>>) && g.ParameterTypes[1] == WellKnownTypes.Int32).Method;
-      internal static readonly MethodInfoParams ContainsTableExprTopNByRankParams = new(ContainsTableExprTopNByRank);
+      internal static readonly GenericMethodDefinitionHandle ContainsTableExprTopNByRankParams = new(ContainsTableExprTopNByRank);
 
       public static readonly MethodInfo ContainsTableExprWithColumnsTopNByRank = containsTableMethods
           .Single(g => g.ParameterTypes.Length == 3 &&
                        g.ParameterTypes[0] == typeof(Expression<Func<ConditionEndpoint, IOperand>>) &&
                        g.ParameterTypes[1].IsArray &&
                        g.ParameterTypes[2] == WellKnownTypes.Int32).Method;
-      internal static readonly MethodInfoParams ContainsTableExprWithColumnsTopNByRankParams = new(ContainsTableExprWithColumnsTopNByRank);
+      internal static readonly GenericMethodDefinitionHandle ContainsTableExprWithColumnsTopNByRankHandle = new(ContainsTableExprWithColumnsTopNByRank);
 
       public static readonly MethodInfo SingleKey = SingleMethods.Single(ft => ft.GetParameterTypes()[0] == typeof(Orm.Key));
-      internal static readonly MethodInfoParams SingleKeyParams = new(SingleKey);
+      internal static readonly GenericMethodDefinitionHandle SingleKeyHandle = new(SingleKey);
 
       public static readonly MethodInfo SingleArray = SingleMethods.Single(ft => ft.GetParameterTypes()[0] == WellKnownTypes.ObjectArray);
-      internal static readonly MethodInfoParams SingleArrayParams = new(SingleArray);
+      internal static readonly GenericMethodDefinitionHandle SingleArrayHandle = new(SingleArray);
 
       public static readonly MethodInfo SingleOrDefaultKey = SingleOrDefaultMethods.Single(ft => ft.GetParameterTypes()[0] == typeof(Orm.Key));
-      internal static readonly MethodInfoParams SingleOrDefaultKeyParams = new(SingleOrDefaultKey);
+      internal static readonly GenericMethodDefinitionHandle SingleOrDefaultKeyHandle = new(SingleOrDefaultKey);
 
       public static readonly MethodInfo SingleOrDefaultArray = SingleOrDefaultMethods.Single(ft => ft.GetParameterTypes()[0] == WellKnownTypes.ObjectArray);
-      internal static readonly MethodInfoParams SingleOrDefaultArrayParams = new(SingleOrDefaultArray);
+      internal static readonly GenericMethodDefinitionHandle SingleOrDefaultArrayHandle = new(SingleOrDefaultArray);
 
       public static readonly MethodInfo Items = typeof(Orm.QueryEndpoint).GetMethod(nameof(Orm.QueryEndpoint.Items));
-      internal static readonly MethodInfoParams ItemsParams = new(Items);
+      internal static readonly GenericMethodDefinitionHandle ItemsHandle = new(Items);
     }
 #pragma warning restore 612,618
 
@@ -228,7 +244,7 @@ namespace Xtensive.Orm.Linq
           .First(m => m.Name == nameof(System.Linq.Enumerable.SingleOrDefault) && m.GetParameters().Length == 1);
 
       public static readonly Type OfTuple = WellKnownInterfaces.EnumerableOfT.CachedMakeGenericType(typeof(Xtensive.Tuples.Tuple));
-      public static readonly MethodInfoParams DefaultIfEmptyParams = new(typeof(System.Linq.Enumerable).GetMethods().First(m => m.Name == nameof(System.Linq.Enumerable.DefaultIfEmpty)));
+      public static readonly GenericMethodDefinitionHandle DefaultIfEmptyHandle = new(typeof(System.Linq.Enumerable).GetMethods().First(m => m.Name == nameof(System.Linq.Enumerable.DefaultIfEmpty)));
       public static readonly MethodInfo Contains = GetMethod(typeof(System.Linq.Enumerable), nameof(System.Linq.Enumerable.Contains), 1, 2);
       public static readonly MethodInfo Cast = GetMethod(typeof(System.Linq.Enumerable), nameof(System.Linq.Enumerable.Cast), 1, 1);
     }

--- a/Orm/Xtensive.Orm/Orm/Linq/WellKnownMembers.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/WellKnownMembers.cs
@@ -16,7 +16,7 @@ using TypeInfo = Xtensive.Orm.Model.TypeInfo;
 
 namespace Xtensive.Orm.Linq
 {
-  public readonly record struct GenericMethodHandle(int MetadataToken, ModuleHandle ModuleHandle)
+  internal readonly record struct GenericMethodHandle(int MetadataToken, ModuleHandle ModuleHandle)
   {
     public GenericMethodHandle(MethodInfo mi)
       : this(mi.MetadataToken, mi.Module.ModuleHandle)
@@ -27,7 +27,7 @@ namespace Xtensive.Orm.Linq
     }
   }
 
-  public readonly record struct GenericMethodDefinitionHandle(int MetadataToken, ModuleHandle ModuleHandle)
+  internal readonly record struct GenericMethodDefinitionHandle(int MetadataToken, ModuleHandle ModuleHandle)
   {
     public GenericMethodDefinitionHandle(MethodInfo mi)
       : this(mi.MetadataToken, mi.Module.ModuleHandle)

--- a/Orm/Xtensive.Orm/Orm/Linq/WellKnownMembers.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/WellKnownMembers.cs
@@ -78,30 +78,30 @@ namespace Xtensive.Orm.Linq
           .Single(g => g.ParameterTypes.Length == 2 &&
                        g.ParameterTypes[0] == typeof(Expression<Func<ConditionEndpoint, IOperand>>) &&
                        g.ParameterTypes[1].IsArray).Method;
-      internal static readonly GenericMethodDefinitionHandle ContainsTableExprWithColumnsParams = new(ContainsTableExprWithColumns);
+      internal static readonly GenericMethodDefinitionHandle ContainsTableExprWithColumnsHandle = new(ContainsTableExprWithColumns);
 
       public static readonly MethodInfo ContainsTableExprTopNByRank = containsTableMethods
           .Single(g => g.ParameterTypes.Length == 2 && g.ParameterTypes[0] == typeof(Expression<Func<ConditionEndpoint, IOperand>>) && g.ParameterTypes[1] == WellKnownTypes.Int32).Method;
-      internal static readonly GenericMethodDefinitionHandle ContainsTableExprTopNByRankParams = new(ContainsTableExprTopNByRank);
+      internal static readonly GenericMethodDefinitionHandle ContainsTableExprTopNByRankHandle = new(ContainsTableExprTopNByRank);
 
       public static readonly MethodInfo ContainsTableExprWithColumnsTopNByRank = containsTableMethods
           .Single(g => g.ParameterTypes.Length == 3 &&
                        g.ParameterTypes[0] == typeof(Expression<Func<ConditionEndpoint, IOperand>>) &&
                        g.ParameterTypes[1].IsArray &&
                        g.ParameterTypes[2] == WellKnownTypes.Int32).Method;
-      internal static readonly GenericMethodDefinitionHandle ContainsTableExprWithColumnsTopNByRankParams = new(ContainsTableExprWithColumnsTopNByRank);
+      internal static readonly GenericMethodDefinitionHandle ContainsTableExprWithColumnsTopNByRankHandle = new(ContainsTableExprWithColumnsTopNByRank);
 
       public static readonly MethodInfo SingleKey = SingleMethods.Single(ft => ft.GetParameterTypes()[0] == typeof(Orm.Key));
-      internal static readonly GenericMethodDefinitionHandle SingleKeyParams = new(SingleKey);
+      internal static readonly GenericMethodDefinitionHandle SingleKeyHandle = new(SingleKey);
 
       public static readonly MethodInfo SingleArray = SingleMethods.Single(ft => ft.GetParameterTypes()[0] == WellKnownTypes.ObjectArray);
-      internal static readonly GenericMethodDefinitionHandle SingleArrayParams = new(SingleArray);
+      internal static readonly GenericMethodDefinitionHandle SingleArrayHandle = new(SingleArray);
 
       public static readonly MethodInfo SingleOrDefaultKey = SingleOrDefaultMethods.Single(ft => ft.GetParameterTypes()[0] == typeof(Orm.Key));
-      internal static readonly GenericMethodDefinitionHandle SingleOrDefaultKeyParams = new(SingleOrDefaultKey);
+      internal static readonly GenericMethodDefinitionHandle SingleOrDefaultKeyHandle = new(SingleOrDefaultKey);
 
       public static readonly MethodInfo SingleOrDefaultArray = SingleOrDefaultMethods.Single(ft => ft.GetParameterTypes()[0] == WellKnownTypes.ObjectArray);
-      internal static readonly GenericMethodDefinitionHandle SingleOrDefaultArrayParams = new(SingleOrDefaultArray);
+      internal static readonly GenericMethodDefinitionHandle SingleOrDefaultArrayHandle = new(SingleOrDefaultArray);
     }
 
     public static class QueryEndpoint

--- a/Orm/Xtensive.Orm/Orm/Linq/WellknownMembers.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/WellknownMembers.Queryable.cs
@@ -26,7 +26,7 @@ namespace Xtensive.Orm.Linq
       public static readonly MethodInfo Count;
       public static readonly MethodInfo CountWithPredicate;
 
-      internal static readonly MethodInfoParams DefaultIfEmptyParams;
+      internal static readonly GenericMethodDefinitionHandle DefaultIfEmptyHandle;
 
       public static readonly MethodInfo DefaultIfEmptyWithDefaultValue;
       public static readonly MethodInfo Distinct;
@@ -208,7 +208,7 @@ namespace Xtensive.Orm.Linq
             case nameof(System.Linq.Queryable.DefaultIfEmpty):
               switch (parameters.Length) {
                 case 1:
-                  DefaultIfEmptyParams = new(methodInfo);
+                  DefaultIfEmptyHandle = new(methodInfo);
                   break;
                 case 2:
                   DefaultIfEmptyWithDefaultValue = methodInfo;

--- a/Orm/Xtensive.Orm/Orm/Linq/WellknownMembers.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/WellknownMembers.Queryable.cs
@@ -25,7 +25,9 @@ namespace Xtensive.Orm.Linq
       public static readonly MethodInfo Contains;
       public static readonly MethodInfo Count;
       public static readonly MethodInfo CountWithPredicate;
-      public static readonly MethodInfo DefaultIfEmpty;
+
+      internal static readonly MethodInfoParams DefaultIfEmptyParams;
+
       public static readonly MethodInfo DefaultIfEmptyWithDefaultValue;
       public static readonly MethodInfo Distinct;
       public static readonly MethodInfo ElementAt;
@@ -206,7 +208,7 @@ namespace Xtensive.Orm.Linq
             case nameof(System.Linq.Queryable.DefaultIfEmpty):
               switch (parameters.Length) {
                 case 1:
-                  DefaultIfEmpty = methodInfo;
+                  DefaultIfEmptyParams = new(methodInfo);
                   break;
                 case 2:
                   DefaultIfEmptyWithDefaultValue = methodInfo;

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -976,10 +976,10 @@ namespace Xtensive.Reflection
     /// to check against.</param>
     /// <returns><see langword="true"/> if the specified <paramref name="method"/> is a specification
     /// of the provided <paramref name="genericMethodDefinition"/>.</returns>
-    public static bool IsGenericMethodSpecificationOf(this MethodInfo method, in MethodInfoParams genericMethodDefinitionPaarams) =>
-      method.MetadataToken == genericMethodDefinitionPaarams.MetadataToken
-      && method.Module == genericMethodDefinitionPaarams.Module
-      && method.IsGenericMethod && genericMethodDefinitionPaarams.IsGenericMethodDefinition;
+    public static bool IsGenericMethodSpecificationOf(this MethodInfo method, in MethodInfoParams genericMethodDefinitionParams) =>
+      method.MetadataToken == genericMethodDefinitionParams.MetadataToken
+      && method.Module == genericMethodDefinitionParams.Module
+      && method.IsGenericMethod && genericMethodDefinitionParams.IsGenericMethodDefinition;
 
     public static Type CachedGetGenericTypeDefinition(this Type type) =>
       GenericTypeDefinitions?.GetOrAdd(type, static t => t.GetGenericTypeDefinition()) ?? type.GetGenericTypeDefinition();

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -976,7 +976,7 @@ namespace Xtensive.Reflection
     /// to check against.</param>
     /// <returns><see langword="true"/> if the specified <paramref name="methodHandle"/> is a specification
     /// of the provided <paramref name="definitionHandle"/>.</returns>
-    public static bool IsGenericMethodSpecificationOf(this in GenericMethodHandle methodHandle, in GenericMethodDefinitionHandle definitionHandle) =>
+    internal static bool IsGenericMethodSpecificationOf(this in GenericMethodHandle methodHandle, in GenericMethodDefinitionHandle definitionHandle) =>
       methodHandle.MetadataToken == definitionHandle.MetadataToken
       && methodHandle.ModuleHandle == definitionHandle.ModuleHandle;
 

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -971,11 +971,11 @@ namespace Xtensive.Reflection
     /// Determines whether given <paramref name="method"/> is a specification
     /// of the provided <paramref name="genericMethodDefinition"/>.
     /// </summary>
-    /// <param name="method">The <see cref="MethodInfo"/> to check.</param>
-    /// <param name="genericMethodDefinition">The <see cref="MethodInfo"/> of the generic method definition
+    /// <param name="methodParams">The <see cref="MethodInfoParams"/> to check.</param>
+    /// <param name="genericMethodDefinitionParams">The <see cref="MethodInfoParams"/> of the generic method definition
     /// to check against.</param>
-    /// <returns><see langword="true"/> if the specified <paramref name="method"/> is a specification
-    /// of the provided <paramref name="genericMethodDefinition"/>.</returns>
+    /// <returns><see langword="true"/> if the specified <paramref name="methodParams"/> is a specification
+    /// of the provided <paramref name="genericMethodDefinitionParams"/>.</returns>
     public static bool IsGenericMethodSpecificationOf(this in MethodInfoParams methodParams, in MethodInfoParams genericMethodDefinitionParams) =>
       methodParams.MetadataToken == genericMethodDefinitionParams.MetadataToken
       && methodParams.Module == genericMethodDefinitionParams.Module

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -976,7 +976,7 @@ namespace Xtensive.Reflection
     /// to check against.</param>
     /// <returns><see langword="true"/> if the specified <paramref name="method"/> is a specification
     /// of the provided <paramref name="genericMethodDefinition"/>.</returns>
-    public static bool IsGenericMethodSpecificationOf(this MethodInfo method, MethodInfoParams genericMethodDefinitionPaarams) =>
+    public static bool IsGenericMethodSpecificationOf(this MethodInfo method, in MethodInfoParams genericMethodDefinitionPaarams) =>
       method.MetadataToken == genericMethodDefinitionPaarams.MetadataToken
       && method.Module == genericMethodDefinitionPaarams.Module
       && method.IsGenericMethod && genericMethodDefinitionPaarams.IsGenericMethodDefinition;

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -977,7 +977,10 @@ namespace Xtensive.Reflection
     /// <returns><see langword="true"/> if the specified <paramref name="method"/> is a specification
     /// of the provided <paramref name="genericMethodDefinition"/>.</returns>
     public static bool IsGenericMethodSpecificationOf(this in MethodInfoParams methodParams, in MethodInfoParams genericMethodDefinitionParams) =>
-      methodParams == genericMethodDefinitionParams;
+      methodParams.MetadataToken == genericMethodDefinitionParams.MetadataToken
+      && methodParams.Module == genericMethodDefinitionParams.Module
+      && methodParams.IsGeneric
+      && genericMethodDefinitionParams.IsGeneric;
 
     public static Type CachedGetGenericTypeDefinition(this Type type) =>
       GenericTypeDefinitions?.GetOrAdd(type, static t => t.GetGenericTypeDefinition()) ?? type.GetGenericTypeDefinition();

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -976,10 +976,8 @@ namespace Xtensive.Reflection
     /// to check against.</param>
     /// <returns><see langword="true"/> if the specified <paramref name="method"/> is a specification
     /// of the provided <paramref name="genericMethodDefinition"/>.</returns>
-    public static bool IsGenericMethodSpecificationOf(this MethodInfo method, in MethodInfoParams genericMethodDefinitionParams) =>
-      method.MetadataToken == genericMethodDefinitionParams.MetadataToken
-      && method.Module == genericMethodDefinitionParams.Module
-      && method.IsGenericMethod && genericMethodDefinitionParams.IsGenericMethodDefinition;
+    public static bool IsGenericMethodSpecificationOf(this in MethodInfoParams methodParams, in MethodInfoParams genericMethodDefinitionParams) =>
+      methodParams == genericMethodDefinitionParams;
 
     public static Type CachedGetGenericTypeDefinition(this Type type) =>
       GenericTypeDefinitions?.GetOrAdd(type, static t => t.GetGenericTypeDefinition()) ?? type.GetGenericTypeDefinition();

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -971,16 +971,14 @@ namespace Xtensive.Reflection
     /// Determines whether given <paramref name="method"/> is a specification
     /// of the provided <paramref name="genericMethodDefinition"/>.
     /// </summary>
-    /// <param name="methodParams">The <see cref="MethodInfoParams"/> to check.</param>
-    /// <param name="genericMethodDefinitionParams">The <see cref="MethodInfoParams"/> of the generic method definition
+    /// <param name="methodHandle">The <see cref="GenericMethodDefinitionHandle"/> to check.</param>
+    /// <param name="definitionHandle">The <see cref="GenericMethodDefinitionHandle"/> of the generic method definition
     /// to check against.</param>
-    /// <returns><see langword="true"/> if the specified <paramref name="methodParams"/> is a specification
-    /// of the provided <paramref name="genericMethodDefinitionParams"/>.</returns>
-    public static bool IsGenericMethodSpecificationOf(this in MethodInfoParams methodParams, in MethodInfoParams genericMethodDefinitionParams) =>
-      methodParams.MetadataToken == genericMethodDefinitionParams.MetadataToken
-      && methodParams.Module == genericMethodDefinitionParams.Module
-      && methodParams.IsGeneric
-      && genericMethodDefinitionParams.IsGeneric;
+    /// <returns><see langword="true"/> if the specified <paramref name="methodHandle"/> is a specification
+    /// of the provided <paramref name="definitionHandle"/>.</returns>
+    public static bool IsGenericMethodSpecificationOf(this in GenericMethodHandle methodHandle, in GenericMethodDefinitionHandle definitionHandle) =>
+      methodHandle.MetadataToken == definitionHandle.MetadataToken
+      && methodHandle.ModuleHandle == definitionHandle.ModuleHandle;
 
     public static Type CachedGetGenericTypeDefinition(this Type type) =>
       GenericTypeDefinitions?.GetOrAdd(type, static t => t.GetGenericTypeDefinition()) ?? type.GetGenericTypeDefinition();

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -4,20 +4,16 @@
 // Created by: Nick Svetlov
 // Created:    2007.06.13
 
-using System;
 using System.Collections;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Threading;
 using Xtensive.Collections;
-using System.Linq;
 using Xtensive.Core;
-
+using Xtensive.Orm.Linq;
 using Xtensive.Sorting;
 using JetBrains.Annotations;
 
@@ -980,11 +976,10 @@ namespace Xtensive.Reflection
     /// to check against.</param>
     /// <returns><see langword="true"/> if the specified <paramref name="method"/> is a specification
     /// of the provided <paramref name="genericMethodDefinition"/>.</returns>
-    public static bool IsGenericMethodSpecificationOf(this MethodInfo method, MethodInfo genericMethodDefinition) =>
-      method.MetadataToken == genericMethodDefinition.MetadataToken
-      && (ReferenceEquals(method.Module, genericMethodDefinition.Module)
-        || method.Module == genericMethodDefinition.Module)
-      && method.IsGenericMethod && genericMethodDefinition.IsGenericMethodDefinition;
+    public static bool IsGenericMethodSpecificationOf(this MethodInfo method, MethodInfoParams genericMethodDefinitionPaarams) =>
+      method.MetadataToken == genericMethodDefinitionPaarams.MetadataToken
+      && method.Module == genericMethodDefinitionPaarams.Module
+      && method.IsGenericMethod && genericMethodDefinitionPaarams.IsGenericMethodDefinition;
 
     public static Type CachedGetGenericTypeDefinition(this Type type) =>
       GenericTypeDefinitions?.GetOrAdd(type, static t => t.GetGenericTypeDefinition()) ?? type.GetGenericTypeDefinition();


### PR DESCRIPTION
Extracting `MethodInfo.MethodInfo.MetadataToken/.Module/.IsGenericMethodDefinition` is not cheap.
They are `virtual` properties.

But we can store them statically for well known `MemberInfo`s in 
`readonly record struct MethodInfoParams(int MetadataToken, Module Module, bool IsGenericMethodDefinition)`

Also:
* Reduce multiple `mc.Arguments` evaluation
* Avoid redundant `ReferenceEqual(module, module)`.  `operator==()` already does it:
https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Reflection/Module.cs#L159
