### PR TITLE
Optimize `TranslateString()`

### DIFF
--- a/Orm/Xtensive.Orm/Caching/MfLruCache.cs
+++ b/Orm/Xtensive.Orm/Caching/MfLruCache.cs
@@ -220,7 +220,7 @@ namespace Xtensive.Caching
 
       Exception error = null;
       int removedCount = 0;
-      double effeciency = 0;
+      double efficiency = 0;
       try {
         // Preparing arrays for selection
         var times = new int[count];
@@ -270,13 +270,13 @@ namespace Xtensive.Caching
         if (efficiencyFactor<0)
           timeShift = -efficiencyFactor; // Constant timeShift is defined
         else {
-          // Relative effeciency factor is defined
+          // Relative efficiency factor is defined
           if (removedCount < 1)
             removedCount = 1;
-          effeciency =
+          efficiency =
             ((double) GcOperationCost * removedCount + time) /
             ((double) GcOperationCost * count + time);
-          timeShift = ((int) Math.Ceiling(Math.Log(1 / effeciency, 2)));
+          timeShift = ((int) Math.Ceiling(Math.Log(1 / efficiency, 2)));
           timeShift += efficiencyFactor;
           if (timeShift > 7)
             timeShift = 7;
@@ -296,7 +296,7 @@ namespace Xtensive.Caching
         // Logging
         if (CoreLog.IsLogged(LogLevel.Debug)) {
           CoreLog.Debug("MfLruCache.CollectGarbage: removed: {0} from {1}, efficiency: {2}, time shift: {3}",
-            removedCount, count, effeciency, timeShift);
+            removedCount, count, efficiency, timeShift);
           if (error!=null)
             CoreLog.Debug(error, "Caught at MfLruCache.CollectGarbage");
         }

--- a/Orm/Xtensive.Orm/Core/InheritableScope.cs
+++ b/Orm/Xtensive.Orm/Core/InheritableScope.cs
@@ -36,7 +36,7 @@ namespace Xtensive.Core
     protected internal InheritableScope()
       : base(false)
     {
-// Must be replaced to more effecient check from the point of performance.
+// Must be replaced to more efficient check from the point of performance.
 //
 //      var type = GetType();
 //      if (allowedType==null) lock (@lock) if (allowedType==null)

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlTranslator.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlTranslator.cs
@@ -2348,11 +2348,18 @@ namespace Xtensive.Sql.Compiler
     /// <param name="str">The string.</param>
     public virtual void TranslateString(IOutput output, string str)
     {
-      // this is more effecient than SqlHelper.QuoteString()
+      // this is more efficient than SqlHelper.QuoteString()
       _ = output.AppendLiteral('\'');
-      foreach (var ch in str) {
-        TranslateChar(output, ch);
+
+      if (str.ContainsAny(['\'', '\\', '\0'])) {
+        foreach (var ch in str) {
+          TranslateChar(output, ch);
+        }
       }
+      else {
+        _ = output.AppendLiteral(str);
+      }
+
       _ = output.AppendLiteral('\'');
     }
 
@@ -2374,21 +2381,6 @@ namespace Xtensive.Sql.Compiler
           break;
       }
     }
-
-    protected virtual void TranslateStringChar(IOutput output, char ch)
-    {
-      switch (ch) {
-        case '\0':
-          break;
-        case '\'':
-          output.AppendLiteral("''");
-          break;
-        default:
-          output.AppendLiteral(ch);
-          break;
-      }
-    }
-
 
     /// <summary>
     /// Translates identifier names (one or several) and writes result to <paramref name="output"/>


### PR DESCRIPTION
* Call `_ = output.AppendLiteral(str);` instead of iterating over string's chars for strings without special chars
* Remove unreferenced `TranslateStringChar()`
* Fix misspelling `effecient` -> `efficient`