### PR TITLE
Memoize `MakeDelegateType()`

### DIFF
--- a/Orm/Xtensive.Orm/Reflection/DelegateHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/DelegateHelper.cs
@@ -477,10 +477,15 @@ namespace Xtensive.Reflection
     internal static Type MakeDelegateType(Type returnType, IEnumerable<Type> parameterTypes, int n)
     {
       ArgumentOutOfRangeException.ThrowIfGreaterThan(n, MaxNumberOfGenericDelegateParameters);
-      return returnType != WellKnownTypes.Void && returnType != null
-        ? FuncTypes[n].MakeGenericType(parameterTypes.Append(returnType).ToArray())
-        : n == 0 ? ActionTypes[0]
-        : ActionTypes[n].MakeGenericType(parameterTypes.ToArray());
+      return TypeHelper.DelegateTypeByParameterTypes.GetOrAdd((returnType, parameterTypes.ToArray(n)),
+        static t => {
+          var len = t.ParameterTypes.Length;
+          return t.ReturnType != WellKnownTypes.Void && t.ReturnType != null
+            ? FuncTypes[len].MakeGenericType(t.ParameterTypes.Append(t.ReturnType).ToArray())
+            : len == 0
+              ? ActionTypes[0]
+              : ActionTypes[len].MakeGenericType(t.ParameterTypes);
+        });
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -58,6 +58,9 @@ namespace Xtensive.Reflection
     private static readonly ConcurrentDictionary<(Type, Type[]), ConstructorInfo> ConstructorInfoByTypes =
       new(new TypesEqualityComparer());
 
+    internal static readonly ConcurrentDictionary<(Type ReturnType, Type[] ParameterTypes), Type> DelegateTypeByParameterTypes =
+      new(new TypesEqualityComparer());
+
     private static readonly ConcurrentDictionary<Type, Type[]> OrderedInterfaces = new();
 
     private static readonly ConcurrentDictionary<Type, Type[]> UnorderedInterfaces = new();


### PR DESCRIPTION
`Type.MakeGenericType()` method is a bottleneck.
I see it during profiling

We have to minize its invocations