### PR TITLE
PERF-281: Optimize `SqlQueryStatement`

### DIFF
--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/BaseSqlVisitor.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/BaseSqlVisitor.cs
@@ -460,14 +460,14 @@ namespace Xtensive.Orm.BulkOperations
       foreach (SqlColumn column in node.Columns)
         VisitInternal(column);
       VisitInternal(node.From);
-      foreach (SqlColumn column in node.GroupBy)
+      foreach (SqlColumn column in node.GroupByReadOnly)
         VisitInternal(column);
       VisitInternal(node.Having);
       foreach (SqlHint hint in node.Hints)
         VisitInternal(hint);
       VisitInternal(node.Limit);
       VisitInternal(node.Offset);
-      foreach (SqlOrder order in node.OrderBy)
+      foreach (SqlOrder order in node.OrderByReadOnly)
         VisitInternal(order);
       VisitInternal(node.Where);
     }

--- a/Orm/Xtensive.Orm.Tests.Sql/CloneTests.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/CloneTests.cs
@@ -360,7 +360,7 @@ namespace Xtensive.Orm.Tests.Sql
       s.Columns.Add(tr2.Asterisk);
       s.From = tr1.InnerJoin(tr2, tr1["ID"]==tr2["ID"]);
       s.Where = SqlDml.Like(tr1["Name"], "Marat");
-      s.Hints.Add(SqlDml.FastFirstRowsHint(10));
+      s.AddHint(SqlDml.FastFirstRowsHint(10));
 
       SqlSelect sClone = (SqlSelect)s.Clone();
       
@@ -544,7 +544,7 @@ namespace Xtensive.Orm.Tests.Sql
       SqlTableRef t = SqlDml.TableRef(table1);
       SqlDelete d = SqlDml.Delete(t);
       d.Where = t[0] < 6;
-      d.Hints.Add(SqlDml.FastFirstRowsHint(10));
+      d.AddHint(SqlDml.FastFirstRowsHint(10));
       SqlDelete dClone = (SqlDelete) d.Clone();
 
       Assert.AreNotEqual(d, dClone);
@@ -599,7 +599,7 @@ namespace Xtensive.Orm.Tests.Sql
       SqlTableRef t = SqlDml.TableRef(table1);
       SqlInsert i = SqlDml.Insert(t);
       i.AddValueRow(( t[0], 1 ), ( t[1], "Anonym" ));
-      i.Hints.Add(SqlDml.FastFirstRowsHint(10));
+      i.AddHint(SqlDml.FastFirstRowsHint(10));
       SqlInsert iClone = (SqlInsert)i.Clone();
 
       Assert.AreNotEqual(i, iClone);
@@ -623,7 +623,7 @@ namespace Xtensive.Orm.Tests.Sql
       u.Values[t[0]] = 1;
       u.Values[t[1]] = "Anonym";
       u.Where = t.Columns["ID"]==1;
-      u.Hints.Add(SqlDml.FastFirstRowsHint(10));
+      u.AddHint(SqlDml.FastFirstRowsHint(10));
       SqlUpdate uClone = (SqlUpdate)u.Clone();
 
       Assert.AreNotEqual(u, uClone);

--- a/Orm/Xtensive.Orm.Tests.Sql/MySQL/SakilaExtractorTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/MySQL/SakilaExtractorTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2011-2020 Xtensive LLC.
+// Copyright (C) 2011-2020 Xtensive LLC.
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 // Created by: Malisa Ncube
@@ -986,7 +986,7 @@ namespace Xtensive.Orm.Tests.Sql.MySQL
       select.Columns.AddRange(c["customer_id"], c["store_id"], c["first_name"], c["last_name"], c["email"]);
       select.Where = c["last_name"]>"JOHNSON";
 
-      select.Hints.Add(SqlDml.NativeHint("idx_last_name"));
+      select.AddHint(SqlDml.NativeHint("idx_last_name"));
 
       Assert.IsTrue(CompareExecuteDataReader(nativeSql, select));
     }

--- a/Orm/Xtensive.Orm.Tests.Sql/SqlServer/MSSQLTests.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/SqlServer/MSSQLTests.cs
@@ -3805,9 +3805,9 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
       var select = SqlDml.Select(abcd);
       select.Limit = 10;
       select.Columns.Add(SqlDml.Asterisk);
