### PR TITLE
Make `.GetAttributes()` extension internal

### DIFF
--- a/Orm/Xtensive.Orm/Reflection/AttributeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/AttributeHelper.cs
@@ -68,7 +68,7 @@ namespace Xtensive.Reflection
         }
       }
 
-      public static TAttribute[] Get(MemberInfo member, AttributeSearchOptions options) =>
+      internal static TAttribute[] Get(MemberInfo member, AttributeSearchOptions options) =>
         Dictionary.GetOrAdd(new PerAttributeKey(member.MetadataToken, member.Module.ModuleHandle, options), ExtractAttributesByKey, member);
     }
 
@@ -79,7 +79,7 @@ namespace Xtensive.Reflection
     /// <param name="member">Member to get attributes of.</param>
     /// <param name="options">Attribute search options.</param>
     /// <returns>An array of attributes of specified type.</returns>
-    public static IReadOnlyList<TAttribute> GetAttributes<TAttribute>(this MemberInfo member, AttributeSearchOptions options = AttributeSearchOptions.InheritNone)
+    internal static IReadOnlyList<TAttribute> GetAttributes<TAttribute>(this MemberInfo member, AttributeSearchOptions options = AttributeSearchOptions.InheritNone)
       where TAttribute : Attribute => AttributeDictionary<TAttribute>.Get(member, options);
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Reflection/AttributeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/AttributeHelper.cs
@@ -94,7 +94,7 @@ namespace Xtensive.Reflection
     /// throws <see cref="InvalidOperationException"/>, if there is more then one attribute of specified type found.
     /// </returns>
     /// <exception cref="InvalidOperationException">Thrown if there is more then one attribute of specified type found.</exception>
-    public static TAttribute GetAttribute<TAttribute>(this MemberInfo member, AttributeSearchOptions options = AttributeSearchOptions.InheritNone)
+    internal static TAttribute GetAttribute<TAttribute>(this MemberInfo member, AttributeSearchOptions options = AttributeSearchOptions.InheritNone)
       where TAttribute : Attribute
     {
       var attributes = AttributeDictionary<TAttribute>.Get(member, options);


### PR DESCRIPTION
This API is not related to ORM.
The App should have its own Attributes cache