### PR TITLE
Replace `object` queryKey by value-type `QueryKey`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Domain.cs
+++ b/Orm/Xtensive.Orm/Orm/Domain.cs
@@ -128,10 +128,9 @@ namespace Xtensive.Orm
 
     internal KeyGeneratorRegistry KeyGenerators { get; private set; }
 
-    internal ConcurrentDictionary<TypeInfo, IReadOnlyList<PrefetchFieldDescriptor>> PrefetchFieldDescriptorCache { get; } =
-       new ConcurrentDictionary<TypeInfo, IReadOnlyList<PrefetchFieldDescriptor>>();
+    internal ConcurrentDictionary<TypeInfo, IReadOnlyList<PrefetchFieldDescriptor>> PrefetchFieldDescriptorCache { get; } = new();
 
-    internal FastConcurrentLruCache<object, (object, ParameterizedQuery)> QueryCache { get; }
+    internal FastConcurrentLruCache<QueryKey, (QueryKey Key, ParameterizedQuery Query)> QueryCache { get; }
 
     internal ConcurrentDictionary<Type, System.Linq.Expressions.MethodCallExpression> RootCallExpressionsCache { get; } = new();
 
@@ -430,7 +429,7 @@ namespace Xtensive.Orm
       GenericKeyFactories = new ConcurrentDictionary<TypeInfo, GenericKeyFactory>();
       EntityDataReader = new EntityDataReader(this);
       KeyGenerators = new KeyGeneratorRegistry();
-      QueryCache = new FastConcurrentLruCache<object, (object, ParameterizedQuery)>(Configuration.QueryCacheSize, k => k.Item1);
+      QueryCache = new(Configuration.QueryCacheSize, k => k.Key);
       Extensions = new ExtensionCollection();
       UpgradeContextCookie = upgradeContextCookie;
       SingleConnection = singleConnection;

--- a/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
@@ -4,29 +4,23 @@
 // Created by: Denis Krjuchkov
 // Created:    2012.01.27
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
-using Xtensive.Caching;
 using Xtensive.Core;
 using Xtensive.Orm.Linq;
 using Xtensive.Orm.Linq.Expressions.Visitors;
