### PR TITLE
Compressed XML Model in `Metadata.Extensions` table

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0760_OverrideFieldNameAttributeRuinsFieldMappingOnUpgrade.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0760_OverrideFieldNameAttributeRuinsFieldMappingOnUpgrade.cs
@@ -30,7 +30,8 @@ namespace Xtensive.Orm.Tests.Issues
       Domain domain = null;
       using (domain = Domain.Build(initialConfiguration)) {
         var metadata = domain.Extensions.Get<MetadataSet>();
-        var savedModel = StoredDomainModel.Deserialize(metadata.Extensions.First().Value);
+        var extension = metadata.Extensions.First();
+        var savedModel = StoredDomainModel.Deserialize(extension.Value, extension.Data);
         var type = savedModel.Types.First(t => t.Name == "EntityWithState");
         var stateField = type.Fields.First(f => f.PropertyName == "State");
 
@@ -52,7 +53,8 @@ namespace Xtensive.Orm.Tests.Issues
 
       using (domain) {
         var metadata = domain.Extensions.Get<MetadataSet>();
-        var savedModel = StoredDomainModel.Deserialize(metadata.Extensions.First().Value);
+        var extension = metadata.Extensions.First();
+        var savedModel = StoredDomainModel.Deserialize(extension.Value, extension.Data);
         var type = savedModel.Types.First(t => t.Name == "EntityWithState");
         var stateField = type.Fields.First(f => f.PropertyName == "State");
 
@@ -74,7 +76,8 @@ namespace Xtensive.Orm.Tests.Issues
       Domain domain = null;
       using (domain = Domain.Build(initialConfiguration)) {
         var metadata = domain.Extensions.Get<MetadataSet>();
-        var savedModel = StoredDomainModel.Deserialize(metadata.Extensions.First().Value);
+        var extension = metadata.Extensions.First();
+        var savedModel = StoredDomainModel.Deserialize(extension.Value, extension.Data);
         var type = savedModel.Types.First(t => t.Name == "EntityWithState");
         var stateField = type.Fields.First(f => f.PropertyName == "State");
 
@@ -96,7 +99,8 @@ namespace Xtensive.Orm.Tests.Issues
 
       using (domain) {
         var metadata = domain.Extensions.Get<MetadataSet>();
-        var savedModel = StoredDomainModel.Deserialize(metadata.Extensions.First().Value);
+        var extension = metadata.Extensions.First();
+        var savedModel = StoredDomainModel.Deserialize(extension.Value, extension.Data);
         var type = savedModel.Types.First(t => t.Name == "EntityWithState");
         var stateField = type.Fields.First(f => f.PropertyName == "State");
 

--- a/Orm/Xtensive.Orm.Tests/Model/SerializationTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Model/SerializationTest.cs
@@ -27,8 +27,8 @@ namespace Xtensive.Orm.Tests.Model
     public void MainTest()
     {
       var model = Domain.Model.ToStoredModel();
-      var serialized = model.Serialize();
-      var result = StoredDomainModel.Deserialize(serialized);
+      var (serialized, compressed) = model.Serialize();
+      var result = StoredDomainModel.Deserialize(serialized, compressed);
       result.UpdateReferences();
     }
   }

--- a/Orm/Xtensive.Orm.Tests/Upgrade/SqlWorkerAndSqlAsyncWorkerTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Upgrade/SqlWorkerAndSqlAsyncWorkerTest.cs
@@ -521,11 +521,16 @@ namespace Xtensive.Orm.Tests.Upgrade
       var create = SqlDdl.Create(table);
       _ = table.CreateColumn(mapping.ExtensionName, columnsTypeMap[mapping.ExtensionName]);
       _ = table.CreateColumn(mapping.ExtensionText, columnsTypeMap[mapping.ExtensionText]);
+      _ = table.CreateColumn(mapping.ExtensionData, columnsTypeMap[mapping.ExtensionData]);
       Execute(create);
 
       var tableRef = SqlDml.TableRef(table);
       var insert = SqlDml.Insert(tableRef);
-      insert.AddValueRow((tableRef[mapping.ExtensionName], "name"), (tableRef[mapping.ExtensionText], "text"));
+      insert.AddValueRow(
+        (tableRef[mapping.ExtensionName], "name"),
+        (tableRef[mapping.ExtensionText], "text"),
+        (tableRef[mapping.ExtensionData], new byte[] { })
+      );
       Execute(insert);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Model/Stored/StoredDomainModel.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/Stored/StoredDomainModel.cs
@@ -5,6 +5,8 @@
 // Created:    2009.05.22
 
 using System.IO;
+using System.IO.Compression;
+using System.Text;
 using System.Xml.Serialization;
 using Xtensive.Core;
 using Xtensive.Orm.Configuration;
@@ -18,7 +20,7 @@ namespace Xtensive.Orm.Model.Stored
   [XmlRoot("DomainModel", Namespace = "")]
   public sealed class StoredDomainModel
   {
-    private static readonly SimpleXmlSerializer<StoredDomainModel> Serializer = new SimpleXmlSerializer<StoredDomainModel>();
+    private static readonly SimpleXmlSerializer<StoredDomainModel> Serializer = new();
 
     /// <summary>
     /// <see cref="DomainModel.Types"/>.
@@ -43,8 +45,28 @@ namespace Xtensive.Orm.Model.Stored
     /// </summary>
     /// <param name="serialized">Serialized instance.</param>
     /// <returns>Deserialized instance.</returns>
-    public static StoredDomainModel Deserialize(string serialized)
+    public static StoredDomainModel Deserialize(string serialized, byte[] data)
     {
+      if (data != null) {
+        string xml;
+        switch (data[0]) {
+          case 0:
+            xml = Encoding.UTF8.GetString(data, 1, data.Length - 1);
+            break;
+          case 1:
+            using (BrotliStream brotliStream = new(new MemoryStream(data, 1, data.Length - 1), CompressionMode.Decompress)) {
+              using StreamReader reader = new(brotliStream, Encoding.UTF8);
+              xml = reader.ReadToEnd();
+            }
+            break;
+          default:
+            throw new NotSupportedException("Invalid data format");
+        }
+        var model = Serializer.Deserialize(xml);
+
+        //!!!TODO  Uncomment following line to switch to Compressed XML serialization
+        // return model;
+      }
       return Serializer.Deserialize(serialized);
     }
 
@@ -52,9 +74,20 @@ namespace Xtensive.Orm.Model.Stored
     /// Serializes this instance to string.
     /// </summary>
     /// <returns>Serialized instance.</returns>
-    public string Serialize()
+    public (string Xml, byte[] Compressed) Serialize()
     {
-      return Serializer.Serialize(this);
+      var xml = Serializer.Serialize(this);
+      MemoryStream ms = new();
+      ms.WriteByte(1);
+      using (BrotliStream brotliStream = new(ms, CompressionLevel.SmallestSize)) {
+        using StreamWriter writer = new(brotliStream, Encoding.UTF8);
+        writer.Write(xml);
+      }
+
+      //!!!TODO  Uncomment following line to switch to Compressed XML serialization
+      // return (null, ms.ToArray());
+
+      return (xml, ms.ToArray());
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Model/Stored/StoredDomainModel.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/Stored/StoredDomainModel.cs
@@ -77,11 +77,10 @@ namespace Xtensive.Orm.Model.Stored
     public (string Xml, byte[] Compressed) Serialize()
     {
       var xml = Serializer.Serialize(this);
-      MemoryStream ms = new();
+      MemoryStream ms = new(1000);
       ms.WriteByte(1);
-      using (BrotliStream brotliStream = new(ms, CompressionLevel.SmallestSize)) {
-        using StreamWriter writer = new(brotliStream, Encoding.UTF8);
-        writer.Write(xml);
+      using (BrotliStream brotliStream = new(ms, CompressionLevel.Optimal)) {
+        brotliStream.Write(Encoding.UTF8.GetBytes(xml));
       }
 
       //!!!TODO  Uncomment following line to switch to Compressed XML serialization

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/ExtensionMetadata.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/ExtensionMetadata.cs
@@ -6,26 +6,23 @@
 
 using Xtensive.Core;
 
-namespace Xtensive.Orm.Upgrade
+namespace Xtensive.Orm.Upgrade;
+
+internal sealed class ExtensionMetadata
 {
-  internal sealed class ExtensionMetadata
+  public string Name { get; }
+  public string Value { get; }
+  public byte[] Data { get; }
+
+  public override string ToString() => Name;
+
+  // Constructors
+
+  public ExtensionMetadata(string name, string value, byte[] data)
   {
-    public string Name { get; private set; }
-
-    public string Value { get; private set; }
-
-    public override string ToString()
-    {
-      return Name;
-    }
-
-    // Constructors
-
-    public ExtensionMetadata(string name, string value)
-    {
-      ArgumentNullException.ThrowIfNull(name);
-      Name = name;
-      Value = value;
-    }
+    ArgumentNullException.ThrowIfNull(name);
+    Name = name;
+    Value = value;
+    Data = data;
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/MetadataExtractor.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/MetadataExtractor.cs
@@ -4,13 +4,8 @@
 // Created by: Denis Krjuchkov
 // Created:    2012.02.16
 
-using System;
-using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Xtensive.Core;
 using Xtensive.Orm.Providers;
 using Xtensive.Sql;
@@ -66,39 +61,39 @@ namespace Xtensive.Orm.Upgrade
 
     private IEnumerable<AssemblyMetadata> ExtractAssemblies(SqlExtractionTask task)
     {
-      var query = CreateQuery(mapping.Assembly, task, mapping.AssemblyName, mapping.AssemblyVersion);
+      var query = CreateQuery(mapping.Assembly, task, [mapping.AssemblyName, mapping.AssemblyVersion]);
       return ExecuteQuery(query, ParseAssembly);
     }
 
     private Task ExtractAssembliesAsync(ICollection<AssemblyMetadata> output, SqlExtractionTask task,
       CancellationToken token)
     {
-      var query = CreateQuery(mapping.Assembly, task, mapping.AssemblyName, mapping.AssemblyVersion);
+      var query = CreateQuery(mapping.Assembly, task, [mapping.AssemblyName, mapping.AssemblyVersion]);
       return ExecuteQueryAsync(output, query, ParseAssembly, token);
     }
 
     private IEnumerable<TypeMetadata> ExtractTypes(SqlExtractionTask task)
     {
-      var query = CreateQuery(mapping.Type, task, mapping.TypeId, mapping.TypeName);
+      var query = CreateQuery(mapping.Type, task, [mapping.TypeId, mapping.TypeName]);
       return ExecuteQuery(query, ParseType);
     }
 
     private Task ExtractTypesAsync(ICollection<TypeMetadata> output, SqlExtractionTask task, CancellationToken token)
     {
-      var query = CreateQuery(mapping.Type, task, mapping.TypeId, mapping.TypeName);
+      var query = CreateQuery(mapping.Type, task, [mapping.TypeId, mapping.TypeName]);
       return ExecuteQueryAsync(output, query, ParseType, token);
     }
 
     private IEnumerable<ExtensionMetadata> ExtractExtensions(SqlExtractionTask task)
     {
-      var query = CreateQuery(mapping.Extension, task, mapping.ExtensionName, mapping.ExtensionText);
+      var query = CreateQuery(mapping.Extension, task, [mapping.ExtensionName, mapping.ExtensionText, mapping.ExtensionData]);
       return ExecuteQuery(query, ParseExtension);
     }
 
     private Task ExtractExtensionsAsync(ICollection<ExtensionMetadata> output, SqlExtractionTask task,
       CancellationToken token)
     {
-      var query = CreateQuery(mapping.Extension, task, mapping.ExtensionName, mapping.ExtensionText);
+      var query = CreateQuery(mapping.Extension, task, [mapping.ExtensionName, mapping.ExtensionText]);
       return ExecuteQueryAsync(output, query, ParseExtension, token);
     }
 
@@ -106,7 +101,8 @@ namespace Xtensive.Orm.Upgrade
     {
       var name = ReadString(reader, 0);
       var text = ReadString(reader, 1);
-      return new ExtensionMetadata(name, text);
+      var data = ReadBytes(reader, 2);
+      return new ExtensionMetadata(name, text, data);
     }
 
     private AssemblyMetadata ParseAssembly(DbDataReader reader)
@@ -143,7 +139,7 @@ namespace Xtensive.Orm.Upgrade
       }
     }
 
-    private static SqlSelect CreateQuery(string tableName, SqlExtractionTask task, params string[] columnNames)
+    private static SqlSelect CreateQuery(string tableName, SqlExtractionTask task, string[] columnNames)
     {
       var catalog = new Catalog(task.Catalog);
       var schema = catalog.CreateSchema(task.Schema);
@@ -165,6 +161,9 @@ namespace Xtensive.Orm.Upgrade
 
     private string ReadString(DbDataReader reader, int index) =>
       reader.IsDBNull(index) ? null : (string) mapping.StringMapping.ReadValue(reader, index);
+
+    private byte[] ReadBytes(DbDataReader reader, int index) =>
+      reader.IsDBNull(index) ? null : (byte[]) mapping.BytesMapping.ReadValue(reader, index);
 
     private int ReadInt(DbDataReader reader, int index) =>
       (int) mapping.IntMapping.ReadValue(reader, index);

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/MetadataExtractor.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/MetadataExtractor.cs
@@ -93,7 +93,7 @@ namespace Xtensive.Orm.Upgrade
     private Task ExtractExtensionsAsync(ICollection<ExtensionMetadata> output, SqlExtractionTask task,
       CancellationToken token)
     {
-      var query = CreateQuery(mapping.Extension, task, [mapping.ExtensionName, mapping.ExtensionText]);
+      var query = CreateQuery(mapping.Extension, task, [mapping.ExtensionName, mapping.ExtensionText, mapping.ExtensionData]);
       return ExecuteQueryAsync(output, query, ParseExtension, token);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/MetadataMapping.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/MetadataMapping.cs
@@ -21,6 +21,7 @@ namespace Xtensive.Orm.Upgrade
     private readonly NameBuilder nameBuilder;
 
     public readonly TypeMapping StringMapping;
+    public readonly TypeMapping BytesMapping;
     public readonly TypeMapping IntMapping;
 
     public readonly string Assembly;
@@ -34,6 +35,7 @@ namespace Xtensive.Orm.Upgrade
     public readonly string Extension;
     public readonly string ExtensionName;
     public readonly string ExtensionText;
+    public readonly string ExtensionData;
 
     private string TableOf(Type type)
     {
@@ -68,8 +70,10 @@ namespace Xtensive.Orm.Upgrade
       Extension = TableOf(typeof (Extension));
       ExtensionName = ColumnOf((Extension x) => x.Name);
       ExtensionText = ColumnOf((Extension x) => x.Text);
+      ExtensionData = ColumnOf((Extension x) => x.Data);
 
       StringMapping = driver.GetTypeMapping(WellKnownTypes.String);
+      BytesMapping = driver.GetTypeMapping(WellKnownTypes.ByteArray);
       IntMapping = driver.GetTypeMapping(WellKnownTypes.Int32);
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/MetadataWriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/MetadataWriter.cs
@@ -4,16 +4,12 @@
 // Created by: Denis Krjuchkov
 // Created:    2012.03.22
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Xtensive.Orm.Providers;
 using Xtensive.Reflection;
 using Xtensive.Sql;
 using Xtensive.Sql.Dml;
 using Xtensive.Sql.Model;
 using Xtensive.Tuples;
-using ArgumentValidator = Xtensive.Core.ArgumentValidator;
 using Tuple = Xtensive.Tuples.Tuple;
 
 namespace Xtensive.Orm.Upgrade
@@ -51,9 +47,16 @@ namespace Xtensive.Orm.Upgrade
         driver.ProviderInfo.Supports(ProviderFeatures.LargeObjects)
         ? ParameterTransmissionType.CharacterLob
         : ParameterTransmissionType.Regular;
+      var extensionDataTransmissionType =
+        driver.ProviderInfo.Supports(ProviderFeatures.LargeObjects)
+        ? ParameterTransmissionType.BinaryLob
+        : ParameterTransmissionType.Regular;
       var descriptor = CreateDescriptor(mapping.Extension,
-        mapping.StringMapping, mapping.ExtensionName, ParameterTransmissionType.Regular,
-        mapping.StringMapping, mapping.ExtensionText, extensionTextTransmissionType,
+        [
+          (mapping.StringMapping, mapping.ExtensionName, ParameterTransmissionType.Regular),
+          (mapping.StringMapping, mapping.ExtensionText, extensionTextTransmissionType),
+          (mapping.BytesMapping, mapping.ExtensionData, extensionDataTransmissionType),
+        ],
         ProvideExtensionMetadataFilter);
 
       executor.Overwrite(descriptor, extensions.Select(item => (Tuple) Tuple.Create(StringStringDescriptor, item.Name, item.Value)));
@@ -68,8 +71,10 @@ namespace Xtensive.Orm.Upgrade
     private void WriteTypes(IEnumerable<TypeMetadata> types)
     {
       var descriptor = CreateDescriptor(mapping.Type,
-        mapping.IntMapping, mapping.TypeId, ParameterTransmissionType.Regular,
-        mapping.StringMapping, mapping.TypeName, ParameterTransmissionType.Regular);
+      [
+        (mapping.IntMapping, mapping.TypeId, ParameterTransmissionType.Regular),
+        (mapping.StringMapping, mapping.TypeName, ParameterTransmissionType.Regular)
+      ]);
 
       executor.Overwrite(descriptor, types.Select(item => (Tuple) Tuple.Create(IntStringDescriptor, item.Id, item.Name)));
     }
@@ -77,24 +82,25 @@ namespace Xtensive.Orm.Upgrade
     private void WriteAssemblies(IEnumerable<AssemblyMetadata> assemblies)
     {
       var descriptor = CreateDescriptor(mapping.Assembly,
-        mapping.StringMapping, mapping.AssemblyName, ParameterTransmissionType.Regular,
-        mapping.StringMapping, mapping.AssemblyVersion, ParameterTransmissionType.Regular);
+      [
+        (mapping.StringMapping, mapping.AssemblyName, ParameterTransmissionType.Regular),
+        (mapping.StringMapping, mapping.AssemblyVersion, ParameterTransmissionType.Regular)
+      ]);
 
       executor.Overwrite(descriptor, assemblies.Select(item => (Tuple) Tuple.Create(StringStringDescriptor, item.Name, item.Version)));
     }
 
     private IPersistDescriptor CreateDescriptor(string tableName,
-      TypeMapping mapping1, string columnName1, ParameterTransmissionType transmissionType1,
-      TypeMapping mapping2, string columnName2, ParameterTransmissionType transmissionType2,
+      (TypeMapping mapping, string columnName, ParameterTransmissionType transmissionType)[] pars,
       Action<SqlDelete> deleteTransform = null)
     {
       var catalog = new Catalog(task.Catalog);
       var schema = catalog.CreateSchema(task.Schema);
       var table = schema.CreateTable(tableName);
 
-      var columnNames = new[] {columnName1, columnName2};
-      var mappings = new[] {mapping1, mapping2};
-      var transmissionTypes = new[] {transmissionType1, transmissionType2};
+      var columnNames = pars.Select(o => o.columnName).ToArray();
+      var mappings = pars.Select(o => o.mapping).ToArray();
+      var transmissionTypes = pars.Select(o => o.transmissionType).ToArray();
 
       var columns = columnNames.Select(table.CreateColumn).ToList();
       var tableRef = SqlDml.TableRef(table);

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/MetadataWriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/MetadataWriter.cs
@@ -20,6 +20,8 @@ namespace Xtensive.Orm.Upgrade
       TupleDescriptor.Create(new[] {WellKnownTypes.Int32, WellKnownTypes.String});
     private static readonly TupleDescriptor StringStringDescriptor =
       TupleDescriptor.Create(new[] {WellKnownTypes.String, WellKnownTypes.String});
+    private static readonly TupleDescriptor StringStringBytesDescriptor =
+      TupleDescriptor.Create([WellKnownTypes.String, WellKnownTypes.String, WellKnownTypes.ByteArray]);
 
     private sealed class Descriptor : IPersistDescriptor
     {
@@ -59,7 +61,8 @@ namespace Xtensive.Orm.Upgrade
         ],
         ProvideExtensionMetadataFilter);
 
-      executor.Overwrite(descriptor, extensions.Select(item => (Tuple) Tuple.Create(StringStringDescriptor, item.Name, item.Value)));
+      executor.Overwrite(descriptor, extensions.Select(item =>
+        (Tuple) Tuple.Create(StringStringBytesDescriptor, item.Name, item.Value, item.Data)));
     }
 
     private void ProvideExtensionMetadataFilter(SqlDelete delete)

--- a/Orm/Xtensive.Orm/Orm/Upgrade/SystemUpgradeHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/SystemUpgradeHandler.cs
@@ -200,8 +200,8 @@ namespace Xtensive.Orm.Upgrade
         // Since we support storage nodes, stored domain model and real model of a node
         // must be synchronized. So we must update types' mappings
         storedModel.UpdateMappings(UpgradeContext.NodeConfiguration);
-        var serializedModel = storedModel.Serialize();
-        var modelExtension = new ExtensionMetadata(WellKnown.DomainModelExtensionName, serializedModel);
+        var (serializedModel, compressed) = storedModel.Serialize();
+        var modelExtension = new ExtensionMetadata(WellKnown.DomainModelExtensionName, serializedModel, compressed);
         var indexesExtension = GetPartialIndexes(domain, types);
         metadata.Assemblies.AddRange(assemblyMetadata);
         metadata.Types.AddRange(typeMetadata);
@@ -251,7 +251,7 @@ namespace Xtensive.Orm.Upgrade
       var items = new StoredPartialIndexFilterInfoCollection {
         Items = indexes
       };
-      return new ExtensionMetadata(WellKnown.PartialIndexDefinitionsExtensionName, items.Serialize());
+      return new ExtensionMetadata(WellKnown.PartialIndexDefinitionsExtensionName, items.Serialize(), null);
     }
 
     private void ParseStoredDomainModel()
@@ -264,7 +264,7 @@ namespace Xtensive.Orm.Upgrade
 
         foreach (var extension in extensions) {
           found = true;
-          var part = StoredDomainModel.Deserialize(extension.Value);
+          var part = StoredDomainModel.Deserialize(extension.Value, extension.Data);
           types.AddRange(part.Types);
         }
 

--- a/Version.props
+++ b/Version.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.2.151</DoVersion>
+    <DoVersion>7.2.152</DoVersion>
     <DoVersionSuffix>servicetitan-test-compressed-xml</DoVersionSuffix>
 </PropertyGroup>
 

--- a/Version.props
+++ b/Version.props
@@ -2,8 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.2.150</DoVersion>
-    <DoVersionSuffix>servicetitan-test-column-optimizer</DoVersionSuffix>
+    <DoVersion>7.2.152</DoVersion>
+    <DoVersionSuffix>servicetitan-test-compressed-xml</DoVersionSuffix>
 </PropertyGroup>
 
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.2.152</DoVersion>
+    <DoVersion>7.2.151</DoVersion>
     <DoVersionSuffix>servicetitan-test-compressed-xml</DoVersionSuffix>
 </PropertyGroup>
 


### PR DESCRIPTION
XML Model presentation in the `Metadata.Extension` table takes many Megabytes

So save space this PR implements Brotli compression.

There will be 3 stages :
1. As first step it saves both: Compressed & Uncompressed XML for backward Compatibility.
When deserializeng, the compressed data is deserialized for testing purposes but ignored.

2. After all environments will be upgraded to the new version we could switch Deserializing to to use Compressed data

3. After all environments will be upgraded to use the Compressed data we can stop writing Uncompressed XML and replace it by NULL
