### PR TITLE
Process `Span<>`/`ReadOnlySpan<>`/`.Contains()` cases in LINQ Expression

### DIFF
--- a/.github/workflows/test-sql.yaml
+++ b/.github/workflows/test-sql.yaml
@@ -19,7 +19,8 @@ jobs:
           timezoneLinux: "UTC"
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
-        with: { dotnet-version: 9 }
+        with:
+          dotnet-version: 9.x
       - name: Setup MSSQL Tools
         uses:  rails-sqlserver/setup-mssql@v1
         with:

--- a/Orm/Xtensive.Orm.Tests/Linq/InTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/InTest.cs
@@ -657,5 +657,18 @@ namespace Xtensive.Orm.Tests.Linq
           select track
         ).ToList();
     }
+
+    // Related to https://github.com/DataObjects-NET/dataobjects-net/issues/402
+    [Test]
+    public void ReadOnlySpanContains_Test()
+    {
+      var result = ReadOnlySpanContains_GetCustomers(["Michelle", "Jack"]);
+      Assert.AreEqual(2, result.Count);
+      Assert.IsTrue(result.Contains("Michelle"));
+      Assert.IsTrue(result.Contains("Jack"));
+    }
+
+    private List<string> ReadOnlySpanContains_GetCustomers(string[] customerNames) =>
+      (from c in Session.Query.All<Customer>() where MemoryExtensions.Contains(customerNames, c.FirstName) select c.FirstName).ToList();
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/ExpressionExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ExpressionExtensions.cs
@@ -78,7 +78,8 @@ namespace Xtensive.Orm.Linq
                                      && !expression.IsSubqueryExpression()
                                      && expressionType != WellKnownTypes.String
                                      && (expressionType.IsOfGenericInterface(WellKnownInterfaces.EnumerableOfT)
-                                        || expressionType.IsOfGenericType(WellKnownTypes.ReadOnlySpanOfT))
+                                        || expressionType.IsOfGenericType(WellKnownTypes.ReadOnlySpanOfT)
+                                        || expressionType.IsOfGenericType(WellKnownTypes.SpanOfT))
                                      && (IsEvaluableCollection(context, expression, expressionType) ||
                                          IsForeignQuery(expression))
              };

--- a/Orm/Xtensive.Orm/Orm/Linq/ExpressionExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ExpressionExtensions.cs
@@ -77,7 +77,8 @@ namespace Xtensive.Orm.Linq
                var expressionType => !IsEntitySet(expressionType)
                                      && !expression.IsSubqueryExpression()
                                      && expressionType != WellKnownTypes.String
-                                     && expressionType.IsOfGenericInterface(WellKnownInterfaces.EnumerableOfT)
+                                     && (expressionType.IsOfGenericInterface(WellKnownInterfaces.EnumerableOfT)
+                                        || expressionType.IsOfGenericType(WellKnownTypes.ReadOnlySpanOfT))
                                      && (IsEvaluableCollection(context, expression, expressionType) ||
                                          IsForeignQuery(expression))
              };

--- a/Orm/Xtensive.Orm/Orm/Linq/QueryHelper.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/QueryHelper.cs
@@ -203,7 +203,7 @@ namespace Xtensive.Orm.Linq
     public static Type GetSequenceElementType(Type type)
     {
       var sequenceType = type.GetGenericInterface(WellKnownInterfaces.EnumerableOfT)
-        ?? (type.IsOfGenericType(WellKnownTypes.ReadOnlySpanOfT) ? type : null);
+        ?? (type.IsOfGenericType(WellKnownTypes.ReadOnlySpanOfT) || type.IsOfGenericType(WellKnownTypes.SpanOfT) ? type : null);
       return sequenceType?.GetGenericArguments()[0];
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/QueryHelper.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/QueryHelper.cs
@@ -202,7 +202,8 @@ namespace Xtensive.Orm.Linq
 
     public static Type GetSequenceElementType(Type type)
     {
-      var sequenceType = type.GetGenericInterface(WellKnownInterfaces.EnumerableOfT);
+      var sequenceType = type.GetGenericInterface(WellKnownInterfaces.EnumerableOfT)
+        ?? (type.IsOfGenericType(WellKnownTypes.ReadOnlySpanOfT) ? type : null);
       return sequenceType?.GetGenericArguments()[0];
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -541,15 +541,20 @@ namespace Xtensive.Orm.Linq
           }
         }
 
-
         // Process local collections
