### PR TITLE
Change type of `TrackingCompletedEventArgs.Changes` to `IReadOnlyCollection<>` for easy empty-checking and to avoid conversions

### DIFF
--- a/Extensions/Xtensive.Orm.Tracking.Tests/TrackingStackFrameTests.cs
+++ b/Extensions/Xtensive.Orm.Tracking.Tests/TrackingStackFrameTests.cs
@@ -71,7 +71,7 @@ namespace Xtensive.Orm.Tracking.Tests
       target.MergeWith(source);
 
       Assert.AreEqual(count, target.Count);
-      Assert.AreEqual(TrackingItemState.Created, target.Single().State);
+      Assert.AreEqual(TrackingItemState.Created, target.Items.Single().State);
     }
 
     [Test]

--- a/Extensions/Xtensive.Orm.Tracking/Internals/SessionTrackingMonitor.cs
+++ b/Extensions/Xtensive.Orm.Tracking/Internals/SessionTrackingMonitor.cs
@@ -2,9 +2,6 @@
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Xtensive.Core;
 using Xtensive.IoC;
 using Xtensive.Orm.Services;
@@ -41,7 +38,7 @@ namespace Xtensive.Orm.Tracking
       if (e.Transaction.IsNested)
         return;
 
-      var items = target.Cast<ITrackingItem>().ToList().AsSafeWrapper();
+      var items = target.Items;
       target.Clear();
 
       RaiseTrackingCompleted(new TrackingCompletedEventArgs(session, items));

--- a/Extensions/Xtensive.Orm.Tracking/Internals/SessionTrackingMonitor.cs
+++ b/Extensions/Xtensive.Orm.Tracking/Internals/SessionTrackingMonitor.cs
@@ -38,10 +38,9 @@ namespace Xtensive.Orm.Tracking
       if (e.Transaction.IsNested)
         return;
 
-      var items = target.Items;
+      TrackingCompletedEventArgs eventArgs = new(session, target.Items);
       target.Clear();
-
-      RaiseTrackingCompleted(new TrackingCompletedEventArgs(session, items));
+      RaiseTrackingCompleted(eventArgs);
     }
 
     private void OnRollbackTransaction(object sender, TransactionEventArgs e)

--- a/Extensions/Xtensive.Orm.Tracking/Internals/TrackingItem.cs
+++ b/Extensions/Xtensive.Orm.Tracking/Internals/TrackingItem.cs
@@ -27,7 +27,7 @@ namespace Xtensive.Orm.Tracking
 
     public IReadOnlyList<ChangedValue> ChangedValues => cachedChangedValues ??= CalculateChangedValues();
 
-    public void MergeWith(TrackingItem source)
+    public void MergeWith(ITrackingItem source)
     {
       ArgumentNullException.ThrowIfNull(source);
 

--- a/Extensions/Xtensive.Orm.Tracking/Internals/TrackingMonitor.cs
+++ b/Extensions/Xtensive.Orm.Tracking/Internals/TrackingMonitor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Xtensive.Orm.Tracking
+﻿namespace Xtensive.Orm.Tracking
 {
   internal abstract class TrackingMonitor : ITrackingMonitor
   {
@@ -24,10 +22,7 @@ namespace Xtensive.Orm.Tracking
     {
       if (disableCount > 0)
         return;
-      var handler = TrackingCompleted;
-      if (handler==null)
-        return;
-      handler.Invoke(this, e);
+      TrackingCompleted?.Invoke(this, e);
     }
   }
 }

--- a/Extensions/Xtensive.Orm.Tracking/Internals/TrackingStackFrame.cs
+++ b/Extensions/Xtensive.Orm.Tracking/Internals/TrackingStackFrame.cs
@@ -4,16 +4,12 @@
 // Created by: Dmitri Maximov
 // Created:    2012.05.16
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using Xtensive.Core;
-
 namespace Xtensive.Orm.Tracking
 {
-  internal readonly struct TrackingStackFrame : IEnumerable<TrackingItem>
+  internal readonly struct TrackingStackFrame()
   {
     private readonly Dictionary<Key, TrackingItem> items = new();
+    public IReadOnlyCollection<TrackingItem> Items => items.Values;
 
     public int Count => items.Count;
 
@@ -34,7 +30,8 @@ namespace Xtensive.Orm.Tracking
 
     public void MergeWith(TrackingStackFrame source)
     {
-      foreach (var sourceItem in source) {
+      foreach (var sourceItem in source.Items) {
+        Register(sourceItem);
         var key = sourceItem.Key;
         if (items.TryGetValue(key, out var existing)) {
           existing.MergeWith(sourceItem);
@@ -43,14 +40,6 @@ namespace Xtensive.Orm.Tracking
           items.Add(key, sourceItem);
         }
       }
-    }
-
-    public IEnumerator<TrackingItem> GetEnumerator() => items.Values.GetEnumerator();
-
-    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-    public TrackingStackFrame()
-    {
     }
   }
 }

--- a/Extensions/Xtensive.Orm.Tracking/TrackingCompletedEventArgs.cs
+++ b/Extensions/Xtensive.Orm.Tracking/TrackingCompletedEventArgs.cs
@@ -20,7 +20,7 @@ namespace Xtensive.Orm.Tracking
     /// <summary>
     /// Gets the changes.
     /// </summary>
-    public IEnumerable<ITrackingItem> Changes { get; }
+    public IReadOnlyCollection<ITrackingItem> Changes { get; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TrackingCompletedEventArgs"/> class.
@@ -28,7 +28,7 @@ namespace Xtensive.Orm.Tracking
     /// <param name="session"><see cref="T:Session"/> instance where the <see cref="Changes"/>
     /// where collected.</param>
     /// <param name="changes">The changes.</param>
-    public TrackingCompletedEventArgs(Session session, IEnumerable<ITrackingItem> changes)
+    public TrackingCompletedEventArgs(Session session, IReadOnlyCollection<ITrackingItem> changes)
     {
       ArgumentNullException.ThrowIfNull(session);
       ArgumentNullException.ThrowIfNull(changes);

--- a/Extensions/Xtensive.Orm.Tracking/TrackingCompletedEventArgs.cs
+++ b/Extensions/Xtensive.Orm.Tracking/TrackingCompletedEventArgs.cs
@@ -2,9 +2,6 @@
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-
 namespace Xtensive.Orm.Tracking
 {
   /// <summary>


### PR DESCRIPTION
Also:
* Add `TrackingStackFrame.Items` property instead on inheriting `IEnumerable<>` to avoid boxing