### PR TITLE
Optimize `ExpressionCompileExtensions`

### DIFF
--- a/Orm/Xtensive.Orm/Core/Extensions/ExpressionCompileExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/ExpressionCompileExtensions.cs
@@ -4,272 +4,269 @@
 // Created by: Denis Krjuchkov
 // Created:    2009.05.07
 
-using System;
 using System.Linq.Expressions;
 using Xtensive.Linq;
 
-namespace Xtensive.Core
+namespace Xtensive.Core;
+
+/// <summary>
+/// Extension methods for compiling strictly typed lambda expressions.
+/// </summary>
+public static class ExpressionCompileExtensions
 {
-  /// <summary>
-  /// Extension methods for compiling strictly typed lambda expressions.
-  /// </summary>
-  public static class ExpressionCompileExtensions
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Func<TResult> CachingCompile<TResult>(this Expression<Func<TResult>> lambda)
   {
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Func<TResult> CachingCompile<TResult>(this Expression<Func<TResult>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Func<object[], TResult>) result.Item1).Bind(result.Item2);
-    }
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Func<object[], TResult>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Func<T1, TResult> CachingCompile<T1, TResult>(this Expression<Func<T1, TResult>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Func<object[], T1, TResult>)result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Func<T1, TResult> CachingCompile<T1, TResult>(this Expression<Func<T1, TResult>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Func<object[], T1, TResult>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Func<T1, T2, TResult> CachingCompile<T1, T2, TResult>(this Expression<Func<T1, T2, TResult>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Func<object[], T1, T2, TResult>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Func<T1, T2, TResult> CachingCompile<T1, T2, TResult>(this Expression<Func<T1, T2, TResult>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Func<object[], T1, T2, TResult>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Func<T1, T2, T3, TResult> CachingCompile<T1, T2, T3, TResult>(this Expression<Func<T1, T2, T3, TResult>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Func<object[], T1, T2, T3, TResult>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Func<T1, T2, T3, TResult> CachingCompile<T1, T2, T3, TResult>(this Expression<Func<T1, T2, T3, TResult>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Func<object[], T1, T2, T3, TResult>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Func<T1, T2, T3, T4, TResult> CachingCompile<T1, T2, T3, T4, TResult>(this Expression<Func<T1, T2, T3, T4, TResult>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Func<object[], T1, T2, T3, T4, TResult>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Func<T1, T2, T3, T4, TResult> CachingCompile<T1, T2, T3, T4, TResult>(this Expression<Func<T1, T2, T3, T4, TResult>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Func<object[], T1, T2, T3, T4, TResult>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Func<T1, T2, T3, T4, T5, TResult> CachingCompile<T1, T2, T3, T4, T5, TResult>(this Expression<Func<T1, T2, T3, T4, T5, TResult>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Func<object[], T1, T2, T3, T4, T5, TResult>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Func<T1, T2, T3, T4, T5, TResult> CachingCompile<T1, T2, T3, T4, T5, TResult>(this Expression<Func<T1, T2, T3, T4, T5, TResult>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Func<object[], T1, T2, T3, T4, T5, TResult>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Func<T1, T2, T3, T4, T5, T6, TResult> CachingCompile<T1, T2, T3, T4, T5, T6, TResult>(this Expression<Func<T1, T2, T3, T4, T5, T6, TResult>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Func<object[], T1, T2, T3, T4, T5, T6, TResult>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Func<T1, T2, T3, T4, T5, T6, TResult> CachingCompile<T1, T2, T3, T4, T5, T6, TResult>(this Expression<Func<T1, T2, T3, T4, T5, T6, TResult>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Func<object[], T1, T2, T3, T4, T5, T6, TResult>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Func<T1, T2, T3, T4, T5, T6, T7, TResult> CachingCompile<T1, T2, T3, T4, T5, T6, T7, TResult>(this Expression<Func<T1, T2, T3, T4, T5, T6, T7, TResult>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Func<object[], T1, T2, T3, T4, T5, T6, T7, TResult>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Func<T1, T2, T3, T4, T5, T6, T7, TResult> CachingCompile<T1, T2, T3, T4, T5, T6, T7, TResult>(this Expression<Func<T1, T2, T3, T4, T5, T6, T7, TResult>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Func<object[], T1, T2, T3, T4, T5, T6, T7, TResult>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Func<object[], T1, T2, T3, T4, T5, T6, T7, T8, TResult>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Func<object[], T1, T2, T3, T4, T5, T6, T7, T8, TResult>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Func<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Func<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Func<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Func<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Func<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Func<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Func<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Func<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Func<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Func<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Func<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Func<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Func<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Func<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Action CachingCompile(this Expression<Action> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Action<object[]>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Action CachingCompile(this Expression<Action> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Action<object[]>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Action<T1> CachingCompile<T1>(this Expression<Action<T1>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Action<object[], T1>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Action<T1> CachingCompile<T1>(this Expression<Action<T1>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Action<object[], T1>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Action<T1, T2> CachingCompile<T1, T2>(this Expression<Action<T1, T2>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Action<object[], T1, T2>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Action<T1, T2> CachingCompile<T1, T2>(this Expression<Action<T1, T2>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Action<object[], T1, T2>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Action<T1, T2, T3> CachingCompile<T1, T2, T3>(this Expression<Action<T1, T2, T3>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Action<object[], T1, T2, T3>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Action<T1, T2, T3> CachingCompile<T1, T2, T3>(this Expression<Action<T1, T2, T3>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Action<object[], T1, T2, T3>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Action<T1, T2, T3, T4> CachingCompile<T1, T2, T3, T4>(this Expression<Action<T1, T2, T3, T4>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Action<object[], T1, T2, T3, T4>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Action<T1, T2, T3, T4> CachingCompile<T1, T2, T3, T4>(this Expression<Action<T1, T2, T3, T4>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Action<object[], T1, T2, T3, T4>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Action<T1, T2, T3, T4, T5> CachingCompile<T1, T2, T3, T4, T5>(this Expression<Action<T1, T2, T3, T4, T5>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Action<object[], T1, T2, T3, T4, T5>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Action<T1, T2, T3, T4, T5> CachingCompile<T1, T2, T3, T4, T5>(this Expression<Action<T1, T2, T3, T4, T5>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Action<object[], T1, T2, T3, T4, T5>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Action<T1, T2, T3, T4, T5, T6> CachingCompile<T1, T2, T3, T4, T5, T6>(this Expression<Action<T1, T2, T3, T4, T5, T6>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Action<object[], T1, T2, T3, T4, T5, T6>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Action<T1, T2, T3, T4, T5, T6> CachingCompile<T1, T2, T3, T4, T5, T6>(this Expression<Action<T1, T2, T3, T4, T5, T6>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Action<object[], T1, T2, T3, T4, T5, T6>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Action<T1, T2, T3, T4, T5, T6, T7> CachingCompile<T1, T2, T3, T4, T5, T6, T7>(this Expression<Action<T1, T2, T3, T4, T5, T6, T7>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Action<object[], T1, T2, T3, T4, T5, T6, T7>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Action<T1, T2, T3, T4, T5, T6, T7> CachingCompile<T1, T2, T3, T4, T5, T6, T7>(this Expression<Action<T1, T2, T3, T4, T5, T6, T7>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Action<object[], T1, T2, T3, T4, T5, T6, T7>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Action<T1, T2, T3, T4, T5, T6, T7, T8> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8>(this Expression<Action<T1, T2, T3, T4, T5, T6, T7, T8>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Action<object[], T1, T2, T3, T4, T5, T6, T7, T8>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Action<T1, T2, T3, T4, T5, T6, T7, T8> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8>(this Expression<Action<T1, T2, T3, T4, T5, T6, T7, T8>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Action<object[], T1, T2, T3, T4, T5, T6, T7, T8>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this Expression<Action<T1, T2, T3, T4, T5, T6, T7, T8, T9>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Action<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this Expression<Action<T1, T2, T3, T4, T5, T6, T7, T8, T9>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Action<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this Expression<Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Action<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this Expression<Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Action<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this Expression<Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Action<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this Expression<Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Action<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this Expression<Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Action<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this Expression<Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Action<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this Expression<Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Action<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this Expression<Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Action<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this Expression<Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Action<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>) result.Item1).Bind(result.Item2);
-    }
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this Expression<Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Action<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>) compiled).Bind(constants);
+  }
 
-    /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
-    /// <returns>Compiled lambda.</returns>
-    public static Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this Expression<Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> lambda)
-    {
-      var result = CachingExpressionCompiler.Instance.Compile(lambda);
-      return ((Action<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>) result.Item1).Bind(result.Item2);
-    }
-
+  /// <summary>Compiles the specified lambda and caches the result of compilation.</summary>
+  /// <returns>Compiled lambda.</returns>
+  public static Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> CachingCompile<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this Expression<Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> lambda)
+  {
+    var (compiled, constants) = CachingExpressionCompiler.Compile(lambda);
+    return ((Action<object[], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>) compiled).Bind(constants);
   }
 }

--- a/Orm/Xtensive.Orm/Linq/Internals/CachingExpressionCompiler.cs
+++ b/Orm/Xtensive.Orm/Linq/Internals/CachingExpressionCompiler.cs
@@ -4,43 +4,25 @@
 // Created by: Denis Krjuchkov
 // Created:    2009.05.06
 
-using System;
 using System.Collections.Concurrent;
 using System.Linq.Expressions;
-using Xtensive.Core;
 
-namespace Xtensive.Linq
+namespace Xtensive.Linq;
+
+internal static class CachingExpressionCompiler
 {
-  internal sealed class CachingExpressionCompiler
+  private static class Traits<TDelegate>
   {
-    public static CachingExpressionCompiler Instance { get; } = new CachingExpressionCompiler();
+    public static readonly ConcurrentDictionary<ExpressionTree, Delegate> Cache = new();
+  }
 
-    private readonly ConcurrentDictionary<ExpressionTree, Delegate> cache =
-      new ConcurrentDictionary<ExpressionTree, Delegate>();
-
-    private static readonly Func<ExpressionTree, Delegate> expressionTreeCompiler = CompileExpressionTree;
-
-    private static Delegate CompileExpressionTree(ExpressionTree tree) =>
-      ((LambdaExpression) tree.ToExpression()).Compile();
-
-    public (Delegate, object[]) Compile(LambdaExpression lambda)
-    {
-      var constantExtractor = new ConstantExtractor(lambda);
-      var expressionTree = constantExtractor.Process().ToExpressionTree();
-      var constants = constantExtractor.GetConstants();
-
-      var compiled = cache.GetOrAdd(expressionTree, expressionTreeCompiler);
-      return (compiled, constants);
-    }
-
-    // For testing only
-    public void ClearCache() => cache.Clear();
-
-
-    // Constructors
-
-    private CachingExpressionCompiler()
-    {
-    }
+  internal static (Delegate Compiled, object[] Constants) Compile<TDelegate>(Expression<TDelegate> lambda)
+  {
+    var constantExtractor = new ConstantExtractor(lambda);
+    var expressionTree = constantExtractor.Process().ToExpressionTree();
+    return (
+      Traits<TDelegate>.Cache.GetOrAdd(expressionTree, static tree => ((LambdaExpression) tree.ToExpression()).Compile()),
+      constantExtractor.GetConstants()
+    );
   }
 }

--- a/Version.props
+++ b/Version.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.2.174</DoVersion>
+    <DoVersion>7.2.175</DoVersion>
     <DoVersionSuffix>servicetitan</DoVersionSuffix>
 </PropertyGroup>
 


### PR DESCRIPTION
Instead of single static cache, keep multiple statically-dispatched caches, one per every Delegate type
(`Traits<TDelegate>.Cache`)