### PR TITLE
Get rid of redundant `.Cast<>` invocations

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Providers/PartialIndexFilterCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/PartialIndexFilterCompiler.cs
@@ -22,11 +22,10 @@ namespace Xtensive.Orm.Providers
 
       var table = SqlDml.TableRef(CreateStubTable(index.ReflectedType.MappingName, fieldsCount));
       // Translation of ColumnRefs without alias seems broken, use original name as alias.
-      var columns = filter.Fields
+      IReadOnlyList<SqlExpression> columns = filter.Fields
         .Select(field => field.Column.Name)
         .Select((name, i) => SqlDml.ColumnRef(table.Columns[i], name))
-        .Cast<SqlExpression>()
-        .ToList(fieldsCount);
+        .ToArray(fieldsCount);
 
       var processor = new ExpressionProcessor(filter.Expression, handlers, null, true, columns);
       var fragment = SqlDml.Fragment(processor.Translate());

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -188,7 +188,7 @@ namespace Xtensive.Orm.Providers
         ? leftTable.Columns
         : left.Request.Statement.Columns;
       IReadOnlyList<SqlExpression> leftExpressions = leftShouldUseReference
-        ? leftTable.Columns.Cast<SqlExpression>().ToArray()
+        ? leftTable.Columns
         : ExtractColumnExpressions(left.Request.Statement);
 
       var rightShouldUseReference = strictJoinWorkAround || ShouldUseQueryReference(provider, right);
@@ -198,8 +198,8 @@ namespace Xtensive.Orm.Providers
       IReadOnlyList<SqlColumn> rightColumns = rightShouldUseReference
         ? rightTable.Columns
         : right.Request.Statement.Columns;
-      var rightExpressions = rightShouldUseReference
-        ? rightTable.Columns.Cast<SqlExpression>().ToArray()
+      IReadOnlyList<SqlExpression> rightExpressions = rightShouldUseReference
+        ? rightTable.Columns
         : ExtractColumnExpressions(right.Request.Statement);
 
       var joinType = provider.JoinType==JoinType.LeftOuter
@@ -207,8 +207,9 @@ namespace Xtensive.Orm.Providers
         : SqlJoinType.InnerJoin;
 
       SqlExpression joinExpression = null;
-      for (int i = 0, n = provider.EqualIndexes.Count(); i < n; ++i) {
-        var (leftInder, rightIndex) = provider.EqualIndexes[i];
+      var providerEqualIndexes = provider.EqualIndexes;
+      for (int i = 0, n = providerEqualIndexes.Count; i < n; ++i) {
+        var (leftInder, rightIndex) = providerEqualIndexes[i];
         var leftExpression = leftExpressions[leftInder];
         var rightExpression = rightExpressions[rightIndex];
         joinExpression &= GetJoinExpression(leftExpression, rightExpression, provider, i);

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlProvider.cs
@@ -33,13 +33,7 @@ namespace Xtensive.Orm.Providers
     /// <summary>
     /// Gets the permanent reference (<see cref="SqlQueryRef"/>) for <see cref="SqlSelect"/> associated with this provider.
     /// </summary>
-    public SqlTable PermanentReference {
-      get {
-        if (permanentReference is null)
-          permanentReference = SqlDml.QueryRef(Request.Statement);
-        return permanentReference;
-      }
-    }
+    public SqlTable PermanentReference => permanentReference ??= SqlDml.QueryRef(Request.Statement);
 
     /// <summary>
     /// Gets the domain handler this provider is bound to.

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlColumn.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlColumn.cs
@@ -10,56 +10,35 @@ namespace Xtensive.Sql.Dml
   [Serializable]
   public abstract class SqlColumn : SqlExpression
   {
-    private string name;
-    private SqlTable sqlTable;
-
     /// <summary>
     /// Gets or sets the name of this instance.
     /// </summary>
     /// <value>The alias.</value>
-    public virtual string Name
-    {
-      get { return name; }
-    }
+    public virtual string Name { get; private set; }
 
     /// <summary>
     /// Gets the table reference.
     /// </summary>
     /// <value>The table reference.</value>
-    public SqlTable SqlTable
-    {
-      get { return sqlTable; }
-    }
+    public SqlTable SqlTable { get; private set; }
 
     public override void ReplaceWith(SqlExpression expression)
     {
       var replacingExpression = ArgumentValidator.EnsureArgumentIs<SqlColumn>(expression);
-      sqlTable = replacingExpression.SqlTable;
-      name = replacingExpression.Name;
+      SqlTable = replacingExpression.SqlTable;
+      Name = replacingExpression.Name;
     }
 
     internal override abstract SqlColumn Clone(SqlNodeCloneContext? context = null);
 
     // Constructor
 
-    internal SqlColumn(SqlTable sqlTable, string name) : base(SqlNodeType.Column)
+    internal SqlColumn(SqlTable sqlTable = null, string name = null) : base(SqlNodeType.Column)
     {
-      this.sqlTable = sqlTable;
-      this.name = name;
+      SqlTable = sqlTable;
+      Name = name;
     }
 
-    internal SqlColumn(string name) : base(SqlNodeType.Column)
-    {
-      this.name = name;
-    }
-
-    internal SqlColumn(SqlTable sqlTable) : base(SqlNodeType.Column)
-    {
-      this.sqlTable = sqlTable;
-    }
-
-    internal SqlColumn() : base(SqlNodeType.Column)
-    {
-    }
+    internal SqlColumn(string name) : this(null, name) { }
   }
 }

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlColumnRef.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlColumnRef.cs
@@ -40,15 +40,9 @@ namespace Xtensive.Sql.Dml
       SqlColumn = sqlColumn;
     }
 
-    internal SqlColumnRef(SqlColumn sqlColumn, string name)
-      : base(null, name)
+    internal SqlColumnRef(SqlColumn sqlColumn, string name = null)
+      : this(null, sqlColumn, name)
     {
-      SqlColumn = sqlColumn;
-    }
-
-    internal SqlColumnRef(SqlColumn sqlColumn)
-    {
-      SqlColumn = sqlColumn;
     }
   }
 }


### PR DESCRIPTION
Also:
* Simplify `SqlColumn`, `SqlColumnRef` constructors