-      select.Hints.Add(SqlDml.JoinHint(SqlJoinMethod.Hash, ab));
-      select.Hints.Add(SqlDml.JoinHint(SqlJoinMethod.Merge, cd));
-      select.Hints.Add(SqlDml.JoinHint(SqlJoinMethod.Loop, abcd));
+      select.AddHint(SqlDml.JoinHint(SqlJoinMethod.Hash, ab));
+      select.AddHint(SqlDml.JoinHint(SqlJoinMethod.Merge, cd));
+      select.AddHint(SqlDml.JoinHint(SqlJoinMethod.Loop, abcd));
 
 
       Assert.IsTrue(CompareExecuteDataReader(nativeSql, select));
@@ -3836,9 +3836,9 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
       var select = SqlDml.Select(abcd);
       select.Limit = 10;
       select.Columns.Add(SqlDml.Asterisk);
-      select.Hints.Add(SqlDml.JoinHint(SqlJoinMethod.Hash, b));
-      select.Hints.Add(SqlDml.JoinHint(SqlJoinMethod.Merge, d));
-      select.Hints.Add(SqlDml.JoinHint(SqlJoinMethod.Loop, abcd));
+      select.AddHint(SqlDml.JoinHint(SqlJoinMethod.Hash, b));
+      select.AddHint(SqlDml.JoinHint(SqlJoinMethod.Merge, d));
+      select.AddHint(SqlDml.JoinHint(SqlJoinMethod.Loop, abcd));
 
       Assert.IsTrue(CompareExecuteDataReader(nativeSql, select));
     }
@@ -3874,8 +3874,8 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
       select.Limit = 10;
       select.Columns.Add(c["EmailAddress"]);
       select.Where = SqlDml.Like(c["EmailAddress"], "a%");
-      select.Hints.Add(SqlDml.FastFirstRowsHint(10));
-      select.Hints.Add(SqlDml.NativeHint("KEEP PLAN, ROBUST PLAN"));
+      select.AddHint(SqlDml.FastFirstRowsHint(10));
+      select.AddHint(SqlDml.NativeHint("KEEP PLAN, ROBUST PLAN"));
       Assert.IsTrue(CompareExecuteDataReader(nativeSql, select));
     }
 
@@ -4046,7 +4046,7 @@ namespace Xtensive.Orm.Tests.Sql.SqlServer
       outerSelect.Columns.Add(categoryName, "SubcategoryName");
 
       outerSelect.Lock = SqlLockType.Exclusive;
-      outerSelect.Hints.Add(new SqlIndexHint("IndexName", subcategories));
+      outerSelect.AddHint(new SqlIndexHint("IndexName", subcategories));
 
       Assert.IsTrue(CompareExecuteDataReader(nativeSql, outerSelect));
     }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -231,9 +231,8 @@ namespace Xtensive.Orm.Providers
       query.Columns.AddRange(joinedTable.AliasedColumns);
       query.Comment = SqlComment.Join(left.Request.Statement.Comment, right.Request.Statement.Comment);
 
-      foreach (var sqlHint in left.Request.Statement.Hints.Concat(right.Request.Statement.Hints))
-      {
-        query.Hints.Add(sqlHint);
+      foreach (var sqlHint in left.Request.Statement.Hints.Concat(right.Request.Statement.Hints)) {
+        query.AddHint(sqlHint);
       }
       return CreateProvider(query, provider, left, right);
     }
@@ -288,10 +287,9 @@ namespace Xtensive.Orm.Providers
         query.Where &= right.Request.Statement.Where;
       query.Columns.AddRange(joinedTable.AliasedColumns);
       query.Comment = SqlComment.Join(left.Request.Statement.Comment, right.Request.Statement.Comment);
-      
-      foreach (var sqlHint in left.Request.Statement.Hints.Concat(right.Request.Statement.Hints))
-      {
-        query.Hints.Add(sqlHint);
+
+      foreach (var sqlHint in left.Request.Statement.Hints.Concat(right.Request.Statement.Hints)) {
+        query.AddHint(sqlHint);
       }
       return CreateProvider(query, bindings, provider, left, right);
     }
@@ -372,7 +370,7 @@ namespace Xtensive.Orm.Providers
       
       var query = compiledSource.Request.Statement;
       var indexName = index.MappingName;
-      query.Hints.Add(new SqlIndexHint(indexName, tableRef));
+      query.AddHint(new SqlIndexHint(indexName, tableRef));
 
       return CreateProvider(query, provider, compiledSource);
     }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlSelectProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlSelectProcessor.cs
