### PR TITLE
Optimize size of `ColumnInfoRef` struct by 24 bytes

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Model/ColumnInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnInfo.cs
@@ -20,10 +20,10 @@ namespace Xtensive.Orm.Model
   public sealed class ColumnInfo : Node, ICloneable
   {
     private ColumnAttributes attributes;
-    private readonly Type valueType;
-    private readonly int? length;
-    private readonly sbyte? scale;
-    private readonly sbyte? precision;
+    private Type valueType;
+    private int? length;
+    private sbyte? scale;
+    private sbyte? precision;
     private object defaultValue;
     private string defaultSqlExpression;
     private FieldInfo fld;
@@ -247,7 +247,22 @@ namespace Xtensive.Orm.Model
     /// <summary>
     /// Clones this instance.
     /// </summary>
-    public ColumnInfo Clone() => (ColumnInfo) MemberwiseClone();
+    public ColumnInfo Clone()
+    {
+      ColumnInfo clone = new ColumnInfo(fld);
+      clone.Name = Name;
+      clone.attributes = attributes;
+      clone.valueType = valueType;
+      clone.length = length;
+      clone.scale = scale;
+      clone.precision = precision;
+      clone.defaultValue = defaultValue;
+      clone.defaultSqlExpression = defaultSqlExpression;
+      clone.indexes = indexes;
+      clone.cultureInfo = cultureInfo;
+
+      return clone;
+    }
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnInfo.cs
@@ -17,14 +17,13 @@ namespace Xtensive.Orm.Model
   /// </summary>
   [DebuggerDisplay("{Name}; Attributes = {Attributes}")]
   [Serializable]
-  public sealed class ColumnInfo : Node, 
-    ICloneable
+  public sealed class ColumnInfo : Node, ICloneable
   {
     private ColumnAttributes attributes;
-    private Type   valueType;
-    private int?   length;
-    private sbyte?   scale;
-    private sbyte?   precision;
+    private readonly Type valueType;
+    private readonly int? length;
+    private readonly sbyte? scale;
+    private readonly sbyte? precision;
     private object defaultValue;
     private string defaultSqlExpression;
     private FieldInfo fld;
@@ -243,30 +242,12 @@ namespace Xtensive.Orm.Model
     #region ICloneable methods
 
     /// <inheritdoc/>
-    object ICloneable.Clone()
-    {
-      return Clone();
-    }
+    object ICloneable.Clone() => Clone();
 
     /// <summary>
     /// Clones this instance.
     /// </summary>
-    public ColumnInfo Clone()
-    {
-      ColumnInfo clone = new ColumnInfo(fld);
-      clone.Name = Name;
-      clone.attributes = attributes;
-      clone.valueType = valueType;
-      clone.length = length;
-      clone.scale = scale;
-      clone.precision = precision;
-      clone.defaultValue = defaultValue;
-      clone.defaultSqlExpression = defaultSqlExpression;
-      clone.indexes = indexes;
-      clone.cultureInfo = cultureInfo;
-
-      return clone;
-    }
+    public ColumnInfo Clone() => (ColumnInfo) MemberwiseClone();
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnInfoRef.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnInfoRef.cs
@@ -18,27 +18,29 @@ namespace Xtensive.Orm.Model
   /// </summary>
   [Serializable]
   [DebuggerDisplay("TypeName = {TypeName}, FieldName = {FieldName}, ColumnName = {ColumnName}, CultureInfo = {CultureInfo}")]
-  public readonly struct ColumnInfoRef: IEquatable<ColumnInfoRef>
+  public readonly struct ColumnInfoRef : IEquatable<ColumnInfoRef>
   {
+    private readonly ColumnInfo columnInfo;
+
     /// <summary>
     /// Gets type name of reflecting <see cref="TypeInfo"/>.
     /// </summary>
-    public string TypeName { get; }
+    public string TypeName => columnInfo.Field.DeclaringType.Name;
 
     /// <summary>
     /// Gets name of the <see cref="FieldInfo"/>.
     /// </summary>
-    public string FieldName { get; }
+    public string FieldName => columnInfo.Field.Name;
 
     /// <summary>
     /// Gets name of the <see cref="ColumnInfo"/>.
     /// </summary>
-    public string ColumnName { get; }
+    public string ColumnName => columnInfo.Name;
 
     /// <summary>
     /// Gets <see cref="CultureInfo"/> info of the <see cref="ColumnInfo"/>.
     /// </summary>
-    public CultureInfo CultureInfo { get; }
+    public CultureInfo CultureInfo => columnInfo.CultureInfo;
 
     /// <summary>
     /// Resolves this instance to <see cref="ColumnInfo"/> object within specified <paramref name="model"/>.
@@ -101,25 +103,7 @@ namespace Xtensive.Orm.Model
     public ColumnInfoRef(ColumnInfo columnInfo)
     {
       ArgumentNullException.ThrowIfNull(columnInfo);
-      TypeName = columnInfo.Field.DeclaringType.Name;
-      FieldName = columnInfo.Field.Name;
-      ColumnName = columnInfo.Name;
-      CultureInfo = columnInfo.CultureInfo;
-    }
-
-
-    /// <summary>
-    ///   Initializes a new instance of this struct.
-    /// </summary>
-    /// <param name="typeName">Column type name.</param>
-    /// <param name="columnName">Column name.</param>
-    /// <param name="cultureInfo">The culture info.</param>
-    public ColumnInfoRef(string typeName, string columnName, CultureInfo cultureInfo)
-    {
-      TypeName = typeName;
-      FieldName = columnName;
-      ColumnName = columnName;
-      CultureInfo = cultureInfo;
+      this.columnInfo = columnInfo;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnInfoRef.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnInfoRef.cs
@@ -63,7 +63,7 @@ namespace Xtensive.Orm.Model
     /// <returns>
     /// The result of the operator.
     /// </returns>
-    public static bool operator !=(in ColumnInfoRef x, in ColumnInfoRef y) => !x.Equals(y);
+    public static bool operator !=(ColumnInfoRef x, ColumnInfoRef y) => !x.Equals(y);
 
     /// <summary>
     /// Implements the operator ==.
@@ -73,7 +73,7 @@ namespace Xtensive.Orm.Model
     /// <returns>
     /// The result of the operator.
     /// </returns>
-    public static bool operator ==(in ColumnInfoRef x, in ColumnInfoRef y) => x.Equals(y);
+    public static bool operator ==(ColumnInfoRef x, ColumnInfoRef y) => x.Equals(y);
 
     /// <inheritdoc/>
     public bool Equals(ColumnInfoRef other) =>

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnInfoRef.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnInfoRef.cs
@@ -25,22 +25,22 @@ namespace Xtensive.Orm.Model
     /// <summary>
     /// Gets type name of reflecting <see cref="TypeInfo"/>.
     /// </summary>
-    public string TypeName => columnInfo.Field.DeclaringType.Name;
+    public string TypeName => columnInfo?.Field.DeclaringType.Name;
 
     /// <summary>
     /// Gets name of the <see cref="FieldInfo"/>.
     /// </summary>
-    public string FieldName => columnInfo.Field.Name;
+    public string FieldName => columnInfo?.Field.Name;
 
     /// <summary>
     /// Gets name of the <see cref="ColumnInfo"/>.
     /// </summary>
-    public string ColumnName => columnInfo.Name;
+    public string ColumnName => columnInfo?.Name;
 
     /// <summary>
     /// Gets <see cref="CultureInfo"/> info of the <see cref="ColumnInfo"/>.
     /// </summary>
-    public CultureInfo CultureInfo => columnInfo.CultureInfo;
+    public CultureInfo CultureInfo => columnInfo?.CultureInfo;
 
     /// <summary>
     /// Resolves this instance to <see cref="ColumnInfo"/> object within specified <paramref name="model"/>.

--- a/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
@@ -17,11 +17,10 @@ namespace Xtensive.Orm.Rse
   {
     private const string ToStringFormat = "{0} = {1}";
 
-    private readonly ColumnInfoRef columnInfo;
     /// <summary>
     /// Gets the reference that describes a column.
     /// </summary>
-    public ref readonly ColumnInfoRef ColumnInfoRef => ref columnInfo;
+    public ColumnInfoRef ColumnInfoRef { get; }
 
     /// <inheritdoc/>
     public override string ToString()
@@ -74,10 +73,10 @@ namespace Xtensive.Orm.Rse
     /// <param name="name"><see cref="Column.Name"/> property value.</param>
     /// <param name="index"><see cref="Column.Index"/> property value.</param>
     /// <param name="type"><see cref="Column.Type"/> property value.</param>
-    public MappedColumn(in ColumnInfoRef columnInfoRef, string name, ColNum index, Type type)
+    public MappedColumn(ColumnInfoRef columnInfoRef, string name, ColNum index, Type type)
       : base(name, index, type, null)
     {
-      columnInfo = columnInfoRef;
+      ColumnInfoRef = columnInfoRef;
     }
 
     #endregion
@@ -87,13 +86,13 @@ namespace Xtensive.Orm.Rse
     private MappedColumn(MappedColumn column, string newName)
       : base(newName, column.Index, column.Type, column)
     {
-      columnInfo = column.ColumnInfoRef;
+      ColumnInfoRef = column.ColumnInfoRef;
     }
 
     private MappedColumn(MappedColumn column, ColNum newIndex)
       : base(column.Name, newIndex, column.Type, column)
     {
-      columnInfo = column.ColumnInfoRef;
+      ColumnInfoRef = column.ColumnInfoRef;
     }
 
     #endregion

--- a/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
@@ -61,7 +61,7 @@ namespace Xtensive.Orm.Rse
     /// <param name="columnInfoRef"><see cref="ColumnInfoRef"/> property value.</param>
     /// <param name="index"><see cref="Column.Index"/> property value.</param>
     /// <param name="type"><see cref="Column.Type"/> property value.</param>
-    public MappedColumn(in ColumnInfoRef columnInfoRef, ColNum index, Type type)
+    public MappedColumn(ColumnInfoRef columnInfoRef, ColNum index, Type type)
       : this(columnInfoRef, columnInfoRef.ColumnName, index, type)
     {
     }


### PR DESCRIPTION
This struct is part of `MappedColumn`
Dumps show that is one of main memory consumers:
![image](https://github.com/user-attachments/assets/148de904-cd86-4e5d-abff-ec976eb05d5c)

Reducing the `ColumnInfoRef` by 24 bytes would save 18MB of RAM for this case.

`ColumnInfo` is immutable type (it locks for changes after model built) and can be used in the `ColumnInfoRef` implementation.

Also:
* Remove unused `ColumnInfoRef(string typeName, string columnName, CultureInfo cultureInfo)` constructor
