### PR TITLE
Make `.ForEach<>` extension `internal` to prevent its usage in the App

### DIFF
--- a/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
@@ -115,7 +115,7 @@ namespace Xtensive.Core
     /// <param name="items">The sequence to apply the <paramref name="action"/> to.</param>
     /// <param name="action">The action to apply.</param>
     [Obsolete("Use foreach statement")]
-    public static void ForEach<T>(this IEnumerable<T> items, Action<T> action)
+    internal static void ForEach<T>(this IEnumerable<T> items, Action<T> action)
     {
       foreach (var item in items)
         action.Invoke(item);


### PR DESCRIPTION
We replace it by `foreach {}`