### PR TITLE
Fix XML Model Deserialization

### DIFF
--- a/Orm/Xtensive.Orm/Core/SimpleXmlSerializer.cs
+++ b/Orm/Xtensive.Orm/Core/SimpleXmlSerializer.cs
@@ -38,8 +38,11 @@ namespace Xtensive.Core
       return (T) serializer.Deserialize(reader);
     }
 
-    public T DeserializeFromStream(Stream stream) =>
-      (T) serializer.Deserialize(stream);
+    public T DeserializeFromStream(Stream stream)
+    {
+      using StreamReader reader = new(stream, leaveOpen: true);
+      return (T) serializer.Deserialize(reader);
+    }
 
     /// <summary>
     /// Serializes value of <typeparamref name="T"/> to string.

--- a/Version.props
+++ b/Version.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.2.173</DoVersion>
+    <DoVersion>7.2.174</DoVersion>
     <DoVersionSuffix>servicetitan</DoVersionSuffix>
 </PropertyGroup>
 


### PR DESCRIPTION
`XmlSerializer` cannot process UTF-8 BOM  (`EF BB BF`)
See https://github.com/dotnet/runtime/issues/63585

And the Model reading fails silently (this operation is under try/catch).

Because of it  no upgrade with Hints is possible
