### PR TITLE
Optimize `PersistRequest` constructor

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/ParameterBinding.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/ParameterBinding.cs
@@ -20,10 +20,6 @@ namespace Xtensive.Orm.Providers
 
     public SqlExpression ParameterReference { get; }
 
-    public static IReadOnlyCollection<T> NormalizeBindings<T>(IEnumerable<T> bindings) where T : ParameterBinding =>
-      bindings != null ? new HashSet<T>(bindings) : Array.Empty<T>();
-
-
     // Constructors
 
     protected ParameterBinding(TypeMapping typeMapping, ParameterTransmissionType transmissionType)

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequest.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequest.cs
@@ -18,6 +18,8 @@ namespace Xtensive.Orm.Providers
   /// </summary>
   public sealed class PersistRequest
   {
+    private static readonly IReadOnlySet<PersistParameterBinding> EmptyBindings = new HashSet<PersistParameterBinding>();
+
     private readonly StorageDriver driver;
 
     private SqlCompilationResult compiledStatement;
@@ -43,7 +45,7 @@ namespace Xtensive.Orm.Providers
     // Constructors
 
     public PersistRequest(
-      StorageDriver driver, SqlStatement statement, IEnumerable<PersistParameterBinding> parameterBindings)
+      StorageDriver driver, SqlStatement statement, IReadOnlySet<PersistParameterBinding> parameterBindings)
     {
       ArgumentNullException.ThrowIfNull(driver);
       ArgumentNullException.ThrowIfNull(statement);
@@ -54,7 +56,7 @@ namespace Xtensive.Orm.Providers
       this.driver = driver;
       Statement = statement;
       CompileUnit = compileUnit;
-      ParameterBindings = ParameterBinding.NormalizeBindings(parameterBindings);
+      ParameterBindings = parameterBindings ?? EmptyBindings;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilder.cs
@@ -70,7 +70,7 @@ namespace Xtensive.Orm.Providers
         var table = context.Mapping[index.ReflectedType];
         var tableRef = SqlDml.TableRef(table);
         var query = SqlDml.Insert(tableRef);
-        var bindings = new List<PersistParameterBinding>();
+        var bindings = new HashSet<PersistParameterBinding>();
 
         var row = new Dictionary<SqlColumn, SqlExpression>(index.Columns.Count);
         foreach (var column in index.Columns) {
@@ -95,7 +95,7 @@ namespace Xtensive.Orm.Providers
         var table = context.Mapping[index.ReflectedType];
         var tableRef = SqlDml.TableRef(table);
         var query = SqlDml.Update(tableRef);
-        var bindings = new List<PersistParameterBinding>();
+        var bindings = new HashSet<PersistParameterBinding>();
 
         foreach (var column in index.Columns) {
           var fieldIndex = GetFieldIndex(context.Type, column);
@@ -137,7 +137,7 @@ namespace Xtensive.Orm.Providers
         var index = context.AffectedIndexes[i];
         var tableRef = SqlDml.TableRef(context.Mapping[index.ReflectedType]);
         var query = SqlDml.Delete(tableRef);
-        var bindings = new List<PersistParameterBinding>();
+        var bindings = new HashSet<PersistParameterBinding>();
         query.Where = BuildKeyFilter(context, tableRef, bindings);
         if (context.Task.ValidateVersion) {
           query.Where &= BuildVersionFilter(context, tableRef, bindings);
@@ -147,7 +147,7 @@ namespace Xtensive.Orm.Providers
       return result;
     }
 
-    private SqlExpression BuildKeyFilter(in PersistRequestBuilderContext context, SqlTableRef filteredTable, List<PersistParameterBinding> currentBindings)
+    private SqlExpression BuildKeyFilter(in PersistRequestBuilderContext context, SqlTableRef filteredTable, ISet<PersistParameterBinding> currentBindings)
     {
       SqlExpression result = null;
       foreach (var column in context.PrimaryIndex.KeyColumns.Keys) {
@@ -163,7 +163,7 @@ namespace Xtensive.Orm.Providers
       return result;
     }
 
-    private SqlExpression BuildVersionFilter(in PersistRequestBuilderContext context, SqlTableRef filteredTable, List<PersistParameterBinding> currentBindings)
+    private SqlExpression BuildVersionFilter(in PersistRequestBuilderContext context, SqlTableRef filteredTable, ISet<PersistParameterBinding> currentBindings)
     {
       SqlExpression result = null;
       foreach (var column in context.Type.GetVersionColumns()) {

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/QueryRequest.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/QueryRequest.cs
@@ -4,10 +4,6 @@
 // Created by: Dmitri Maximov
 // Created:    2008.08.22
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Xtensive.Core;
 using Xtensive.Orm.Configuration;
 using Xtensive.Sql.Compiler;
 using Xtensive.Sql.Dml;
@@ -20,16 +16,18 @@ namespace Xtensive.Orm.Providers
   /// </summary>
   public sealed class QueryRequest : IQueryRequest
   {
+    private static readonly IReadOnlySet<QueryParameterBinding> EmptyBindings = new HashSet<QueryParameterBinding>();
+
     private readonly StorageDriver driver;
 
     private DbDataReaderAccessor? accessor;
     private SqlCompilationResult compiledStatement;
 
     public SqlSelect Statement { get; private set; }
-    public IEnumerable<QueryParameterBinding> ParameterBindings { get; private set; }
+    public IEnumerable<QueryParameterBinding> ParameterBindings { get; }
 
-    public TupleDescriptor TupleDescriptor { get; private set; }
-    public QueryRequestOptions Options { get; private set; }
+    public TupleDescriptor TupleDescriptor { get; }
+    public QueryRequestOptions Options { get; }
 
     public NodeConfiguration NodeConfiguration { get; private set; }
 
@@ -60,7 +58,7 @@ namespace Xtensive.Orm.Providers
     // Constructors
 
     public QueryRequest(
-      StorageDriver driver, SqlSelect statement, IEnumerable<QueryParameterBinding> parameterBindings,
+      StorageDriver driver, SqlSelect statement, IReadOnlySet<QueryParameterBinding> parameterBindings,
       TupleDescriptor tupleDescriptor, QueryRequestOptions options)
     {
       ArgumentNullException.ThrowIfNull(driver);
@@ -69,13 +67,13 @@ namespace Xtensive.Orm.Providers
 
       this.driver = driver;
       Statement = statement;
-      ParameterBindings = ParameterBinding.NormalizeBindings(parameterBindings);
+      ParameterBindings = parameterBindings ?? EmptyBindings;
       TupleDescriptor = tupleDescriptor;
       Options = options;
     }
 
     public QueryRequest(
-      StorageDriver driver, SqlSelect statement, IEnumerable<QueryParameterBinding> parameterBindings,
+      StorageDriver driver, SqlSelect statement, IReadOnlySet<QueryParameterBinding> parameterBindings,
       TupleDescriptor tupleDescriptor, QueryRequestOptions options, NodeConfiguration nodeConfiguration)
     {
       ArgumentNullException.ThrowIfNull(driver);
@@ -84,7 +82,7 @@ namespace Xtensive.Orm.Providers
 
       this.driver = driver;
       Statement = statement;
-      ParameterBindings = ParameterBinding.NormalizeBindings(parameterBindings);
+      ParameterBindings = parameterBindings ?? EmptyBindings;
       TupleDescriptor = tupleDescriptor;
       Options = options;
       NodeConfiguration = nodeConfiguration;

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/UserQueryRequest.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/UserQueryRequest.cs
@@ -4,8 +4,6 @@
 // Created by: Denis Krjuchkov
 // Created:    2012.02.25
 
-using System.Collections.Generic;
-using Xtensive.Core;
 using Xtensive.Sql.Compiler;
 
 namespace Xtensive.Orm.Providers
@@ -19,17 +17,17 @@ namespace Xtensive.Orm.Providers
       return compiledStatement;
     }
 
-    public IEnumerable<QueryParameterBinding> ParameterBindings { get; private set; }
+    public IEnumerable<QueryParameterBinding> ParameterBindings { get; }
 
     // Constructors
 
-    public UserQueryRequest(SqlCompilationResult compiledStatement, IEnumerable<QueryParameterBinding> parameterBindings)
+    public UserQueryRequest(SqlCompilationResult compiledStatement, IReadOnlySet<QueryParameterBinding> parameterBindings)
     {
       ArgumentNullException.ThrowIfNull(compiledStatement);
       ArgumentNullException.ThrowIfNull(parameterBindings);
 
       this.compiledStatement = compiledStatement;
-      ParameterBindings = ParameterBinding.NormalizeBindings(parameterBindings);
+      ParameterBindings = parameterBindings;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Helpers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Helpers.cs
@@ -36,11 +36,11 @@ namespace Xtensive.Orm.Providers
       CompilableProvider origin, params ExecutableProvider[] sources)
     {
       var allowBatching = true;
-      var parameterBindings = extraBindings ?? Enumerable.Empty<QueryParameterBinding>();
+      var parameterBindings = extraBindings?.ToHashSet() ?? new();
       foreach (var provider in sources.OfType<SqlProvider>()) {
         var queryRequest = provider.Request;
         allowBatching &= queryRequest.CheckOptions(QueryRequestOptions.AllowOptimization);
-        parameterBindings = parameterBindings.Concat(queryRequest.ParameterBindings);
+        parameterBindings.UnionWith(queryRequest.ParameterBindings);
       }
 
       var tupleDescriptor = origin.Header.TupleDescriptor;
@@ -136,7 +136,7 @@ namespace Xtensive.Orm.Providers
         : booleanExpressionConverter.BooleanToInt(originalExpression);
 
     protected QueryRequest CreateQueryRequest(StorageDriver driver, SqlSelect statement,
-      IEnumerable<QueryParameterBinding> parameterBindings,
+      IReadOnlySet<QueryParameterBinding> parameterBindings,
       TupleDescriptor tupleDescriptor, QueryRequestOptions options)
     {
       if (Handlers.Domain.Configuration.ShareStorageSchemaOverNodes) {

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Include.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Include.cs
@@ -24,7 +24,7 @@ namespace Xtensive.Orm.Providers
       var source = Compile(provider.Source);
       var resultQuery = ExtractSqlSelect(provider, source);
       var sourceColumns = ExtractColumnExpressions(resultQuery);
-      var bindings = source.Request.ParameterBindings;
+      var bindings = source.Request.ParameterBindings.ToHashSet();
       var filterDataSource = provider.FilterDataSource.CachingCompile();
       var requestOptions = QueryRequestOptions.Empty;
       SqlExpression resultExpression;
@@ -82,8 +82,8 @@ namespace Xtensive.Orm.Providers
       resultExpression = GetBooleanColumnExpression(resultExpression);
       var calculatedColumn = provider.Header.Columns[provider.Header.Length - 1];
       AddInlinableColumn(provider, calculatedColumn, resultQuery, resultExpression);
-      if (extraBinding!=null) {
-        bindings = bindings.Append(extraBinding);
+      if (extraBinding != null) {
+        bindings.Add(extraBinding);
       }
 
       var request = CreateQueryRequest(Driver, resultQuery, bindings, provider.Header.TupleDescriptor, requestOptions);

--- a/Orm/Xtensive.Orm/Orm/Providers/TemporaryTables/TemporaryTableManager.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/TemporaryTables/TemporaryTableManager.cs
@@ -109,7 +109,7 @@ namespace Xtensive.Orm.Providers
       Lazy<PersistRequest> CreateLazyPersistRequest(ushort batchSize)
       {
         return new Lazy<PersistRequest>(() => {
-          var bindings = new List<PersistParameterBinding>(batchSize);
+          var bindings = new HashSet<PersistParameterBinding>(batchSize);
           var statement = MakeUpInsertQuery(tableRef, typeMappings, bindings, hasColumns, batchSize);
           var persistRequest = new PersistRequest(driver, statement, bindings);
           persistRequest.Prepare();
@@ -214,7 +214,7 @@ namespace Xtensive.Orm.Providers
     }
 
     private SqlInsert MakeUpInsertQuery(SqlTableRef temporaryTable,
-      TypeMapping[] typeMappings, List<PersistParameterBinding> storeRequestBindings, bool hasColumns, ushort rows = 1)
+      TypeMapping[] typeMappings, ISet<PersistParameterBinding> storeRequestBindings, bool hasColumns, ushort rows = 1)
     {
       var insertStatement = SqlDml.Insert(temporaryTable);
       if (!hasColumns) {

--- a/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryBuilder.cs
@@ -95,7 +95,7 @@ namespace Xtensive.Orm.Services
 
       return new QueryRequest(new UserQueryRequest(
         compiledQuery,
-        bindings.Select(b => b.RealBinding)));
+        bindings.Select(b => b.RealBinding).ToHashSet()));
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/MetadataWriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/MetadataWriter.cs
@@ -109,12 +109,12 @@ namespace Xtensive.Orm.Upgrade
       var tableRef = SqlDml.TableRef(table);
 
       var insert = SqlDml.Insert(tableRef);
-      var bindings = new PersistParameterBinding[columns.Count];
+      var bindings = new HashSet<PersistParameterBinding>(columns.Count);
       var row = new Dictionary<SqlColumn, SqlExpression>(columns.Count);
       for (ColNum i = 0; i < columns.Count; i++) {
         var binding = new PersistParameterBinding(mappings[i], i, transmissionTypes[i]);
         row.Add(tableRef.Columns[i], binding.ParameterReference);
-        bindings[i] = binding;
+        bindings.Add(binding);
       }
       insert.ValueRows.Add(row);
 

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilationResult.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlCompilationResult.cs
@@ -19,8 +19,6 @@ namespace Xtensive.Sql.Compiler
     private readonly IReadOnlyDictionary<object, string> parameterNames;
     private volatile int lastResultLength;
 
-    private readonly TypeIdRegistry typeIdRegistry;
-
     /// <inheritdoc/>
     public override string ToString()
     {
@@ -75,9 +73,7 @@ namespace Xtensive.Sql.Compiler
     // Constructors
 
     internal SqlCompilationResult(IReadOnlyList<Node> result,
-      IReadOnlyDictionary<object, string> parameterNames,
-      TypeIdRegistry typeIdRegistry
-      )
+      IReadOnlyDictionary<object, string> parameterNames)
     {
       switch (result.Count) {
         case 0:
@@ -91,7 +87,6 @@ namespace Xtensive.Sql.Compiler
           break;
       }
       this.parameterNames = parameterNames.Count > 0 ? parameterNames : null;
-      this.typeIdRegistry = typeIdRegistry;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlCompiler.cs
@@ -45,7 +45,7 @@ namespace Xtensive.Sql.Compiler
       configuration = compilerConfiguration;
       context = new SqlCompilerContext(configuration);
       unit.AcceptVisitor(this);
-      return new SqlCompilationResult(context.Output.Children, context.ParameterNameProvider.NameTable, typeIdRegistry);
+      return new SqlCompilationResult(context.Output.Children, context.ParameterNameProvider.NameTable);
     }
 
     #region Visitors

--- a/Orm/Xtensive.Orm/Sql/SqlDriver.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlDriver.cs
@@ -62,7 +62,7 @@ namespace Xtensive.Sql
     public SqlCompilationResult Compile(ISqlCompileUnit statement)
     {
       ArgumentNullException.ThrowIfNull(statement);
-      return CreateCompiler().Compile(statement, new SqlCompilerConfiguration(), null);
+      return CreateCompiler().Compile(statement, new SqlCompilerConfiguration());
     }
 
     /// <summary>
@@ -77,7 +77,7 @@ namespace Xtensive.Sql
       ArgumentNullException.ThrowIfNull(statement);
       ArgumentNullException.ThrowIfNull(configuration);
       ValidateCompilerConfiguration(configuration);
-      return CreateCompiler().Compile(statement, configuration, typeIdRegistry);
+      return CreateCompiler().Compile(statement, configuration);
     }
 
     /// <summary>


### PR DESCRIPTION
These bindings are always "normalized" into `HashSet<>`
No need to create intermediate list

Also:
* Remove `NormalizeBindings()` function, not used anymore.
* Remove unused field `SqlCompilationResult.typeIdRegistry`  (created some time ago for our Shared Cache implementation)