-        if (mc.Object.IsLocalCollection(context)) {
-          // IList.Contains
-          // List.Contains
-          // Array.Contains
-          var parameters = method.GetParameters();
-          if (methodName == nameof(ICollection<int>.Contains) && parameters.Length == 1)
-            return VisitContains(mc.Object, mc.Arguments[0], false);
+        if (methodName == nameof(ICollection<int>.Contains)) {
+          if (mc.Object.IsLocalCollection(context)) {
+            // IList.Contains
+            // List.Contains
+            // Array.Contains
+            var parameters = method.GetParameters();
+            if (parameters.Length == 1)
+              return VisitContains(mc.Object, mc.Arguments[0], false);
+          }
+          else if (methodDeclaringType == typeof(MemoryExtensions)) {
+            // ReadOnlySpan<>.Contains
+            return VisitContains(mc.Arguments[0], mc.Arguments[1], false);
+          }
         }
 
         var result = base.VisitMethodCall(mc);

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -1770,7 +1770,7 @@ namespace Xtensive.Orm.Linq
     private ProjectionExpression VisitLocalCollectionSequence<TItem>(Expression sequence)
     {
       var type = sequence.Type;
-      if (type.IsOfGenericType(WellKnownTypes.ReadOnlySpanOfT)) {
+      if (type.IsOfGenericType(WellKnownTypes.ReadOnlySpanOfT) || type.IsOfGenericType(WellKnownTypes.SpanOfT)) {
         sequence = Expression.Call(sequence, type.GetMethod("ToArray"));
       }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -1771,7 +1771,7 @@ namespace Xtensive.Orm.Linq
     {
       var type = sequence.Type;
       if (type.IsOfGenericType(WellKnownTypes.ReadOnlySpanOfT)) {
-        sequence = Expression.Call(sequence, type.GetMethod(nameof(ReadOnlySpan<>.ToArray)));
+        sequence = Expression.Call(sequence, type.GetMethod("ToArray"));
       }
 
       return CreateLocalCollectionProjectionExpression(typeof(TItem), ParameterAccessorFactory.CreateAccessorExpression<IEnumerable<TItem>>(

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -1767,9 +1767,17 @@ namespace Xtensive.Orm.Linq
         string.Format(Strings.ExExpressionXIsNotASequence, expressionPart.ToString(true)));
     }
 
-    private ProjectionExpression VisitLocalCollectionSequence<TItem>(Expression sequence) =>
-      CreateLocalCollectionProjectionExpression(typeof(TItem), ParameterAccessorFactory.CreateAccessorExpression<IEnumerable<TItem>>(
+    private ProjectionExpression VisitLocalCollectionSequence<TItem>(Expression sequence)
+    {
+      var type = sequence.Type;
+      if (type.IsOfGenericType(WellKnownTypes.ReadOnlySpanOfT)) {
+        var methodToArray = type.GetMethod(nameof(ReadOnlySpan<>.ToArray));
+        sequence = Expression.Call(sequence, methodToArray);
+      }
+
+      return CreateLocalCollectionProjectionExpression(typeof(TItem), ParameterAccessorFactory.CreateAccessorExpression<IEnumerable<TItem>>(
         compiledQueryScope is not null ? compiledQueryScope.QueryParameterReplacer.Replace(sequence) : sequence).CachingCompile(), this, sequence);
+    }
 
     private Expression VisitContainsAny(Expression setA, Expression setB, bool isRoot, Type elementType)
     {

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -1771,8 +1771,7 @@ namespace Xtensive.Orm.Linq
     {
       var type = sequence.Type;
       if (type.IsOfGenericType(WellKnownTypes.ReadOnlySpanOfT)) {
-        var methodToArray = type.GetMethod(nameof(ReadOnlySpan<>.ToArray));
-        sequence = Expression.Call(sequence, methodToArray);
+        sequence = Expression.Call(sequence, type.GetMethod(nameof(ReadOnlySpan<>.ToArray)));
       }
 
       return CreateLocalCollectionProjectionExpression(typeof(TItem), ParameterAccessorFactory.CreateAccessorExpression<IEnumerable<TItem>>(

--- a/Orm/Xtensive.Orm/Reflection/WellKnownTypes.cs
+++ b/Orm/Xtensive.Orm/Reflection/WellKnownTypes.cs
@@ -83,5 +83,6 @@ namespace Xtensive.Reflection
     public static readonly Type DefaultMemberAttribute = typeof(DefaultMemberAttribute);
 
     public static readonly Type ReadOnlySpanOfT = typeof(ReadOnlySpan<>);
+    public static readonly Type SpanOfT = typeof(Span<>);
   }
 }

--- a/Orm/Xtensive.Orm/Reflection/WellKnownTypes.cs
+++ b/Orm/Xtensive.Orm/Reflection/WellKnownTypes.cs
@@ -81,5 +81,7 @@ namespace Xtensive.Reflection
     public static readonly Type ObjectArray = typeof(object[]);
 
     public static readonly Type DefaultMemberAttribute = typeof(DefaultMemberAttribute);
+
+    public static readonly Type ReadOnlySpanOfT = typeof(ReadOnlySpan<>);
   }
 }

--- a/Version.props
+++ b/Version.props
@@ -2,8 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.2.160</DoVersion>
-    <DoVersionSuffix>servicetitan</DoVersionSuffix>
+    <DoVersion>7.2.161</DoVersion>
+    <DoVersionSuffix>servicetitan-span</DoVersionSuffix>
 </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
.NET9 C# compiler in `Preview` mode sometime generates `Span<>` or `ReadOnlySpan<>.Contains()`  instead of `IEnumerable.Contains()` call.

for example in such case:
```
    private List<string> ReadOnlySpanContains_GetCustomers(string[] customerNames) =>
      (from c in Session.Query.All<Customer>() where customerNames.Contains(c.FirstName) select c.FirstName).ToList();
```

We should correctly process it.
In this fix, we just apply `.ToArray()` to `ReadOnlySpan<>`