### PR TITLE
Disable `RedundantColumnOptimizer` as a workaround of `.In()` in `let` bug

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Linq/InTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/InTest.cs
@@ -595,7 +595,6 @@ namespace Xtensive.Orm.Tests.Linq
     }
 
     // Related to https://github.com/DataObjects-NET/dataobjects-net/issues/402
-    [Explicit]
     [Test]
     public void UnusedLetImpactsQueryTest()
     {

--- a/Orm/Xtensive.Orm/Orm/Providers/DomainHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/DomainHandler.cs
@@ -99,7 +99,6 @@ namespace Xtensive.Orm.Providers
       return new CompositePreCompiler(
         applyCorrector,
         skipTakeCorrector,
-        RedundantColumnOptimizer.Instance,
         OrderingCorrector);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
@@ -1,4 +1,4 @@
-&// Copyright (C) 2010-2024 Xtensive LLC.
+// Copyright (C) 2010-2024 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2024 Xtensive LLC.
+&// Copyright (C) 2010-2024 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
@@ -113,8 +113,10 @@ namespace Xtensive.Orm.Rse.Transformation
       var colMap = mappings[provider.Source];
       mappings[provider] = colMap;
 
+      if (newSourceProvider == provider.Source)
+        return provider;
       var predicate = TranslateLambda(colMap, provider.Predicate);
-      return newSourceProvider == provider.Source && predicate == provider.Predicate
+      return predicate == provider.Predicate
         ? provider
         : new FilterProvider(newSourceProvider, (Expression<Func<Tuple, bool>>) predicate);
     }

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
@@ -1,4 +1,4 @@
-&// Copyright (C) 2010-2024 Xtensive LLC.
+// Copyright (C) 2010-2024 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
@@ -113,10 +113,8 @@ namespace Xtensive.Orm.Rse.Transformation
       var colMap = mappings[provider.Source];
       mappings[provider] = colMap;
 
-      if (newSourceProvider == provider.Source)
-        return provider;
       var predicate = TranslateLambda(colMap, provider.Predicate);
-      return predicate == provider.Predicate
+      return newSourceProvider == provider.Source && predicate == provider.Predicate
         ? provider
         : new FilterProvider(newSourceProvider, (Expression<Func<Tuple, bool>>) predicate);
     }

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2024 Xtensive LLC.
+&// Copyright (C) 2010-2024 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 


### PR DESCRIPTION
Fixing https://github.com/DataObjects-NET/dataobjects-net/issues/402

As a side effect some SQL queries will have longer text.

Also:
* Activate `UnusedLetImpactsQueryTest`
