### PR TITLE
Optimize `Dictionary<>` allocation

### DIFF
--- a/Orm/Xtensive.Orm/Core/Extensions/StringExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/StringExtensions.cs
@@ -547,13 +547,5 @@ namespace Xtensive.Core
         ? value
         : value.Substring(start - 1, actualLength);
     }
-
-    internal static bool Contains(this string str, string value, StringComparison comparison)
-    {
-      ArgumentNullException.ThrowIfNull(str);
-      ArgumentNullException.ThrowIfNull(value);
-
-      return str.IndexOf(value, comparison) >= 0;
-    }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ExtendedExpressionReplacer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ExtendedExpressionReplacer.cs
@@ -4,8 +4,6 @@
 // Created by: Alexis Kochetov
 // Created:    2009.04.27
 
-using System;
-using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using Xtensive.Orm.Rse.Providers;
@@ -115,26 +113,24 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
 
     internal override Expression VisitConstructorExpression(ConstructorExpression expression)
     {
-      var arguments = new List<Expression>();
       var bindings = new Dictionary<MemberInfo, Expression>(expression.Bindings.Count);
       var nativeBindings = new Dictionary<MemberInfo, Expression>(expression.NativeBindings.Count);
       bool recreate = false;
+      var arguments = new Expression[expression.ConstructorArguments.Count];
+      int i = 0;
       foreach (var argument in expression.ConstructorArguments) {
         var result = Visit(argument);
-        if (result != argument)
-          recreate = true;
-        arguments.Add(result);
+        recreate |= (result != argument);
+        arguments[i++] = result;
       }
       foreach (var binding in expression.Bindings) {
         var result = Visit(binding.Value);
-        if (result != binding.Value)
-          recreate = true;
+        recreate |= (result != binding.Value);
         bindings.Add(binding.Key, result);
       }
       foreach (var nativeBinding in expression.NativeBindings) {
         var result = Visit(nativeBinding.Value);
-        if (result!=nativeBinding.Value)
-          recreate = true;
+        recreate |= (result != nativeBinding.Value);
         nativeBindings.Add(nativeBinding.Key, result);
       }
       if (!recreate)

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
@@ -10,24 +10,16 @@ using Xtensive.Orm.Model;
 
 namespace Xtensive.Orm.Linq.Materialization
 {
-  internal sealed class MaterializationContext
+  using EntityMappingCache = (TypeMapping? SingleItem, Dictionary<int, TypeMapping> Items);
+
+  internal class MaterializationContext(Session session, int entityCount)
   {
-    #region Nested type: EntityMappingCache
-
-    private struct EntityMappingCache
-    {
-      public TypeMapping? SingleItem;
-      public Dictionary<int, TypeMapping> Items;
-    }
-
-    #endregion
-
-    private readonly EntityMappingCache[] entityMappings;
+    private readonly EntityMappingCache[] entityMappings = new EntityMappingCache[entityCount];
 
     /// <summary>
     /// Gets the session in which materialization is executing.
     /// </summary>
-    public Session Session { get; }
+    public Session Session => session;
 
     /// <summary>
     /// Gets model of current <see cref="DomainModel">domain model.</see>
@@ -52,12 +44,12 @@ namespace Xtensive.Orm.Linq.Materialization
     public TypeMapping GetTypeMapping(int entityIndex, TypeInfo approximateType, int typeId, IEnumerable<(ColNum From, ColNum To)> columns)
     {
       ref var cache = ref entityMappings[entityIndex];
-      if (cache.SingleItem is TypeMapping result) {
+      if (cache.SingleItem is { } result) {
         return typeId == ResolveTypeToNodeSpecificTypeIdentifier(result.Type)
           ? result
           : throw new ArgumentOutOfRangeException("typeId");
       }
-      if (cache.Items.TryGetValue(typeId, out result))
+      if (cache.Items?.TryGetValue(typeId, out result) == true)
         return result;
 
       var type = TypeIdRegistry[typeId];
@@ -83,22 +75,11 @@ namespace Xtensive.Orm.Linq.Materialization
       if (type.Hierarchy.Root.IsLeaf && approximateType==type)
         cache.SingleItem = result;
       else
-        cache.Items.Add(typeId, result);
+        (cache.Items ??= new()).Add(typeId, result);
 
       return result;
     }
 
     private int ResolveTypeToNodeSpecificTypeIdentifier(TypeInfo typeInfo) => TypeIdRegistry[typeInfo];
-
-    // Constructors
-
-    public MaterializationContext(Session session, int entityCount)
-    {
-      Session = session;
-
-      entityMappings = new EntityMappingCache[entityCount];
-      for (int i = 0; i < entityMappings.Length; i++)
-        entityMappings[i] = new() { Items = new Dictionary<int, TypeMapping>() };
-    }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/Materializer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/Materializer.cs
@@ -2,26 +2,13 @@
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
-using System;
 using Xtensive.Core;
 using Xtensive.Orm.Rse;
 
-namespace Xtensive.Orm.Linq.Materialization
+namespace Xtensive.Orm.Linq.Materialization;
+
+internal readonly struct Materializer(Func<RecordSetReader, Session, ParameterContext, object> materializeMethod)
 {
-  internal readonly struct Materializer
-  {
-    private readonly Func<RecordSetReader, Session, ParameterContext, object> materializeMethod;
-
-    public QueryResult<T> Invoke<T>(RecordSetReader recordSetReader, Session session, ParameterContext parameterContext)
-    {
-      var reader = (IMaterializingReader<T>)
-        materializeMethod.Invoke(recordSetReader, session, parameterContext);
-      return new QueryResult<T>(reader, session.GetLifetimeToken());
-    }
-
-    public Materializer(Func<RecordSetReader,Session,ParameterContext,object> materializeMethod)
-    {
-      this.materializeMethod = materializeMethod;
-    }
-  }
+  public QueryResult<T> Invoke<T>(RecordSetReader recordSetReader, Session session, ParameterContext parameterContext) =>
+    new((IMaterializingReader<T>) materializeMethod(recordSetReader, session, parameterContext), session.GetLifetimeToken());
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
@@ -4,9 +4,6 @@
 // Created by: Alexis Kochetov
 // Created:    2009.05.28
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Xtensive.Core;
@@ -33,6 +30,9 @@ namespace Xtensive.Orm.Linq
     private static readonly ParameterExpression TupleReader = Expression.Parameter(typeof(RecordSetReader), "tupleReader");
     private static readonly ParameterExpression Session = Expression.Parameter(typeof(Session), "session");
     private static readonly IReadOnlyList<ParameterExpression> TupleReaderSessionParameterContext = [TupleReader, Session, ParameterContext];
+
+    private static readonly Expression<Func<Session, int, MaterializationContext>> MaterializationContextCtor =
+      (s, entityCount) => new MaterializationContext(s, entityCount);
 
     private readonly CompiledQueryProcessingScope compiledQueryScope;
 
@@ -134,9 +134,7 @@ namespace Xtensive.Orm.Linq
           : MaterializationHelper.CreateItemMaterializerMethodInfo.CachedMakeGenericMethodInvoker(elementType);
       var itemMaterializer = itemMaterializerFactoryMethod.Invoke(null, materializationInfo.Expression, itemProjector.AggregateType);
 
-      Expression<Func<Session, int, MaterializationContext>> materializationContextCtor =
-        (s, entityCount) => new MaterializationContext(s, entityCount);
-      var materializationContextExpression = materializationContextCtor
+      var materializationContextExpression = MaterializationContextCtor
         .BindParameters(Session, Expr.Constant(materializationInfo.EntitiesInRow));
 
       Expression body = Expression.Call(

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
@@ -80,16 +80,17 @@ namespace Xtensive.Orm.Linq
       return translatedQuery;
     }
 
+    private static readonly IReadOnlyList<ColNum> SingleColumn = [0];
+
     private static ProjectionExpression Optimize(ProjectionExpression origin)
     {
       var originProvider = origin.ItemProjector.DataSource;
 
       var usedColumns = origin.ItemProjector
-        .GetColumns(ColumnExtractionModes.KeepSegment | ColumnExtractionModes.KeepTypeId | ColumnExtractionModes.OmitLazyLoad)
-        .ToList();
+        .GetColumns(ColumnExtractionModes.KeepSegment | ColumnExtractionModes.KeepTypeId | ColumnExtractionModes.OmitLazyLoad);
 
       if (usedColumns.Count == 0)
-        usedColumns.Add(0);
+        usedColumns = SingleColumn;
       if (usedColumns.Count < origin.ItemProjector.DataSource.Header.Length) {
         var resultProvider = new SelectProvider(originProvider, usedColumns);
         using var columnMap = new ColumnMap(usedColumns);


### PR DESCRIPTION
* Allocate `EntityMappingCache.Items`  Dictionary<> on demand
* Make immutable `MaterializationContextCtor` static
* Reduce allocations in `Translator.Optimize()`
* Remove unused `string.Contains()` extension