### PR TITLE
Revert checking for Non-`public` search for `.IsNullOrEmpty()`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/MemberCompilation/MemberCompilerProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/MemberCompilation/MemberCompilerProvider.cs
@@ -184,7 +184,7 @@ namespace Xtensive.Orm.Linq.MemberCompilation
             Strings.ExCompilerXHasInvalidTargetType, compiler.GetFullName(true)));
 
       var parameterTypes = ValidateCompilerParametersAndExtractTargetSignature(compiler, isGeneric);
-      var bindingFlags = BindingFlags.Public | BindingFlags.NonPublic;
+      var bindingFlags = BindingFlags.Public;
 
       if (isCtor)
         bindingFlags |= BindingFlags.Instance;


### PR DESCRIPTION
Post-fix of https://github.com/servicetitan/dataobjects-net/pull/336

Test whether this change is necessary if we removed `str.IsNullOrEmpty()` usages in DO expressions.