### PR TITLE
Get rid of `unsafe` code from  `TruncateToNetDecimal()` implemetation

### DIFF
--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -162,10 +162,9 @@ internal static class InternalHelpers
       return sqlDecimal.Value; // throws OverflowException.
     }
 
-    byte maxZeroCount = 0;
-    while (maxZeroCount < scale && (inputData[maxZeroCount >> 6] & (1 << maxZeroCount)) == 0) {
-      maxZeroCount++;
-    }
+    byte maxZeroCount = (byte)BitOperations.TrailingZeroCount(inputData[0]);
+    if (maxZeroCount > scale)
+      maxZeroCount = scale;
 
     var realScale = scale;
     var dividerPow = maxZeroCount > 9 ? (byte) 9 : maxZeroCount;

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -146,8 +146,7 @@ internal static class InternalHelpers
   }
 
   private static UInt128 FromSqlDecimalData(int[] a) =>
-    new((uint) a[0] | ((ulong) (uint) a[1] << 32),
-      (uint) a[2] | ((ulong) (uint) a[3] << 32));
+    new((uint) a[2] | ((ulong) (uint) a[3] << 32), (uint) a[0] | ((ulong) (uint) a[1] << 32));
 
   internal static decimal TruncateToNetDecimal(SqlDecimal sqlDecimal)
   {

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -166,8 +166,7 @@ internal static class InternalHelpers
     var realScale = scale;
     var dividerPow = maxZeroCount > 9 ? (byte) 9 : maxZeroCount;
 
-    UInt128 data = new((ulong)inputData[2] | ((ulong)inputData[3] << 32),
-      (ulong)inputData[0] | ((ulong)inputData[1] << 32));
+    UInt128 data = FromSqlDecimalData(inputData);
 
     if (dividerPow > 5) {
       var divider = PowersOf10[dividerPow];

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -147,9 +147,10 @@ internal static class InternalHelpers
         (u128, _) = UInt128.DivRem(u128, Ten);
       }
 
-      return u128 <= Max96bitValue
-        ? new((int) u128, (int) (u128 >> 32), (int) (u128 >> 64), !sqlDecimal.IsPositive, scale)
-        : throw;
+      if (u128 > Max96bitValue) {
+        throw;
+      }
+      return new((int) u128, (int) (u128 >> 32), (int) (u128 >> 64), !sqlDecimal.IsPositive, scale);
     }
   }
 }

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -27,6 +27,8 @@ internal static class InternalHelpers
 
   private static readonly UInt128 Max96bitValue = new(0xFFFFFFFFUL, ulong.MaxValue);
 
+  private static readonly UInt128 Ten = 10;
+
   /// <summary>
   ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
   ///     directly from your code. This API may change or be removed in future releases.
