### PR TITLE
Make code .NET10-compatible

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
-    <MSExtVersion Condition="'$(TargetFramework)' == 'net9.0'">9.0.0</MSExtVersion>
-    <MSExtVersion Condition="'$(TargetFramework)' == 'net10.0'">10.0.0</MSExtVersion>
+    <MSExtVersion Condition="'$(TargetFramework)' == 'net9.0'">9.0.2</MSExtVersion>
+    <MSExtVersion Condition="'$(TargetFramework)' == 'net10.0'">9.0.2</MSExtVersion>
     <MSExtVersion2>$(MSExtVersion)</MSExtVersion2>
-    <MSExtVersion2 Condition="'$(TargetFramework)' == 'net10.0'">10.0.0</MSExtVersion2>
+    <MSExtVersion2 Condition="'$(TargetFramework)' == 'net10.0'">9.0.2</MSExtVersion2>
   </PropertyGroup>
   <ItemGroup Label="Nupkg Versions">
     <PackageVersion Include="System.CodeDom"                            Version="$(MSExtVersion)"/>

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0187_TypeCastInContain.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0187_TypeCastInContain.cs
@@ -55,14 +55,14 @@ namespace Xtensive.Orm.Tests.Issues
     [Test]
     public void ParentsContainsChildWithImplicitCastTest()
     {
-      var parents = GlobalSession.Query.All<Parent>().ToArray();
+      IReadOnlyList<Parent> parents = GlobalSession.Query.All<Parent>().ToArray();
       var result = GlobalSession.Query.All<Child>().Where(child => parents.Contains(child)).ToArray();
     }
 
     [Test]
     public void ParentsContainsChildWithExplicitCastTest()
     {
-      var parents = GlobalSession.Query.All<Parent>().ToArray();
+      IReadOnlyList<Parent> parents = GlobalSession.Query.All<Parent>().ToArray();
       var result = GlobalSession.Query.All<Child>().Where(child => parents.Contains(child as Parent)).ToArray();
     }
 
