### PR TITLE
Add .NET 9 compatibility

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,7 +42,7 @@
     <NoWarn Condition="$(MSBuildProjectName.Contains('Tests')) == 'true'">$(NoWarn);SYSLIB0011</NoWarn>
     <!-- Enable Usage of BinaryFormatter in test projects -->
     <EnableUnsafeBinaryFormatterSerialization
-      Condition="'$(TargetFramework)'=='net8.0' AND $(MSBuildProjectName.Contains('Tests')) == 'true'">true</EnableUnsafeBinaryFormatterSerialization>
+      Condition="('$(TargetFramework)'=='net8.0' OR '$(TargetFramework)'=='net9.0') AND $(MSBuildProjectName.Contains('Tests')) == 'true'">true</EnableUnsafeBinaryFormatterSerialization>
      <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 

--- a/MSBuild/DataObjects.Net.targets
+++ b/MSBuild/DataObjects.Net.targets
@@ -13,8 +13,8 @@
   <XtensiveOrmPath Condition="'$(XtensiveOrmPath)'==''">$(MSBuildThisFileDirectory)</XtensiveOrmPath>
   <XtensiveOrmPath Condition="!HasTrailingSlash('$(XtensiveOrmPath)')">$(XtensiveOrmPath)\</XtensiveOrmPath>
   <XtensiveWeaverFramework>net8.0</XtensiveWeaverFramework>
-  <XtensiveWeaverFramework Condition="'$(TargetFramework)'=='net7.0'">net7.0</XtensiveWeaverFramework>
-  <XtensiveWeaverFramework Condition="'$(TargetFramework)'=='net6.0'">net6.0</XtensiveWeaverFramework>
+  <XtensiveWeaverFramework Condition="'$(TargetFramework)'=='net9.0'">net9.0</XtensiveWeaverFramework>
+  <XtensiveWeaverFramework Condition="'$(TargetFramework)'=='net8.0'">net8.0</XtensiveWeaverFramework>
   <XtensiveOrmWeaver Condition="'$(XtensiveOrmWeaver)'==''">$(XtensiveOrmPath)tools\weaver\$(XtensiveWeaverFramework)\Xtensive.Orm.Weaver.dll</XtensiveOrmWeaver>
   <XtensiveOrmBuildDependsOn>$(XtensiveOrmBuildDependsOn)</XtensiveOrmBuildDependsOn>
 </PropertyGroup>

--- a/Orm/Xtensive.Orm.Tests/Issues/Issue0788_EntityIsDetached.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/Issue0788_EntityIsDetached.cs
@@ -27,18 +27,18 @@ namespace Xtensive.Orm.Tests.Issues.Issue0788_EntityIsDetached_Model
     public string Token { get; private set; }
 
     [Field]
-    public Lock LockObject { get; private set; }
+    public LockEntity LockEntityObject { get; private set; }
 
     public bool Signalled
     {
-      get { return (null==LockObject); }
+      get { return (null==LockEntityObject); }
     }
 
     protected SyncObject(string token, Guid requestorId, bool signalled)
       : base(token)
     {
       if (!signalled) {
-        //  Подпорка
+        //  Hello
         //LockObject = new Lock(token, requestorId, this);
       }
     }
@@ -46,7 +46,7 @@ namespace Xtensive.Orm.Tests.Issues.Issue0788_EntityIsDetached_Model
 
   [KeyGenerator(KeyGeneratorKind.None)]
   [HierarchyRoot]
