### PR TITLE
Optimization: Make `ColumnCollection` readonly struct

### DIFF
--- a/Orm/Xtensive.Orm.SqlServer/Orm.Providers.SqlServer/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Orm.Providers.SqlServer/SqlCompiler.cs
@@ -35,7 +35,7 @@ namespace Xtensive.Orm.Providers.SqlServer
 
       var index = provider.PrimaryIndex.Resolve(Handlers.Domain.Model);
       var table = Mapping[index.ReflectedType];
-      var columns = provider.Header.Columns.Select(column => column.Name).ToList();
+      var columns = provider.Header.Columns.Columns.Select(column => column.Name).ToList();
 
       if (provider.TopN == null) {
         fromTable = SqlDml.FreeTextTable(table, criteriaBinding.ParameterReference, columns);
@@ -66,7 +66,7 @@ namespace Xtensive.Orm.Providers.SqlServer
 
       var index = provider.PrimaryIndex.Resolve(Handlers.Domain.Model);
       var table = Mapping[index.ReflectedType];
-      var columns = provider.Header.Columns.Select(column => column.Name).ToList();
+      var columns = provider.Header.Columns.Columns.Select(column => column.Name).ToList();
 
       var targetColumnNames = provider.TargetColumns.Select(c => c.Name).ToArray();
       if (provider.TopN == null) {

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -420,7 +420,7 @@ namespace Xtensive.Orm.Providers
       var source = provider.Source is RawProvider rawProvider
             ? (ExecutableProvider) (new Rse.Providers.ExecutableRawProvider(rawProvider))
             : Compile(provider.Source);
-      var columnNames = provider.Header.Columns.Select(column => column.Name).ToArray();
+      var columnNames = provider.Header.Columns.Columns.Select(column => column.Name).ToArray();
       var descriptor = DomainHandler.TemporaryTableManager
         .BuildDescriptor(Mapping, provider.Name, provider.Header.TupleDescriptor, columnNames);
       var request = CreateQueryRequest(Driver, descriptor.QueryStatement, null, descriptor.TupleDescriptor, QueryRequestOptions.Empty);
@@ -553,7 +553,7 @@ namespace Xtensive.Orm.Providers
 
       var query = ExtractSqlSelect(provider, source);
       var rowNumber = SqlDml.RowNumber();
-      query.Columns.Add(rowNumber, header.Columns.Last().Name);
+      query.Columns.Add(rowNumber, header.Columns.Columns.Last().Name);
       var columns = ExtractColumnExpressions(query);
       foreach (var order in directionCollection)
         rowNumber.OrderBy.Add(columns[order.Key], order.Value==Direction.Positive);
@@ -592,7 +592,7 @@ namespace Xtensive.Orm.Providers
 
     protected override void Initialize()
     {
-      foreach (var column in RootProvider.Header.Columns)
+      foreach (var column in RootProvider.Header.Columns.Columns)
         rootColumns.Add(column.Origin);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
@@ -4,154 +4,91 @@
 // Created by: Alexey Kochetov
 // Created:    2007.09.24
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using Xtensive.Core;
 
+namespace Xtensive.Orm.Rse;
 
-namespace Xtensive.Orm.Rse
+/// <summary>
+/// Collection of <see cref="Column"/> items.
+/// </summary>
+[Serializable]
+public readonly struct ColumnCollection
 {
+  private readonly Dictionary<string, int> nameIndex;
+
+  public IReadOnlyList<Column> Columns { get; }
+
   /// <summary>
-  /// Collection of <see cref="Column"/> items.
+  /// Gets the number of <see href="Column"/>s in the collection.
   /// </summary>
-  [Serializable]
-  public sealed class ColumnCollection : IReadOnlyList<Column>
+  public ColNum Count => (ColNum)Columns.Count;
+
+
+  /// <summary>
+  /// Gets a <see href="Column"/> instance by its index.
+  /// </summary>
+  public Column this[int index] => Columns[index];
+
+  /// <summary>
+  /// Gets <see cref="Column"/> by provided <paramref name="fullName"/>.
+  /// </summary>
+  /// <remarks>
+  /// Returns <see cref="Column"/> if it was found; otherwise <see langword="null"/>.
+  /// </remarks>
+  /// <param name="fullName">Full name of the <see cref="Column"/> to find.</param>
+  public Column this[string fullName] =>
+    nameIndex.TryGetValue(fullName, out var index) ? Columns[index] : null;
+
+  /// <summary>
+  /// Determines whether the collecton contains specified column
+  /// </summary>
+  /// <param name="column"></param>
+  /// <returns></returns>
+  public bool Contains(Column column) =>
+    Columns is ICollection<Column> colColumns ? colColumns.Contains(column) : Columns.Contains(column);
+
+  /// <summary>
+  /// Joins this collection with specified the column collection.
+  /// </summary>
+  /// <param name="joined">The joined.</param>
+  /// <returns>The joined collection.</returns>
+  public ColumnCollection Join(IEnumerable<Column> joined)
   {
-    public struct Enumerator : IEnumerator<Column>, IEnumerator
-    {
-      private readonly IReadOnlyList<Column> list;
-      private int index;
-      public Column Current { get; private set; }
+    return new ColumnCollection(Columns.Concat(joined).ToList());
+  }
 
-      object IEnumerator.Current =>
-        index == 0 || index == list.Count + 1
-          ? throw new InvalidOperationException("Enumeration cannot happen")
-          : Current;
+  /// <summary>
+  /// Aliases the specified <see cref="Column"/> collection.
+  /// </summary>
+  /// <param name="alias">The alias to add.</param>
+  /// <returns>Aliased collection of columns.</returns>
+  public ColumnCollection Alias(string alias)
+  {
+    ArgumentException.ThrowIfNullOrEmpty(alias);
+    return new ColumnCollection(Columns.Select(column => column.Clone(alias + "." + column.Name)).ToArray(Count));
+  }
 
-      public void Dispose()
-      {
-      }
+  // Constructors
 
-      public bool MoveNext()
-      {
-        if (index < list.Count) {
-          Current = list[index++];
-          return true;
-        }
-        index = list.Count + 1;
-        Current = default;
-        return false;
-      }
-
-      void IEnumerator.Reset()
-      {
-        index = 0;
-        Current = default;
-      }
-
-      internal Enumerator(IReadOnlyList<Column> list)
-      {
-        this.list = list;
-        index = 0;
-        Current = default;
-      }
-    }
-
-    private readonly Dictionary<string, int> nameIndex;
-    private readonly IReadOnlyList<Column> columns;
-
-    /// <summary>
-    /// Gets the number of <see href="Column"/>s in the collection.
-    /// </summary>
-    public ColNum Count => (ColNum)columns.Count;
-
-    int IReadOnlyCollection<Column>.Count => columns.Count;
-
-    /// <summary>
-    /// Gets a <see href="Column"/> instance by its index.
-    /// </summary>
-    public Column this[int index] => columns[index];
-
-    /// <summary>
-    /// Gets <see cref="Column"/> by provided <paramref name="fullName"/>.
-    /// </summary>
-    /// <remarks>
-    /// Returns <see cref="Column"/> if it was found; otherwise <see langword="null"/>.
-    /// </remarks>
-    /// <param name="fullName">Full name of the <see cref="Column"/> to find.</param>
-    public Column this[string fullName] =>
-      nameIndex.TryGetValue(fullName, out var index) ? columns[index] : null;
-
-    /// <summary>
-    /// Determines whether the collecton contains specified column
-    /// </summary>
-    /// <param name="column"></param>
-    /// <returns></returns>
-    public bool Contains(Column column)
-    {
-      if (columns is ICollection<Column> colColumns)
-        return colColumns.Contains(column);
-      return columns.Contains(column);
-    }
-
-    /// <summary>
-    /// Joins this collection with specified the column collection.
-    /// </summary>
-    /// <param name="joined">The joined.</param>
-    /// <returns>The joined collection.</returns>
-    public ColumnCollection Join(IEnumerable<Column> joined)
-    {
-      return new ColumnCollection(this.Concat(joined).ToList());
-    }
-
-    /// <summary>
-    /// Aliases the specified <see cref="Column"/> collection.
-    /// </summary>
-    /// <param name="alias">The alias to add.</param>
-    /// <returns>Aliased collection of columns.</returns>
-    public ColumnCollection Alias(string alias)
-    {
-      ArgumentException.ThrowIfNullOrEmpty(alias);
-      return new ColumnCollection(this.Select(column => column.Clone(alias + "." + column.Name)).ToArray(Count));
-    }
-
-    /// <summary>
-    /// Returns an enumerator that iterates through the <see href="ColumnCollection"/>.
-    /// </summary>
-    public Enumerator GetEnumerator() => new Enumerator(this);
-
-    /// <summary>
-    /// Returns an enumerator that iterates through the <see href="ColumnCollection"/>.
-    /// </summary>
-    IEnumerator<Column> IEnumerable<Column>.GetEnumerator() => GetEnumerator();
-
-    /// <inheritdoc/>
-    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-    // Constructors
-
-    /// <summary>
-    /// Initializes a new instance of this class.
-    /// </summary>
-    /// <param name="columns">Collection of items to add.</param>
-    /// <remarks>
-    /// <paramref name="columns"/> is used to initialize inner field directly
-    /// to save time on avoiding collection copy. If you pass an <see cref="IReadOnlyList{Column}"/>
-    /// implementor that, in fact, can be changed, make sure the passed collection doesn't change afterwards.
-    /// Ideally, use arrays instead of <see cref="List{T}"/> or similar collections.
-    /// Changing the passed collection afterwards will lead to unpredictable results.
-    /// </remarks>
-    public ColumnCollection(IReadOnlyList<Column> columns)
-    {
-      //!!! Direct initialization by parameter is unsafe performance optimization: See remarks in ctor summary!
-      this.columns = columns;
-      var count = this.columns.Count;
-      nameIndex = new Dictionary<string, int>(count);
-      for (var index = count; index-- > 0;) {
-        nameIndex.Add(this.columns[index].Name, index);
-      }
+  /// <summary>
+  /// Initializes a new instance of this class.
+  /// </summary>
+  /// <param name="columns">Collection of items to add.</param>
+  /// <remarks>
+  /// <paramref name="columns"/> is used to initialize inner field directly
+  /// to save time on avoiding collection copy. If you pass an <see cref="IReadOnlyList{Column}"/>
+  /// implementor that, in fact, can be changed, make sure the passed collection doesn't change afterwards.
+  /// Ideally, use arrays instead of <see cref="List{T}"/> or similar collections.
+  /// Changing the passed collection afterwards will lead to unpredictable results.
+  /// </remarks>
+  public ColumnCollection(IReadOnlyList<Column> columns)
+  {
+    //!!! Direct initialization by parameter is unsafe performance optimization: See remarks in ctor summary!
+    Columns = columns;
+    var count = Columns.Count;
+    nameIndex = new Dictionary<string, int>(count);
+    for (var index = count; index-- > 0;) {
+      nameIndex.Add(Columns[index].Name, index);
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/SelectProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/SelectProvider.cs
@@ -32,7 +32,7 @@ namespace Xtensive.Orm.Rse.Providers
     /// <inheritdoc/>
     protected override string ParametersToString()
     {
-      return Header.Columns.Select(c => c.Name).ToCommaDelimitedString();
+      return Header.Columns.Columns.Select(c => c.Name).ToCommaDelimitedString();
     }
 
     internal override Provider Visit(ProviderVisitor visitor) => visitor.VisitSelect(this);

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -64,7 +64,7 @@ namespace Xtensive.Orm.Rse
       ColumnCollection resultColumns = Columns.Alias(alias);
 
       return new RecordSetHeader(
-        TupleDescriptor, resultColumns, ColumnGroups, OrderTupleDescriptor, Order);
+        TupleDescriptor, resultColumns.Columns, ColumnGroups, OrderTupleDescriptor, Order);
     }
 
     /// <summary>
@@ -75,7 +75,7 @@ namespace Xtensive.Orm.Rse
     public RecordSetHeader Add(Column column)
     {
       var newColumns = new List<Column>(Columns.Count + 1);
-      newColumns.AddRange(Columns);
+      newColumns.AddRange(Columns.Columns);
       newColumns.Add(column);
 
       var newTupleDescriptor = CreateTupleDescriptor(newColumns);
@@ -96,7 +96,7 @@ namespace Xtensive.Orm.Rse
     public RecordSetHeader Add(IReadOnlyList<Column> columns)
     {
       var n = Columns.Count + columns.Count;
-      var newColumns = Columns.Concat(columns).ToArray(n);
+      var newColumns = Columns.Columns.Concat(columns).ToArray(n);
 
       var newTupleDescriptor = CreateTupleDescriptor(newColumns);
 
@@ -118,10 +118,10 @@ namespace Xtensive.Orm.Rse
       var columnCount = Columns.Count;
       var newColumns = new Column[columnCount + joined.Columns.Count];
       int j = 0;
-      foreach (var c in Columns) {
+      foreach (var c in Columns.Columns) {
         newColumns[j++] = c;
       }
-      foreach (var c in joined.Columns) {
+      foreach (var c in joined.Columns.Columns) {
         newColumns[j++] = c.Clone((ColNum) (columnCount + c.Index));
       }
 
@@ -201,7 +201,7 @@ namespace Xtensive.Orm.Rse
     {
       return new RecordSetHeader(
         TupleDescriptor,
-        Columns,
+        Columns.Columns,
         ColumnGroups,
         TupleDescriptor,
         sortOrder);
@@ -269,7 +269,7 @@ namespace Xtensive.Orm.Rse
     /// <inheritdoc/>
     public override string ToString()
     {
-      return Columns.Select(c => c.ToString()).ToCommaDelimitedString();
+      return Columns.Columns.Select(c => c.ToString()).ToCommaDelimitedString();
     }
 
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
@@ -42,7 +42,7 @@ namespace Xtensive.Orm.Rse.Transformation
       var source = VisitCompilable(provider.Source);
 
       var currentMapping = mappings[provider.Source];
-      var calulatedColumn = provider.Header.Columns.Last();
+      var calulatedColumn = provider.Header.Columns.Columns.Last();
       mappings[provider] = Merge(currentMapping, [calulatedColumn.Index]);
       if (source == provider.Source) {
         return provider;
@@ -260,7 +260,7 @@ namespace Xtensive.Orm.Rse.Transformation
       using ColumnMap sourceMap = new(mappings[provider.Source]);
       var currentMap = mappings[provider];
 
-      mappings[provider] = provider.Header.Columns.Select(c => c.Index).ToList(provider.Header.Columns.Count);
+      mappings[provider] = provider.Header.Columns.Columns.Select(c => c.Index).ToList(provider.Header.Columns.Count);
 
       if (source == provider.Source) {
         return provider;
@@ -325,7 +325,7 @@ namespace Xtensive.Orm.Rse.Transformation
       mappings[provider.Source] = mappings[provider].Where(i => i < sourceLength).ToList();
       var newSource = VisitCompilable(provider.Source);
       var currentMapping = mappings[provider.Source];
-      var rowNumberColumn = provider.Header.Columns.Last();
+      var rowNumberColumn = provider.Header.Columns.Columns.Last();
       mappings[provider] = Merge(currentMapping, [rowNumberColumn.Index]);
       return newSource == provider.Source
         ? provider
@@ -340,7 +340,7 @@ namespace Xtensive.Orm.Rse.Transformation
 
       if (hasGrouping) {
         mappings.Add(provider.Sources[0],
-          Merge(mappings[provider], provider.Header.Columns.Select((c, i) => (ColNum)i)));
+          Merge(mappings[provider], provider.Header.Columns.Columns.Select((c, i) => (ColNum)i)));
       }
       else {
         OnRecursionEntrance(provider);

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyFilterRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyFilterRewriter.cs
@@ -36,7 +36,7 @@ namespace Xtensive.Orm.Rse.Transformation
         var sourceIndex = mc.GetTupleAccessArgument();
         if (mc.GetApplyParameter() != null)
           return Expression.Call(LeftTupleParameter, mc.Method, mc.Arguments[0]);
-        var name = sourceColumns.Single(column => column.Index == sourceIndex).Name;
+        var name = sourceColumns.Columns.Single(column => column.Index == sourceIndex).Name;
         int currentIndex = targetColumns[name].Index;
         return Expression.Call(mc.Object, mc.Method, Expr.Constant(currentIndex));
       }
@@ -47,8 +47,6 @@ namespace Xtensive.Orm.Rse.Transformation
       ColumnCollection predicateColumns, ColumnCollection currentColumns)
     {
       ArgumentNullException.ThrowIfNull(predicate);
-      ArgumentNullException.ThrowIfNull(predicateColumns);
-      ArgumentNullException.ThrowIfNull(currentColumns);
       if (predicateColumns.Count == 0)
         throw Exceptions.CollectionIsEmpty("predicateColumns");
       if (currentColumns.Count == 0)

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyPredicateCollector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyPredicateCollector.cs
@@ -46,7 +46,7 @@ namespace Xtensive.Orm.Rse.Transformation
       if (CheckPredicatesExist()) {
         foreach (var parameterPair in owner.State.Predicates)
           foreach (var predicatePair in parameterPair.Value)
-            foreach (var column in predicatePair.Item2)
+            foreach (var column in predicatePair.Item2.Columns)
               if (provider.GroupColumnIndexes.Contains(column.Index)) {
                 ApplyProviderCorrectorRewriter.ThrowInvalidOperationException(
                   Strings.ExColumnsUsedByPredicateContainingApplyParameterAreRemoved);

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyProviderCorrectorRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyProviderCorrectorRewriter.cs
@@ -414,7 +414,7 @@ namespace Xtensive.Orm.Rse.Transformation
         column => {
           var newColumnExpression = (Expression<Func<Tuple, object>>) calculateExpressionRewriter
             .Rewrite(column.Expression, column.Expression.Parameters[0], columnCollection, sourceHeaderColumns);
-          var currentName = columnCollection.Single(c => c.Index==column.Index).Name;
+          var currentName = columnCollection.Columns.Single(c => c.Index==column.Index).Name;
           return new CalculatedColumnDescriptor(currentName, column.Type, newColumnExpression);
         });
       return source.Calculate(ccd.ToArray());

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/CalculateRelatedExpressionRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/CalculateRelatedExpressionRewriter.cs
@@ -25,8 +25,6 @@ namespace Xtensive.Orm.Rse.Transformation
     {
       ArgumentNullException.ThrowIfNull(expression);
       ArgumentNullException.ThrowIfNull(substituteParameter);
-      ArgumentNullException.ThrowIfNull(sourceColumns);
-      ArgumentNullException.ThrowIfNull(targetColumns);
       substitute = substituteParameter;
       this.sourceColumns = sourceColumns;
       this.targetColumns = targetColumns;
@@ -46,7 +44,7 @@ namespace Xtensive.Orm.Rse.Transformation
       if (mc.Object.NodeType == ExpressionType.Parameter
         && mc.Object.Type == WellKnownOrmTypes.Tuple) {
         var sourceIndex = visited.GetTupleAccessArgument();
-        var name = sourceColumns.Single(column => column.Index == sourceIndex).Name;
+        var name = sourceColumns.Columns.Single(column => column.Index == sourceIndex).Name;
         int currentIndex = targetColumns[name].Index;
         return Expression.Call(visited.Object, visited.Method, Expr.Constant(currentIndex));
       }

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/CollectorHelper.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/CollectorHelper.cs
@@ -69,7 +69,7 @@ namespace Xtensive.Orm.Rse.Transformation
     {
       foreach (var providerPair in currentState)
         foreach (var predicatePair in providerPair.Value)
-          if (!CheckPresenceOfOldColumns(predicatePair.Item2, mappedColumns))
+          if (!CheckPresenceOfOldColumns(predicatePair.Item2.Columns, mappedColumns))
             ApplyProviderCorrectorRewriter.ThrowInvalidOperationException(descriptionProvider());
     }
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/SkipTakeRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/SkipTakeRewriter.cs
@@ -40,7 +40,7 @@ namespace Xtensive.Orm.Rse.Transformation
         if (requiresRowNumber) {
           // Arrray to avoid access to modified closure
           string[] columnName = {String.Format(Strings.RowNumberX, rowNumberCount++)};
-          while (visitedProvider.Header.Columns.Any(column => column.Name==columnName[0]))
+          while (visitedProvider.Header.Columns.Columns.Any(column => column.Name==columnName[0]))
             columnName[0] = String.Format(Strings.RowNumberX, rowNumberCount++);
           visitedProvider = new RowNumberProvider(visitedProvider, columnName[0]);
         }


### PR DESCRIPTION
According a Dump we have `182,304`  instances of this type in memory.
`class` type overhead over `struct` is 24 bytes.
Converting it into `readonly struct` will save >4MB

Also:
* Introduced a new property `ColumnCollection.Columns` as a replacement of removed inheriting of `IReadOnlyList<Column>`
