### PR TITLE
Optimize `MaterializationContext`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
@@ -267,7 +267,7 @@ namespace Xtensive.Orm.Linq.Materialization
         return Expression.Convert(
           Expression.Call(
             WellKnownMembers.CreateStructure,
-            Expression.Field(itemMaterializationContextParameter, ItemMaterializationContext.SessionFieldInfo),
+            Expression.Property(itemMaterializationContextParameter, ItemMaterializationContext.SessionPropertyInfo),
             Expression.Constant(expression.Type),
             persistentTupleExpression),
           expression.Type);
@@ -313,7 +313,7 @@ namespace Xtensive.Orm.Linq.Materialization
       return Expression.Convert(
         Expression.Call(
           WellKnownMembers.CreateStructure,
-          Expression.Field(itemMaterializationContextParameter, ItemMaterializationContext.SessionFieldInfo),
+          Expression.Property(itemMaterializationContextParameter, ItemMaterializationContext.SessionPropertyInfo),
           Expression.Constant(expression.Type),
           persistentTupleExpression),
         expression.Type);
@@ -330,7 +330,7 @@ namespace Xtensive.Orm.Linq.Materialization
         WellKnownMembers.Key.Create,
         Expression.Constant(context.Domain),
         Expression.Property(
-          Expression.Field(itemMaterializationContextParameter, ItemMaterializationContext.SessionFieldInfo),
+          Expression.Property(itemMaterializationContextParameter, ItemMaterializationContext.SessionPropertyInfo),
           WellKnownMembers.SessionNodeId),
         Expression.Constant(expression.EntityType),
         TypeReferenceAccuracyConstantExpression,

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ItemMaterializationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ItemMaterializationContext.cs
@@ -17,7 +17,7 @@ namespace Xtensive.Orm.Linq.Materialization
     public static readonly MethodInfo IsMaterializedMethodInfo = WellKnownOrmTypes.ItemMaterializationContext.GetMethod(nameof(IsMaterialized));
     public static readonly MethodInfo GetEntityMethodInfo = WellKnownOrmTypes.ItemMaterializationContext.GetMethod(nameof(GetEntity));
     public static readonly MethodInfo MaterializeMethodInfo = WellKnownOrmTypes.ItemMaterializationContext.GetMethod(nameof(Materialize));
-    public static readonly System.Reflection.FieldInfo SessionFieldInfo = WellKnownOrmTypes.ItemMaterializationContext.GetField(nameof(Session));
+    public static readonly System.Reflection.PropertyInfo SessionPropertyInfo = WellKnownOrmTypes.ItemMaterializationContext.GetProperty(nameof(Session));
 
     public readonly MaterializationContext MaterializationContext;
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ItemMaterializationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ItemMaterializationContext.cs
@@ -2,8 +2,6 @@
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Reflection;
 using Xtensive.Core;
 using Xtensive.Orm.Internals;
