### PR TITLE
Optimize `PersistRequest`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/CommandFactory.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/CommandFactory.cs
@@ -54,7 +54,7 @@ namespace Xtensive.Orm.Providers
       var result = new List<CommandPart>(task.RequestSequence.Count);
       int parameterIndex = 0;
       foreach (var request in task.RequestSequence) {
-        var compilationResult = request.GetCompiledStatement();
+        var compilationResult = request.CompiledStatement;
         var configuration = shareStorageNodesOverNodes
           ? new SqlPostCompilerConfiguration(nodeConfiguration.GetDatabaseMapping(), nodeConfiguration.GetSchemaMapping())
           : new SqlPostCompilerConfiguration();

--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/SqlPersistTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/SqlPersistTask.cs
@@ -26,7 +26,7 @@ namespace Xtensive.Orm.Providers
     /// <summary>
     /// Requests to execute.
     /// </summary>
-    public readonly IReadOnlyCollection<PersistRequest> RequestSequence;
+    public readonly IReadOnlyCollection<PreparedPersistRequest> RequestSequence;
 
     /// <summary>
     /// A tuple that stores changed column values.
@@ -57,38 +57,38 @@ namespace Xtensive.Orm.Providers
 
     // Constructors
 
-    public SqlPersistTask(PersistRequest request, Tuple tuple = null)
+    public SqlPersistTask(PreparedPersistRequest request, Tuple tuple = null)
     {
-      RequestSequence = new PersistRequest[1] { request };
+      RequestSequence = [request];
       Tuple = tuple;
     }
 
-    public SqlPersistTask(PersistRequest request, IReadOnlyList<Tuple> tuples)
+    public SqlPersistTask(PreparedPersistRequest request, IReadOnlyList<Tuple> tuples)
     {
-      RequestSequence = new PersistRequest[1] { request };
+      RequestSequence = [request];
       Tuples = tuples;
     }
 
     [Obsolete]
-    public SqlPersistTask(Key key, IEnumerable<PersistRequest> requestSequence, Tuple tuple)
-      : this(key, (requestSequence as IReadOnlyCollection<PersistRequest>)?? requestSequence.ToList(), tuple)
+    public SqlPersistTask(Key key, IEnumerable<PreparedPersistRequest> requestSequence, Tuple tuple)
+      : this(key, (requestSequence as IReadOnlyCollection<PreparedPersistRequest>)?? requestSequence.ToList(), tuple)
     {
     }
 
     [Obsolete]
-    public SqlPersistTask(Key key, IEnumerable<PersistRequest> requestSequence, Tuple tuple, Tuple originalTuple, bool validateRowCount)
-      : this(key, (requestSequence as IReadOnlyCollection<PersistRequest>) ?? requestSequence.ToList(), tuple, originalTuple, validateRowCount)
+    public SqlPersistTask(Key key, IEnumerable<PreparedPersistRequest> requestSequence, Tuple tuple, Tuple originalTuple, bool validateRowCount)
+      : this(key, (requestSequence as IReadOnlyCollection<PreparedPersistRequest>) ?? requestSequence.ToList(), tuple, originalTuple, validateRowCount)
     {
     }
 
-    public SqlPersistTask(Key key, IReadOnlyCollection<PersistRequest> requestSequence, Tuple tuple)
+    public SqlPersistTask(Key key, IReadOnlyCollection<PreparedPersistRequest> requestSequence, Tuple tuple)
     {
       EntityKey = key;
       RequestSequence = requestSequence;
       Tuple = tuple;
     }
 
-    public SqlPersistTask(Key key, IReadOnlyCollection<PersistRequest> requestSequence, Tuple tuple, Tuple originalTuple, bool validateRowCount)
+    public SqlPersistTask(Key key, IReadOnlyCollection<PreparedPersistRequest> requestSequence, Tuple tuple, Tuple originalTuple, bool validateRowCount)
     {
       EntityKey = key;
       RequestSequence = requestSequence;

--- a/Orm/Xtensive.Orm/Orm/Providers/Interfaces/IPersistDescriptors.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Interfaces/IPersistDescriptors.cs
@@ -13,12 +13,12 @@ namespace Xtensive.Orm.Providers
     /// <summary>
     /// Request to store data.
     /// </summary>
-    PersistRequest StoreRequest { get; }
+    PreparedPersistRequest StoreRequest { get; }
 
     /// <summary>
     /// Request to clear data.
     /// </summary>
-    PersistRequest ClearRequest { get; }
+    PreparedPersistRequest ClearRequest { get; }
   }
 
   public interface IMultiRecordPersistDescriptor : IPersistDescriptor
@@ -28,7 +28,7 @@ namespace Xtensive.Orm.Providers
     /// protion can't be stored by neither <see cref="StoreBigBatchRequest"/>
     /// nor <see cref="StoreSmallBatchRequest"/>.
     /// </summary>
-    Lazy<PersistRequest> StoreSingleRecordRequest { get { return new Lazy<PersistRequest>(StoreRequest); } }
+    Lazy<PreparedPersistRequest> StoreSingleRecordRequest => new(StoreRequest);
 
     /// <summary>
     /// Request that stores smaller portion of data at a time.
@@ -36,7 +36,7 @@ namespace Xtensive.Orm.Providers
     /// due to smaller size. When data portion size becomes smaller than the reqired by
     /// this request the <see cref="StoreSingleRecordRequest"/> will be used.
     /// </summary>
-    Lazy<PersistRequest> StoreSmallBatchRequest { get; }
+    Lazy<PreparedPersistRequest> StoreSmallBatchRequest { get; }
 
     /// <summary>
     /// Request that stores big portion of data at a time. The request is used
@@ -44,6 +44,6 @@ namespace Xtensive.Orm.Providers
     /// <see cref="StoreSmallBatchRequest"/> or even <see cref="StoreSingleRecordRequest" />
     /// will be used.
     /// </summary>
-    Lazy<PersistRequest> StoreBigBatchRequest { get; }
+    Lazy<PreparedPersistRequest> StoreBigBatchRequest { get; }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/Persister.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Persister.cs
@@ -93,14 +93,8 @@ namespace Xtensive.Orm.Providers
       }
     }
 
