### PR TITLE
Make `TVP` case-insensitive to be consistent with default `SQL_Latin1_General_CP1_CI_AS` SQL Server collation

### DIFF
--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/SqlDataRecordList.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/SqlDataRecordList.cs
@@ -48,7 +48,7 @@ public class SqlDataRecordList(IReadOnlyList<Tuple> tuples, SqlDbType sqlDbType)
       case SqlDbType.NVarChar: {
         SqlMetaData[] metaData = [new("Value", sqlDbType, tuples.Max(t => (t.GetValueOrDefault(0) as string)?.Length ?? 20))];
         SqlDataRecord record = new(metaData);
-        HashSet<string> added = new();
+        HashSet<string> added = new(StringComparer.Ordinal);
         foreach (var valueObj in tuples.Select(t => t.GetValueOrDefault(0)).Where(o => o != null)) {
           string castValue = (string) valueObj;
           if (added.Add(castValue)) {

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/SqlDataRecordList.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/SqlDataRecordList.cs
@@ -48,7 +48,7 @@ public class SqlDataRecordList(IReadOnlyList<Tuple> tuples, SqlDbType sqlDbType)
       case SqlDbType.NVarChar: {
         SqlMetaData[] metaData = [new("Value", sqlDbType, tuples.Max(t => (t.GetValueOrDefault(0) as string)?.Length ?? 20))];
         SqlDataRecord record = new(metaData);
-        HashSet<string> added = new(StringComparer.Ordinal);
+        HashSet<string> added = new(StringComparer.OrdinalIgnoreCase);
         foreach (var valueObj in tuples.Select(t => t.GetValueOrDefault(0)).Where(o => o != null)) {
           string castValue = (string) valueObj;
           if (added.Add(castValue)) {

--- a/Orm/Xtensive.Orm.Tests/Linq/InTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/InTest.cs
@@ -646,5 +646,16 @@ namespace Xtensive.Orm.Tests.Linq
                   select track;
       query.ToList();
     }
+
+    [Test]
+    [MutePostgreSql]
+    public void CaseInsensitive_TVP_Test()
+    {
+      string[] names = ["Abc", "ABC"];
+      (from track in Session.Query.All<Track>()
+          where track.Name.In(IncludeAlgorithm.TableValuedParameter, names)
+          select track
+        ).ToList();
+    }
   }
 }


### PR DESCRIPTION
See discussion: https://servicetitan.slack.com/archives/CB3JFPYLB/p1732296537021069

Also:
* Add test `CaseInsensitive_TVP_Test`