### PR TITLE
Optimize GetQueryableMethod()

### DIFF
--- a/Orm/Xtensive.Orm/Linq/QueryableVisitor.cs
+++ b/Orm/Xtensive.Orm/Linq/QueryableVisitor.cs
@@ -87,10 +87,16 @@ public abstract class QueryableVisitor : ExpressionVisitor
   /// <param name="call">A call to process.</param>
   /// <returns><see cref="QueryableMethodKind"/> for the specified expression,
   /// or null if method is not a LINQ method.</returns>
-  public static QueryableMethodKind? GetQueryableMethod(MethodCallExpression call) =>
-    call?.Method.DeclaringType is { } declaringType
-    && (declaringType == WellKnownTypes.Queryable || declaringType == WellKnownTypes.Enumerable)
-    && QueryableMethodKindFromName.TryGetValue(call.Method.Name, out var v)
-      ? v
-      : null;
+  public static QueryableMethodKind? GetQueryableMethod(MethodCallExpression call)
+  {
+    if (call?.Method is { } method) {
+      var declaringType = method.DeclaringType;
+      return (declaringType == WellKnownTypes.Queryable || declaringType == WellKnownTypes.Enumerable)
+             && QueryableMethodKindFromName.TryGetValue(method.Name, out var v)
+        ? v
+        : null;
+    }
+
+    return null;
+  }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/Model/QueryFactory.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Model/QueryFactory.cs
@@ -62,7 +62,7 @@ namespace Xtensive.Orm.Linq.Model
     {
       var sourceItemType = projection.Parameters[0].Type;
       var resultItemType = projection.Body.Type;
-      var method = QueryableMethodInfo.Select.MakeGenericMethod(sourceItemType, resultItemType);
+      var method = QueryableMethodInfo.Select.CachedMakeGenericMethod(sourceItemType, resultItemType);
       return Expression.Call(method, source, projection);
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/AggregateOptimizer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/AggregateOptimizer.cs
@@ -4,9 +4,6 @@
 // Created by: Denis Krjuchkov
 // Created:    2013.12.10
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Xtensive.Core;
@@ -170,11 +167,11 @@ namespace Xtensive.Orm.Linq.Rewriters
     {
       var methodKind = QueryableVisitor.GetQueryableMethod(mc);
       if (methodKind==QueryableMethodKind.Select) {
-        var selectSource = mc.Arguments[0] as MethodCallExpression;
-        if (selectSource!=null) {
+        var mcArguments = mc.Arguments;
+        if (mcArguments[0] is MethodCallExpression selectSource) {
           var sourceMethodKind = QueryableVisitor.GetQueryableMethod(selectSource);
           if (sourceMethodKind==QueryableMethodKind.GroupBy) {
-            var projection = mc.Arguments[1].StripQuotes();
+            var projection = mcArguments[1].StripQuotes();
             var newSelectSource = VisitGroupBy(selectSource, projection);
             if (newSelectSource!=selectSource)
               return QueryFactory.Select(newSelectSource, projection);
@@ -195,7 +192,7 @@ namespace Xtensive.Orm.Linq.Rewriters
       var projection = groupBy.ResultSelector ?? selectProjection;
       if (projection!=null) {
         var referenceFieldAccessors = AggregateProjectionFinder.Execute(projection)
-          .Select(ReferenceFieldAccessExtractor.Execute)
+          .Select(static o => ReferenceFieldAccessExtractor.Execute(o))
           .Where(item => item!=null)
           .ToList();
         if (referenceFieldAccessors.Count > 0) {


### PR DESCRIPTION
* Reduce number of `.Method` property dereferences
* Use `CachedMakeGenericMethod()` to save allocation