### PR TITLE
Optimize `PersistParameterBinding`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/ParameterBinding.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/ParameterBinding.cs
@@ -4,10 +4,6 @@
 // Created by: Dmitri Maximov
 // Created:    2008.09.26
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Xtensive.Core;
 using Xtensive.Sql;
 using Xtensive.Sql.Dml;
 

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/ParameterTransmissionType.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/ParameterTransmissionType.cs
@@ -12,7 +12,7 @@ namespace Xtensive.Orm.Providers
   /// Possible way of delivering parameter to server
   /// for <see cref="QueryParameterBinding"/> and <see cref="PersistParameterBinding"/>.
   /// </summary>
-  public enum ParameterTransmissionType
+  public enum ParameterTransmissionType : byte
   {
     /// <summary>
     /// Indicates that no special handling of parameter is performed.

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistParameterBinding.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistParameterBinding.cs
@@ -4,57 +4,39 @@
 // Created by: Dmitri Maximov
 // Created:    2008.09.25
 
-using System;
-using Xtensive.Core;
 using Xtensive.Sql;
 
-namespace Xtensive.Orm.Providers
+namespace Xtensive.Orm.Providers;
+
+/// <summary>
+/// A binding of a parameter for <see cref="PersistRequest"/>.
+/// </summary>
+public sealed class PersistParameterBinding(
+  TypeMapping typeMapping,
+  ushort rowIndex,
+  ColNum fieldIndex,
+  ParameterTransmissionType transmissionType = ParameterTransmissionType.Regular,
+  PersistParameterBindingType bindingType = PersistParameterBindingType.Regular
+) : ParameterBinding(typeMapping, transmissionType)
 {
-  /// <summary>
-  /// A binding of a parameter for <see cref="PersistRequest"/>.
-  /// </summary>
-  public sealed class PersistParameterBinding : ParameterBinding
+  public ushort RowIndex { get; } = rowIndex;
+  public ColNum FieldIndex { get; } = fieldIndex;
+  public PersistParameterBindingType BindingType { get; } = bindingType;
+
+  // Constructors
+
+  public PersistParameterBinding(TypeMapping typeMapping, ColNum fieldIndex, ParameterTransmissionType transmissionType, PersistParameterBindingType bindingType)
+    : this(typeMapping, 0, fieldIndex, transmissionType, bindingType)
   {
-    public int RowIndex { get; private set; }
+  }
 
-    public int FieldIndex { get; private set; }
+  public PersistParameterBinding(TypeMapping typeMapping, ColNum fieldIndex, ParameterTransmissionType transmissionType)
+    : this(typeMapping, fieldIndex, transmissionType, PersistParameterBindingType.Regular)
+  {
+  }
 
-    public PersistParameterBindingType BindingType { get; private set; }
-
-    // Constructors
-
-    public PersistParameterBinding(TypeMapping typeMapping, int rowIndex, int fieldIndex,
-      ParameterTransmissionType transmissionType, PersistParameterBindingType bindingType)
-      : base(typeMapping, transmissionType)
-    {
-      RowIndex = rowIndex;
-      FieldIndex = fieldIndex;
-      BindingType = bindingType;
-    }
-
-    public PersistParameterBinding(TypeMapping typeMapping, int fieldIndex, ParameterTransmissionType transmissionType, PersistParameterBindingType bindingType)
-      : this(typeMapping, 0, fieldIndex, transmissionType, bindingType)
-    {
-    }
-
-    public PersistParameterBinding(TypeMapping typeMapping, int rowIndex, int fieldIndex, ParameterTransmissionType transmissionType)
-      : this(typeMapping, rowIndex, fieldIndex, transmissionType, PersistParameterBindingType.Regular)
-    {
-    }
-
-    public PersistParameterBinding(TypeMapping typeMapping, int fieldIndex, ParameterTransmissionType transmissionType)
-      : this(typeMapping, fieldIndex, transmissionType, PersistParameterBindingType.Regular)
-    {
-    }
-
-    public PersistParameterBinding(TypeMapping typeMapping, int rowIndex, int fieldIndex)
-      : this(typeMapping, rowIndex, fieldIndex, ParameterTransmissionType.Regular, PersistParameterBindingType.Regular)
-    {
-    }
-
-    public PersistParameterBinding(TypeMapping typeMapping, int fieldIndex)
-      : this(typeMapping, fieldIndex, ParameterTransmissionType.Regular, PersistParameterBindingType.Regular)
-    {
-    }
+  public PersistParameterBinding(TypeMapping typeMapping, ColNum fieldIndex)
+    : this(typeMapping, fieldIndex, ParameterTransmissionType.Regular, PersistParameterBindingType.Regular)
+  {
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistParameterBindingType.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistParameterBindingType.cs
@@ -3,7 +3,7 @@ namespace Xtensive.Orm.Providers
   /// <summary>
   /// Possible types of <see cref="PersistParameterBinding"/>.
   /// </summary>
-  public enum PersistParameterBindingType
+  public enum PersistParameterBindingType : byte
   {
     /// <summary>
     /// Regular parameter. Parameter value is obtained thru difference tuple.

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilder.cs
@@ -63,7 +63,7 @@ namespace Xtensive.Orm.Providers
       return result.AsSafeWrapper();
     }
 
-    protected virtual List<PersistRequest> BuildInsertRequest(PersistRequestBuilderContext context)
+    protected virtual List<PersistRequest> BuildInsertRequest(in PersistRequestBuilderContext context)
     {
       var result = new List<PersistRequest>();
       foreach (var index in context.AffectedIndexes) {
@@ -88,7 +88,7 @@ namespace Xtensive.Orm.Providers
       return result;
     }
 
-    protected virtual List<PersistRequest> BuildUpdateRequest(PersistRequestBuilderContext context)
+    protected virtual List<PersistRequest> BuildUpdateRequest(in PersistRequestBuilderContext context)
     {
       var result = new List<PersistRequest>();
       foreach (var index in context.AffectedIndexes) {
@@ -130,7 +130,7 @@ namespace Xtensive.Orm.Providers
       return result;
     }
 
-    protected virtual List<PersistRequest> BuildRemoveRequest(PersistRequestBuilderContext context)
+    protected virtual List<PersistRequest> BuildRemoveRequest(in PersistRequestBuilderContext context)
     {
       var result = new List<PersistRequest>();
       for (var i = context.AffectedIndexes.Count - 1; i >= 0; i--) {
@@ -147,7 +147,7 @@ namespace Xtensive.Orm.Providers
       return result;
     }
 
-    private SqlExpression BuildKeyFilter(PersistRequestBuilderContext context, SqlTableRef filteredTable, List<PersistParameterBinding> currentBindings)
+    private SqlExpression BuildKeyFilter(in PersistRequestBuilderContext context, SqlTableRef filteredTable, List<PersistParameterBinding> currentBindings)
     {
       SqlExpression result = null;
       foreach (var column in context.PrimaryIndex.KeyColumns.Keys) {
@@ -163,7 +163,7 @@ namespace Xtensive.Orm.Providers
       return result;
     }
 
-    private SqlExpression BuildVersionFilter(PersistRequestBuilderContext context, SqlTableRef filteredTable, List<PersistParameterBinding> currentBindings)
+    private SqlExpression BuildVersionFilter(in PersistRequestBuilderContext context, SqlTableRef filteredTable, List<PersistParameterBinding> currentBindings)
     {
       SqlExpression result = null;
       foreach (var column in context.Type.GetVersionColumns()) {
@@ -193,7 +193,7 @@ namespace Xtensive.Orm.Providers
       return result;
     }
 
-    private bool AddFakeVersionColumnUpdate(PersistRequestBuilderContext context, SqlUpdate update, SqlTableRef filteredTable)
+    private bool AddFakeVersionColumnUpdate(in PersistRequestBuilderContext context, SqlUpdate update, SqlTableRef filteredTable)
     {
       foreach (var column in context.Type.GetVersionColumns()) {
         var columnExpression = filteredTable[column.Name];
@@ -210,7 +210,7 @@ namespace Xtensive.Orm.Providers
       return false;
     }
 
-    private PersistParameterBinding GetBinding(PersistRequestBuilderContext context, ColumnInfo column, Table table, int fieldIndex)
+    private PersistParameterBinding GetBinding(PersistRequestBuilderContext context, ColumnInfo column, Table table, ColNum fieldIndex)
     {
       if (!context.ParameterBindings.TryGetValue(column, out var binding)) {
         var typeMapping = driver.GetTypeMapping(column);
@@ -236,15 +236,10 @@ namespace Xtensive.Orm.Providers
         : ParameterTransmissionType.Regular;
     }
 
-    private static int GetFieldIndex(TypeInfo type, ColumnInfo column)
-    {
-      if (!type.Fields.TryGetValue(column.Field.Name, out var field)
-        || field.Column == null
-        || field.Column.ValueType != column.ValueType) {
-        return -1;
-      }
-      return field.MappingInfo.Offset;
-    }
+    private static ColNum GetFieldIndex(TypeInfo type, ColumnInfo column) =>
+      type.Fields.TryGetValue(column.Field.Name, out var field) && field.Column?.ValueType == column.ValueType
+        ? field.MappingInfo.Offset
+        : (ColNum)(-1);
 
     /// <inheritdoc/>
     protected override void Initialize()

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilderContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilderContext.cs
@@ -4,9 +4,6 @@
 // Created by: Dmitri Maximov
 // Created:    2008.08.29
 
-using System.Collections.Generic;
-using System.Linq;
-using Xtensive.Collections;
 using Xtensive.Core;
 using Xtensive.Orm.Configuration;
 using Xtensive.Orm.Model;
@@ -16,23 +13,23 @@ namespace Xtensive.Orm.Providers
   /// <summary>
   /// <see cref="PersistRequestBuilder"/> context.
   /// </summary>
-  public sealed class PersistRequestBuilderContext
+  public readonly struct PersistRequestBuilderContext
   {
-    public PersistRequestBuilderTask Task { get; private set; }
+    public PersistRequestBuilderTask Task { get; }
 
-    public ModelMapping Mapping { get; private set; }
+    public ModelMapping Mapping { get; }
 
-    public NodeConfiguration NodeConfiguration { get; private set; }
+    public NodeConfiguration NodeConfiguration { get; }
 
-    public TypeInfo Type { get; private set; }
+    public TypeInfo Type { get; }
 
-    public IReadOnlyList<IndexInfo> AffectedIndexes { get; private set;}
+    public IReadOnlyList<IndexInfo> AffectedIndexes { get; }
 
-    public IndexInfo PrimaryIndex { get; private set; }
+    public IndexInfo PrimaryIndex { get; }
 
-    public Dictionary<ColumnInfo, PersistParameterBinding> ParameterBindings { get; private set; }
+    public Dictionary<ColumnInfo, PersistParameterBinding> ParameterBindings { get; }
 
-    public Dictionary<ColumnInfo, PersistParameterBinding> VersionParameterBindings { get; private set; }
+    public Dictionary<ColumnInfo, PersistParameterBinding> VersionParameterBindings { get; }
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Providers/TemporaryTables/TemporaryTableManager.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/TemporaryTables/TemporaryTableManager.cs
@@ -106,7 +106,7 @@ namespace Xtensive.Orm.Providers
 
       return result;
 
-      Lazy<PersistRequest> CreateLazyPersistRequest(int batchSize)
+      Lazy<PersistRequest> CreateLazyPersistRequest(ushort batchSize)
       {
         return new Lazy<PersistRequest>(() => {
           var bindings = new List<PersistParameterBinding>(batchSize);
@@ -214,7 +214,7 @@ namespace Xtensive.Orm.Providers
     }
 
     private SqlInsert MakeUpInsertQuery(SqlTableRef temporaryTable,
-      TypeMapping[] typeMappings, List<PersistParameterBinding> storeRequestBindings, bool hasColumns, int rows = 1)
+      TypeMapping[] typeMappings, List<PersistParameterBinding> storeRequestBindings, bool hasColumns, ushort rows = 1)
     {
       var insertStatement = SqlDml.Insert(temporaryTable);
       if (!hasColumns) {
@@ -222,8 +222,8 @@ namespace Xtensive.Orm.Providers
         return insertStatement;
       }
 
-      for (var rowIndex = 0; rowIndex < rows; ++rowIndex) {
-        var fieldIndex = 0;
+      for (ushort rowIndex = 0; rowIndex < rows; ++rowIndex) {
+        ColNum fieldIndex = 0;
         var row = new Dictionary<SqlColumn, SqlExpression>(temporaryTable.Columns.Count);
         foreach (var column in temporaryTable.Columns) {
           var typeMapping = typeMappings[fieldIndex];

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/MetadataWriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/MetadataWriter.cs
@@ -111,7 +111,7 @@ namespace Xtensive.Orm.Upgrade
       var insert = SqlDml.Insert(tableRef);
       var bindings = new PersistParameterBinding[columns.Count];
       var row = new Dictionary<SqlColumn, SqlExpression>(columns.Count);
-      for (int i = 0; i < columns.Count; i++) {
+      for (ColNum i = 0; i < columns.Count; i++) {
         var binding = new PersistParameterBinding(mappings[i], i, transmissionTypes[i]);
         row.Add(tableRef.Columns[i], binding.ParameterReference);
         bindings[i] = binding;


### PR DESCRIPTION
I see in the dump >500K instances of `PersistParameterBinding`:
```
510,644    24,510,912 Xtensive.Orm.Providers.PersistParameterBinding
```
Reducing field sizes to `enum: byte` and Int16 (`ColNum`) should save >1MB RAM.

Also make `PersistRequestBuilderContext` readonly struct