### PR TITLE
Optimize `DataTable.Columns` - avoid unnecessary type casting

### DIFF
--- a/.github/actions/mssql-fts/Dockerfile
+++ b/.github/actions/mssql-fts/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04
+FROM mcr.microsoft.com/mssql/server:2022-CU16-ubuntu-22.04
 USER root
 
 ENV ACCEPT_EULA=Y \

--- a/.github/workflows/test-sql.yaml
+++ b/.github/workflows/test-sql.yaml
@@ -20,6 +20,11 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with: { dotnet-version: 8 }
+      - name: Setup MSSQL Tools
+        uses:  rails-sqlserver/setup-mssql@v1
+        with:
+          components: sqlcmd
+          version: 2022
       - name: Build SQL Docker image with FTS feature
         run: docker build -t sql .github/actions/mssql-fts
 #      - uses: ikalnytskyi/action-setup-postgres@v6 

--- a/.github/workflows/test-sql.yaml
+++ b/.github/workflows/test-sql.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Build
         run: dotnet build -v q Orm.sln
       - name: Init Test DB
-        run: /opt/mssql-tools18/bin/sqlcmd -U sa -P $SQL_PASSWD -C -i Orm/Xtensive.Orm.Tests.Framework/DO-Tests.sql && /opt/mssql-tools18/bin/sqlcmd -U sa -P $SQL_PASSWD -C -i Orm/Xtensive.Orm.Tests.Framework/DO-Tests-Plus.sql
+        run: sqlcmd -U sa -P $SQL_PASSWD -C -i Orm/Xtensive.Orm.Tests.Framework/DO-Tests.sql && sqlcmd -U sa -P $SQL_PASSWD -C -i Orm/Xtensive.Orm.Tests.Framework/DO-Tests-Plus.sql
 #      - name: Create PostgreSQL DO Tests Config file
 #        run: echo default=postgresql://dotest:dotest@localhost/dotest >$DO_CONFIG_FILE
 #      - name: Xtensive.Orm.Tests.Sql with PostgreSQL

--- a/.github/workflows/test-sql.yaml
+++ b/.github/workflows/test-sql.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Build
         run: dotnet build -v q Orm.sln
       - name: Init Test DB
-        run: sqlcmd -U sa -P $SQL_PASSWD -C -i Orm/Xtensive.Orm.Tests.Framework/DO-Tests.sql && sqlcmd -U sa -P $SQL_PASSWD -C -i Orm/Xtensive.Orm.Tests.Framework/DO-Tests-Plus.sql
+        run: /opt/mssql-tools18/bin/sqlcmd -U sa -P $SQL_PASSWD -C -i Orm/Xtensive.Orm.Tests.Framework/DO-Tests.sql && /opt/mssql-tools18/bin/sqlcmd -U sa -P $SQL_PASSWD -C -i Orm/Xtensive.Orm.Tests.Framework/DO-Tests-Plus.sql
 #      - name: Create PostgreSQL DO Tests Config file
 #        run: echo default=postgresql://dotest:dotest@localhost/dotest >$DO_CONFIG_FILE
 #      - name: Xtensive.Orm.Tests.Sql with PostgreSQL

--- a/Orm/Xtensive.Orm/Core/Extensions/ArrayExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/ArrayExtensions.cs
@@ -37,24 +37,6 @@ namespace Xtensive.Core
     }
 
     /// <summary>
-    /// Clones <paramref name="source"/> array with element conversion.
-    /// </summary>
-    /// <typeparam name="TItem">The type of item.</typeparam>
-    /// <typeparam name="TNewItem">The type of item to convert to.</typeparam>
-    /// <param name="source">The array to convert.</param>
-    /// <param name="converter">A delegate that converts each element.</param>
-    /// <returns>An array of converted elements.</returns>
-    public static TNewItem[] Convert<TItem, TNewItem>(this TItem[] source, Converter<TItem, TNewItem> converter)
-    {
-      ArgumentNullException.ThrowIfNull(converter);
-      var items = new TNewItem[source.Length];
-      int i = 0;
-      foreach (TItem item in source)
-        items[i++] = converter(item);
-      return items;
-    }
-
-    /// <summary>
     /// Gets the index of first occurrence of the <paramref name="item"/>
     /// in the <paramref name="items"/> array, if found;
     /// otherwise returns <see langword="-1"/>.

