### PR TITLE
Optimize `GenericExpressionVisitor` usage

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
@@ -30,8 +30,8 @@ namespace Xtensive.Orm.Linq
 
     public override Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
-      Func<Expression, Expression> genericBinder =
-        e => GenericExpressionVisitor<IMappedExpression>.Process(e, mapped => mapped.BindParameter(parameter, processedExpressions));
+      GenericExpressionVisitor<IMappedExpression> genericVisitor = new(mapped => mapped.BindParameter(parameter, processedExpressions));
+      var genericBinder = genericVisitor.Process;
       return new ConstructorExpression(
         Type,
         Bindings.ToDictionary(kvp => kvp.Key, kvp => genericBinder(kvp.Value)),
@@ -42,8 +42,8 @@ namespace Xtensive.Orm.Linq
 
     public override Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
     {
-      Func<Expression, Expression> genericRemover =
-        e => GenericExpressionVisitor<IMappedExpression>.Process(e, mapped => mapped.RemoveOuterParameter(processedExpressions));
+      GenericExpressionVisitor<IMappedExpression> genericVisitor = new(mapped => mapped.RemoveOuterParameter(processedExpressions));
+      var genericRemover = genericVisitor.Process;
       var result = new ConstructorExpression(
         Type,
         Bindings.ToDictionary(kvp => kvp.Key, kvp => genericRemover(kvp.Value)),
@@ -61,10 +61,10 @@ namespace Xtensive.Orm.Linq
           return mapped.Remap(offset, new Dictionary<Expression, Expression>());
         return (Expression) mapped;
       };
-      var newBindings = Bindings.ToDictionary(kvp => kvp.Key, kvp => GenericExpressionVisitor<IMappedExpression>.Process(kvp.Value, remapper));
-      var newConstructorArguments = ConstructorArguments
-        .Select(arg => GenericExpressionVisitor<IMappedExpression>.Process(arg, remapper)).ToArray();
-      var newNativeBindings = NativeBindings.ToDictionary(kvp => kvp.Key, kvp => GenericExpressionVisitor<IMappedExpression>.Process(kvp.Value, remapper));
+      GenericExpressionVisitor<IMappedExpression> genericVisitor = new(remapper);
+      var newBindings = Bindings.ToDictionary(kvp => kvp.Key, kvp => genericVisitor.Process(kvp.Value));
+      var newConstructorArguments = ConstructorArguments.Select(genericVisitor.Process).ToArray();
+      var newNativeBindings = NativeBindings.ToDictionary(kvp => kvp.Key, kvp => genericVisitor.Process(kvp.Value));
       var result = new ConstructorExpression(
         Type,
         newBindings,
@@ -82,9 +82,10 @@ namespace Xtensive.Orm.Linq
           return mapped.Remap(map, new Dictionary<Expression, Expression>());
         return (Expression) mapped;
       };
-      var newBindings = Bindings.ToDictionary(kvp => kvp.Key, kvp => GenericExpressionVisitor<IMappedExpression>.Process(kvp.Value, remapper));
-      var newConstructorArguments = ConstructorArguments.Select(arg => GenericExpressionVisitor<IMappedExpression>.Process(arg, remapper)).ToArray();
-      var newNativeBindings = NativeBindings.ToDictionary(kvp => kvp.Key, kvp => GenericExpressionVisitor<IMappedExpression>.Process(kvp.Value, remapper));
+      GenericExpressionVisitor<IMappedExpression> genericVisitor = new(remapper);
+      var newBindings = Bindings.ToDictionary(kvp => kvp.Key, kvp => genericVisitor.Process(kvp.Value));
+      var newConstructorArguments = ConstructorArguments.Select(genericVisitor.Process).ToArray();
+      var newNativeBindings = NativeBindings.ToDictionary(kvp => kvp.Key, kvp => genericVisitor.Process(kvp.Value));
       return new ConstructorExpression(Type, newBindings, newNativeBindings, Constructor, newConstructorArguments);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/SubQueryExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/SubQueryExpression.cs
@@ -83,8 +83,7 @@ namespace Xtensive.Orm.Linq.Expressions
 
       // Remap Field parametrized parameters
       var item = GenericExpressionVisitor<IMappedExpression>.Process(ProjectionExpression.ItemProjector.Item, mapped => {
-        var parametrizedExpression = mapped as ParameterizedExpression;
-        if (parametrizedExpression!=null && parametrizedExpression.OuterParameter==OuterParameter)
+        if (mapped is ParameterizedExpression parametrizedExpression && parametrizedExpression.OuterParameter==OuterParameter)
           return mapped.Remap(map, new Dictionary<Expression, Expression>());
         return (Expression) mapped;
       });

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/GenericExpressionVisitor.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/GenericExpressionVisitor.cs
@@ -4,59 +4,46 @@
 // Created by: Alexis Kochetov
 // Created:    2009.05.21
 
-using System;
 using System.Linq.Expressions;
 using ExpressionVisitor = Xtensive.Linq.ExpressionVisitor;
 
-namespace Xtensive.Orm.Linq.Expressions.Visitors
+namespace Xtensive.Orm.Linq.Expressions.Visitors;
+
+internal sealed class GenericExpressionVisitor<T>(Func<T, Expression> genericProcessor) : ExpressionVisitor
+  where T : class
 {
-  internal sealed class GenericExpressionVisitor<T> : ExpressionVisitor
-    where T : class
+  public static Expression Process(Expression target, Func<T, Expression> genericProcessor) =>
+    new GenericExpressionVisitor<T>(genericProcessor).Process(target);
+
+  public Expression Process(Expression target)
   {
-    private readonly Func<T, Expression> genericProcessor;
+    if (RemapScope.CurrentContext!=null)
+      return Visit(target);
 
-    public static Expression Process(Expression target, Func<T, Expression> genericProcessor)
-    {
-      var visitor = new GenericExpressionVisitor<T>(genericProcessor);
-      
-      if (RemapScope.CurrentContext!=null)
-        return visitor.Visit(target);
+    using (new RemapScope())
+      return Visit(target);
+  }
 
-      using (new RemapScope())
-        return visitor.Visit(target);
+  protected override Expression VisitUnknown(Expression e)
+  {
+    if (e is T mapped)
+      return VisitGenericExpression(mapped);
+
+    if (e is ExtendedExpression extendedExpression && extendedExpression.ExtendedType == ExtendedExpressionType.Marker) {
+      var marker = (MarkerExpression) e;
+      var result = Visit(marker.Target);
+      if (result == marker.Target)
+        return result;
+      return new MarkerExpression(result, marker.MarkerType);
     }
 
-    protected override Expression VisitUnknown(Expression e)
-    {
-      var mapped = e as T;
-      if (mapped!=null)
-        return VisitGenericExpression(mapped);
+    return base.VisitUnknown(e);
+  }
 
-      var extendedExpression = e as ExtendedExpression;
-      if (extendedExpression != null && extendedExpression.ExtendedType == ExtendedExpressionType.Marker) {
-        var marker = (MarkerExpression) e;
-        var result = Visit(marker.Target);
-        if (result == marker.Target)
-          return result;
-        return new MarkerExpression(result, marker.MarkerType);
-      }
-
-      return base.VisitUnknown(e);
-    }
-
-    private Expression VisitGenericExpression(T generic)
-    {
-      if (genericProcessor!=null)
-        return genericProcessor.Invoke(generic);
-      throw new NotSupportedException(Strings.ExUnableToUseBaseImplementationOfVisitGenericExpressionWithoutSpecifyingGenericProcessorDelegate);
-    }
-
-
-    // Constructors
-
-    private GenericExpressionVisitor(Func<T, Expression> mappingProcessor)
-    {
-      genericProcessor = mappingProcessor;
-    }
+  private Expression VisitGenericExpression(T generic)
+  {
+    if (genericProcessor!=null)
+      return genericProcessor.Invoke(generic);
+    throw new NotSupportedException(Strings.ExUnableToUseBaseImplementationOfVisitGenericExpressionWithoutSpecifyingGenericProcessorDelegate);
   }
 }


### PR DESCRIPTION
Avoid allocating `GenericExpressionVisitor<IMappedExpression>` for every lambda invocation
Share its instance between calls