### PR TITLE
Get rid of `CachedGetGenericTypeDefinition()`

### DIFF
--- a/Orm/Xtensive.Orm.Tests.Core/Reflection/TypeHelperTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Reflection/TypeHelperTest.cs
@@ -349,7 +349,7 @@ namespace Xtensive.Orm.Tests.Core.Reflection
       sName = t.GetShortName();
       Assert.AreEqual("A<Int32,String>+B<Boolean>", sName);
 
-      t = t.CachedGetGenericTypeDefinition().GetGenericArguments()[2];
+      t = t.GetGenericTypeDefinition().GetGenericArguments()[2];
       fName = t.GetFullName();
       Assert.AreEqual("T3", fName);
       sName = t.GetShortName();

--- a/Orm/Xtensive.Orm.Tests/Linq/QueryDumper.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/QueryDumper.cs
@@ -236,12 +236,12 @@ namespace Xtensive.Orm.Tests.Linq
 
         if (value==null || ((GetMemberType(value.GetType())==MemberType.Primitive
           || GetMemberType(value.GetType())==MemberType.Unknown) && !value.GetType().IsGenericType)
-            || (value.GetType().IsGenericType && value.GetType().CachedGetGenericTypeDefinition()!=typeof (Grouping<,>))
+            || (value.GetType().IsGenericType && value.GetType().GetGenericTypeDefinition()!=typeof (Grouping<,>))
               && (GetMemberType(value.GetType())==MemberType.Primitive
                 || GetMemberType(value.GetType())==MemberType.Unknown))
           depth = AddNode(value, null, ref document, itemNode, depth);
 
