### PR TITLE
New versioning scheme

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.2.0.147</DoVersion>
+    <DoVersion>7.2.147.0</DoVersion>
     <DoVersionSuffix>servicetitan</DoVersionSuffix>
 </PropertyGroup>
 


### PR DESCRIPTION
Sometime we have to support and patch two (or more) DO versions.
For example for now we have
* `7.2.0.147-servicetitan` in `72pulsar`
* `7.2.0.142-2-servicetitan-tvp` in `71.2orion`
This looks ugly.

I'm suggesting to modify numbering, that we will have
 `7.2.147.0-servicetitan` & `7.2.142.2-servicetitan-tvp`

4 numbers in version is simpler than 5
