### PR TITLE
Add `dataobjects.sql_length` histogram metric

### DIFF
--- a/Orm/Xtensive.Orm/Diagnostics/Metrics.cs
+++ b/Orm/Xtensive.Orm/Diagnostics/Metrics.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.Metrics;
 
 namespace Xtensive.Diagnostics;
@@ -9,10 +8,12 @@ public class Metrics
 
   public static Meter Meter { get; } = new("DataObjects");
 
-  public static Counter<long> BuffersReceived = Meter.CreateCounter<long>("SqlClient.BuffersReceived");
-  public static Counter<long> ServerRoundtrips = Meter.CreateCounter<long>("SqlClient.ServerRoundtrips");
-  public static Counter<long> SelectRows = Meter.CreateCounter<long>("SqlClient.SelectRows");
-  public static Counter<long> Transactions = Meter.CreateCounter<long>("SqlClient.Transactions");
+  public static readonly Counter<long> BuffersReceived = Meter.CreateCounter<long>("SqlClient.BuffersReceived");
+  public static readonly Counter<long> ServerRoundtrips = Meter.CreateCounter<long>("SqlClient.ServerRoundtrips");
+  public static readonly Counter<long> SelectRows = Meter.CreateCounter<long>("SqlClient.SelectRows");
+  public static readonly Counter<long> Transactions = Meter.CreateCounter<long>("SqlClient.Transactions");
 
-  public static Counter<int> SqlErrorCounter = Meter.CreateCounter<int>("dataobjects.sql_error");
+  public static readonly Counter<int> SqlErrorCounter = Meter.CreateCounter<int>("dataobjects.sql_error");
+
+  public static readonly Histogram<int> SqlLength = Meter.CreateHistogram<int>("dataobjects.sql_length");
 }

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilationResult.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilationResult.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using Xtensive.Diagnostics;
 using Xtensive.Orm.Model;
 
 namespace Xtensive.Sql.Compiler
@@ -66,6 +67,7 @@ namespace Xtensive.Sql.Compiler
         return resultText;
       string result = PostCompiler.Process(resultNodes, configuration, lastResultLength);
       lastResultLength = result.Length;
+      Metrics.SqlLength.Record(lastResultLength);
       return result;
     }
 


### PR DESCRIPTION
It would be useful to measure how DO's optimizers impact SQL command length