-  internal class Lock : Entity
+  internal class LockEntity : Entity
   {
     [Field(Length = 128)]
     [Key]
@@ -72,7 +72,7 @@ namespace Xtensive.Orm.Tests.Issues.Issue0788_EntityIsDetached_Model
     /// </summary>
     /// <param name="token">Token</param>
     /// <param name="requestorId">Requestor Id</param>
-    public Lock(string token, Guid requestorId)
+    public LockEntity(string token, Guid requestorId)
       : base(token)
     {
       RequestorId = requestorId;
@@ -85,7 +85,7 @@ namespace Xtensive.Orm.Tests.Issues.Issue0788_EntityIsDetached_Model
     /// <param name="token">Token</param>
     /// <param name="requestorId">Requestor Id</param>
     /// <param name="owner">Owning <see cref="SyncObject"/></param>
-    public Lock(string token, Guid requestorId, SyncObject owner)
+    public LockEntity(string token, Guid requestorId, SyncObject owner)
       : base(token)
     {
       //using(Session.Pin(this))
@@ -106,7 +106,7 @@ namespace Xtensive.Orm.Tests.Issues
     protected override DomainConfiguration BuildConfiguration()
     {
       var config = base.BuildConfiguration();
-      config.Types.Register(typeof (Lock).Assembly, typeof (Lock).Namespace);
+      config.Types.Register(typeof (LockEntity).Assembly, typeof (LockEntity).Namespace);
       return config;
     }
 
@@ -116,12 +116,12 @@ namespace Xtensive.Orm.Tests.Issues
       using (var session = Domain.OpenSession()) {
         Guid key = new Guid("{0AF02FA4-F6C6-4A78-A569-9E5225281E27}");
         Event evt = null;
-        Lock evtLock;
+        LockEntity evtLockEntity;
 
         using (var transactionScope = session.OpenTransaction()) {
           evt = new Event("dep", key, false);
-          evtLock = new Lock("dep", key, null);
-          evtLock.OwnerObject = evt;
+          evtLockEntity = new LockEntity("dep", key, null);
+          evtLockEntity.OwnerObject = evt;
           transactionScope.Complete();
         }
       }

--- a/Orm/Xtensive.Orm/Collections/TypeRegistry.cs
+++ b/Orm/Xtensive.Orm/Collections/TypeRegistry.cs
@@ -110,7 +110,6 @@ namespace Xtensive.Collections
     public bool Register(in TypeRegistration action)
     {
       EnsureNotLocked();
-      ArgumentNullException.ThrowIfNull(action);
       if (actionSet.Contains(action))
         return false;
       actionSet.Add(action);

--- a/Orm/Xtensive.Orm/Orm/Operations/ValidateVersionOperation.cs
+++ b/Orm/Xtensive.Orm/Orm/Operations/ValidateVersionOperation.cs
@@ -90,7 +90,6 @@ namespace Xtensive.Orm.Operations
     public ValidateVersionOperation(Key key, VersionInfo version)
       : base(key)
     {
-      ArgumentNullException.ThrowIfNull(version);
       Version = version;
     }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/CompilationService.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CompilationService.cs
@@ -32,7 +32,6 @@ namespace Xtensive.Orm.Providers
     public ExecutableProvider Compile(CompilableProvider provider, CompilerConfiguration configuration)
     {
       ArgumentNullException.ThrowIfNull(provider);
-      ArgumentNullException.ThrowIfNull(configuration);
 
       var preCompiler = preCompilerProvider.Invoke(configuration);
       var compiler = compilerProvider.Invoke(configuration);

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
@@ -247,8 +247,6 @@ namespace Xtensive.Orm
     public static IQueryable<TSource> Lock<TSource>(this IQueryable<TSource> source, LockMode lockMode, LockBehavior lockBehavior)
     {
       ArgumentNullException.ThrowIfNull(source);
-      ArgumentNullException.ThrowIfNull(lockMode);
-      ArgumentNullException.ThrowIfNull(lockBehavior);
 
       var providerType = source.Provider.GetType();
       if (providerType!=WellKnownOrmTypes.QueryProvider) {

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/IndexHintProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/IndexHintProvider.cs
@@ -30,7 +30,6 @@ namespace Xtensive.Orm.Rse.Providers
     public IndexHintProvider(CompilableProvider source, IndexInfoRef index)
       : base(ProviderType.IndexHint, source)
     {
-      ArgumentNullException.ThrowIfNull(index);
       Index = index;
       Initialize();
     }

--- a/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryBuilder.cs
@@ -106,8 +106,6 @@ namespace Xtensive.Orm.Services
     /// <returns>Created command.</returns>
     public QueryCommand CreateCommand(QueryRequest request)
     {
-      ArgumentNullException.ThrowIfNull(request);
-
       var command = commandFactory.CreateCommand();
       var session = Session;
       command.AddPart(commandFactory.CreateQueryPart(request.RealRequest, new ParameterContext()));


### PR DESCRIPTION
Also:
* Fix `CA2264` warning - checking value types for `null`
* Fixed Cyrillic word in wrong encoding in commment
* Rename `Lock` type into `LockEntity` in tests to avoid ambiguity with new .NET9 type