--- a/Orm/Xtensive.Orm/Sql/Model/DataTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Model/DataTable.cs
@@ -57,7 +57,7 @@ namespace Xtensive.Sql.Model
     /// Gets the columns.
     /// </summary>
     /// <value>The columns.</value>
-    public abstract IList<DataTableColumn> Columns { get; }
+    public abstract IReadOnlyList<DataTableColumn> Columns { get; }
     
     #endregion
 

--- a/Orm/Xtensive.Orm/Sql/Model/Domain.cs
+++ b/Orm/Xtensive.Orm/Sql/Model/Domain.cs
@@ -90,13 +90,7 @@ namespace Xtensive.Sql.Model
     /// Gets the constraints.
     /// </summary>
     /// <value>The constraints.</value>
-    IList<Constraint> IConstrainable.Constraints
-    {
-      get
-      {
-        return constraints.ToArray().Convert(i => (Constraint)i);
-      }
-    }
+    IReadOnlyList<Constraint> IConstrainable.Constraints => constraints;
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Sql/Model/Interfaces/IConstrainable.cs
+++ b/Orm/Xtensive.Orm/Sql/Model/Interfaces/IConstrainable.cs
@@ -15,6 +15,6 @@ namespace Xtensive.Sql.Model
     /// Gets the node constraints.
     /// </summary>
     /// <value>The constraints.</value>
-    IList<Constraint> Constraints { get; }
+    IReadOnlyList<Constraint> Constraints { get; }
   }
 }

--- a/Orm/Xtensive.Orm/Sql/Model/Table.cs
+++ b/Orm/Xtensive.Orm/Sql/Model/Table.cs
@@ -148,10 +148,7 @@ namespace Xtensive.Sql.Model
     /// Gets the columns.
     /// </summary>
     /// <value>The columns.</value>
-    public override IList<DataTableColumn> Columns
-    {
-      get { return TableColumns.ToArray().Convert(i => (DataTableColumn) i); }
-    }
+    public override IReadOnlyList<DataTableColumn> Columns => TableColumns;
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Sql/Model/Table.cs
+++ b/Orm/Xtensive.Orm/Sql/Model/Table.cs
@@ -158,10 +158,7 @@ namespace Xtensive.Sql.Model
     /// Gets the node constraints.
     /// </summary>
     /// <value>The constraints.</value>
-    IList<Constraint> IConstrainable.Constraints
-    {
-      get { return constraints.ToArray().Convert(i => (Constraint)i); }
-    }
+    IReadOnlyList<Constraint> IConstrainable.Constraints => constraints;
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Sql/Model/View.cs
+++ b/Orm/Xtensive.Orm/Sql/Model/View.cs
@@ -89,11 +89,7 @@ namespace Xtensive.Sql.Model
     /// Gets the columns.
     /// </summary>
     /// <value>The columns.</value>
-    public override IList<DataTableColumn> Columns {
-      get {
-        return ViewColumns.ToArray().Convert(i => (DataTableColumn) i);
-      }
-    }
+    public override IReadOnlyList<DataTableColumn> Columns => ViewColumns;
 
     #endregion
 


### PR DESCRIPTION
Also:
* Avoid casting in `IConstrainable.Constraints`
* Removed unused `.Convert<>()` extension
* Install  `rails-sqlserver/setup-mssql@v1` in GitHub action, as `sqlcmd` command is not available by default now
* Upgrade SQL Server image to `2022-CU16-ubuntu-22.04`