-    private IReadOnlyCollection<PersistRequest> GetOrBuildRequest(StorageNode node, PersistRequestBuilderTask task)
-    {
-      var cache = node.PersistRequestCache;
-      if (cache.TryGetValue(task, out var result))
-        return result;
-      result = requestBuilder.Build(node, task);
-      return cache.TryAdd(task, result) ? result : cache[task];
-    }
+    private IReadOnlyCollection<PreparedPersistRequest> GetOrBuildRequest(StorageNode node, PersistRequestBuilderTask task) =>
+      node.PersistRequestCache.GetOrAdd(task, static (t, x) => x.requestBuilder.Build(x.node, t), (requestBuilder, node));
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequest.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequest.cs
@@ -4,59 +4,49 @@
 // Created by: Dmitri Maximov
 // Created:    2008.08.22
 
-using System;
-using System.Collections.Generic;
 using Xtensive.Core;
 using Xtensive.Orm.Configuration;
 using Xtensive.Sql;
 using Xtensive.Sql.Compiler;
 
-namespace Xtensive.Orm.Providers
+namespace Xtensive.Orm.Providers;
+
+public record struct PreparedPersistRequest(
+  SqlCompilationResult CompiledStatement,
+  IReadOnlyCollection<PersistParameterBinding> ParameterBindings
+);
+
+/// <summary>
+/// Modification (INSERT, UPDATE, DELETE) request.
+/// </summary>
+public readonly struct PersistRequest
 {
-  /// <summary>
-  /// Modification (INSERT, UPDATE, DELETE) request.
-  /// </summary>
-  public sealed class PersistRequest
+  private static readonly IReadOnlySet<PersistParameterBinding> EmptyBindings = new HashSet<PersistParameterBinding>();
+
+  private readonly StorageDriver driver;
+
+  public SqlStatement Statement { get; }
+
+  public ISqlCompileUnit CompileUnit { get; }
+
+  public IReadOnlyCollection<PersistParameterBinding> ParameterBindings { get; }
+
+  public PreparedPersistRequest Prepare() => new(driver.Compile(CompileUnit), ParameterBindings);
+
+  // Constructors
+
+  public PersistRequest(
+    StorageDriver driver, SqlStatement statement, IReadOnlySet<PersistParameterBinding> parameterBindings)
   {
-    private static readonly IReadOnlySet<PersistParameterBinding> EmptyBindings = new HashSet<PersistParameterBinding>();
+    ArgumentNullException.ThrowIfNull(driver);
+    ArgumentNullException.ThrowIfNull(statement);
 
-    private readonly StorageDriver driver;
+    var compileUnit = statement as ISqlCompileUnit
+      ?? throw new ArgumentException("Statement is not ISqlCompileUnit");
 
-    private SqlCompilationResult compiledStatement;
-
-    public SqlStatement Statement { get; private set; }
-
-    public ISqlCompileUnit CompileUnit { get; private set; }
-
-    public IReadOnlyCollection<PersistParameterBinding> ParameterBindings { get; }
-
-    public SqlCompilationResult GetCompiledStatement() =>
-      compiledStatement ?? throw new InvalidOperationException(Strings.ExRequestIsNotPrepared);
-
-    public void Prepare()
-    {
-      if (compiledStatement != null)
-        return;
-      compiledStatement = driver.Compile(CompileUnit);
-      CompileUnit = null;
-      Statement = null;
-    }
-
-    // Constructors
-
-    public PersistRequest(
-      StorageDriver driver, SqlStatement statement, IReadOnlySet<PersistParameterBinding> parameterBindings)
-    {
-      ArgumentNullException.ThrowIfNull(driver);
-      ArgumentNullException.ThrowIfNull(statement);
-
-      var compileUnit = statement as ISqlCompileUnit
-        ?? throw new ArgumentException("Statement is not ISqlCompileUnit");
-
-      this.driver = driver;
-      Statement = statement;
-      CompileUnit = compileUnit;
-      ParameterBindings = parameterBindings ?? EmptyBindings;
-    }
+    this.driver = driver;
+    Statement = statement;
+    CompileUnit = compileUnit;
+    ParameterBindings = parameterBindings ?? EmptyBindings;
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilder.cs
@@ -24,7 +24,7 @@ namespace Xtensive.Orm.Providers
     private ProviderInfo providerInfo;
     private StorageDriver driver;
 
-    internal IReadOnlyList<PersistRequest> Build(StorageNode node, PersistRequestBuilderTask task)
+    internal IReadOnlyList<PreparedPersistRequest> Build(StorageNode node, PersistRequestBuilderTask task)
     {
       var context = new PersistRequestBuilderContext(task, node.Mapping, node.Configuration);
       List<PersistRequest> result;
@@ -52,15 +52,10 @@ namespace Xtensive.Orm.Providers
           bindings.UnionWith(request.ParameterBindings);
         }
         var batchRequest = new PersistRequest(driver, batch, bindings);
-        batchRequest.Prepare();
-        return new List<PersistRequest> { batchRequest }.AsSafeWrapper();
+        return [batchRequest.Prepare()];
       }
 
-      foreach (var item in result) {
-        item.Prepare();
-      }
-
-      return result.AsSafeWrapper();
+      return result.Select(request => request.Prepare()).ToArray();
     }
 
     protected virtual List<PersistRequest> BuildInsertRequest(in PersistRequestBuilderContext context)

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilderTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilderTask.cs
@@ -5,7 +5,6 @@
 // Created:    2008.08.29
 
 using System.Collections;