@@ -178,7 +180,7 @@ internal static class InternalHelpers
     }
 
     for (; realScale > 0 && data > Max96bitValue; realScale--) {
-      (data, _) = UInt128.DivRem(data, 10);
+      (data, _) = UInt128.DivRem(data, Ten);
     }
 
     if (data > Max96bitValue) {

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -139,25 +139,17 @@ internal static class InternalHelpers
     var inputData = sqlDecimal.Data;
     var scale = sqlDecimal.Scale;
 
-    if (inputData[3] == 0) {
-      if (scale <= 28) {
-        return sqlDecimal.Value;
+    if (scale > 28 || scale > 0 && inputData[3] != 0) {
+      var data = FromSqlDecimalData(inputData);
+
+      for (; scale > 0 && data > Max96bitValue; --scale) {
+        (data, _) = UInt128.DivRem(data, Ten);
       }
-    }
-    else if (scale == 0) {
-      return sqlDecimal.Value; // throws OverflowException.
-    }
 
-    var data = FromSqlDecimalData(inputData);
-
-    for (; scale > 0 && data > Max96bitValue; --scale) {
-      (data, _) = UInt128.DivRem(data, Ten);
+      if (data <= Max96bitValue) {
+        return new((int) data, (int) (data >> 32), (int) (data >> 64), !sqlDecimal.IsPositive, scale);
+      }     
     }
-
-    if (data > Max96bitValue) {
-      return sqlDecimal.Value; // throws OverflowException.
-    }
-
-    return new((int) data, (int) (data >> 32), (int) (data >> 64), !sqlDecimal.IsPositive, scale);
+    return sqlDecimal.Value; // throws OverflowException is the value is out of decimal range.
   }
 }

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -144,7 +144,7 @@ internal static class InternalHelpers
       var u128 = FromSqlDecimalData(sqlDecimal.Data);   // sqlDecimal.Data allocates a new array
 
       for (; scale > 0 && u128 > Max96bitValue; --scale) {
-        u128 = UInt128.DivRem(u128, Ten).Quotient;
+        u128 /= Ten;
       }
 
       if (u128 > Max96bitValue) {

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -164,11 +164,10 @@ internal static class InternalHelpers
     }
 
     var maxZeroCount = Math.Min(scale, BitOperations.TrailingZeroCount(inputData[0]));
-    var dividerPow = Math.Min(maxZeroCount, 9);
     var realScale = scale;
     var data = FromSqlDecimalData(inputData);
 
-    if (dividerPow > 5) {
+    if (Math.Min(maxZeroCount, 9) is > 5 and var dividerPow) {
       var divider = PowersOf10[dividerPow];
       for (; realScale >= dividerPow; realScale -= dividerPow) {
         (data, var rem) = UInt128.DivRem(data, divider);

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -137,9 +137,7 @@ internal static class InternalHelpers
   internal static decimal TruncateToNetDecimal(SqlDecimal sqlDecimal)
   {
     var inputData = sqlDecimal.Data;
-    var scale = sqlDecimal.Scale;
-
-    if (scale > 28 || scale > 0 && inputData[3] != 0) {
+    if (sqlDecimal.Scale is var scale && (scale > 28 || scale > 0 && inputData[3] != 0)) {
       var u128 = FromSqlDecimalData(inputData);
 
       for (; scale > 0 && u128 > Max96bitValue; --scale) {
@@ -148,7 +146,7 @@ internal static class InternalHelpers
 
       if (u128 <= Max96bitValue) {
         return new((int) u128, (int) (u128 >> 32), (int) (u128 >> 64), !sqlDecimal.IsPositive, scale);
-      }     
+      }
     }
     return sqlDecimal.Value; // throws OverflowException is the value is out of decimal range.
   }

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -6,26 +6,12 @@
 
 using Microsoft.Data.SqlClient;
 using System.Data.SqlTypes;
-using System.Numerics;
 using Xtensive.Diagnostics;
 
 namespace Xtensive.Sql.Drivers.SqlServer;
 
 internal static class InternalHelpers
 {
-  private static readonly UInt128[] PowersOf10 = [
-    1,
-    10,
-    100,
-    1000,
-    10000,
-    100000,
-    1000000,
-    10000000,
-    100000000,
-    1000000000
-  ];
-
   private static readonly UInt128 Max96bitValue = new(0xFFFFFFFFUL, ulong.MaxValue);
 
   private static readonly UInt128 Ten = 10;
@@ -151,7 +137,7 @@ internal static class InternalHelpers
   internal static decimal TruncateToNetDecimal(SqlDecimal sqlDecimal)
   {
     var inputData = sqlDecimal.Data;
-    int scale = sqlDecimal.Scale;
+    var scale = sqlDecimal.Scale;
 
     if (inputData[3] == 0) {
       if (scale <= 28) {
@@ -162,21 +148,9 @@ internal static class InternalHelpers
       return sqlDecimal.Value; // throws OverflowException.
     }
 
-    var maxZeroCount = Math.Min(scale, BitOperations.TrailingZeroCount(inputData[0]));
-    var realScale = scale;
     var data = FromSqlDecimalData(inputData);
 
-    if (Math.Min(maxZeroCount, 9) is > 5 and var dividerPow) {
-      var divider = PowersOf10[dividerPow];
-      for (; realScale >= dividerPow; realScale -= dividerPow) {
-        (data, var rem) = UInt128.DivRem(data, divider);
-        if (rem != 0) {
-          break;
-        }
-      }
-    }
-
-    for (; realScale > 0 && data > Max96bitValue; realScale--) {
+    for (; scale > 0 && data > Max96bitValue; --scale) {
       (data, _) = UInt128.DivRem(data, Ten);
     }
 
@@ -184,6 +158,6 @@ internal static class InternalHelpers
       return sqlDecimal.Value; // throws OverflowException.
     }
 
-    return new((int) data, (int) (data >> 32), (int) (data >> 64), !sqlDecimal.IsPositive, (byte) realScale);
+    return new((int) data, (int) (data >> 32), (int) (data >> 64), !sqlDecimal.IsPositive, scale);
   }
 }

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -185,6 +185,6 @@ internal static class InternalHelpers
       return sqlDecimal.Value; // throws OverflowException.
     }
 
-    return new((int) data, (int) (data >> 32), (int) (data >> 64), !sqlDecimal.IsPositive, realScale);
+    return new((int) data, (int) (data >> 32), (int) (data >> 64), !sqlDecimal.IsPositive, (byte) realScale);
   }
 }

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -137,7 +137,7 @@ internal static class InternalHelpers
   internal static decimal TruncateToNetDecimal(SqlDecimal sqlDecimal)
   {
     try {
-      return sqlDecimal.Value; // throws OverflowException is the value is out of decimal range.
+      return sqlDecimal.Value; // throws OverflowException if the value is out of decimal range.
     }
     catch (OverflowException) {
       var inputData = sqlDecimal.Data;

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -4,219 +4,187 @@
 // Created by: Alexey Kulakov
 // Created:    2020.04.10
 
-using System;
-using System.Collections.Generic;
 using Microsoft.Data.SqlClient;
 using System.Data.SqlTypes;
-using System.Diagnostics.Metrics;
 using Xtensive.Diagnostics;
 
-namespace Xtensive.Sql.Drivers.SqlServer
+namespace Xtensive.Sql.Drivers.SqlServer;
+
+internal static class InternalHelpers
 {
-  internal static class InternalHelpers
+  private static readonly UInt128[] PowersOf10 = [
+    1,
+    10,
+    100,
+    1000,
+    10000,
+    100000,
+    1000000,
+    10000000,
+    100000000,
+    1000000000
+  ];
+
+  private static readonly UInt128 Max96bitValue = new(0xFFFFFFFFUL, ulong.MaxValue);
+
+  /// <summary>
+  ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+  ///     directly from your code. This API may change or be removed in future releases.
+  /// </summary>
+  public static bool ShouldRetryOn(Exception ex)
   {
-    private static readonly uint[] PowersOf10 = {
-      1,
-      10,
-      100,
-      1000,
-      10000,
-      100000,
-      1000000,
-      10000000,
-      100000000,
-      1000000000
-    };
-
-    /// <summary>
-    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-    ///     directly from your code. This API may change or be removed in future releases.
-    /// </summary>
-    public static bool ShouldRetryOn(Exception ex)
-    {
-      ArgumentNullException.ThrowIfNull(ex);
-      if (ex is SqlException sqlException) {
-        foreach (SqlError err in sqlException.Errors) {
-          Metrics.SqlErrorCounter.Add(1, KeyValuePair.Create("Code", (object)err.Number));
-        }
-
-        foreach (SqlError err in sqlException.Errors) {
-          switch (err.Number) {
-            // SQL Error Code: 49920
-            // Cannot process request. Too many operations in progress for subscription "%ld".
-            // The service is busy processing multiple requests for this subscription.
-            // Requests are currently blocked for resource optimization. Query sys.dm_operation_status for operation status.
-            // Wait until pending requests are complete or delete one of your pending requests and retry your request later.
-            case 49920:
-            // SQL Error Code: 49919
-            // Cannot process create or update request. Too many create or update operations in progress for subscription "%ld".
-            // The service is busy processing multiple create or update requests for your subscription or server.
-            // Requests are currently blocked for resource optimization. Query sys.dm_operation_status for pending operations.
-            // Wait till pending create or update requests are complete or delete one of your pending requests and
-            // retry your request later.
-            case 49919:
-            // SQL Error Code: 49918
-            // Cannot process request. Not enough resources to process request.
-            // The service is currently busy.Please retry the request later.
-            case 49918:
-            // SQL Error Code: 41839
-            // Transaction exceeded the maximum number of commit dependencies.
-            case 41839:
-            // SQL Error Code: 41325
-            // The current transaction failed to commit due to a serializable validation failure.
-            case 41325:
-            // SQL Error Code: 41305
-            // The current transaction failed to commit due to a repeatable read validation failure.
-            case 41305:
-            // SQL Error Code: 41302
-            // The current transaction attempted to update a record that has been updated since the transaction started.
-            case 41302:
-            // SQL Error Code: 41301
-            // Dependency failure: a dependency was taken on another transaction that later failed to commit.
-            case 41301:
-            // SQL Error Code: 40613
-            // Database XXXX on server YYYY is not currently available. Please retry the connection later.
-            // If the problem persists, contact customer support, and provide them the session tracing ID of ZZZZZ.
-            case 40613:
-            // SQL Error Code: 40501
-            // The service is currently busy. Retry the request after 10 seconds. Code: (reason code to be decoded).
-            case 40501:
-            // SQL Error Code: 40197
-            // The service has encountered an error processing your request. Please try again.
-            case 40197:
-            // SQL Error Code: 10929
-            // Resource ID: %d. The %s minimum guarantee is %d, maximum limit is %d and the current usage for the database is %d.
-            // However, the server is currently too busy to support requests greater than %d for this database.
-            // For more information, see http://go.microsoft.com/fwlink/?LinkId=267637. Otherwise, please try again.
-            case 10929:
-            // SQL Error Code: 10928
-            // Resource ID: %d. The %s limit for the database is %d and has been reached. For more information,
-            // see http://go.microsoft.com/fwlink/?LinkId=267637.
-            case 10928:
-            // SQL Error Code: 10060
-            // A network-related or instance-specific error occurred while establishing a connection to SQL Server.
-            // The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server
-            // is configured to allow remote connections. (provider: TCP Provider, error: 0 - A connection attempt failed
-            // because the connected party did not properly respond after a period of time, or established connection failed
-            // because connected host has failed to respond.)"}
-            case 10060:
-            // SQL Error Code: 10054
-            // A transport-level error has occurred when sending the request to the server.
-            // (provider: TCP Provider, error: 0 - An existing connection was forcibly closed by the remote host.)
-            case 10054:
-            // SQL Error Code: 10053
-            // A transport-level error has occurred when receiving results from the server.
-            // An established connection was aborted by the software in your host machine.
-            case 10053:
-            // SQL Error Code: 1205
-            // Deadlock
-            case 1205:
-            // SQL Error Code: 233
-            // The client was unable to establish a connection because of an error during connection initialization process before login.
-            // Possible causes include the following: the client tried to connect to an unsupported version of SQL Server;
-            // the server was too busy to accept new connections; or there was a resource limitation (insufficient memory or maximum
-            // allowed connections) on the server. (provider: TCP Provider, error: 0 - An existing connection was forcibly closed by
-            // the remote host.)
-            case 233:
-            // SQL Error Code: 121
-            // The semaphore timeout period has expired
-            case 121:
-            // SQL Error Code: 64
-            // A connection was successfully established with the server, but then an error occurred during the login process.
-            // (provider: TCP Provider, error: 0 - The specified network name is no longer available.)
-            case 64:
-            // DBNETLIB Error Code: 20
-            // The instance of SQL Server you attempted to connect to does not support encryption.
-            case 20:
-              return true;
-              // This exception can be thrown even if the operation completed successfully, so it's safer to let the application fail.
-              // DBNETLIB Error Code: -2
-              // Timeout expired. The timeout period elapsed prior to completion of the operation or the server is not responding. The statement has been terminated.
-              //case -2:
-          }
-        }
-
-        return false;
+    ArgumentNullException.ThrowIfNull(ex);
+    if (ex is SqlException sqlException) {
+      foreach (SqlError err in sqlException.Errors) {
+        Metrics.SqlErrorCounter.Add(1, KeyValuePair.Create("Code", (object)err.Number));
       }
 
-      Metrics.SqlErrorCounter.Add(1, KeyValuePair.Create("Code", (object)ex.GetType().Name));
-      return ex is TimeoutException;
+      foreach (SqlError err in sqlException.Errors) {
+        switch (err.Number) {
+          // SQL Error Code: 49920
+          // Cannot process request. Too many operations in progress for subscription "%ld".
+          // The service is busy processing multiple requests for this subscription.
+          // Requests are currently blocked for resource optimization. Query sys.dm_operation_status for operation status.
+          // Wait until pending requests are complete or delete one of your pending requests and retry your request later.
+          case 49920:
+          // SQL Error Code: 49919
+          // Cannot process create or update request. Too many create or update operations in progress for subscription "%ld".
+          // The service is busy processing multiple create or update requests for your subscription or server.
+          // Requests are currently blocked for resource optimization. Query sys.dm_operation_status for pending operations.
+          // Wait till pending create or update requests are complete or delete one of your pending requests and
+          // retry your request later.
+          case 49919:
+          // SQL Error Code: 49918
+          // Cannot process request. Not enough resources to process request.
+          // The service is currently busy.Please retry the request later.
+          case 49918:
+          // SQL Error Code: 41839
+          // Transaction exceeded the maximum number of commit dependencies.
+          case 41839:
+          // SQL Error Code: 41325
+          // The current transaction failed to commit due to a serializable validation failure.
+          case 41325:
+          // SQL Error Code: 41305
+          // The current transaction failed to commit due to a repeatable read validation failure.
+          case 41305:
+          // SQL Error Code: 41302
+          // The current transaction attempted to update a record that has been updated since the transaction started.
+          case 41302:
+          // SQL Error Code: 41301
+          // Dependency failure: a dependency was taken on another transaction that later failed to commit.
+          case 41301:
+          // SQL Error Code: 40613
+          // Database XXXX on server YYYY is not currently available. Please retry the connection later.
+          // If the problem persists, contact customer support, and provide them the session tracing ID of ZZZZZ.
+          case 40613:
+          // SQL Error Code: 40501
+          // The service is currently busy. Retry the request after 10 seconds. Code: (reason code to be decoded).
+          case 40501:
+          // SQL Error Code: 40197
+          // The service has encountered an error processing your request. Please try again.
+          case 40197:
+          // SQL Error Code: 10929
+          // Resource ID: %d. The %s minimum guarantee is %d, maximum limit is %d and the current usage for the database is %d.
+          // However, the server is currently too busy to support requests greater than %d for this database.
+          // For more information, see http://go.microsoft.com/fwlink/?LinkId=267637. Otherwise, please try again.
+          case 10929:
+          // SQL Error Code: 10928
+          // Resource ID: %d. The %s limit for the database is %d and has been reached. For more information,
+          // see http://go.microsoft.com/fwlink/?LinkId=267637.
+          case 10928:
+          // SQL Error Code: 10060
+          // A network-related or instance-specific error occurred while establishing a connection to SQL Server.
+          // The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server
+          // is configured to allow remote connections. (provider: TCP Provider, error: 0 - A connection attempt failed
+          // because the connected party did not properly respond after a period of time, or established connection failed
+          // because connected host has failed to respond.)"}
+          case 10060:
+          // SQL Error Code: 10054
+          // A transport-level error has occurred when sending the request to the server.
+          // (provider: TCP Provider, error: 0 - An existing connection was forcibly closed by the remote host.)
+          case 10054:
+          // SQL Error Code: 10053
+          // A transport-level error has occurred when receiving results from the server.
+          // An established connection was aborted by the software in your host machine.
+          case 10053:
+          // SQL Error Code: 1205
+          // Deadlock
+          case 1205:
+          // SQL Error Code: 233
+          // The client was unable to establish a connection because of an error during connection initialization process before login.
+          // Possible causes include the following: the client tried to connect to an unsupported version of SQL Server;
+          // the server was too busy to accept new connections; or there was a resource limitation (insufficient memory or maximum
+          // allowed connections) on the server. (provider: TCP Provider, error: 0 - An existing connection was forcibly closed by
+          // the remote host.)
+          case 233:
+          // SQL Error Code: 121
+          // The semaphore timeout period has expired
+          case 121:
+          // SQL Error Code: 64
+          // A connection was successfully established with the server, but then an error occurred during the login process.
+          // (provider: TCP Provider, error: 0 - The specified network name is no longer available.)
+          case 64:
+          // DBNETLIB Error Code: 20
+          // The instance of SQL Server you attempted to connect to does not support encryption.
+          case 20:
+            return true;
+            // This exception can be thrown even if the operation completed successfully, so it's safer to let the application fail.
+            // DBNETLIB Error Code: -2
+            // Timeout expired. The timeout period elapsed prior to completion of the operation or the server is not responding. The statement has been terminated.
+            //case -2:
+        }
+      }
+
+      return false;
     }
 
-    internal static unsafe decimal TruncateToNetDecimal(SqlDecimal sqlDecimal)
-    {
-      var inputData = sqlDecimal.Data;
-      var scale = sqlDecimal.Scale;
+    Metrics.SqlErrorCounter.Add(1, KeyValuePair.Create("Code", (object)ex.GetType().Name));
+    return ex is TimeoutException;
+  }
 
-      if (inputData[3] == 0) {
-        if (scale <= 28) {
-          return sqlDecimal.Value;
-        }
+  internal static decimal TruncateToNetDecimal(SqlDecimal sqlDecimal)
+  {
+    var inputData = sqlDecimal.Data;
+    var scale = sqlDecimal.Scale;
+
+    if (inputData[3] == 0) {
+      if (scale <= 28) {
+        return sqlDecimal.Value;
       }
-      else if (scale == 0) {
-        return sqlDecimal.Value; // throws OverflowException.
-      }
+    }
+    else if (scale == 0) {
+      return sqlDecimal.Value; // throws OverflowException.
+    }
 
-      fixed (int* inputS = inputData) {
-        var input = (uint*) inputS;
-        byte maxZeroCount = 0;
-        while (maxZeroCount < scale && (input[maxZeroCount >> 6] & (1 << maxZeroCount)) == 0) {
-          maxZeroCount++;
-        }
+    byte maxZeroCount = 0;
+    while (maxZeroCount < scale && (inputData[maxZeroCount >> 6] & (1 << maxZeroCount)) == 0) {
+      maxZeroCount++;
+    }
 
-        var realScale = scale;
-        var outputData = sqlDecimal.Data;
-        fixed (int* outputS = outputData) {
-          var output = (uint*) outputS;
-          var dividerPow = maxZeroCount > 9 ? (byte) 9 : maxZeroCount;
-          if (dividerPow > 5) {
-            var divider = PowersOf10[dividerPow];
-            for (byte length = 4; realScale >= dividerPow; realScale -= dividerPow) {
-              if (DivHasRem(input, ref length, divider)) {
-                break;
-              }
+    var realScale = scale;
+    var dividerPow = maxZeroCount > 9 ? (byte) 9 : maxZeroCount;
 
-              output[0] = input[0];
-              output[1] = input[1];
-              output[2] = input[2];
-              output[3] = input[3];
-            }
-          }
+    UInt128 data = new((ulong)inputData[2] | ((ulong)inputData[3] << 32),
+      (ulong)inputData[0] | ((ulong)inputData[1] << 32));
 
-          for (byte length = 4; realScale > 0 && output[3] != 0; realScale--) {
-            _ = DivHasRem(output, ref length, 10);
-          }
-
-          if (output[3] != 0) {
-            return sqlDecimal.Value; // throws OverflowException.
-          }
-
-          return new decimal(outputS[0], outputS[1], outputS[2], !sqlDecimal.IsPositive, realScale);
+    if (dividerPow > 5) {
+      var divider = PowersOf10[dividerPow];
+      for (; realScale >= dividerPow; realScale -= dividerPow) {
+        (data, var rem) = UInt128.DivRem(data, divider);
+        if (rem != 0) {
+          break;
         }
       }
     }
 
-    private static unsafe bool DivHasRem(uint* bits, ref byte length, uint divider)
-    {
-      unchecked {
-        ulong rem = 0;
-        var tempBits = bits + length;
-        for (byte i = 0; i < length; i++) {
-          var bit = *(--tempBits);
-          if (bit == 0 && i == 0) {
-            length--;
-            i--;
-            continue;
-          }
-
-          var num = (rem << 32) + bit;
-          bit = (uint) (num / divider);
-          rem = (uint) (num - (ulong) bit * divider);
-          *tempBits = bit;
-        }
-
-        return rem > 0;
-      }
+    for (; realScale > 0 && data > Max96bitValue; realScale--) {
+      (data, _) = UInt128.DivRem(data, 10);
     }
+
+    if (data > Max96bitValue) {
+      return sqlDecimal.Value; // throws OverflowException.
+    }
+
+    return new((int) data, (int) (data >> 32), (int) (data >> 64), !sqlDecimal.IsPositive, realScale);
   }
 }

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -137,7 +137,7 @@ internal static class InternalHelpers
   internal static decimal TruncateToNetDecimal(SqlDecimal sqlDecimal)
   {
     var inputData = sqlDecimal.Data;
-    if (sqlDecimal.Scale is var scale && (scale > 28 || scale > 0 && inputData[3] != 0)) {
+    if (sqlDecimal.Scale is var scale && (scale > 28 || inputData[3] != 0)) {
       var u128 = FromSqlDecimalData(inputData);
 
       for (; scale > 0 && u128 > Max96bitValue; --scale) {

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -152,7 +152,7 @@ internal static class InternalHelpers
   internal static decimal TruncateToNetDecimal(SqlDecimal sqlDecimal)
   {
     var inputData = sqlDecimal.Data;
-    var scale = sqlDecimal.Scale;
+    int scale = sqlDecimal.Scale;
 
     if (inputData[3] == 0) {
       if (scale <= 28) {
@@ -163,13 +163,9 @@ internal static class InternalHelpers
       return sqlDecimal.Value; // throws OverflowException.
     }
 
-    byte maxZeroCount = (byte)BitOperations.TrailingZeroCount(inputData[0]);
-    if (maxZeroCount > scale)
-      maxZeroCount = scale;
-
+    var maxZeroCount = Math.Min(scale, BitOperations.TrailingZeroCount(inputData[0]));
+    var dividerPow = Math.Min(maxZeroCount, 9);
     var realScale = scale;
-    var dividerPow = maxZeroCount > 9 ? (byte) 9 : maxZeroCount;
-
     var data = FromSqlDecimalData(inputData);
 
     if (dividerPow > 5) {

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -137,7 +137,7 @@ internal static class InternalHelpers
   internal static decimal TruncateToNetDecimal(SqlDecimal sqlDecimal)
   {
     try {
-      return sqlDecimal.Value; // throws OverflowException if the value is out of decimal range.
+      return sqlDecimal.Value; // throws an OverflowException if the value is out of the decimal range.
     }
     catch (OverflowException) {
       var scale = sqlDecimal.Scale;

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -136,18 +136,21 @@ internal static class InternalHelpers
 
   internal static decimal TruncateToNetDecimal(SqlDecimal sqlDecimal)
   {
-    var inputData = sqlDecimal.Data;
-    if (sqlDecimal.Scale is var scale && (scale > 28 || inputData[3] != 0)) {
+    try {
+      return sqlDecimal.Value; // throws OverflowException is the value is out of decimal range.
+    }
+    catch (OverflowException) {
+      var inputData = sqlDecimal.Data;
+      var scale = sqlDecimal.Scale;
       var u128 = FromSqlDecimalData(inputData);
 
       for (; scale > 0 && u128 > Max96bitValue; --scale) {
         (u128, _) = UInt128.DivRem(u128, Ten);
       }
 
-      if (u128 <= Max96bitValue) {
-        return new((int) u128, (int) (u128 >> 32), (int) (u128 >> 64), !sqlDecimal.IsPositive, scale);
-      }
+      return u128 <= Max96bitValue
+        ? new((int) u128, (int) (u128 >> 32), (int) (u128 >> 64), !sqlDecimal.IsPositive, scale)
+        : throw;
     }
-    return sqlDecimal.Value; // throws OverflowException is the value is out of decimal range.
   }
 }

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -144,6 +144,10 @@ internal static class InternalHelpers
     return ex is TimeoutException;
   }
 
+  private static UInt128 FromSqlDecimalData(int[] a) =>
+    new((uint) a[0] | ((ulong) (uint) a[1] << 32),
+      (uint) a[2] | ((ulong) (uint) a[3] << 32));
+
   internal static decimal TruncateToNetDecimal(SqlDecimal sqlDecimal)
   {
     var inputData = sqlDecimal.Data;
@@ -166,7 +170,7 @@ internal static class InternalHelpers
     var realScale = scale;
     var dividerPow = maxZeroCount > 9 ? (byte) 9 : maxZeroCount;
 
-    UInt128 data = FromSqlDecimalData(inputData);
+    var data = FromSqlDecimalData(inputData);
 
     if (dividerPow > 5) {
       var divider = PowersOf10[dividerPow];

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -144,7 +144,7 @@ internal static class InternalHelpers
       var u128 = FromSqlDecimalData(sqlDecimal.Data);   // sqlDecimal.Data allocates a new array
 
       for (; scale > 0 && u128 > Max96bitValue; --scale) {
-        (u128, _) = UInt128.DivRem(u128, Ten);
+        u128 = UInt128.DivRem(u128, Ten).Quotient;
       }
 
       if (u128 > Max96bitValue) {

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -140,14 +140,14 @@ internal static class InternalHelpers
     var scale = sqlDecimal.Scale;
 
     if (scale > 28 || scale > 0 && inputData[3] != 0) {
-      var data = FromSqlDecimalData(inputData);
+      var u128 = FromSqlDecimalData(inputData);
 
-      for (; scale > 0 && data > Max96bitValue; --scale) {
-        (data, _) = UInt128.DivRem(data, Ten);
+      for (; scale > 0 && u128 > Max96bitValue; --scale) {
+        (u128, _) = UInt128.DivRem(u128, Ten);
       }
 
-      if (data <= Max96bitValue) {
-        return new((int) data, (int) (data >> 32), (int) (data >> 64), !sqlDecimal.IsPositive, scale);
+      if (u128 <= Max96bitValue) {
+        return new((int) u128, (int) (u128 >> 32), (int) (u128 >> 64), !sqlDecimal.IsPositive, scale);
       }     
     }
     return sqlDecimal.Value; // throws OverflowException is the value is out of decimal range.

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -140,7 +140,7 @@ internal static class InternalHelpers
       return sqlDecimal.Value; // throws OverflowException if the value is out of decimal range.
     }
     catch (OverflowException) {
-      var inputData = sqlDecimal.Data;
+      var inputData = sqlDecimal.Data;    // Allocates a new array
       var scale = sqlDecimal.Scale;
       var u128 = FromSqlDecimalData(inputData);
 

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -6,6 +6,7 @@
 
 using Microsoft.Data.SqlClient;
 using System.Data.SqlTypes;
+using System.Numerics;
 using Xtensive.Diagnostics;
 
 namespace Xtensive.Sql.Drivers.SqlServer;

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/InternalHelpers.cs
@@ -140,9 +140,8 @@ internal static class InternalHelpers
       return sqlDecimal.Value; // throws OverflowException if the value is out of decimal range.
     }
     catch (OverflowException) {
-      var inputData = sqlDecimal.Data;    // Allocates a new array
       var scale = sqlDecimal.Scale;
-      var u128 = FromSqlDecimalData(inputData);
+      var u128 = FromSqlDecimalData(sqlDecimal.Data);   // sqlDecimal.Data allocates a new array
 
       for (; scale > 0 && u128 > Max96bitValue; --scale) {
         (u128, _) = UInt128.DivRem(u128, Ten);


### PR DESCRIPTION
We can use `UInt128` type for big-integer arithmetic instead of pinning arrays.
`DivHasRem()` can be replaced by `UInt128.DivRem()`

Try `sqlDecimal.Value` inside try/catch first to avoid array allocaton by `SqDecimal.Data`