### PR TITLE
Add .NET9 compatibility

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [ master-servicetitan ]
 env:
-  DO_TargetFrameworks: net8.0
+  DO_TargetFrameworks: net8.0;net9.0
 jobs:
   build-and-test:
     name: build-and-test
@@ -14,7 +14,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8
+          dotnet-version: 9
       - name: Build
         run: dotnet build -c Release -v q
       - name: Tests.Core

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [ master-servicetitan ]
 env:
-  DO_TargetFrameworks: net8.0;net9.0
+  DO_TargetFrameworks: net9.0;net8.0
 jobs:
   build-and-test:
     name: build-and-test

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -7,7 +7,7 @@ jobs:
     name: bump-version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Bump
         run: gawk -i inplace '{match($0,/(^.+DoVersion>[0-9]+.[0-9]+.[0-9]+.)([0-9]+)/,a);if(a[2]>0){print a[1]a[2]+1"</DoVersion>"}else{print $0}}' Version.props
       - name: Commit

--- a/.github/workflows/dotnet_build_master.yml
+++ b/.github/workflows/dotnet_build_master.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,16 +2,16 @@ name: Publish Nuget Package
 on:
   workflow_dispatch:
 env:
-  DO_TargetFrameworks: net8.0
+  DO_TargetFrameworks: net8.0;net9.0
 jobs:
   build-and-publish:
     name: Build & Publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
-        with: { dotnet-version: 8 }
+        uses: actions/setup-dotnet@v4
+        with: { dotnet-version: 9 }
       - name: Create User.Directory.Build.props
         run: echo >User.Directory.Build.props '<?xml version="1.0" encoding="utf-8"?><Project ToolsVersion="latest"><PropertyGroup Label="User defined variables"><DoNugetFeedUserName>nuget-publish-dataobjects</DoNugetFeedUserName><DoNugetFeedPassword>' ${{ secrets.NUGET_FEED_PASSWORD }} '</DoNugetFeedPassword><DoNugetFeedUrl>https://pkgs.dev.azure.com/servicetitan-packages/nuget/_packaging/servicetitan-nuget/nuget/v3/index.json</DoNugetFeedUrl></PropertyGroup></Project>'
       - name: Build & Publish

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,7 +2,7 @@ name: Publish Nuget Package
 on:
   workflow_dispatch:
 env:
-  DO_TargetFrameworks: net8.0;net9.0
+  DO_TargetFrameworks: net9.0;net8.0
 jobs:
   build-and-publish:
     name: Build & Publish

--- a/.github/workflows/test-sql.yaml
+++ b/.github/workflows/test-sql.yaml
@@ -5,7 +5,7 @@ on:
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DO_CONFIG_FILE: "/tmp/do-test.cfg"
-  DO_TargetFrameworks: net8.0;net9.0
+  DO_TargetFrameworks: net9.0
   SQL_PASSWD: dbatools.I0
 jobs:
   test-with-sql:

--- a/.github/workflows/test-sql.yaml
+++ b/.github/workflows/test-sql.yaml
@@ -5,7 +5,7 @@ on:
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DO_CONFIG_FILE: "/tmp/do-test.cfg"
-  DO_TargetFrameworks: net8.0
+  DO_TargetFrameworks: net8.0;net9.0
   SQL_PASSWD: dbatools.I0
 jobs:
   test-with-sql:
@@ -19,7 +19,7 @@ jobs:
           timezoneLinux: "UTC"
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
-        with: { dotnet-version: 8 }
+        with: { dotnet-version: 9 }
       - name: Setup MSSQL Tools
         uses:  rails-sqlserver/setup-mssql@v1
         with:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,8 +37,6 @@
     <DoIsIdeBuild>false</DoIsIdeBuild>
     <DoIsIdeBuild Condition="$(BuildingInsideVisualStudio) == 'true'">true</DoIsIdeBuild>
 
-    <TargetFramework>net8.0</TargetFramework>
-
     <!-- Disable "BinaryFormatter is obsolete" warnings for test projects -->
     <NoWarn>$(NoWarn);CS0618;CS0672;CS1570;CS1572;CS1573;CS1574;CS1587;CS1734;NU1901;NU1902;NU1903;NU1904;SYSLIB0050;SYSLIB0051;</NoWarn>
     <NoWarn Condition="$(MSBuildProjectName.Contains('Tests')) == 'true'">$(NoWarn);SYSLIB0011</NoWarn>
