### PR TITLE
Process `ReadOnlySpan<Key>` case (appears with .NET `9.0.200` SDK)

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -1849,11 +1849,10 @@ namespace Xtensive.Orm.Linq
       return nullableFields;
     }
 
-    private bool IsKeyCollection(Type localCollectionType)
-    {
-      return (localCollectionType.IsArray && localCollectionType.GetElementType() == WellKnownOrmTypes.Key)
-        || IEnumerableOfKeyType.IsAssignableFrom(localCollectionType);
-    }
+    private bool IsKeyCollection(Type localCollectionType) =>
+      (localCollectionType.IsArray && localCollectionType.GetElementType() == WellKnownOrmTypes.Key)
+        || IEnumerableOfKeyType.IsAssignableFrom(localCollectionType)
+        || localCollectionType.IsOfGenericType(WellKnownTypes.ReadOnlySpanOfT) && localCollectionType.GetGenericArguments()[0] == WellKnownOrmTypes.Key;
 
     internal void RestoreState(in TranslatorState previousState) =>
       State = previousState;

--- a/Orm/Xtensive.Orm/Orm/Linq/WellKnownMembers.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/WellKnownMembers.cs
@@ -249,6 +249,12 @@ namespace Xtensive.Orm.Linq
       public static readonly MethodInfo Cast = GetMethod(typeof(System.Linq.Enumerable), nameof(System.Linq.Enumerable.Cast), 1, 1);
     }
 
+    public static class MemoryExtensions
+    {
+      public static readonly MethodInfo ContainsInReadOnlySpan = typeof(System.MemoryExtensions).GetMethods()
+        .Where(m => m.Name == "Contains" && m.GetParameterTypes()[0].GetGenericTypeDefinition() == WellKnownTypes.ReadOnlySpanOfT).First();
+    }
+
     // IEntity
     public static readonly PropertyInfo IEntityKey = WellKnownOrmInterfaces.Entity.GetProperty(WellKnown.KeyFieldName);
     public static readonly PropertyInfo TypeId = WellKnownOrmInterfaces.Entity.GetProperty(WellKnown.TypeIdFieldName);

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
@@ -90,6 +90,13 @@ namespace Xtensive.Orm.Providers
       if (evaluator.CanBeEvaluated(e)) {
         if (parameterExtractor.IsParameter(e))
           return VisitParameterAccess(e, smartNull);
+        if (e.NodeType == ExpressionType.Call) {
+          var mc = (MethodCallExpression) e;
+          var methodDeclaringType = mc.Method.DeclaringType;
+          if (methodDeclaringType.IsGenericType && methodDeclaringType.GetGenericTypeDefinition() == WellKnownTypes.ReadOnlySpanOfT) {
+            e = mc.Arguments[0];
+          }
+        }
         return VisitConstant(ExpressionEvaluator.Evaluate(e));
       }
       return base.Visit(e);
@@ -410,8 +417,12 @@ namespace Xtensive.Orm.Providers
       var arguments = mc.Arguments.SelectToArray(a => Visit(a));
       var mi = mc.Method;
 
-      if (mc.Object!=null && mc.Object.Type!=mi.ReflectedType)
+      if (mc.Object!=null && mc.Object.Type!=mi.ReflectedType) {
         mi = mc.Object.Type.GetMethod(mi.Name, mi.GetParameterTypes());
+      }
+      else if (mi.IsGenericMethod && mi.GetGenericMethodDefinition() == WellKnownMembers.MemoryExtensions.ContainsInReadOnlySpan) {
+        mi = WellKnownMembers.Enumerable.Contains.CachedMakeGenericMethod(mi.GetGenericArguments()[0]);
+      }
 
       return CompileMember(mi, Visit(mc.Object), arguments);
     }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 { 
   "sdk": {
     "allowPrerelease": true,
-    "version": "9.0.102",
+    "version": "9.0.200",
     "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
This is a follow up of https://github.com/servicetitan/dataobjects-net/pull/328

Also add following processing to `ExpressionProcessor`:
* Replace `ReadOnlySpan<>.Contains()` by `IEnumerable<>.Contains()` 
* Remove implicit casting of `T[]` into `ReadOnlySpan<T>` 