### PR TITLE
PERF-269: Optimization: `DerivedColumn` class so decrease allocation size of `MappedColumn`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Rse/AggregateColumn.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/AggregateColumn.cs
@@ -12,7 +12,7 @@ namespace Xtensive.Orm.Rse
   /// Aggregate column of the <see cref="RecordSetHeader"/>.
   /// </summary>
   [Serializable]
-  public sealed class AggregateColumn : Column
+  public sealed class AggregateColumn : DerivedColumn
   {
     private const string ToStringFormat = "{0} = {1} on ({2})";
 
@@ -70,14 +70,14 @@ namespace Xtensive.Orm.Rse
     #region Clone constructors
 
     private AggregateColumn(AggregateColumn column, string newName)
-      : base(newName, column.Index, column.Type, column)
+      : base(newName, column.Index, column.Type, column.Origin)
     {
       AggregateType = column.AggregateType;
       SourceIndex = column.SourceIndex;
     }
 
     private AggregateColumn(AggregateColumn column, ColNum newIndex)
-      : base(column.Name, newIndex, column.Type, column)
+      : base(column.Name, newIndex, column.Type, column.Origin)
     {
       AggregateType = column.AggregateType;
       SourceIndex = column.SourceIndex;

--- a/Orm/Xtensive.Orm/Orm/Rse/CalculatedColumn.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/CalculatedColumn.cs
@@ -18,7 +18,7 @@ namespace Xtensive.Orm.Rse
   /// Calculated column of the <see cref="RecordSetHeader"/>.
   /// </summary>
   [Serializable]
-  public sealed class CalculatedColumn : Column
+  public sealed class CalculatedColumn : DerivedColumn
   {
     private const string ToStringFormat = "{0} = {1}";
 
@@ -63,13 +63,13 @@ namespace Xtensive.Orm.Rse
     #region Clone constructors
 
     private CalculatedColumn(CalculatedColumn column, string newName)
-      : base(newName, column.Index, column.Type, column)
+      : base(newName, column.Index, column.Type, column.Origin)
     {
       Expression = column.Expression;
     }
  
     private CalculatedColumn(CalculatedColumn column, ColNum newIndex)
-      : base(column.Name, newIndex, column.Type, column)
+      : base(column.Name, newIndex, column.Type, column.Origin)
     {
       Expression = column.Expression;
     }

--- a/Orm/Xtensive.Orm/Orm/Rse/Column.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Column.cs
@@ -4,111 +4,84 @@
 // Created by: Elena Vakhtina
 // Created:    2008.09.09
 
-namespace Xtensive.Orm.Rse
+namespace Xtensive.Orm.Rse;
+
+/// <summary>
+/// Base class for any column of the <see cref="RecordSetHeader"/>.
+/// </summary>
+[Serializable]
+public abstract class Column(string name, ColNum index, Type type) : IEquatable<Column>
 {
   /// <summary>
-  /// Base class for any column of the <see cref="RecordSetHeader"/>.
+  /// Gets origin <see cref="Column"/> for this instance.
   /// </summary>
-  [Serializable]
-  public abstract class Column : IEquatable<Column>
-  {
-    private const string ToStringFormat = "{0} {1} ({2})";
+  public virtual Column Origin => this;
 
-    /// <summary>
-    /// Gets origin <see cref="Column"/> for this instance.
-    /// </summary>
-    public virtual Column Origin => this;
+  /// <summary>
+  /// Gets the column name.
+  /// </summary>
+  public string Name { get; } = name;
 
-    /// <summary>
-    /// Gets the column name.
-    /// </summary>
-    public string Name { get; private set; }
+  /// <summary>
+  /// Gets the column index.
+  /// </summary>
+  public ColNum Index { get; } = index;
 
-    /// <summary>
-    /// Gets the column index.
-    /// </summary>
-    public ColNum Index { get; }
+  /// <summary>
+  /// Gets the column type.
+  /// </summary>
+  public Type Type { get; } = type;
 
-    /// <summary>
-    /// Gets the column type.
-    /// </summary>
-    public Type Type { get; private set; }
+  /// <inheritdoc/>
+  public bool Equals(Column other) =>
+    other is not null && (ReferenceEquals(this, other) || Name == other.Name);
 
-    #region Equals, GetHashCode, ==, !=
+  /// <inheritdoc/>
+  public override bool Equals(object obj) => obj is Column other && Equals(other);
 
-    /// <inheritdoc/>
-    public bool Equals(Column other) =>
-      other is not null && (ReferenceEquals(this, other) || Name == other.Name);
+  /// <inheritdoc/>
+  public override int GetHashCode() => Name.GetHashCode();
 
-    /// <inheritdoc/>
-    public override bool Equals(object obj) => obj is Column other && Equals(other);
+  /// <summary>
+  /// Implements the operator ==.
+  /// </summary>
+  /// <param name="left">The left.</param>
+  /// <param name="right">The right.</param>
+  /// <returns>
+  /// The result of the operator.
+  /// </returns>
+  public static bool operator ==(Column left, Column right) => left?.Equals(right) ?? right is null;
 
-    /// <inheritdoc/>
-    public override int GetHashCode() => Name.GetHashCode();
+  /// <summary>
+  /// Implements the operator !=.
+  /// </summary>
+  /// <param name="left">The left.</param>
+  /// <param name="right">The right.</param>
+  /// <returns>
+  /// The result of the operator.
+  /// </returns>
+  public static bool operator !=(Column left, Column right) => !(left == right);
 
-    /// <summary>
-    /// Implements the operator ==.
-    /// </summary>
-    /// <param name="left">The left.</param>
-    /// <param name="right">The right.</param>
-    /// <returns>
-    /// The result of the operator.
-    /// </returns>
-    public static bool operator ==(Column left, Column right) => left?.Equals(right) ?? right is null;
+  /// <inheritdoc/>
+  public override string ToString() => $"{Type.Name} {Name} ({Index})";
 
-    /// <summary>
-    /// Implements the operator !=.
-    /// </summary>
-    /// <param name="left">The left.</param>
-    /// <param name="right">The right.</param>
-    /// <returns>
-    /// The result of the operator.
-    /// </returns>
-    public static bool operator !=(Column left, Column right) => !(left == right);
+  /// <summary>
+  /// Creates clone of the column, but with another <see cref="Index"/>.
+  /// </summary>
+  /// <param name="newIndex">The new index value.</param>
+  /// <returns>Clone of the column, but with another <see cref="Index"/>.</returns>
+  public abstract Column Clone(ColNum newIndex);
 
-    #endregion
+  /// <summary>
+  /// Creates clone of the column, but with another <see cref="Name"/>.
+  /// </summary>
+  /// <param name="newName">The new name value.</param>
+  /// <returns>Clone of the column, but with another <see cref="Name"/>.</returns>
+  public abstract Column Clone(string newName);
+}
 
-    /// <inheritdoc/>
-    public override string ToString()
-    {
-      return string.Format(ToStringFormat, Type.Name, Name, Index);
-    }
-
-    /// <summary>
-    /// Creates clone of the column, but with another <see cref="Index"/>.
-    /// </summary>
-    /// <param name="newIndex">The new index value.</param>
-    /// <returns>Clone of the column, but with another <see cref="Index"/>.</returns>
-    public abstract Column Clone(ColNum newIndex);
-
-    /// <summary>
-    /// Creates clone of the column, but with another <see cref="Name"/>.
-    /// </summary>
-    /// <param name="newName">The new name value.</param>
-    /// <returns>Clone of the column, but with another <see cref="Name"/>.</returns>
-    public abstract Column Clone(string newName);
-
-
-    // Constructors
-
-    /// <summary>
-    /// Initializes a new instance of this class..
-    /// </summary>
-    /// <param name="name"><see cref="Name"/> property value.</param>
-    /// <param name="index"><see cref="Index"/> property value.</param>
-    /// <param name="type"><see cref="Type"/> property value.</param>
-    /// <param name="originalColumn">Original column.</param>
-    protected Column(string name, ColNum index, Type type)
-    {
-      Name = name;
-      Index = index;
-      Type = type;
-    }
-  }
-
-  public abstract class DerivedColumn(string name, ColNum index, Type type, Column origin)
-    : Column(name, index, type)
-  {
-    public override Column Origin => origin ?? this;
-  }
+public abstract class DerivedColumn(string name, ColNum index, Type type, Column origin)
+  : Column(name, index, type)
+{
+  public override Column Origin => origin ?? this;
 }

--- a/Orm/Xtensive.Orm/Orm/Rse/Column.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Column.cs
@@ -4,9 +4,6 @@
 // Created by: Elena Vakhtina
 // Created:    2008.09.09
 
-using System;
-
-
 namespace Xtensive.Orm.Rse
 {
   /// <summary>
@@ -20,7 +17,7 @@ namespace Xtensive.Orm.Rse
     /// <summary>
     /// Gets origin <see cref="Column"/> for this instance.
     /// </summary>
-    public Column Origin { get; private set; }
+    public virtual Column Origin => this;
 
     /// <summary>
     /// Gets the column name.
@@ -101,12 +98,17 @@ namespace Xtensive.Orm.Rse
     /// <param name="index"><see cref="Index"/> property value.</param>
     /// <param name="type"><see cref="Type"/> property value.</param>
     /// <param name="originalColumn">Original column.</param>
-    protected Column(string name, ColNum index, Type type, Column originalColumn)
+    protected Column(string name, ColNum index, Type type)
     {
       Name = name;
       Index = index;
       Type = type;
-      Origin = originalColumn is null ? this : originalColumn.Origin;
     }
+  }
+
+  public abstract class DerivedColumn(string name, ColNum index, Type type, Column origin)
+    : Column(name, index, type)
+  {
+    public override Column Origin => origin ?? this;
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
@@ -59,6 +59,8 @@ public class MappedColumn(ColumnInfoRef columnInfoRef, string name, ColNum index
 
 }
 
+// The purpose of this class is minimize allocation size of `MappedColumn`
+// Non self-referencing `Origin` property is a rare case
 internal sealed class DerivedMappedColumn(string name, ColNum index, Type type, Column origin, ColumnInfoRef columnInfoRef)
   : MappedColumn(columnInfoRef, name, index, type)
 {

--- a/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
@@ -4,97 +4,72 @@
 // Created by: Alexey Kochetov
 // Created:    2007.09.21
 
-using System;
 using Xtensive.Orm.Model;
 
-namespace Xtensive.Orm.Rse
+namespace Xtensive.Orm.Rse;
+
+/// <summary>
+/// Mapped column of the <see cref="RecordSetHeader"/>.
+/// </summary>
+[Serializable]
+public sealed class MappedColumn(ColumnInfoRef columnInfoRef, string name, ColNum index, Type type)
+  : Column(name, index, type)
 {
+  private const string ToStringFormat = "{0} = {1}";
+
   /// <summary>
-  /// Mapped column of the <see cref="RecordSetHeader"/>.
+  /// Gets the reference that describes a column.
   /// </summary>
-  [Serializable]
-  public sealed class MappedColumn : Column
+  public ColumnInfoRef ColumnInfoRef { get; } = columnInfoRef;
+
+  /// <inheritdoc/>
+  public override string ToString()
   {
-    private const string ToStringFormat = "{0} = {1}";
-
-    /// <summary>
-    /// Gets the reference that describes a column.
-    /// </summary>
-    public ColumnInfoRef ColumnInfoRef { get; }
-
-    /// <inheritdoc/>
-    public override string ToString()
-    {
-      return string.Format(ToStringFormat, base.ToString(), ColumnInfoRef);
-    }
-
-    /// <inheritdoc/>
-    public override Column Clone(ColNum newIndex)
-    {
-      return new MappedColumn(ColumnInfoRef, Name, newIndex, Type);
-    }
-
-    /// <inheritdoc/>
-    public override Column Clone(string newName)
-    {
-      return new MappedColumn(this, newName);
-    }
-
-    // Constructors
-
-    #region Basic constructors
-
-    /// <summary>
-    /// Initializes a new instance of this class.
-    /// </summary>
-    /// <param name="name"><see cref="Column.Name"/> property value.</param>
-    /// <param name="index"><see cref="Column.Index"/> property value.</param>
-    /// <param name="type"><see cref="Column.Type"/> property value.</param>
-    public MappedColumn(string name, ColNum index, Type type)
-      : this(default, name, index, type)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of this class.
-    /// </summary>
-    /// <param name="columnInfoRef"><see cref="ColumnInfoRef"/> property value.</param>
-    /// <param name="index"><see cref="Column.Index"/> property value.</param>
-    /// <param name="type"><see cref="Column.Type"/> property value.</param>
-    public MappedColumn(ColumnInfoRef columnInfoRef, ColNum index, Type type)
-      : this(columnInfoRef, columnInfoRef.ColumnName, index, type)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of this class.
-    /// </summary>
-    /// <param name="columnInfoRef"><see cref="ColumnInfoRef"/> property value.</param>
-    /// <param name="name"><see cref="Column.Name"/> property value.</param>
-    /// <param name="index"><see cref="Column.Index"/> property value.</param>
-    /// <param name="type"><see cref="Column.Type"/> property value.</param>
-    public MappedColumn(ColumnInfoRef columnInfoRef, string name, ColNum index, Type type)
-      : base(name, index, type, null)
-    {
-      ColumnInfoRef = columnInfoRef;
-    }
-
-    #endregion
-
-    #region Clone constructors
-
-    private MappedColumn(MappedColumn column, string newName)
-      : base(newName, column.Index, column.Type, column)
-    {
-      ColumnInfoRef = column.ColumnInfoRef;
-    }
-
-    private MappedColumn(MappedColumn column, ColNum newIndex)
-      : base(column.Name, newIndex, column.Type, column)
-    {
-      ColumnInfoRef = column.ColumnInfoRef;
-    }
-
-    #endregion
+    return string.Format(ToStringFormat, base.ToString(), ColumnInfoRef);
   }
+
+  /// <inheritdoc/>
+  public override Column Clone(ColNum newIndex) => new MappedColumn(ColumnInfoRef, Name, newIndex, Type);
+
+  /// <inheritdoc/>
+  public override Column Clone(string newName) => new DerivedMappedColumn(newName, Index, Type, Origin, ColumnInfoRef);
+
+  // Constructors
+
+  #region Basic constructors
+
+  /// <summary>
+  /// Initializes a new instance of this class.
+  /// </summary>
+  /// <param name="name"><see cref="Column.Name"/> property value.</param>
+  /// <param name="index"><see cref="Column.Index"/> property value.</param>
+  /// <param name="type"><see cref="Column.Type"/> property value.</param>
+  public MappedColumn(string name, ColNum index, Type type)
+    : this(default, name, index, type)
+  {
+  }
+
+  /// <summary>
+  /// Initializes a new instance of this class.
+  /// </summary>
+  /// <param name="columnInfoRef"><see cref="ColumnInfoRef"/> property value.</param>
+  /// <param name="index"><see cref="Column.Index"/> property value.</param>
+  /// <param name="type"><see cref="Column.Type"/> property value.</param>
+  public MappedColumn(ColumnInfoRef columnInfoRef, ColNum index, Type type)
+    : this(columnInfoRef, columnInfoRef.ColumnName, index, type)
+  {
+  }
+
+  #endregion
+
+}
+
+internal sealed class DerivedMappedColumn(string name, ColNum index, Type type, Column origin, ColumnInfoRef columnInfoRef)
+  : DerivedColumn(name, index, type, origin)
+{
+  public ColumnInfoRef ColumnInfoRef { get; } = columnInfoRef;
+
+  public override Column Clone(ColNum newIndex) => new MappedColumn(ColumnInfoRef, Name, newIndex, Type);
+
+  public override Column Clone(string newName) => new DerivedMappedColumn(newName, Index, Type, Origin, ColumnInfoRef);
 }

--- a/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
@@ -12,7 +12,7 @@ namespace Xtensive.Orm.Rse;
 /// Mapped column of the <see cref="RecordSetHeader"/>.
 /// </summary>
 [Serializable]
-public sealed class MappedColumn(ColumnInfoRef columnInfoRef, string name, ColNum index, Type type)
+public class MappedColumn(ColumnInfoRef columnInfoRef, string name, ColNum index, Type type)
   : Column(name, index, type)
 {
   private const string ToStringFormat = "{0} = {1}";
@@ -65,11 +65,7 @@ public sealed class MappedColumn(ColumnInfoRef columnInfoRef, string name, ColNu
 }
 
 internal sealed class DerivedMappedColumn(string name, ColNum index, Type type, Column origin, ColumnInfoRef columnInfoRef)
-  : DerivedColumn(name, index, type, origin)
+  : MappedColumn(columnInfoRef, name, index, type)
 {
-  public ColumnInfoRef ColumnInfoRef { get; } = columnInfoRef;
-
-  public override Column Clone(ColNum newIndex) => new MappedColumn(ColumnInfoRef, Name, newIndex, Type);
-
-  public override Column Clone(string newName) => new DerivedMappedColumn(newName, Index, Type, Origin, ColumnInfoRef);
+  public override Column Origin => origin ?? this;
 }

--- a/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/MappedColumn.cs
@@ -15,18 +15,13 @@ namespace Xtensive.Orm.Rse;
 public class MappedColumn(ColumnInfoRef columnInfoRef, string name, ColNum index, Type type)
   : Column(name, index, type)
 {
-  private const string ToStringFormat = "{0} = {1}";
-
   /// <summary>
   /// Gets the reference that describes a column.
   /// </summary>
   public ColumnInfoRef ColumnInfoRef { get; } = columnInfoRef;
 
   /// <inheritdoc/>
-  public override string ToString()
-  {
-    return string.Format(ToStringFormat, base.ToString(), ColumnInfoRef);
-  }
+  public override string ToString() => $"{base.ToString()} = {ColumnInfoRef}";
 
   /// <inheritdoc/>
   public override Column Clone(ColNum newIndex) => new MappedColumn(ColumnInfoRef, Name, newIndex, Type);

--- a/Orm/Xtensive.Orm/Orm/Rse/SystemColumn.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/SystemColumn.cs
@@ -13,7 +13,7 @@ namespace Xtensive.Orm.Rse
   /// System column of the <see cref="RecordSetHeader"/>.
   /// </summary>
   [Serializable]
-  public class SystemColumn : Column
+  public class SystemColumn : DerivedColumn
   {
     /// <inheritdoc/>
     public override Column Clone(ColNum newIndex)
@@ -41,12 +41,12 @@ namespace Xtensive.Orm.Rse
     #region Clone constructors
 
     private SystemColumn(SystemColumn column, ColNum newIndex)
-      : base(column.Name, newIndex, column.Type, column)
+      : base(column.Name, newIndex, column.Type, column.Origin)
     {
     }
 
     private SystemColumn(SystemColumn column, string newName)
-      : base(newName, column.Index, column.Type, column)
+      : base(newName, column.Index, column.Type, column.Origin)
     {
     }
 


### PR DESCRIPTION
A typical process has ~4M instances of `MappedColumn`.
![image](https://github.com/user-attachments/assets/72c9e374-3e4f-40e2-9bb1-ec26cd3d2e83)

Most of them have `Origin` pointing to `this`.

With this PR we introduce `DerivedMappedColumn` for which `Origin != this` (rare case).
The typical `MappedColumn` object will allocate 8 bytes less.

This will save ~ 35 MB of RAM