### PR TITLE
Optimize `AllocateParameterAndReplacer()`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
@@ -188,7 +188,7 @@ namespace Xtensive.Orm.Internals
             return GetClosureAccessor();
           if (closureType.DeclaringType is { } closureTypeDeclaringType
               && expressionType.IsAssignableFrom(closureTypeDeclaringType)
-              && info.Fields.FirstOrDefault(field => field.FieldType == expressionType) is { } memberInfo) {
+              && info.Fields?.FirstOrDefault(field => field.FieldType == expressionType) is { } memberInfo) {
             return Expression.MakeMemberAccess(GetClosureAccessor(), memberInfo);
           }
         }

--- a/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
@@ -159,40 +159,43 @@ namespace Xtensive.Orm.Internals
       var closureType = queryTarget.GetType();
       var parameterType = WellKnownOrmTypes.ParameterOfT.CachedMakeGenericType(closureType);
       var valueMemberInfo = parameterType.GetProperty(nameof(Parameter<object>.Value), closureType);
+      MemberExpression closureAccessor = null;
       queryParameter = (Parameter) System.Activator.CreateInstance(parameterType, "pClosure");
+      bool? closureTypeIsClosure = null;
+      FieldInfo[] closureTypeFields = null;
       queryParameterReplacer = new ExtendedExpressionReplacer(expression => {
         if (expression.NodeType == ExpressionType.Constant) {
-          if ((expression as ConstantExpression).Value == null) {
-          return null;
-        }
-        if (expression.Type.IsClosure()) {
-          if (expression.Type==closureType) {
-            return Expression.MakeMemberAccess(Expression.Constant(queryParameter, parameterType), valueMemberInfo);
-          }
-            else {
-          throw new NotSupportedException(string.Format(
-            Strings.ExExpressionDefinedOutsideOfCachingQueryClosure, expression));
-        }
+          if (((ConstantExpression)expression).Value is null) {
+            return null;
           }
 
-        if (closureType.DeclaringType==null) {
-            if (expression.Type.IsAssignableFrom(closureType))
-            return Expression.MakeMemberAccess(Expression.Constant(queryParameter, parameterType), valueMemberInfo);
+          var expressionType = expression.Type;
+          if (expressionType.IsClosure()) {
+            return expressionType == closureType
+              ? GetClosureAccessor()
+              : throw new NotSupportedException(string.Format(Strings.ExExpressionDefinedOutsideOfCachingQueryClosure, expression));
           }
-        else {
-            if (expression.Type.IsAssignableFrom(closureType))
-            return Expression.MakeMemberAccess(Expression.Constant(queryParameter, parameterType), valueMemberInfo);
-            if (expression.Type.IsAssignableFrom(closureType.DeclaringType)) {
-            var memberInfo = closureType.TryGetFieldInfoFromClosure(expression.Type);
-              if (memberInfo != null)
-              return Expression.MakeMemberAccess(
-                Expression.MakeMemberAccess(Expression.Constant(queryParameter, parameterType), valueMemberInfo),
-                memberInfo);
+
+          if (expressionType.IsAssignableFrom(closureType))
+            return GetClosureAccessor();
+          if (closureType.DeclaringType is { } closureTypeDeclaringType && expressionType.IsAssignableFrom(closureTypeDeclaringType)) {
+            if (closureTypeIsClosure is null) {
+              closureTypeIsClosure = closureType.IsClosure();
+              closureTypeFields = closureTypeIsClosure.Value ? closureType.GetFields() : null;
+            }
+
+            if (closureTypeIsClosure.Value
+                && closureTypeFields.FirstOrDefault(field => field.FieldType == expressionType) is { } memberInfo) {
+              return Expression.MakeMemberAccess(GetClosureAccessor(), memberInfo);
             }
           }
         }
+
         return null;
       });
+
+      MemberExpression GetClosureAccessor() =>
+        closureAccessor ??= Expression.MakeMemberAccess(Expression.Constant(queryParameter, parameterType), valueMemberInfo);
     }
 
     private ParameterizedQuery GetCachedQuery() =>

--- a/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
@@ -168,7 +168,7 @@ namespace Xtensive.Orm.Internals
           parameterType.GetProperty(nameof(Parameter<object>.Value), ct),
           ct.IsClosure() ? ct.GetFields() : null
         );
-      });
+      }, 10_000);
       MemberExpression closureAccessor = null;
       queryParameter = (Parameter) System.Activator.CreateInstance(info.ParameterType, "pClosure");
       queryParameterReplacer = new ExtendedExpressionReplacer(expression => {

--- a/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
@@ -17,6 +17,8 @@ namespace Xtensive.Orm.Internals
 
   internal class CompiledQueryRunner
   {
+    private record struct ClosureTypeInfo(Type ParameterType, PropertyInfo ValueMemberInfo, FieldInfo[] Fields);
+
     private static readonly ExtendedExpressionReplacer NoopReplacer = new(e => e);
 
     private readonly Domain domain;
@@ -159,12 +161,16 @@ namespace Xtensive.Orm.Internals
       }
 
       var closureType = queryTarget.GetType();
-      var parameterType = WellKnownOrmTypes.ParameterOfT.CachedMakeGenericType(closureType);
-      var valueMemberInfo = parameterType.GetProperty(nameof(Parameter<object>.Value), closureType);
+      var info = Memoizer.Get(closureType, static ct => {
+        var parameterType = WellKnownOrmTypes.ParameterOfT.CachedMakeGenericType(ct);
+        return new ClosureTypeInfo(
+          parameterType,
+          parameterType.GetProperty(nameof(Parameter<object>.Value), ct),
+          ct.IsClosure() ? ct.GetFields() : null
+        );
+      });
       MemberExpression closureAccessor = null;
-      queryParameter = (Parameter) System.Activator.CreateInstance(parameterType, "pClosure");
-      bool? closureTypeIsClosure = null;
-      FieldInfo[] closureTypeFields = null;
+      queryParameter = (Parameter) System.Activator.CreateInstance(info.ParameterType, "pClosure");
       queryParameterReplacer = new ExtendedExpressionReplacer(expression => {
         if (expression.NodeType == ExpressionType.Constant) {
           if (((ConstantExpression)expression).Value is null) {
@@ -180,16 +186,10 @@ namespace Xtensive.Orm.Internals
 
           if (expressionType.IsAssignableFrom(closureType))
             return GetClosureAccessor();
-          if (closureType.DeclaringType is { } closureTypeDeclaringType && expressionType.IsAssignableFrom(closureTypeDeclaringType)) {
-            if (closureTypeIsClosure is null) {
-              closureTypeIsClosure = closureType.IsClosure();
-              closureTypeFields = closureTypeIsClosure.Value ? closureType.GetFields() : null;
-            }
-
-            if (closureTypeIsClosure.Value
-                && closureTypeFields.FirstOrDefault(field => field.FieldType == expressionType) is { } memberInfo) {
-              return Expression.MakeMemberAccess(GetClosureAccessor(), memberInfo);
-            }
+          if (closureType.DeclaringType is { } closureTypeDeclaringType
+              && expressionType.IsAssignableFrom(closureTypeDeclaringType)
+              && info.Fields.FirstOrDefault(field => field.FieldType == expressionType) is { } memberInfo) {
+            return Expression.MakeMemberAccess(GetClosureAccessor(), memberInfo);
           }
         }
 
@@ -197,7 +197,7 @@ namespace Xtensive.Orm.Internals
       });
 
       MemberExpression GetClosureAccessor() =>
-        closureAccessor ??= Expression.MakeMemberAccess(Expression.Constant(queryParameter, parameterType), valueMemberInfo);
+        closureAccessor ??= Expression.MakeMemberAccess(Expression.Constant(queryParameter, info.ParameterType), info.ValueMemberInfo);
     }
 
     private ParameterizedQuery GetCachedQuery() =>

--- a/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
@@ -17,6 +17,8 @@ namespace Xtensive.Orm.Internals
 
   internal class CompiledQueryRunner
   {
+    private static readonly ExtendedExpressionReplacer NoopReplacer = new(e => e);
+
     private readonly Domain domain;
     private readonly Session session;
     private readonly QueryEndpoint endpoint;
@@ -152,7 +154,7 @@ namespace Xtensive.Orm.Internals
     {
       if (queryTarget == null) {
         queryParameter = null;
-        queryParameterReplacer = new ExtendedExpressionReplacer(e => e);
+        queryParameterReplacer = NoopReplacer;
         return;
       }
 

--- a/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/CompiledQueryRunner.cs
@@ -186,8 +186,7 @@ namespace Xtensive.Orm.Internals
 
           if (expressionType.IsAssignableFrom(closureType))
             return GetClosureAccessor();
-          if (closureType.DeclaringType is { } closureTypeDeclaringType
-              && expressionType.IsAssignableFrom(closureTypeDeclaringType)
+          if (expressionType.IsAssignableFrom(closureType.DeclaringType)
               && info.Fields?.FirstOrDefault(field => field.FieldType == expressionType) is { } memberInfo) {
             return Expression.MakeMemberAccess(GetClosureAccessor(), memberInfo);
           }

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -1261,18 +1261,6 @@ namespace Xtensive.Reflection
 
     #region Private \ internal methods
 
-    /// <summary>
-    /// Gets information about field in closure.
-    /// </summary>
-    /// <param name="closureType">Closure type.</param>
-    /// <param name="fieldType">Type of field in closure.</param>
-    /// <returns>If field of <paramref name="fieldType"/> exists in closure then returns
-    /// <see cref="MemberInfo"/> of that field, otherwise, <see langword="null"/>.</returns>
-    internal static MemberInfo TryGetFieldInfoFromClosure(this Type closureType, Type fieldType) =>
-      closureType.IsClosure()
-        ? closureType.GetFields().FirstOrDefault(field => field.FieldType == fieldType)
-        : null;
-
     private static string TrimGenericSuffix(string @string)
     {
       var backtickPosition = @string.IndexOf('`');

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -1188,9 +1188,11 @@ namespace Xtensive.Reflection
     /// </returns>
     public static bool IsClosure(this Type type)
     {
+      if (type.BaseType != WellKnownTypes.Object) {
+        return false;
+      }
       var typeName = type.Name;
-      return type.BaseType == WellKnownTypes.Object
-        && (typeName.StartsWith("<>", StringComparison.Ordinal) || typeName.StartsWith("VB$", StringComparison.Ordinal))
+      return (typeName.StartsWith("<>", StringComparison.Ordinal) || typeName.StartsWith("VB$", StringComparison.Ordinal))
         && typeName.IndexOf("DisplayClass", StringComparison.Ordinal) >= 0
         && type.IsDefined(CompilerGeneratedAttributeType, false);
     }


### PR DESCRIPTION
Avoid composing the same expression
 `Expression.MakeMemberAccess(Expression.Constant(queryParameter, parameterType), valueMemberInfo)`
multiple times

Also:
* Memoize `ClosureTypeInfo(Type ParameterType, PropertyInfo ValueMemberInfo, FieldInfo[] Fields)` for reusing
* static `CompiledQueryRunner.NoopReplacer` to save allocations
* Optimize `IsClosure()` - don't extract Type name while unnecessary
* Remove redundant `closureType.DeclaringType != null` check (`IsAssignableFrom()` returns `false` with `null` arg)