### PR TITLE
Don't hide exceptions in `StoredDomainModel.Deserialize()`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Upgrade/SystemUpgradeHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/SystemUpgradeHandler.cs
@@ -280,6 +280,7 @@ namespace Xtensive.Orm.Upgrade
       }
       catch (Exception e) {
         UpgradeLog.Warning(e, Strings.LogFailedToExtractDomainModelFromStorage);
+        throw;
       }
     }
 


### PR DESCRIPTION
The bug with BOM was unnoticed for a month because of swallowed Exception

Let's not hide it.