### PR TITLE
Bugfix: ensure `TrackingCompletedEventArgs.Changes` are alive after clearing `TrackingStackFrame`

### DIFF
--- a/Extensions/Xtensive.Orm.Tracking/Internals/TrackingStackFrame.cs
+++ b/Extensions/Xtensive.Orm.Tracking/Internals/TrackingStackFrame.cs
@@ -9,7 +9,7 @@ namespace Xtensive.Orm.Tracking
   internal readonly struct TrackingStackFrame()
   {
     private readonly Dictionary<Key, TrackingItem> items = new();
-    public IReadOnlyCollection<TrackingItem> Items => items.Values;
+    public IReadOnlyCollection<TrackingItem> Items => items.Values.ToArray();
 
     public int Count => items.Count;
 

--- a/Version.props
+++ b/Version.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.2.158</DoVersion>
+    <DoVersion>7.2.159</DoVersion>
     <DoVersionSuffix>servicetitan</DoVersionSuffix>
 </PropertyGroup>
 


### PR DESCRIPTION
The bug was introduced in https://github.com/servicetitan/dataobjects-net/pull/319