### PR TITLE
Optimization: Convert `QueryEndpoint` to `readonly struct`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
@@ -45,11 +45,11 @@ namespace Xtensive.Orm
     public IQueryRootBuilder RootBuilder { get; }
 
     public bool Equals(QueryEndpoint other) =>
-      session == other.session && Provider == other.Provider && RootBuilder == other.RootBuilder;
+      Provider == other.Provider && RootBuilder == other.RootBuilder;
 
     public override bool Equals(object obj) => obj is QueryEndpoint other && Equals(other);
 
-    public override int GetHashCode() => HashCode.Combine(session, Provider, RootBuilder);
+    public override int GetHashCode() => HashCode.Combine(Provider, RootBuilder);
 
     /// <summary>
     /// The "starting point" for any LINQ query -

--- a/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
@@ -29,13 +29,13 @@ namespace Xtensive.Orm
   [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
   public readonly struct QueryEndpoint : IEquatable<QueryEndpoint>
   {
-    private readonly Session session;
-
     /// <summary>
     /// Gets <see cref="IQueryProvider"/> implementation
     /// for this session.
     /// </summary>
     public QueryProvider Provider { get; }
+
+    private Session session => Provider.Session;
 
     /// <summary>
     /// Gets <see cref="IQueryRootBuilder"/> associated with this instance.
@@ -988,14 +988,12 @@ namespace Xtensive.Orm
     {
       ArgumentNullException.ThrowIfNull(provider);
       Provider = provider;
-      session = provider.Session;
     }
 
     internal QueryEndpoint(QueryEndpoint outerEndpoint, IQueryRootBuilder queryRootBuilder)
     {
       ArgumentNullException.ThrowIfNull(queryRootBuilder);
       Provider = outerEndpoint.Provider;
-      session = outerEndpoint.session;
       RootBuilder = queryRootBuilder;
     }
   }

--- a/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
@@ -35,7 +35,7 @@ namespace Xtensive.Orm
     /// </summary>
     public QueryProvider Provider { get; }
 
-    private Session session => Provider.Session;
+    private Session Session => Provider.Session;
 
     /// <summary>
     /// Gets <see cref="IQueryRootBuilder"/> associated with this instance.
@@ -257,7 +257,7 @@ namespace Xtensive.Orm
 
     /// <summary>
     /// Resolves (gets) the <see cref="Entity"/> by the specified <paramref name="key"/>
-    /// in the current <see cref="session"/>.
+    /// in the current <see cref="Session"/>.
     /// </summary>
     /// <param name="key">The key to resolve.</param>
     /// <returns>
@@ -278,7 +278,7 @@ namespace Xtensive.Orm
 
     /// <summary>
     /// Resolves (gets) the <see cref="Entity"/> by the specified <paramref name="key"/>
-    /// in the current <see cref="session"/>.
+    /// in the current <see cref="Session"/>.
     /// </summary>
     /// <param name="key">The key to resolve.</param>
     /// <returns>
@@ -299,7 +299,7 @@ namespace Xtensive.Orm
 
     /// <summary>
     /// Resolves (gets) the <see cref="Entity"/> by the specified <paramref name="key"/>
-    /// in the current <see cref="session"/>.
+    /// in the current <see cref="Session"/>.
     /// </summary>
     /// <param name="key">The key to resolve.</param>
     /// <returns>
@@ -312,6 +312,7 @@ namespace Xtensive.Orm
       if (key == null) {
         return null;
       }
+      var session = Session;
       using var tx = session.OpenAutoTransaction();
       EntityState state;
       if (!session.LookupStateInCache(key, out state)) {
@@ -339,7 +340,7 @@ namespace Xtensive.Orm
 
     /// <summary>
     /// Resolves (gets) the <see cref="Entity"/> by the specified <paramref name="key"/>
-    /// in the current <see cref="session"/>.
+    /// in the current <see cref="Session"/>.
     /// </summary>
     /// <param name="key">The key to resolve.</param>
     /// <returns>
@@ -351,7 +352,8 @@ namespace Xtensive.Orm
       if (key == null) {
         return null;
       }
-      using var tx = session.OpenAutoTransaction();
+      var session = Session;
+      await using var tx = session.OpenAutoTransaction();
       EntityState state;
       if (!session.LookupStateInCache(key, out state)) {
         if (session.IsDebugEventLoggingEnabled) {
@@ -378,7 +380,7 @@ namespace Xtensive.Orm
 
     /// <summary>
     /// Resolves (gets) the <see cref="Entity"/> by the specified <paramref name="key"/>
-    /// in the current <see cref="session"/>.
+    /// in the current <see cref="Session"/>.
     /// </summary>
     /// <typeparam name="T">Type of the entity.</typeparam>
     /// <param name="key">The key to resolve.</param>
@@ -394,7 +396,7 @@ namespace Xtensive.Orm
 
     /// <summary>
     /// Resolves (gets) the <see cref="Entity"/> by the specified <paramref name="keyValues"/>
-    /// in the current <see cref="session"/>.
+    /// in the current <see cref="Session"/>.
     /// </summary>
     /// <typeparam name="T">Type of the entity.</typeparam>
     /// <param name="keyValues">Key values.</param>
@@ -410,7 +412,7 @@ namespace Xtensive.Orm
 
     /// <summary>
     /// Resolves (gets) the <see cref="Entity"/> by the specified <paramref name="key"/>
-    /// in the current <see cref="session"/>.
+    /// in the current <see cref="Session"/>.
     /// </summary>
     /// <typeparam name="T">Type of the entity.</typeparam>
     /// <param name="key">The key to resolve.</param>
@@ -425,7 +427,7 @@ namespace Xtensive.Orm
 
     /// <summary>
     /// Resolves (gets) the <see cref="Entity"/> by the specified <paramref name="keyValues"/>
-    /// in the current <see cref="session"/>.
+    /// in the current <see cref="Session"/>.
     /// </summary>
     /// <typeparam name="T">Type of the entity.</typeparam>
     /// <param name="keyValues">Key values.</param>
@@ -440,7 +442,7 @@ namespace Xtensive.Orm
 
     /// <summary>
     /// Resolves (gets) the <see cref="Entity"/> by the specified <paramref name="key"/>
-    /// in the current <see cref="session"/>.
+    /// in the current <see cref="Session"/>.
     /// </summary>
     /// <typeparam name="T">Type of the entity.</typeparam>
     /// <param name="key">The key to resolve.</param>
@@ -453,7 +455,7 @@ namespace Xtensive.Orm
 
     /// <summary>
     /// Resolves (gets) the <see cref="Entity"/> by the specified <paramref name="keyValues"/>
-    /// in the current <see cref="session"/>.
+    /// in the current <see cref="Session"/>.
     /// </summary>
     /// <typeparam name="T">Type of the entity.</typeparam>
     /// <param name="keyValues">Key values.</param>
@@ -469,7 +471,7 @@ namespace Xtensive.Orm
 
     /// <summary>
     /// Resolves (gets) the <see cref="Entity"/> by the specified <paramref name="key"/>
-    /// in the current <see cref="session"/>.
+    /// in the current <see cref="Session"/>.
     /// </summary>
     /// <typeparam name="T">Type of the entity.</typeparam>
     /// <param name="key">The key to resolve.</param>
@@ -481,7 +483,7 @@ namespace Xtensive.Orm
 
     /// <summary>
     /// Resolves (gets) the <see cref="Entity"/> by the specified <paramref name="keyValues"/>
-    /// in the current <see cref="session"/>.
+    /// in the current <see cref="Session"/>.
     /// </summary>
     /// <typeparam name="T">Type of the entity.</typeparam>
     /// <param name="keyValues">Key values.</param>
@@ -502,7 +504,7 @@ namespace Xtensive.Orm
     public PrefetchQuery<T> Many<T>(IEnumerable<Key> keys)
       where T : class, IEntity
     {
-      return new PrefetchQuery<T>(session, keys);
+      return new PrefetchQuery<T>(Session, keys);
     }
 
     /// <summary>
@@ -517,15 +519,15 @@ namespace Xtensive.Orm
       where T : class, IEntity
     {
       var elementType = typeof (TElement);
-      var sess = session;
+      var session = Session;
       Func<TElement, Key> selector =
         elementType == WellKnownTypes.ObjectArray
-        ? e => Key.Create(sess.Domain, sess.StorageNodeId, typeof(T), TypeReferenceAccuracy.BaseType, (object[]) (object) e)
+        ? e => Key.Create(session.Domain, session.StorageNodeId, typeof(T), TypeReferenceAccuracy.BaseType, (object[]) (object) e)
         : WellKnownOrmTypes.Tuple.IsAssignableFrom(elementType)
-          ? e => Key.Create(sess.Domain, sess.StorageNodeId, typeof(T), TypeReferenceAccuracy.BaseType, (Tuple) (object) e)
-          : e => Key.Create(sess.Domain, sess.StorageNodeId, typeof(T), TypeReferenceAccuracy.BaseType, new object[] { e });
+          ? e => Key.Create(session.Domain, session.StorageNodeId, typeof(T), TypeReferenceAccuracy.BaseType, (Tuple) (object) e)
+          : e => Key.Create(session.Domain, session.StorageNodeId, typeof(T), TypeReferenceAccuracy.BaseType, new object[] { e });
 
-      return new PrefetchQuery<T>(sess, keys.Select(selector));
+      return new PrefetchQuery<T>(session, keys.Select(selector));
     }
 
     #region Execute methods
@@ -966,6 +968,7 @@ namespace Xtensive.Orm
             return entity.Key;
         }
       }
+      var session = Session;
       return Key.Create(session.Domain, session.StorageNodeId, typeof(T), TypeReferenceAccuracy.BaseType, keyValues);
     }
 
@@ -973,7 +976,7 @@ namespace Xtensive.Orm
     {
       return RootBuilder!=null
         ? RootBuilder.BuildRootExpression(elementType)
-        : session.Domain.RootCallExpressionsCache.GetOrAdd(elementType, (t) => Expression.Call(null, WellKnownMembers.Query.All.MakeGenericMethod(t)));
+        : Session.Domain.RootCallExpressionsCache.GetOrAdd(elementType, (t) => Expression.Call(null, WellKnownMembers.Query.All.MakeGenericMethod(t)));
     }
 
     private static void ThrowKeyNotFoundException(Key key) =>

--- a/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
@@ -27,15 +27,9 @@ namespace Xtensive.Orm
   /// and finally, resolve <see cref="Key"/>s to <see cref="Entity">entities</see>.
   /// </summary>
   [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
-  public sealed class QueryEndpoint
+  public readonly struct QueryEndpoint
   {
     private readonly Session session;
-
-    /// <summary>
-    /// Gets outer <see cref="QueryEndpoint"/>.
-    /// For root <see cref="QueryEndpoint"/> returns <see langword="null"/>.
-    /// </summary>
-    public QueryEndpoint Outer { get; private set; }
 
     /// <summary>
     /// Gets <see cref="IQueryProvider"/> implementation
@@ -48,7 +42,7 @@ namespace Xtensive.Orm
     /// If <see cref="IQueryRootBuilder"/> is not set for this instance
     /// returns <see langword="null"/>.
     /// </summary>
-    public IQueryRootBuilder RootBuilder { get; private set; }
+    public IQueryRootBuilder RootBuilder { get; }
 
     /// <summary>
     /// The "starting point" for any LINQ query -
@@ -516,16 +510,13 @@ namespace Xtensive.Orm
       where T : class, IEntity
     {
       var elementType = typeof (TElement);
-      Func<TElement, Key> selector;
-      if (elementType==WellKnownTypes.ObjectArray) {
-        selector = e => Key.Create(session.Domain, session.StorageNodeId, typeof (T), TypeReferenceAccuracy.BaseType, (object[]) (object) e);
-      }
-      else if (WellKnownOrmTypes.Tuple.IsAssignableFrom(elementType)) {
-        selector = e => Key.Create(session.Domain, session.StorageNodeId, typeof (T), TypeReferenceAccuracy.BaseType, (Tuple) (object) e);
-      }
-      else {
-        selector = e => Key.Create(session.Domain, session.StorageNodeId, typeof (T), TypeReferenceAccuracy.BaseType, new object[] {e});
-      }
+      var sess = session;
+      Func<TElement, Key> selector =
+        elementType == WellKnownTypes.ObjectArray
+        ? e => Key.Create(sess.Domain, sess.StorageNodeId, typeof(T), TypeReferenceAccuracy.BaseType, (object[]) (object) e)
+        : WellKnownOrmTypes.Tuple.IsAssignableFrom(elementType)
+          ? e => Key.Create(sess.Domain, sess.StorageNodeId, typeof(T), TypeReferenceAccuracy.BaseType, (Tuple) (object) e)
+          : e => Key.Create(sess.Domain, sess.StorageNodeId, typeof(T), TypeReferenceAccuracy.BaseType, new object[] { e });
 
       return new PrefetchQuery<T>(session, keys.Select(selector));
     }

--- a/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
@@ -525,7 +525,7 @@ namespace Xtensive.Orm
           ? e => Key.Create(sess.Domain, sess.StorageNodeId, typeof(T), TypeReferenceAccuracy.BaseType, (Tuple) (object) e)
           : e => Key.Create(sess.Domain, sess.StorageNodeId, typeof(T), TypeReferenceAccuracy.BaseType, new object[] { e });
 
-      return new PrefetchQuery<T>(session, keys.Select(selector));
+      return new PrefetchQuery<T>(sess, keys.Select(selector));
     }
 
     #region Execute methods

--- a/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
@@ -27,7 +27,7 @@ namespace Xtensive.Orm
   /// and finally, resolve <see cref="Key"/>s to <see cref="Entity">entities</see>.
   /// </summary>
   [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
-  public readonly struct QueryEndpoint
+  public readonly struct QueryEndpoint : IEquatable<QueryEndpoint>
   {
     private readonly Session session;
 
@@ -43,6 +43,13 @@ namespace Xtensive.Orm
     /// returns <see langword="null"/>.
     /// </summary>
     public IQueryRootBuilder RootBuilder { get; }
+
+    public bool Equals(QueryEndpoint other) =>
+      session == other.session && Provider == other.Provider && RootBuilder == other.RootBuilder;
+
+    public override bool Equals(object obj) => obj is QueryEndpoint other && Equals(other);
+
+    public override int GetHashCode() => HashCode.Combine(session, Provider, RootBuilder);
 
     /// <summary>
     /// The "starting point" for any LINQ query -
@@ -986,7 +993,6 @@ namespace Xtensive.Orm
 
     internal QueryEndpoint(QueryEndpoint outerEndpoint, IQueryRootBuilder queryRootBuilder)
     {
-      ArgumentNullException.ThrowIfNull(outerEndpoint);
       ArgumentNullException.ThrowIfNull(queryRootBuilder);
       Provider = outerEndpoint.Provider;
       session = outerEndpoint.session;

--- a/Version.props
+++ b/Version.props
@@ -2,8 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.2.181</DoVersion>
-    <DoVersionSuffix>servicetitan</DoVersionSuffix>
+    <DoVersion>7.2.182</DoVersion>
+    <DoVersionSuffix>servicetitan-test</DoVersionSuffix>
 </PropertyGroup>
 
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -2,8 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.2.183</DoVersion>
-    <DoVersionSuffix>servicetitan-test</DoVersionSuffix>
+    <DoVersion>7.2.184</DoVersion>
+    <DoVersionSuffix>servicetitan</DoVersionSuffix>
 </PropertyGroup>
 
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.2.182</DoVersion>
+    <DoVersion>7.2.183</DoVersion>
     <DoVersionSuffix>servicetitan-test</DoVersionSuffix>
 </PropertyGroup>
 


### PR DESCRIPTION
Also:
* Implement `IEquitable<>` because some Monolith's tests compare `QueryEndpoint` for equaility
* Remove unused `QueryEndpoint.Outer` property
* Remove `session` field. It can accessed as `Provider.Session`