@@ -76,7 +76,7 @@ namespace Xtensive.Orm.Tests.Issues
     [Test]
     public void ChildContainsParentWithImplicitCast()
     {
-      var children = GlobalSession.Query.All<Child>().ToArray();
+      IReadOnlyList<Child> children = GlobalSession.Query.All<Child>().ToArray();
       var result = GlobalSession.Query.All<Child>().Where(a => children.Contains(a.Parent)).ToArray();
     }
 

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0743_IncludeDoesNotWorkWithSubqueries.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0743_IncludeDoesNotWorkWithSubqueries.cs
@@ -339,7 +339,7 @@ namespace Xtensive.Orm.Tests.Issues
     {
       using (var session = Domain.OpenSession())
       using (var tx = session.OpenTransaction()) {
-        var values = new[] { MyEnum.Bar, MyEnum.Foo };
+        IReadOnlyList<MyEnum> values = [MyEnum.Bar, MyEnum.Foo];
         var result = session.Query.All<TestEntity>()
           .Select(e => values.Contains(e.List.FirstOrDefault().Link.Value3.Value)).ToArray();
 

--- a/Orm/Xtensive.Orm.Tests/Linq/NullableEnumMaterializationTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/NullableEnumMaterializationTest.cs
@@ -67,7 +67,7 @@ namespace Xtensive.Orm.Tests.Linq
     {
       using (var session = Domain.OpenSession())
       using (var tx = session.OpenTransaction()) {
-        var values = new[] {MyEnum.Bar, MyEnum.Foo};
+        IReadOnlyList<MyEnum> values = [MyEnum.Bar, MyEnum.Foo];
         var query = session.Query.All<EntityWithNullableEnum>()
           .Select(e => new {
             Id = e.Id,
@@ -101,7 +101,7 @@ namespace Xtensive.Orm.Tests.Linq
     {
       using (var session = Domain.OpenSession())
       using (var tx = session.OpenTransaction()) {
-        var values = new[] {MyEnum.Bar, MyEnum.Foo};
+        IReadOnlyList<MyEnum> values = [MyEnum.Bar, MyEnum.Foo];
         var query = session.Query.All<RefEntity>()
           .Select(e => new {
             Id = e.Id,

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
@@ -307,6 +307,10 @@ namespace Xtensive.Orm
       values == null ? false : values.Contains(source);
 #pragma warning restore IDE0060 // Remove unused parameter
 
+    [Obsolete("Use '.OuterJoin()' extension instead.")]
+    public static IQueryable<TResult> LeftJoin<TOuter, TInner, TKey, TResult>(this IQueryable<TOuter> outer, IEnumerable<TInner> inner, Expression<Func<TOuter, TKey>> outerKeySelector, Expression<Func<TInner, TKey>> innerKeySelector, Expression<Func<TOuter, TInner, TResult>> resultSelector) =>
+      OuterJoin(outer, inner, outerKeySelector, innerKeySelector, resultSelector);
+
     /// <summary>
     /// Correlates the elements of two sequences based on matching keys.
     /// </summary>
@@ -322,7 +326,7 @@ namespace Xtensive.Orm
     /// <returns></returns>
     /// <exception cref="ArgumentNullException">One of provided arguments is <see langword="null" />.</exception>
     /// <exception cref="NotSupportedException">Queryable is not a <see cref="Xtensive.Orm.Linq"/> query.</exception>
-    public static IQueryable<TResult> LeftJoin<TOuter, TInner, TKey, TResult>(this IQueryable<TOuter> outer, IEnumerable<TInner> inner, Expression<Func<TOuter, TKey>> outerKeySelector, Expression<Func<TInner, TKey>> innerKeySelector, Expression<Func<TOuter, TInner, TResult>> resultSelector)
+    public static IQueryable<TResult> OuterJoin<TOuter, TInner, TKey, TResult>(this IQueryable<TOuter> outer, IEnumerable<TInner> inner, Expression<Func<TOuter, TKey>> outerKeySelector, Expression<Func<TInner, TKey>> innerKeySelector, Expression<Func<TOuter, TInner, TResult>> resultSelector)
     {
       ArgumentNullException.ThrowIfNull(outer);
       ArgumentNullException.ThrowIfNull(inner);

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
@@ -307,9 +307,9 @@ namespace Xtensive.Orm
       values == null ? false : values.Contains(source);
 #pragma warning restore IDE0060 // Remove unused parameter
 
-    [Obsolete("Use '.OuterJoin()' extension instead.")]
+    [Obsolete("Use '.LeftOuterJoin()' extension instead.")]
     public static IQueryable<TResult> LeftJoin<TOuter, TInner, TKey, TResult>(this IQueryable<TOuter> outer, IEnumerable<TInner> inner, Expression<Func<TOuter, TKey>> outerKeySelector, Expression<Func<TInner, TKey>> innerKeySelector, Expression<Func<TOuter, TInner, TResult>> resultSelector) =>
-      OuterJoin(outer, inner, outerKeySelector, innerKeySelector, resultSelector);
+      LeftOuterJoin(outer, inner, outerKeySelector, innerKeySelector, resultSelector);
 
     /// <summary>
     /// Correlates the elements of two sequences based on matching keys.
@@ -326,7 +326,7 @@ namespace Xtensive.Orm
     /// <returns></returns>
     /// <exception cref="ArgumentNullException">One of provided arguments is <see langword="null" />.</exception>
     /// <exception cref="NotSupportedException">Queryable is not a <see cref="Xtensive.Orm.Linq"/> query.</exception>
-    public static IQueryable<TResult> OuterJoin<TOuter, TInner, TKey, TResult>(this IQueryable<TOuter> outer, IEnumerable<TInner> inner, Expression<Func<TOuter, TKey>> outerKeySelector, Expression<Func<TInner, TKey>> innerKeySelector, Expression<Func<TOuter, TInner, TResult>> resultSelector)
+    public static IQueryable<TResult> LeftOuterJoin<TOuter, TInner, TKey, TResult>(this IQueryable<TOuter> outer, IEnumerable<TInner> inner, Expression<Func<TOuter, TKey>> outerKeySelector, Expression<Func<TInner, TKey>> innerKeySelector, Expression<Func<TOuter, TInner, TResult>> resultSelector)
     {
       ArgumentNullException.ThrowIfNull(outer);
       ArgumentNullException.ThrowIfNull(inner);


### PR DESCRIPTION
* Use `IReadOnlyList<>` instead of arrays in tests to make `.Contains()` in DO expressions compilable.

* Rename `IQueryable<>.LeftJoin()` extension to `.LeftOuterJoin()` to avoid ambiguity with LINQ `.LeftJoin()` in .NET10. See https://github.com/dotnet/runtime/issues/110292
Mark `.LeftJoin()` as `[Obsolete]` (will be removed after switching to .NET10)
