### PR TITLE
Optimize `RecordSetHeader.Order` - use static empty instance when there is no order

### DIFF
--- a/Orm/Xtensive.Orm/Collections/FlagCollection.cs
+++ b/Orm/Xtensive.Orm/Collections/FlagCollection.cs
@@ -232,15 +232,12 @@ namespace Xtensive.Collections
     /// <inheritdoc/>
     public IEnumerator<KeyValuePair<TKey, TFlag>> GetEnumerator()
     {
-      for (int i = 0; i < keys.Count; i++)
+      for (int i = 0, count = keys.Count; i < count; i++)
         yield return new KeyValuePair<TKey, TFlag>(keys[i], Converter.ConvertBackward(flags[1 << i]));
     }
 
     /// <inheritdoc/>
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-      return ((IEnumerable<KeyValuePair<TKey, TFlag>>)this).GetEnumerator();
-    }
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -4,7 +4,6 @@
 // Created by: Alexey Kochetov
 // Created:    2007.09.13
 
-using System.Buffers;
 using Xtensive.Collections;
 using Xtensive.Core;
 using Xtensive.Orm.Model;
@@ -20,6 +19,8 @@ namespace Xtensive.Orm.Rse
   [Serializable]
   public sealed class RecordSetHeader
   {
+    private static readonly DirectionCollection<ColNum> EmptyOrder = new();
+
     private TupleDescriptor orderTupleDescriptor;
 
     /// <summary>
@@ -344,8 +345,17 @@ namespace Xtensive.Orm.Rse
 
       ColumnGroups = columnGroups ?? [];
       orderTupleDescriptor = orderKeyDescriptor ?? TupleDescriptor.Empty;
-      Order = order ?? new DirectionCollection<ColNum>();
-      Order.Lock(true);
+      if (order != null) {
+        (Order = order).Lock();
+      }
+      else {
+        Order = EmptyOrder;
+      }
+    }
+
+    static RecordSetHeader()
+    {
+      EmptyOrder.Lock();
     }
   }
 }


### PR DESCRIPTION
There are 150K instances of `DirectionCollection<ColNum> Order` in RAM.

And often they are "default" empty 
