### PR TITLE
Allow to assign `Node.Name` only once to avoid on-change subscriptions overhead

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0760_OverrideFieldNameAttributeRuinsFieldMappingOnUpgrade.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0760_OverrideFieldNameAttributeRuinsFieldMappingOnUpgrade.cs
@@ -5,10 +5,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using NUnit.Framework;
 using Xtensive.Orm.Building;
 using Xtensive.Orm.Building.Definitions;
+using Xtensive.Orm.Model;
 using Xtensive.Orm.Model.Stored;
 using Xtensive.Orm.Tests.Issues.IssueJira0760_OverrideFieldNameAttributeRuinsFieldMappingOnUpgradeModel;
 using Xtensive.Orm.Upgrade;
@@ -145,10 +147,12 @@ namespace Xtensive.Orm.Tests.Issues.IssueJira0760_OverrideFieldNameAttributeRuin
 
     public void OnDefinitionsBuilt(BuildingContext context, DomainModelDef model)
     {
-      var stateField = model.Types[typeof(EntityWithState)].Fields["State"];
-
-      stateField.Name = "EntityWithState.State";
+      var fields = model.Types[typeof(EntityWithState)].Fields;
+      var stateField = fields["State"];
+      fields.Remove(stateField);
+      typeof(Node).GetField("name", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(stateField, "EntityWithState.State");
       stateField.MappingName = "EntityWithState.State";
+      fields.Add(stateField);
     }
   }
 

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.cs
@@ -791,8 +791,7 @@ namespace Xtensive.Orm.Building.Builders
           yield return column;
         }
         else if (!column.IsSystem) {
-          var clone = column.Clone();
-          clone.Name = nameBuilder.BuildColumnName(column);
+          var clone = column.Clone(nameBuilder.BuildColumnName(column));
           clone.Field.MappingName = clone.Name;
           _ = valueColumns.Add(clone.Name);
           yield return clone;

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/ModelBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/ModelBuilder.cs
@@ -373,8 +373,7 @@ namespace Xtensive.Orm.Building.Builders
         var underlyingType = GenerateAuxiliaryType(association);
 
         // Defining auxiliary type
-        var underlyingTypeDef = modelDefBuilder.DefineType(underlyingType);
-        underlyingTypeDef.Name = association.Name;
+        var underlyingTypeDef = modelDefBuilder.DefineType(underlyingType, association.Name);
         underlyingTypeDef.MappingName = context.NameBuilder.BuildAuxiliaryTypeMappingName(association);
         // Copy mapping information from master type
         underlyingTypeDef.MappingSchema = association.OwnerType.MappingSchema;

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/ModelDefBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/ModelDefBuilder.cs
@@ -224,10 +224,10 @@ namespace Xtensive.Orm.Building.Builders
 
     #region Definition-related members
 
-    public TypeDef DefineType(Type type)
+    public TypeDef DefineType(Type type, string name = null)
     {
       var typeDef = new TypeDef(this, type, context.Validator);
-      typeDef.Name = context.NameBuilder.BuildTypeName(context, typeDef);
+      typeDef.Name = name ?? context.NameBuilder.BuildTypeName(context, typeDef);
 
       if (!(type.UnderlyingSystemType.IsInterface || type.IsAbstract)) {
         var sta = type.GetAttribute<SystemTypeAttribute>(AttributeSearchOptions.Default);

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/TypeBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/TypeBuilder.cs
@@ -325,7 +325,7 @@ namespace Xtensive.Orm.Building.Builders
     private void BuildInheritedField(TypeInfo type, FieldInfo inheritedField)
     {
       BuildLog.Info(nameof(Strings.LogBuildingInheritedFieldXY), type.Name, inheritedField.Name);
-      var field = inheritedField.Clone();
+      var field = inheritedField.Clone(null);
       type.Fields.Add(field);
       field.ReflectedType = type;
       field.DeclaringType = inheritedField.DeclaringType;
@@ -343,7 +343,8 @@ namespace Xtensive.Orm.Building.Builders
       var buffer = fields.ToList();
 
       foreach (var field in buffer) {
-        var clone = field.Clone();
+        var newName = target.IsDeclared ? context.NameBuilder.BuildNestedFieldName(target, field) : null;
+        var clone = field.Clone(newName);
         if (target.SkipVersion) {
           clone.SkipVersion = true;
         }
@@ -351,7 +352,6 @@ namespace Xtensive.Orm.Building.Builders
         clone.IsSystem = false;
         clone.IsLazyLoad = field.IsLazyLoad || target.IsLazyLoad;
         if (target.IsDeclared) {
-          clone.Name = context.NameBuilder.BuildNestedFieldName(target, field);
           clone.OriginalName = field.OriginalName;
           // One-field reference
           if (target.IsEntity && buffer.Count == 1) {
@@ -428,9 +428,8 @@ namespace Xtensive.Orm.Building.Builders
 
     private ColumnInfo BuildInheritedColumn(FieldInfo field, ColumnInfo ancestor)
     {
-      var column = ancestor.Clone();
+      var column = ancestor.Clone(context.NameBuilder.BuildColumnName(field, ancestor));
       column.Field = field;
-      column.Name = context.NameBuilder.BuildColumnName(field, ancestor);
       column.IsDeclared = field.IsDeclared;
       column.IsPrimaryKey = field.IsPrimaryKey;
       column.IsNullable = field.IsNullable;

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnInfo.cs
@@ -249,8 +249,7 @@ namespace Xtensive.Orm.Model
     /// </summary>
     public ColumnInfo Clone()
     {
-      ColumnInfo clone = new ColumnInfo(fld);
-      clone.Name = Name;
+      ColumnInfo clone = new(fld) { Name = Name };
       clone.attributes = attributes;
       clone.valueType = valueType;
       clone.length = length;

--- a/Orm/Xtensive.Orm/Orm/Model/ColumnInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/ColumnInfo.cs
@@ -242,14 +242,14 @@ namespace Xtensive.Orm.Model
     #region ICloneable methods
 
     /// <inheritdoc/>
-    object ICloneable.Clone() => Clone();
+    object ICloneable.Clone() => Clone(null);
 
     /// <summary>
     /// Clones this instance.
     /// </summary>
-    public ColumnInfo Clone()
+    public ColumnInfo Clone(string newName)
     {
-      ColumnInfo clone = new(fld) { Name = Name };
+      ColumnInfo clone = new(fld) { Name = newName ?? Name };
       clone.attributes = attributes;
       clone.valueType = valueType;
       clone.length = length;

--- a/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/FieldInfo.cs
@@ -758,15 +758,15 @@ namespace Xtensive.Orm.Model
     #region ICloneable methods
 
     /// <inheritdoc/>
-    object ICloneable.Clone() => Clone();
+    object ICloneable.Clone() => Clone(null);
 
     /// <summary>
     /// Clones this instance.
     /// </summary>
-    public FieldInfo Clone()
+    public FieldInfo Clone(string newName)
     {
       var clone = new FieldInfo(declaringType, reflectedType, Attributes) {
-        Name = Name,
+        Name = newName ?? Name,
         OriginalName = OriginalName,
         MappingName = MappingName,
         underlyingProperty = underlyingProperty,

--- a/Orm/Xtensive.Orm/Orm/Model/Node.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/Node.cs
@@ -15,7 +15,7 @@ namespace Xtensive.Orm.Model
   ///An abstract base class for model node.
   /// </summary>
   [Serializable]
-  public abstract class Node : LockableBase, IChangeNotifier
+  public abstract class Node : LockableBase
   {
     private string name;
 
@@ -24,21 +24,14 @@ namespace Xtensive.Orm.Model
     /// </summary>
     public string Name
     {
-      get { return name; }
+      get => name;
       set {
         EnsureNotLocked();
+        if (name is not null)
+          throw new InvalidOperationException("The node Name is locked.");
         ValidateName(value);
-        ChangeState("Name", delegate { name = value; });
+        name = value;
       }
-    }
-
-    private void ChangeState(string property, Action onChangeStateDelegate)
-    {
-      if (Changing != null)
-        Changing(this, new ChangeNotifierEventArgs(property));
-      onChangeStateDelegate();
-      if (Changed != null)
-        Changed(this, new ChangeNotifierEventArgs(property));
     }
 
     /// <summary>
@@ -48,16 +41,6 @@ namespace Xtensive.Orm.Model
     protected virtual void ValidateName(string newName)
     {
     }
-
-    #region IChangeNotifier Members
-
-    /// <inheritdoc/>
-    public event EventHandler<ChangeNotifierEventArgs> Changing;
-
-    /// <inheritdoc/>
-    public event EventHandler<ChangeNotifierEventArgs> Changed;
-
-    #endregion
 
     /// <summary>
     /// Updates the internal state of this instance.

--- a/Orm/Xtensive.Orm/Orm/Model/Node.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/Node.cs
@@ -25,7 +25,7 @@ namespace Xtensive.Orm.Model
     public string Name
     {
       get => name;
-      set {
+      internal set {
         EnsureNotLocked();
         if (name is not null)
           throw new InvalidOperationException("The node Name is locked.");

--- a/Version.props
+++ b/Version.props
@@ -2,8 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.2.163</DoVersion>
-    <DoVersionSuffix>servicetitan</DoVersionSuffix>
+    <DoVersion>7.2.164</DoVersion>
+    <DoVersionSuffix>servicetitan-test</DoVersionSuffix>
 </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Dumps show that `Node`s' on-Name-Change subscriptions take > 11MB
![image](https://github.com/user-attachments/assets/1fa0b400-ad14-411c-8015-885fa71ad1a4)

But they are not used, because the Domain Model is immutable.
And the App does not use provided API to modify the built model.

In this PR I've added checking to ensure `Node.Name` is allowed to be assigned only once to non-null value.
It would be better to convert it into `init` setter, but will require massive refactoring.

Also:
* `Node` doesn't implement `IChangeNotifier` anymore
* Make `Node.Name` setter be `internal`