@@ -435,9 +435,9 @@ namespace Xtensive.Orm.Providers
     {
       foreach (var column in node.Columns)
         Visit(column);
-      foreach (var column in node.GroupBy)
+      foreach (var column in node.GroupByReadOnly)
         Visit(column);
-      foreach (var column in node.OrderBy)
+      foreach (var column in node.OrderByReadOnly)
         Visit(column);
       if (node.From != null)
         Visit(node.From);
@@ -455,7 +455,7 @@ namespace Xtensive.Orm.Providers
 
       var isCurrentRoot = ReferenceEquals(node, rootSelect);
       var keepOrderBy = isCurrentRoot || hasPaging;
-      if (!keepOrderBy)
+      if (!keepOrderBy && node.OrderByReadOnly.Count > 0)
         node.OrderBy.Clear();
 
       if (!isCurrentRoot) {
@@ -464,7 +464,7 @@ namespace Xtensive.Orm.Providers
       }
 
       var addOrderBy = hasPaging
-        && node.OrderBy.Count==0
+        && node.OrderByReadOnly.Count==0
         && providerInfo.Supports(ProviderFeatures.PagingRequiresOrderBy);
 
       if (addOrderBy)

--- a/Orm/Xtensive.Orm/Sql/Compiler/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/SqlCompiler.cs
@@ -1687,13 +1687,13 @@ namespace Xtensive.Sql.Compiler
     /// <param name="node">Statement to visit.</param>
     protected virtual void VisitSelectGroupBy(SqlSelect node)
     {
-      if (node.GroupBy.Count <= 0) {
+      if (node.GroupByReadOnly.Count <= 0) {
         return;
       }
       // group by
       translator.SelectGroupBy(context, node);
       using (context.EnterCollectionScope()) {
-        foreach (var item in node.GroupBy) {
+        foreach (var item in node.GroupByReadOnly) {
           AppendCollectionDelimiterIfNecessary(AppendColumnDelimiter);
           var cr = item as SqlColumnRef;
           if (cr is not null) {
@@ -1718,13 +1718,13 @@ namespace Xtensive.Sql.Compiler
     /// <param name="node">Statement to visit.</param>
     protected virtual void VisitSelectOrderBy(SqlSelect node)
     {
-      if (node.OrderBy.Count <= 0) {
+      if (node.OrderByReadOnly.Count <= 0) {
         return;
       }
 
       translator.SelectOrderBy(context, node);
       using (context.EnterCollectionScope()) {
-        foreach (var item in node.OrderBy) {
+        foreach (var item in node.OrderByReadOnly) {
           AppendCollectionDelimiterIfNecessary(AppendColumnDelimiter);
           item.AcceptVisitor(this);
         }

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlLockType.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlLockType.cs
@@ -9,7 +9,7 @@ using System;
 namespace Xtensive.Sql.Dml
 {
   [Flags]
-  public enum SqlLockType
+  public enum SqlLockType : byte
   {
     Empty = 0,
     Shared = 1,

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlDelete.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlDelete.cs
@@ -72,7 +72,7 @@ namespace Xtensive.Sql.Dml
 
         if (t.Hints.Count > 0)
           foreach (SqlHint hint in t.Hints)
-            clone.Hints.Add(hint.Clone(c));
+            clone.AddHint(hint.Clone(c));
 
         return clone;
       });

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlInsert.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlInsert.cs
@@ -47,7 +47,7 @@ namespace Xtensive.Sql.Dml
 
         if (t.Hints.Count > 0) {
           foreach (SqlHint hint in t.Hints)
-            clone.Hints.Add(hint.Clone(c));
+            clone.AddHint(hint.Clone(c));
         }
         return clone;
       });

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlQueryStatement.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlQueryStatement.cs
@@ -2,30 +2,21 @@
 // All rights reserved.
 // For conditions of distribution and use, see license.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
+namespace Xtensive.Sql.Dml;
 
-namespace Xtensive.Sql.Dml
+/// <summary>
+/// Base class for DML statements.
+/// </summary>
+[Serializable]
+public abstract class SqlQueryStatement(SqlNodeType nodeType) : SqlStatement(nodeType)
 {
+  private List<SqlHint> hints;
+
   /// <summary>
-  /// Base class for DML statements.
+  /// Gets the collection of join hints.
   /// </summary>
-  [Serializable]
-  public abstract class SqlQueryStatement : SqlStatement
-  {
-    private IList<SqlHint> hints;
+  /// <value>The collection of join hints.</value>
+  public IReadOnlyList<SqlHint> Hints => hints ?? [];
 
-    /// <summary>
-    /// Gets the collection of join hints.
-    /// </summary>
-    /// <value>The collection of join hints.</value>
-    public IList<SqlHint> Hints => hints ??= new Collection<SqlHint>();
-
-    // Constructors
-
-    protected SqlQueryStatement(SqlNodeType nodeType) : base(nodeType)
-    {
-    }
-  }
+  public void AddHint(SqlHint hint) => (hints ??= new(1)).Add(hint);
 }

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlSelect.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlSelect.cs
@@ -61,8 +61,7 @@ namespace Xtensive.Sql.Dml
       get { return where; }
       set
       {
-        if (value is not null)
-          SqlValidator.EnsureIsBooleanExpression(value);
+        SqlValidator.EnsureIsBooleanExpression(value);
         where = value;
       }
     }
@@ -73,6 +72,8 @@ namespace Xtensive.Sql.Dml
     /// <value>The collection of columns.</value>
     public SqlColumnCollection GroupBy => groupBy ??= new();
 
+    public IReadOnlyList<SqlColumn> GroupByReadOnly => groupBy ??= [];
+
     /// <summary>
     /// Gets or sets the having clause.
     /// </summary>
@@ -82,8 +83,7 @@ namespace Xtensive.Sql.Dml
       get { return having; }
       set
       {
-        if (value is not null)
-          SqlValidator.EnsureIsBooleanExpression(value);
+        SqlValidator.EnsureIsBooleanExpression(value);
         having = value;
       }
     }
@@ -93,6 +93,8 @@ namespace Xtensive.Sql.Dml
     /// </summary>
     /// <value>The order by clause.</value>
     public SqlOrderCollection OrderBy => orderBy ??= new();
+
+    public IReadOnlyList<SqlOrder> OrderByReadOnly => orderBy ??= [];
 
     /// <summary>
     /// Gets or sets a value indicating whether this <see cref="SqlSelect"/> is distinct.
@@ -168,7 +170,7 @@ namespace Xtensive.Sql.Dml
 
         if (t.Hints.Count > 0)
           foreach (SqlHint hint in t.Hints)
-            clone.Hints.Add(hint.Clone(c));
+            clone.AddHint(hint.Clone(c));
 
         return clone;
       });
@@ -183,14 +185,14 @@ namespace Xtensive.Sql.Dml
         : SqlDml.Select(From);
       result.Columns.AddRange(Columns);
       result.Distinct = Distinct;
-      result.GroupBy.AddRange(GroupBy);
+      result.GroupBy.AddRange(GroupByReadOnly);
       result.Having = Having;
       result.Offset = Offset;
       result.Limit = Limit;
-      foreach (var order in OrderBy)
+      foreach (var order in OrderByReadOnly)
         result.OrderBy.Add(order);
       foreach (var hint in Hints)
-        result.Hints.Add(hint);
+        result.AddHint(hint);
       result.Where = Where;
       result.Lock = Lock;
       result.Comment = Comment;

--- a/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlUpdate.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Statements/SqlUpdate.cs
@@ -83,7 +83,7 @@ namespace Xtensive.Sql.Dml
           clone.Limit = t.where.Clone(c);
         if (t.Hints.Count > 0)
           foreach (SqlHint hint in t.Hints)
-            clone.Hints.Add(hint.Clone(c));
+            clone.AddHint(hint.Clone(c));
 
         return clone;
       });

--- a/Orm/Xtensive.Orm/Sql/SqlNodeType.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlNodeType.cs
@@ -7,7 +7,7 @@ using System;
 namespace Xtensive.Sql
 {
   [Serializable]
-  public enum SqlNodeType
+  public enum SqlNodeType : byte
   {
     Action,
     Add,


### PR DESCRIPTION
In queries `.Hints`, `.OrderBy`, `.GroupBy` are empty frequently.
No need to allocate Collection/List for them just to enumerate it

Also:
* Make some `enum`s  byte-size
* Don't check for `null` before `SqlValidator.EnsureIsBooleanExpression(value)` - it allows `null` as input