-using Xtensive.Orm.Providers;
-using Xtensive.Orm.Rse.Providers;
 using Xtensive.Reflection;
 
 namespace Xtensive.Orm.Internals
 {
+  internal record struct QueryKey(object Key, int MetadataToken, ModuleHandle ModuleHandle, string StorageNodeId);
+
   internal class CompiledQueryRunner
   {
     private readonly Domain domain;
     private readonly Session session;
     private readonly QueryEndpoint endpoint;
-    private readonly object queryKey;
+    private readonly QueryKey queryKey;
     private readonly object queryTarget;
     private readonly ParameterContext outerContext;
 
@@ -217,7 +211,7 @@ namespace Xtensive.Orm.Internals
       return parameterContext;
     }
 
-    public CompiledQueryRunner(QueryEndpoint endpoint, object queryKey, object queryTarget, ParameterContext outerContext = null)
+    private CompiledQueryRunner(QueryEndpoint endpoint, (object Key, int MetadataToken, ModuleHandle ModuleHandle) keyParts, object queryTarget, ParameterContext outerContext = null)
     {
       session = endpoint.Provider.Session;
       domain = session.Domain;
@@ -227,9 +221,19 @@ namespace Xtensive.Orm.Internals
       this.outerContext = outerContext;
 
       var domainConfig = domain.Configuration;
-      this.queryKey = domainConfig.ShareStorageSchemaOverNodes && domainConfig.PreferTypeIdsAsQueryParameters
-        ? queryKey
-        : (queryKey, session.StorageNodeId);
+      queryKey = new(keyParts.Key, keyParts.MetadataToken, keyParts.ModuleHandle,
+        domainConfig.ShareStorageSchemaOverNodes && domainConfig.PreferTypeIdsAsQueryParameters ? null : session.StorageNodeId
+      );
+    }
+
+    public CompiledQueryRunner(QueryEndpoint endpoint, MethodInfo methodInfo, object queryTarget, ParameterContext outerContext = null)
+      : this(endpoint, (methodInfo, methodInfo.MetadataToken, methodInfo.Module.ModuleHandle), queryTarget, outerContext)
+    {
+    }
+
+    public CompiledQueryRunner(QueryEndpoint endpoint, object key, object queryTarget, ParameterContext outerContext = null)
+      : this(endpoint, (key, 0, default), queryTarget, outerContext)
+    {
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
@@ -232,7 +232,9 @@ namespace Xtensive.Orm.Internals
     }
 
     public CompiledQueryRunner(QueryEndpoint endpoint, object key, object queryTarget, ParameterContext outerContext = null)
-      : this(endpoint, (key, 0, default), queryTarget, outerContext)
+      : this(endpoint,
+        key is MethodInfo methodInfo ? (methodInfo, methodInfo.MetadataToken, methodInfo.Module.ModuleHandle) : (key, 0, default),
+        queryTarget, outerContext)
     {
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
@@ -211,7 +211,7 @@ namespace Xtensive.Orm.Internals
       return parameterContext;
     }
 
-    private CompiledQueryRunner(QueryEndpoint endpoint, (object Key, int MetadataToken, ModuleHandle ModuleHandle) keyParts, object queryTarget, ParameterContext outerContext = null)
+    private CompiledQueryRunner(QueryEndpoint endpoint, (object Key, int MetadataToken, ModuleHandle ModuleHandle) keyParts, object queryTarget, ParameterContext outerContext)
     {
       session = endpoint.Provider.Session;
       domain = session.Domain;

--- a/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
@@ -880,6 +880,9 @@ namespace Xtensive.Orm
     public DelayedQuery<TElement> CreateDelayedQuery<TElement>(object key, Func<QueryEndpoint, IQueryable<TElement>> query) =>
       new CompiledQueryRunner(this, key, query.Target).CreateDelayedQuery(query);
 
+    public DelayedQuery<TElement> CreateDelayedQuery<TElement>(MethodInfo key, Func<QueryEndpoint, IQueryable<TElement>> query) =>
+      new CompiledQueryRunner(this, key, query.Target).CreateDelayedQuery(query);
+
     /// <summary>
     /// Creates future query and registers it for the later execution.
     /// The associated query will be cached.

--- a/Orm/Xtensive.Orm/Orm/StorageNodeManager.cs
+++ b/Orm/Xtensive.Orm/Orm/StorageNodeManager.cs
@@ -64,13 +64,11 @@ namespace Xtensive.Orm
 
       if (removeResult && clearQueryCache) {
         var domainConfig = handlers.Domain.Configuration;
-        if (domainConfig.ShareStorageSchemaOverNodes && domainConfig.PreferTypeIdsAsQueryParameters) {
-          return removeResult;
-        }
-
-        var queryCache = (Caching.FastConcurrentLruCache<object, (object, Linq.ParameterizedQuery)>) handlers.Domain.QueryCache;
-        foreach (var key in queryCache.Keys.Where(k => k is ValueTuple<object, string> pair && pair.Item2 == nodeId).ToList()) {
-          queryCache.RemoveKey(key);
+        if (!(domainConfig.ShareStorageSchemaOverNodes && domainConfig.PreferTypeIdsAsQueryParameters)) {
+          var queryCache = handlers.Domain.QueryCache;
+          foreach (var key in queryCache.Keys.Where(k => k.StorageNodeId == nodeId).ToList()) {
+            queryCache.RemoveKey(key);
+          }
         }
       }
       return removeResult;


### PR DESCRIPTION
`MethodInfo` is a key of `Domain.QueryCache` frequently.

Use `Metadata/ModuleHandle` as parts of key for efficient hash function