-using Microsoft.VisualBasic;
 using Xtensive.Orm.Model;
 
 namespace Xtensive.Orm.Providers

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilderTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestBuilderTask.cs
@@ -4,8 +4,8 @@
 // Created by: Dmitri Maximov
 // Created:    2008.08.29
 
-using System;
 using System.Collections;
+using Microsoft.VisualBasic;
 using Xtensive.Orm.Model;
 
 namespace Xtensive.Orm.Providers
@@ -13,52 +13,46 @@ namespace Xtensive.Orm.Providers
   /// <summary>
   /// A task for <see cref="PersistRequestBuilder"/>.
   /// </summary>
-  public sealed class PersistRequestBuilderTask
+  public sealed class PersistRequestBuilderTask : IEquatable<PersistRequestBuilderTask>
   {
     private readonly int hashCode;
 
     /// <summary>
     /// Gets the type.
     /// </summary>
-    public TypeInfo Type { get; private set; }
+    public TypeInfo Type { get; }
 
     /// <summary>
     /// Gets the field map that describes updated fields.
     /// </summary>
-    public BitArray ChangedFields { get; private set; }
+    public BitArray ChangedFields { get; }
 
     /// <summary>
     /// Gets the field map that describes available (fetched) fields.
     /// </summary>
-    public BitArray AvailableFields { get; private set; }
+    public BitArray AvailableFields { get; }
 
     /// <summary>
     /// Gets the <see cref="PersistRequestKind"/>.
     /// </summary>
-    public PersistRequestKind Kind { get; private set; }
+    public PersistRequestKind Kind { get; }
 
     /// <summary>
     /// Gets flag indicating if validation should be performed.
     /// </summary>
-    public bool ValidateVersion { get; private set; }
+    public bool ValidateVersion { get; }
+
+    public bool Equals(PersistRequestBuilderTask other) =>
+      ReferenceEquals(this, other)
+        || other is not null
+          && Type == other.Type
+          && Kind == other.Kind
+          && ValidateVersion == other.ValidateVersion
+          && CompareBits(AvailableFields, other.AvailableFields)
+          && CompareBits(ChangedFields, other.ChangedFields);
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
-    {
-      if (ReferenceEquals(this, obj))
-        return true;
-      if (obj is PersistRequestBuilderTask other) {
-        if (Type != other.Type)
-          return false;
-        if (Kind != other.Kind)
-          return false;
-        if (ValidateVersion != other.ValidateVersion)
-          return false;
-        return CompareBits(AvailableFields, other.AvailableFields)
-          && CompareBits(ChangedFields, other.ChangedFields);
-      }
-      return false;
-    }
+    public override bool Equals(object obj) => obj is PersistRequestBuilderTask other && Equals(other);
 
     /// <inheritdoc/>
     public override int GetHashCode() => hashCode;
@@ -78,11 +72,11 @@ namespace Xtensive.Orm.Providers
 
     private bool CompareBits(BitArray left, BitArray right)
     {
-      if (left==null && right==null)
+      if (left == null && right == null)
         return true;
-      if (left!=null && right!=null && left.Count==right.Count) {
-        for (var i = 0; i < left.Count; i++)
-          if (left[i]!=right[i])
+      if (left != null && right != null && left.Count == right.Count) {
+        for (int i = 0, n = left.Count; i < n; i++)
+          if (left[i] != right[i])
             return false;
         return true;
       }

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestKind.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/PersistRequestKind.cs
@@ -9,7 +9,7 @@ namespace Xtensive.Orm.Providers
   /// <summary>
   /// Kinds of <see cref="PersistRequest"/>.
   /// </summary>
-  public enum PersistRequestKind
+  public enum PersistRequestKind : sbyte
   {
     /// <summary>
     /// Insert request.

--- a/Orm/Xtensive.Orm/Orm/Providers/TemporaryTables/TemporaryTableDescriptor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/TemporaryTables/TemporaryTableDescriptor.cs
@@ -41,37 +41,37 @@ namespace Xtensive.Orm.Providers
     /// <summary>
     /// Gets or sets the persist request used to store batched data in temporary table.
     /// </summary>
-    public Lazy<PersistRequest> LazyLevel1BatchStoreRequest { get; set; }
+    public Lazy<PreparedPersistRequest> LazyLevel1BatchStoreRequest { get; set; }
 
     /// <summary>
     /// Gets or sets the persist request used to store batched data in temporary table.
     /// </summary>
-    public Lazy<PersistRequest> LazyLevel2BatchStoreRequest { get; set; }
+    public Lazy<PreparedPersistRequest> LazyLevel2BatchStoreRequest { get; set; }
 
     /// <summary>
     /// Gets or sets the persist request used to store data in temporary table.
     /// </summary>
-    public Lazy<PersistRequest> StoreSingleRecordRequest { get; set; }
+    public Lazy<PreparedPersistRequest> StoreSingleRecordRequest { get; set; }
 
     /// <summary>
     /// Gets or sets the persist request used to store batched data in temporary table.
     /// </summary>
-    public Lazy<PersistRequest> StoreSmallBatchRequest { get; set; }
+    public Lazy<PreparedPersistRequest> StoreSmallBatchRequest { get; set; }
 
     /// <summary>
     /// Gets or sets the persist request used to store batched data in temporary table.
     /// </summary>
-    public Lazy<PersistRequest> StoreBigBatchRequest { get; set; }
+    public Lazy<PreparedPersistRequest> StoreBigBatchRequest { get; set; }
 
     /// <summary>
     /// Gets the persist request used to store data in temporary table.
     /// </summary>
-    PersistRequest IPersistDescriptor.StoreRequest => StoreSingleRecordRequest.Value;
+    PreparedPersistRequest IPersistDescriptor.StoreRequest => StoreSingleRecordRequest.Value;
 
     /// <summary>
     /// Gets or sets the clear reqest used to delete all data from temporary table.
     /// </summary>
-    public PersistRequest ClearRequest { get; set; }
+    public PreparedPersistRequest ClearRequest { get; set; }
 
     /// <summary>
     /// Gets or sets the query statement associated with this table descriptor.

--- a/Orm/Xtensive.Orm/Orm/Providers/TemporaryTables/TemporaryTableManager.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/TemporaryTables/TemporaryTableManager.cs
@@ -99,20 +99,17 @@ namespace Xtensive.Orm.Providers
         StoreSmallBatchRequest = CreateLazyPersistRequest(WellKnown.MultiRowInsertSmallBatchSize),
         StoreBigBatchRequest = CreateLazyPersistRequest(WellKnown.MultiRowInsertBigBatchSize),
 
-        ClearRequest = new PersistRequest(Handlers.StorageDriver, useTruncate ? SqlDdl.Truncate(table) : SqlDml.Delete(tableRef), null),
+        ClearRequest = new PersistRequest(Handlers.StorageDriver, useTruncate ? SqlDdl.Truncate(table) : SqlDml.Delete(tableRef), null).Prepare(),
       };
-
-      result.ClearRequest.Prepare();
 
       return result;
 
-      Lazy<PersistRequest> CreateLazyPersistRequest(ushort batchSize)
+      Lazy<PreparedPersistRequest> CreateLazyPersistRequest(ushort batchSize)
       {
-        return new Lazy<PersistRequest>(() => {
+        return new Lazy<PreparedPersistRequest>(() => {
           var bindings = new HashSet<PersistParameterBinding>(batchSize);
           var statement = MakeUpInsertQuery(tableRef, typeMappings, bindings, hasColumns, batchSize);
-          var persistRequest = new PersistRequest(driver, statement, bindings);
-          persistRequest.Prepare();
+          var persistRequest = new PersistRequest(driver, statement, bindings).Prepare();
           return persistRequest;
         });
       }

--- a/Orm/Xtensive.Orm/Orm/StorageNode.cs
+++ b/Orm/Xtensive.Orm/Orm/StorageNode.cs
@@ -73,7 +73,7 @@ namespace Xtensive.Orm
     /// </summary>
     internal ConcurrentDictionary<AssociationInfo, (CompilableProvider, Parameter<Xtensive.Tuples.Tuple>)> RefsToEntityQueryCache { get; } = new();
     internal ConcurrentDictionary<SequenceInfo, CachingSequence> KeySequencesCache { get; } = new();
-    internal ConcurrentDictionary<PersistRequestBuilderTask, IReadOnlyList<PersistRequest>> PersistRequestCache { get; } = new();
+    internal ConcurrentDictionary<PersistRequestBuilderTask, IReadOnlyList<PreparedPersistRequest>> PersistRequestCache { get; } = new();
 
     /// <inheritdoc/>
     public Session OpenSession() =>

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/MetadataWriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/Metadata/MetadataWriter.cs
@@ -25,8 +25,8 @@ namespace Xtensive.Orm.Upgrade
 
     private sealed class Descriptor : IPersistDescriptor
     {
-      public PersistRequest StoreRequest { get; set; }
-      public PersistRequest ClearRequest { get; set; }
+      public PreparedPersistRequest StoreRequest { get; set; }
+      public PreparedPersistRequest ClearRequest { get; set; }
     }
 
     private readonly StorageDriver driver;
@@ -119,14 +119,10 @@ namespace Xtensive.Orm.Upgrade
       insert.ValueRows.Add(row);
 
       var delete = SqlDml.Delete(tableRef);
-      if (deleteTransform!=null)
-        deleteTransform.Invoke(delete);
+      deleteTransform?.Invoke(delete);
 
-      var storeRequest = new PersistRequest(driver, insert, bindings);
-      var clearRequest = new PersistRequest(driver, delete, null);
-
-      storeRequest.Prepare();
-      clearRequest.Prepare();
+      var storeRequest = new PersistRequest(driver, insert, bindings).Prepare();
+      var clearRequest = new PersistRequest(driver, delete, null).Prepare();
 
       return new Descriptor {
         StoreRequest = storeRequest,


### PR DESCRIPTION
Split it into two immutable types:
* `record struct PreparedPersistRequest`
* `readonly struct PersistRequest`

Because of two stages of request preparation.

There were ~40K retained instances.
This optimization will save >1MB

Also:
* Make `PersistRequestBuilderTask` immutable
* Make `PersistRequestKind` `sbyte enum` to reduce size of `PersistRequestBuilderTask`.