-        else if (value.GetType().IsGenericType && value.GetType().CachedGetGenericTypeDefinition()==typeof (Grouping<,>)) {
+        else if (value.GetType().IsGenericType && value.GetType().GetGenericTypeDefinition()==typeof (Grouping<,>)) {
           var exactValue = (IEnumerable) value;
           foreach (var val in exactValue) {
             itemNode = document.CreateElement("Item" + itemIndex);
@@ -570,10 +570,10 @@ namespace Xtensive.Orm.Tests.Linq
           var properties = type.GetProperties();
           foreach (var info in properties) {
             if (info.PropertyType.IsGenericType && 
-              (info.PropertyType.CachedGetGenericTypeDefinition()==typeof (IQueryable<>)
-              || info.PropertyType.CachedGetGenericTypeDefinition()==typeof (IEnumerable<>)
-              || info.PropertyType.CachedGetGenericTypeDefinition()==typeof (SubQuery<>)
-              || info.PropertyType.CachedGetGenericTypeDefinition()==typeof (Grouping<,>)
+              (info.PropertyType.GetGenericTypeDefinition()==typeof (IQueryable<>)
+              || info.PropertyType.GetGenericTypeDefinition()==typeof (IEnumerable<>)
+              || info.PropertyType.GetGenericTypeDefinition()==typeof (SubQuery<>)
+              || info.PropertyType.GetGenericTypeDefinition()==typeof (Grouping<,>)
               ))
               EnumerateAll((IEnumerable) info.GetValue(o, null));
           }

--- a/Orm/Xtensive.Orm/Orm/Linq/ExpressionExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ExpressionExtensions.cs
@@ -96,7 +96,7 @@ namespace Xtensive.Orm.Linq
         if (((ConstantExpression) expression).Value is IQueryable value) {
           var type = value.GetType();
           if (type.IsGenericType) {
-            var definition = type.CachedGetGenericTypeDefinition();
+            var definition = type.GetGenericTypeDefinition();
             return definition != WellKnownInterfaces.QueryableOfT && definition != WellKnownTypes.QueryableOfT;
           }
         }

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/RedundantColumnRemover.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/RedundantColumnRemover.cs
@@ -25,7 +25,7 @@ namespace Xtensive.Orm.Rse.Transformation
     private static readonly MethodInfo SelectMethodInfo = WellKnownTypes.Enumerable
       .GetMethods()
       .Single(methodInfo => methodInfo.Name == nameof(Enumerable.Select)
-        && methodInfo.GetParameters()[1].ParameterType.CachedGetGenericTypeDefinition() == WellKnownTypes.FuncOfTArgTResultType)
+        && methodInfo.GetParameters()[1].ParameterType.GetGenericTypeDefinition() == WellKnownTypes.FuncOfTArgTResultType)
       .CachedMakeGenericMethod(WellKnownOrmTypes.Tuple, WellKnownOrmTypes.Tuple);
 
     protected override (CompilableProvider, IReadOnlyList<ColNum>) OverrideRightApplySource(ApplyProvider applyProvider, CompilableProvider provider, IReadOnlyList<ColNum> requestedMapping)

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/UpgradeHintsProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/UpgradeHintsProcessor.cs
@@ -179,7 +179,7 @@ namespace Xtensive.Orm.Upgrade.Internals
     {
       var genericTypeDefLookup = (
         from triplet in genericTypeMapping
-        group triplet by triplet.Item2.CachedGetGenericTypeDefinition()
+        group triplet by triplet.Item2.GetGenericTypeDefinition()
           into g
         select (Definition: g.Key, Instances: g.ToArray())
         ).ToDictionary(g => g.Definition);
@@ -548,7 +548,7 @@ namespace Xtensive.Orm.Upgrade.Internals
     {
       var genericTypes = new ClassifiedCollection<Type, (Type, Type[])>(pair => new[] { pair.Item1 });
       foreach (var typeInfo in model.Types.Where(type => type.UnderlyingType.IsGenericType)) {
-        var typeDefinition = typeInfo.UnderlyingType.CachedGetGenericTypeDefinition();
+        var typeDefinition = typeInfo.UnderlyingType.GetGenericTypeDefinition();
         genericTypes.Add((typeDefinition, typeInfo.UnderlyingType.GetGenericArguments()));
       }
       return genericTypes;

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -75,9 +75,6 @@ namespace Xtensive.Reflection
 
     private static readonly ConcurrentDictionary<(int, ModuleHandle, Type, Type), MethodInvoker> GenericMethodInvokers2 = new();
 
-    // .NET8+ caches GenericTypeDefinition
-    private static readonly ConcurrentDictionary<Type, Type> GenericTypeDefinitions = Environment.Version.Major < 8 ? new() : null;
-
     private static readonly ConcurrentDictionary<(Type, Type), Type> GenericTypeInstances1 = new();
 
     private static readonly ConcurrentDictionary<(Type, Type, Type), Type> GenericTypeInstances2 = new();
@@ -610,7 +607,7 @@ namespace Xtensive.Reflection
                 }
 
                 projectedConstraint = constraint
-                  .CachedGetGenericTypeDefinition()
+                  .GetGenericTypeDefinition()
                   .MakeGenericType(projectedConstraintArguments);
               }
 
@@ -973,11 +970,8 @@ namespace Xtensive.Reflection
       methodHandle.MetadataToken == definitionHandle.MetadataToken
       && methodHandle.ModuleHandle == definitionHandle.ModuleHandle;
 
-    public static Type CachedGetGenericTypeDefinition(this Type type) =>
-      GenericTypeDefinitions?.GetOrAdd(type, static t => t.GetGenericTypeDefinition()) ?? type.GetGenericTypeDefinition();
-
     public static bool IsGenericType(this Type type, Type other) =>
-      type.IsGenericType && CachedGetGenericTypeDefinition(type) == other;
+      type.IsGenericType && type.GetGenericTypeDefinition() == other;
 
     /// <summary>
     /// Makes generic <see cref="MethodInfo"/> for given definition and type argument


### PR DESCRIPTION
.NET8+ itself caches it: https://github.com/dotnet/runtime/pull/78288