### PR TITLE
Let the `OperationCanceledException` propagate in `.Translate()`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/QueryProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/QueryProvider.cs
@@ -166,7 +166,7 @@ namespace Xtensive.Orm.Linq
         var context = new TranslatorContext(Session, compilerConfiguration, expression, compiledQueryScope);
         return context.Translator.Translate();
       }
-      catch (Exception ex) {
+      catch (Exception ex) when (ex is not OperationCanceledException) {
         string serializedExpression = null;
         try {
           serializedExpression = expression.ToString(true);


### PR DESCRIPTION
This is related to https://github.com/servicetitan/app/pull/118097

We don't want a misleading "Translation error" in logs just becase a Request was aborted (`WebRequestAbortedException`)