@@ -55,7 +53,7 @@
     <Configuration Condition="$(Configuration) == ''">Debug</Configuration>
     <TargetFrameworks>$(TargetFrameworks)</TargetFrameworks>  <!-- the property -->
     <TargetFrameworks Condition="'$(TargetFrameworks)'==''">$(DO_TargetFrameworks)</TargetFrameworks> <!-- env var -->
-    <TargetFrameworks Condition="'$(TargetFrameworks)'==''">net8.0</TargetFrameworks> <!-- fallback to default -->
+    <TargetFrameworks Condition="'$(TargetFrameworks)'==''">net9.0</TargetFrameworks> <!-- fallback to default -->
   </PropertyGroup>
 
   <PropertyGroup Condition = "$(Configuration.Contains('Debug')) == 'true'">
@@ -71,7 +69,7 @@
   <PropertyGroup>
     <NoLogo>true</NoLogo>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>Preview</LangVersion>
     <SolutionDir Condition="$(SolutionDir) == ''">$([MSBuild]::EnsureTrailingSlash(
       $([MSBuild]::GetDirectoryNameOfFileAbove('$(MSBuildThisFileDirectory)', 'Orm.sln'))))</SolutionDir>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
@@ -87,7 +85,7 @@
     <ProjectAssetsFile>$(MSBuildProjectExtensionsPath)project.assets.json</ProjectAssetsFile>
     <ProjectAssetsCacheFile>$(MSBuildProjectExtensionsPath)$(TargetFramework)\$(MSBuildProjectName).assets.cache</ProjectAssetsCacheFile>
     <OrmKeyFile>$(SolutionDir)Orm\Orm.snk</OrmKeyFile>
-	<NoWarn>$(NoWarn);NETSDK1138</NoWarn>
+    <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
   </PropertyGroup>
   <!-- Populate standard properties. -->
   <PropertyGroup>

--- a/MSBuild/DataObjects.Net.targets
+++ b/MSBuild/DataObjects.Net.targets
@@ -12,7 +12,8 @@
   <CompileDependsOn>$(CompileDependsOn);XtensiveOrmBuild</CompileDependsOn>
   <XtensiveOrmPath Condition="'$(XtensiveOrmPath)'==''">$(MSBuildThisFileDirectory)</XtensiveOrmPath>
   <XtensiveOrmPath Condition="!HasTrailingSlash('$(XtensiveOrmPath)')">$(XtensiveOrmPath)\</XtensiveOrmPath>
-  <XtensiveWeaverFramework>net8.0</XtensiveWeaverFramework>
+  <XtensiveWeaverFramework>net9.0</XtensiveWeaverFramework>
+  <XtensiveWeaverFramework Condition="'$(TargetFramework)'=='net8.0'">net8.0</XtensiveWeaverFramework>
   <XtensiveOrmWeaver Condition="'$(XtensiveOrmWeaver)'==''">$(XtensiveOrmPath)tools\weaver\$(XtensiveWeaverFramework)\Xtensive.Orm.Weaver.dll</XtensiveOrmWeaver>
   <XtensiveOrmBuildDependsOn>$(XtensiveOrmBuildDependsOn)</XtensiveOrmBuildDependsOn>
 </PropertyGroup>