@@ -14,20 +12,20 @@ using TypeInfo = Xtensive.Orm.Model.TypeInfo;
 
 namespace Xtensive.Orm.Linq.Materialization
 {
-  internal sealed class ItemMaterializationContext
+  internal readonly struct ItemMaterializationContext
   {
     public static readonly MethodInfo IsMaterializedMethodInfo = WellKnownOrmTypes.ItemMaterializationContext.GetMethod(nameof(IsMaterialized));
     public static readonly MethodInfo GetEntityMethodInfo = WellKnownOrmTypes.ItemMaterializationContext.GetMethod(nameof(GetEntity));
     public static readonly MethodInfo MaterializeMethodInfo = WellKnownOrmTypes.ItemMaterializationContext.GetMethod(nameof(Materialize));
     public static readonly System.Reflection.FieldInfo SessionFieldInfo = WellKnownOrmTypes.ItemMaterializationContext.GetField(nameof(Session));
 
-    public readonly Session Session;
     public readonly MaterializationContext MaterializationContext;
 
-    private readonly TypeIdRegistry typeIdRegistry;
     private readonly Entity[] entities;
-
     public ParameterContext ParameterContext { get; }
+
+    public Session Session => MaterializationContext.Session;
+    private TypeIdRegistry typeIdRegistry => Session.StorageNode.TypeIdRegistry;
 
     public bool IsMaterialized(int index) => entities[index] != null;
 
@@ -75,9 +73,7 @@ namespace Xtensive.Orm.Linq.Materialization
     {
       ParameterContext = parameterContext;
       MaterializationContext = materializationContext;
-      Session = materializationContext.Session;
 
-      typeIdRegistry = Session.StorageNode.TypeIdRegistry;
       entities = new Entity[materializationContext.EntitiesInRow];
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
@@ -25,14 +25,14 @@ namespace Xtensive.Orm.Linq.Materialization
     private readonly EntityMappingCache[] entityMappings;
 
     /// <summary>
-    /// Gets model of current <see cref="DomainModel">domain model.</see>
-    /// </summary>
-    public DomainModel Model => Session.Domain.Model;
-
-    /// <summary>
     /// Gets the session in which materialization is executing.
     /// </summary>
     public Session Session { get; }
+
+    /// <summary>
+    /// Gets model of current <see cref="DomainModel">domain model.</see>
+    /// </summary>
+    public DomainModel Model => Session.Domain.Model;
 
     /// <summary>
     /// Gets count of entities in query row.

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
@@ -88,12 +88,7 @@ namespace Xtensive.Orm.Linq.Materialization
       return result;
     }
 
-    private int ResolveTypeToNodeSpecificTypeIdentifier(TypeInfo typeInfo)
-    {
-      ArgumentNullException.ThrowIfNull(typeInfo);
-      return TypeIdRegistry[typeInfo];
-    }
-
+    private int ResolveTypeToNodeSpecificTypeIdentifier(TypeInfo typeInfo) => TypeIdRegistry[typeInfo];
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
@@ -4,10 +4,6 @@
 // Created by: Alexis Kochetov
 // Created:    2009.05.29
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Xtensive.Core;
 using Xtensive.Tuples.Transform;
 using Xtensive.Orm.Internals;
 using Xtensive.Orm.Model;
@@ -31,27 +27,22 @@ namespace Xtensive.Orm.Linq.Materialization
     /// <summary>
     /// Gets model of current <see cref="DomainModel">domain model.</see>
     /// </summary>
-    public DomainModel Model { get; private set; }
+    public DomainModel Model => Session.Domain.Model;
 
     /// <summary>
     /// Gets the session in which materialization is executing.
     /// </summary>
-    public Session Session { get; private set; }
+    public Session Session { get; }
 
     /// <summary>
     /// Gets count of entities in query row.
     /// </summary>
-    public int EntitiesInRow { get; private set; }
+    public int EntitiesInRow => entityMappings.Length;
 
     /// <summary>
     /// Gets <see cref="StorageNode">node</see> specific type identifiers registry of current node.
     /// </summary>
-    public TypeIdRegistry TypeIdRegistry
-    {
-      get {
-        return Session.StorageNode.TypeIdRegistry;
-      }
-    }
+    public TypeIdRegistry TypeIdRegistry => Session.StorageNode.TypeIdRegistry;
 
     /// <summary>
     /// Gets or sets queue of materialization actions.
@@ -109,15 +100,10 @@ namespace Xtensive.Orm.Linq.Materialization
     public MaterializationContext(Session session, int entityCount)
     {
       Session = session;
-      Model = session.Domain.Model;
-      EntitiesInRow = entityCount;
 
       entityMappings = new EntityMappingCache[entityCount];
-
       for (int i = 0; i < entityMappings.Length; i++)
-        entityMappings[i] = new EntityMappingCache {
-          Items = new Dictionary<int, TypeMapping>()
-        };
+        entityMappings[i] = new() { Items = new Dictionary<int, TypeMapping>() };
     }
   }
 }


### PR DESCRIPTION
Reduce number of fields

Also:
* Convert `ItemMaterializationContext` into `readonly struct`
* Remove redundant null-check before `TypeIdRegistry[typeInfo]`. This indexed accessor already checks for `typeInfo==null`