--- a/Orm/Xtensive.Orm.Tests.Core/Comparison/ComparerProviderTests.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Comparison/ComparerProviderTests.cs
@@ -18,6 +18,7 @@ namespace Xtensive.Orm.Tests.Core.Comparison
   [TestFixture]
   public class ComparerProviderTests
   {
+    [Explicit]
     [Test]
     public void SerializationTest()
     {

--- a/Orm/Xtensive.Orm.Tests.Core/Linq/SerializableExpressionsTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Linq/SerializableExpressionsTest.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 
 namespace Xtensive.Orm.Tests.Core.Linq
 {
+  [Explicit]
   [TestFixture]
   public class SerializableExpressionsTest : ExpressionTestBase
   {

--- a/Orm/Xtensive.Orm.Tests.Core/Tuples/LongTupleTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Tuples/LongTupleTest.cs
@@ -16,6 +16,7 @@ namespace Xtensive.Orm.Tests.Core.Tuples
   [TestFixture]
   public class LongTupleTest
   {
+    [Explicit]
     [Test]
     public void CombinedTest()
     {

--- a/Orm/Xtensive.Orm.Tests.Core/Tuples/TupleSerializationTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Tuples/TupleSerializationTest.cs
@@ -12,6 +12,7 @@ using Tuple = Xtensive.Tuples.Tuple;
 
 namespace Xtensive.Orm.Tests.Core.Tuples
 {
+  [Explicit]
   [TestFixture]
   public class TupleSerializationTest
   {

--- a/Orm/Xtensive.Orm.Tests/Model/FieldConverterTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Model/FieldConverterTest.cs
@@ -126,6 +126,7 @@ namespace Xtensive.Orm.Tests.Model
       }
     }
 
+    [Explicit]
     [Test]
     public void CollectionTest()
     {

--- a/Orm/Xtensive.Orm.Tests/Model/VersionInfoTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Model/VersionInfoTest.cs
@@ -200,7 +200,8 @@ namespace Xtensive.Orm.Tests.Model
       Assert.IsTrue(simpleType.GetVersionColumns().Any(pair => pair.Field==simpleType.Fields["StructureField.ReferenceField.Id"]));
       Assert.IsFalse(simpleType.GetVersionColumns().Any(pair => pair.Field==simpleType.Fields["ByteArrayField"]));
     }
-    
+
+    [Explicit]
     [Test]
     public void SerializeVersionInfoTest()
     {

--- a/Orm/Xtensive.Orm.Tests/Storage/RefTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/RefTest.cs
@@ -19,6 +19,7 @@ namespace Xtensive.Orm.Tests.Storage.RefTest
     public int Id { get; private set; }
   }
 
+  [Explicit]
   [TestFixture]
   public class RefTest : AutoBuildTest
   {

--- a/Orm/Xtensive.Orm.Tests/Storage/SerializationTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/SerializationTest.cs
@@ -104,6 +104,7 @@ namespace Xtensive.Orm.Tests.SerializationTestModel
 
 namespace Xtensive.Orm.Tests.Storage
 {
+  [Explicit]
   public class SerializationTest : AutoBuildTest
   {
     private readonly BinaryFormatter formatter = new BinaryFormatter();

--- a/Orm/Xtensive.Orm.Tests/Storage/SerializedQueryTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/SerializedQueryTest.cs
@@ -19,6 +19,7 @@ using Xtensive.Orm.Providers;
 
 namespace Xtensive.Orm.Tests.Storage
 {
+  [Explicit]
   [TestFixture]
   public class SerializedQueryTest : ChinookDOModelTest
   {

--- a/Orm/Xtensive.Orm.Tests/Storage/UpdateVersionTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/UpdateVersionTest.cs
@@ -508,6 +508,7 @@ namespace Xtensive.Orm.Tests.Storage
       }
     }
 
+    [Explicit]
     [Test]
     public void SerializeVersionInfoTest()
     {

--- a/Orm/Xtensive.Orm.Tests/Storage/VersionRootTests.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/VersionRootTests.cs
@@ -240,6 +240,7 @@ namespace Xtensive.Orm.Tests.Storage
       }
     }
 
+    [Explicit]
     [Test]
     public void SerializeVersionInfoTest()
     {

--- a/Orm/Xtensive.Orm/Orm/Internals/FieldAccessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/FieldAccessor.cs
@@ -13,14 +13,14 @@ namespace Xtensive.Orm.Internals
 {
   internal abstract class FieldAccessor
   {
-    private FieldInfo field;
+    private FieldInfo fld;
 
     public FieldInfo Field {
-      get { return field; }
+      get { return fld; }
       set {
-        if (field!=null)
+        if (fld !=null)
           throw Exceptions.AlreadyInitialized("Field");
-        field = value;
+        fld = value;
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/LocalCollectionExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/LocalCollectionExpression.cs
@@ -27,9 +27,9 @@ namespace Xtensive.Orm.Linq.Expressions
 
     public IEnumerable<ColumnExpression> Columns =>
       Fields
-        .SelectMany(field => field.Value is ColumnExpression
-          ? new[] { field.Value }
-          : ((LocalCollectionExpression) field.Value).Columns.Cast<IMappedExpression>())
+        .SelectMany(fld => fld.Value is ColumnExpression
+          ? new[] { fld.Value }
+          : ((LocalCollectionExpression) fld.Value).Columns.Cast<IMappedExpression>())
         .Cast<ColumnExpression>();
 
     public override LocalCollectionExpression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions)

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnInfo.cs
@@ -27,7 +27,7 @@ namespace Xtensive.Orm.Model
     private sbyte?   precision;
     private object defaultValue;
     private string defaultSqlExpression;
-    private FieldInfo field;
+    private FieldInfo fld;
     private NodeCollection<IndexInfo> indexes;
     private CultureInfo cultureInfo = CultureInfo.InvariantCulture;
 
@@ -123,11 +123,11 @@ namespace Xtensive.Orm.Model
     /// </summary>
     public FieldInfo Field {
       [DebuggerStepThrough]
-      get { return field; }
+      get { return fld; }
       [DebuggerStepThrough]
       set {
         EnsureNotLocked();
-        field = value;
+        fld = value;
       }
     }
 
@@ -227,7 +227,7 @@ namespace Xtensive.Orm.Model
         return false;
       if (ReferenceEquals(this, obj))
         return true;
-      return field.Equals(obj.field);
+      return fld.Equals(obj.fld);
     }
 
     /// <inheritdoc/>
@@ -236,7 +236,7 @@ namespace Xtensive.Orm.Model
       || obj is ColumnInfo other && Equals(other);
 
     /// <inheritdoc/>
-    public override int GetHashCode() => field.GetHashCode();
+    public override int GetHashCode() => fld.GetHashCode();
 
     #endregion
 
@@ -253,7 +253,7 @@ namespace Xtensive.Orm.Model
     /// </summary>
     public ColumnInfo Clone()
     {
-      ColumnInfo clone = new ColumnInfo(field);
+      ColumnInfo clone = new ColumnInfo(fld);
       clone.Name = Name;
       clone.attributes = attributes;
       clone.valueType = valueType;
@@ -280,7 +280,7 @@ namespace Xtensive.Orm.Model
     public ColumnInfo(FieldInfo field)
     {
       indexes = NodeCollection<IndexInfo>.Empty;
-      this.field = field;
+      this.fld = field;
       IsSystem = field.IsSystem;
       IsDeclared = true;
       IsNullable = field.IsNullable;
@@ -311,7 +311,7 @@ namespace Xtensive.Orm.Model
     public ColumnInfo(FieldInfo field, Type valueType)
     {
       indexes = NodeCollection<IndexInfo>.Empty;
-      this.field = field;
+      this.fld = field;
       this.valueType = valueType;
       IsSystem = field.IsSystem;
       IsDeclared = true;

--- a/Orm/Xtensive.Orm/Orm/Model/Stored/StoredFieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/Stored/StoredFieldInfo.cs
@@ -70,11 +70,11 @@ namespace Xtensive.Orm.Model.Stored
         else {
           var queue = new Queue<StoredFieldInfo>();
           queue.Enqueue(this);
-          while (queue.TryDequeue(out var field)) {
-            if (field.IsPrimitive)
-              result.Add(field);
+          while (queue.TryDequeue(out var fld)) {
+            if (fld.IsPrimitive)
+              result.Add(fld);
             else
-              foreach (var child in field.Fields)
+              foreach (var child in fld.Fields)
                 queue.Enqueue(child);
           }
         }

--- a/Orm/Xtensive.Orm/Orm/Model/TypeDiscriminatorMap.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeDiscriminatorMap.cs
@@ -22,17 +22,17 @@ namespace Xtensive.Orm.Model
     private TypeInfo @default;
     private readonly Dictionary<object, TypeInfo> map = new Dictionary<object, TypeInfo>();
     private readonly Dictionary<TypeInfo, object> reversedMap = new Dictionary<TypeInfo, object>();
-    private FieldInfo field;
+    private FieldInfo fld;
 
     public FieldInfo Field
     {
-      get { return field; }
+      get { return fld; }
       set
       {
         EnsureNotLocked();
-        if (field != null)
+        if (fld != null)
           throw new InvalidOperationException(Strings.ExTypeDiscriminatorFieldIsAlreadySet);
-        field = value;
+        fld = value;
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Persistent.cs
+++ b/Orm/Xtensive.Orm/Orm/Persistent.cs
@@ -729,26 +729,12 @@ namespace Xtensive.Orm
     #region IDataErrorInfo members
 
     /// <inheritdoc/>
-    string IDataErrorInfo.this[string columnName]
-    {
-      get {
-        if (!CanBeValidated)
-          return string.Empty;
-        var result = GetValidationResult(columnName);
-        return result != null ? result.ErrorMessage : string.Empty;
-      }
-    }
+    string IDataErrorInfo.this[string columnName] =>
+      CanBeValidated ? GetValidationResult(columnName)?.ErrorMessage ?? string.Empty : string.Empty;
 
     /// <inheritdoc/>
-    string IDataErrorInfo.Error
-    {
-      get {
-        if (!CanBeValidated)
-          return string.Empty;
-        var result = GetValidationResult();
-        return result != null ? result.ErrorMessage : string.Empty;
-      }
-    }
+    string IDataErrorInfo.Error =>
+      CanBeValidated ? GetValidationResult()?.ErrorMessage ?? string.Empty : string.Empty;
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/Validation/ValidationResult.cs
+++ b/Orm/Xtensive.Orm/Orm/Validation/ValidationResult.cs
@@ -18,7 +18,7 @@ namespace Xtensive.Orm.Validation
     private readonly IValidator source;
     private readonly bool isError;
     private readonly string errorMessage;
-    private readonly FieldInfo field;
+    private readonly FieldInfo fld;
     private readonly object value;
 
     /// <summary>
@@ -66,7 +66,7 @@ namespace Xtensive.Orm.Validation
 
       this.source = source;
       this.errorMessage = errorMessage;
-      this.field = field;
+      this.fld = field;
       this.value = value;
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Validation/ValidationResult.cs
+++ b/Orm/Xtensive.Orm/Orm/Validation/ValidationResult.cs
@@ -8,43 +8,37 @@ namespace Xtensive.Orm.Validation
   /// </summary>
   public class ValidationResult
   {
-    private static readonly ValidationResult SuccessInstance = new ValidationResult();
+    private static readonly ValidationResult SuccessInstance = new();
 
     /// <summary>
     /// Gets successful validation result.
     /// </summary>
     public static ValidationResult Success { get { return SuccessInstance; } }
 
-    private readonly IValidator source;
-    private readonly bool isError;
-    private readonly string errorMessage;
-    private readonly FieldInfo fld;
-    private readonly object value;
-
     /// <summary>
     /// Gets validator that produced validation error.
     /// </summary>
-    public IValidator Source { get { return source; } }
+    public IValidator Source { get; }
 
     /// <summary>
     /// Gets value indicating validation status.
     /// </summary>
-    public bool IsError { get { return isError; } }
+    public bool IsError { get; }
 
     /// <summary>
     /// Gets error message.
     /// </summary>
-    public string ErrorMessage { get { return errorMessage; } }
+    public string ErrorMessage { get; }
 
     /// <summary>
     /// Gets field validated field.
     /// </summary>
-    public FieldInfo Field { get { return field; } }
+    public FieldInfo Field { get; }
 
     /// <summary>
     /// Gets validated value.
     /// </summary>
-    public object Value { get { return value; } }
+    public object Value { get; }
 
     private ValidationResult()
     {
@@ -62,12 +56,11 @@ namespace Xtensive.Orm.Validation
       ArgumentNullException.ThrowIfNull(source);
       ArgumentException.ThrowIfNullOrEmpty(errorMessage);
 
-      isError = true;
-
-      this.source = source;
-      this.errorMessage = errorMessage;
-      this.fld = field;
-      this.value = value;
+      IsError = true;
+      Source = source;
+      ErrorMessage = errorMessage;
+      Field = field;
+      Value = value;
     }
   }
 }

--- a/Version.props
+++ b/Version.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.2.159</DoVersion>
+    <DoVersion>7.2.160</DoVersion>
     <DoVersionSuffix>servicetitan</DoVersionSuffix>
 </PropertyGroup>
 

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 { 
   "sdk": {
-    "allowPrerelease": false,
-    "version": "8.0.302",
+    "allowPrerelease": true,
+    "version": "9.0.101",
     "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
* `field` is a context keyword now, rename `field` identifiers to `fld`.
* Mark `Serialization` tests as `[Explicit]` because `BinaryFormatter` is removed from .NET9