### PR TITLE
Support `Guid[]` as TVP parameters

### DIFF
--- a/Extensions/Xtensive.Orm.BulkOperations.Tests/ContainsTest.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations.Tests/ContainsTest.cs
@@ -2,8 +2,6 @@
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
-using System;
-using System.Linq;
 using NUnit.Framework;
 using Xtensive.Orm.BulkOperations.ContainsTestModel;
 using Xtensive.Orm.Configuration;
@@ -18,11 +16,15 @@ namespace Xtensive.Orm.BulkOperations.ContainsTestModel
     public long Id { get; private set; }
 
     [Field]
+    public Guid Guid { get; private set; }
+
+    [Field]
     public int ProjectedValueAdjustment { get; set; }
 
-    public TagType(Session session, long id)
+    public TagType(Session session, long id, Guid guid)
       :base(session, id)
     {
+      Guid = guid;
     }
   }
 }
@@ -32,6 +34,7 @@ namespace Xtensive.Orm.BulkOperations.Tests
   public class ContainsTest : BulkOperationBaseTest
   {
     private long[] tagIds;
+    private Guid[] guids;
 
     protected override DomainConfiguration BuildConfiguration()
     {
@@ -40,13 +43,17 @@ namespace Xtensive.Orm.BulkOperations.Tests
       return configuration;
     }
 
+    private static Guid IntToGuid(int v) =>
+      new((uint)v, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+
     protected override void PopulateData()
     {
       tagIds = Enumerable.Range(0, 100).Select(i => (long) i).ToArray();
+      guids = tagIds.Select(v => IntToGuid((int)v)).ToArray();
       using (var session = Domain.OpenSession())
       using (var transaction = session.OpenTransaction()) {
         foreach (var id in tagIds.Concat(Enumerable.Repeat(1000, 1).Select(i => (long) i))) {
-          _ = new TagType(session, id) { ProjectedValueAdjustment = -1 };
+          _ = new TagType(session, id, IntToGuid((int)id)) { ProjectedValueAdjustment = -1 };
         }
 
         transaction.Complete();
@@ -133,6 +140,23 @@ namespace Xtensive.Orm.BulkOperations.Tests
         var ids = tagIds.Concat(Enumerable.Range(4000, 5000).Select(o => (long)o));
         var updatedRows = session.Query.All<TagType>()
           .Where(t => t.Id.In(ids))
+          .Set(t => t.ProjectedValueAdjustment, 2)
+          .Update();
+        Assert.That(updatedRows, Is.EqualTo(100));
+        Assert.That(session.Query.All<TagType>().Count(t => t.ProjectedValueAdjustment == 2 && t.Id <= 200), Is.EqualTo(100));
+        Assert.That(session.Query.All<TagType>().Count(t => t.ProjectedValueAdjustment == -1 && t.Id > 700), Is.EqualTo(1));
+      }
+
+    }
+
+    [Test]
+    public void TestManyGuids()
+    {
+      using (var session = Domain.OpenSession())
+      using (var tx = session.OpenTransaction()) {
+        var ids = guids.Concat(Enumerable.Range(4000, 5000).Select(IntToGuid));
+        var updatedRows = session.Query.All<TagType>()
+          .Where(t => t.Guid.In(ids))
           .Set(t => t.ProjectedValueAdjustment, 2)
           .Update();
         Assert.That(updatedRows, Is.EqualTo(100));

--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/QueryOperation.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/QueryOperation.cs
@@ -2,11 +2,7 @@
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
-using Xtensive.Core;
 using Xtensive.Orm.Linq;
 using Xtensive.Orm.Model;
 using Xtensive.Orm.Providers;
@@ -82,7 +78,7 @@ namespace Xtensive.Orm.BulkOperations
     #region Non-public methods
 
     private bool CanUseTvp(Type fieldType) =>
-      (fieldType == typeof(long) || fieldType == typeof(int) || fieldType == typeof(string))
+      WellKnownTypes.TypesWithTvpSupport.Contains(fieldType)
       && DomainHandler.Handlers.ProviderInfo.Supports(ProviderFeatures.TableValuedParameters);
 
     protected abstract SqlTableRef GetStatementTable(SqlStatement statement);

--- a/Extensions/Xtensive.Orm.BulkOperations/Internals/QueryOperation.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations/Internals/QueryOperation.cs
@@ -78,7 +78,7 @@ namespace Xtensive.Orm.BulkOperations
     #region Non-public methods
 
     private bool CanUseTvp(Type fieldType) =>
-      WellKnownTypes.TypesWithTvpSupport.Contains(fieldType)
+      TypeHelper.TypesWithTvpSupport.Contains(fieldType)
       && DomainHandler.Handlers.ProviderInfo.Supports(ProviderFeatures.TableValuedParameters);
 
     protected abstract SqlTableRef GetStatementTable(SqlStatement statement);

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/Driver.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/Driver.cs
@@ -28,12 +28,15 @@ internal class Driver(CoreServerInfo coreServerInfo, ErrorMessageParser errorMes
         CREATE TYPE [{TypeMapper.LongListTypeName}] AS TABLE ([Value] BIGINT NOT NULL PRIMARY KEY);
       IF NOT EXISTS(SELECT 1 FROM sys.types WHERE name = '{TypeMapper.StringListTypeName}')
         CREATE TYPE [{TypeMapper.StringListTypeName}] AS TABLE ([Value] NVARCHAR(256) NOT NULL PRIMARY KEY);
+      IF NOT EXISTS(SELECT 1 FROM sys.types WHERE name = '{TypeMapper.GuidListTypeName}')
+        CREATE TYPE [{TypeMapper.GuidListTypeName}] AS TABLE ([Value] UNIQUEIDENTIFIER NOT NULL PRIMARY KEY);
       """);
 
   protected override void RegisterCustomMappings(TypeMappingRegistryBuilder builder)
   {
     base.RegisterCustomMappings(builder);
     builder.Add(typeof(List<long>), null, builder.Mapper.BindLongList, null);
+    builder.Add(typeof(List<Guid>), null, builder.Mapper.BindGuidList, null);
     builder.Add(typeof(List<string>), null, builder.Mapper.BindStringList, null);
 
     // As far as SqlGeometry and SqlGeography have no support in .Net Standard

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/Driver.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/Driver.cs
@@ -4,9 +4,6 @@
 // Created by: Denis Krjuchkov
 // Created:    2009.07.07
 
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Xtensive.Sql.Compiler;
 using Xtensive.Sql.Info;
 using ISqlExecutor = Xtensive.Orm.Providers.ISqlExecutor;

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/SqlDataRecordList.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/SqlDataRecordList.cs
@@ -45,6 +45,18 @@ public class SqlDataRecordList(IReadOnlyList<Tuple> tuples, SqlDbType sqlDbType)
           }
         }
       } break;
+      case SqlDbType.UniqueIdentifier: {
+        SqlMetaData[] metaData = [new("Value", sqlDbType, tuples.Max(t => (t.GetValueOrDefault(0) as string)?.Length ?? 20))];
+        SqlDataRecord record = new(metaData);
+        HashSet<Guid> added = [];
+        foreach (var valueObj in tuples.Select(t => t.GetValueOrDefault(0)).Where(o => o != null)) {
+          Guid castValue = (Guid) valueObj;
+          if (added.Add(castValue)) {
+            record.SetSqlGuid(0, castValue);
+            yield return record;
+          }
+        }
+      } break;
       case SqlDbType.NVarChar: {
         SqlMetaData[] metaData = [new("Value", sqlDbType, tuples.Max(t => (t.GetValueOrDefault(0) as string)?.Length ?? 20))];
         SqlDataRecord record = new(metaData);

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/SqlDataRecordList.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/SqlDataRecordList.cs
@@ -46,7 +46,7 @@ public class SqlDataRecordList(IReadOnlyList<Tuple> tuples, SqlDbType sqlDbType)
         }
       } break;
       case SqlDbType.UniqueIdentifier: {
-        SqlMetaData[] metaData = [new("Value", sqlDbType, tuples.Max(t => (t.GetValueOrDefault(0) as string)?.Length ?? 20))];
+        SqlMetaData[] metaData = [new("Value", sqlDbType)];
         SqlDataRecord record = new(metaData);
         HashSet<Guid> added = [];
         foreach (var valueObj in tuples.Select(t => t.GetValueOrDefault(0)).Where(o => o != null)) {

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/TypeMapper.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/TypeMapper.cs
@@ -17,6 +17,7 @@ namespace Xtensive.Sql.Drivers.SqlServer.v10
   {
     public const string
       LongListTypeName = "_DO_LongList",
+      GuidListTypeName = "_DO_GuidList",
       StringListTypeName = "_DO_StringList";
 
     public override void BindDateTime(DbParameter parameter, object value)
@@ -40,10 +41,16 @@ namespace Xtensive.Sql.Drivers.SqlServer.v10
       var sqlParameter = (SqlParameter) parameter;
       sqlParameter.SqlDbType = SqlDbType.Structured;
       sqlParameter.Value = new SqlDataRecordList((List<Tuple>) value, sqlDbType) switch { var o => o.IsEmpty ? null : o };
-      sqlParameter.TypeName = sqlDbType == SqlDbType.BigInt ? LongListTypeName : StringListTypeName;
+      sqlParameter.TypeName =
+        sqlDbType switch {
+          SqlDbType.BigInt => LongListTypeName,
+          SqlDbType.UniqueIdentifier => GuidListTypeName,
+          _ => StringListTypeName
+        };
     }
 
     public override void BindLongList(DbParameter parameter, object value) => BindList(parameter, value, SqlDbType.BigInt);
+    public override void BindGuidList(DbParameter parameter, object value) => BindList(parameter, value, SqlDbType.UniqueIdentifier);
     public override void BindStringList(DbParameter parameter, object value) => BindList(parameter, value, SqlDbType.NVarChar);
   }
 }

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/TypeMapper.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/TypeMapper.cs
@@ -4,53 +4,50 @@
 // Created by: Denis Krjuchkov
 // Created:    2009.07.02
 
-using System;
-using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using Microsoft.Data.SqlClient;
 using Tuple = Xtensive.Tuples.Tuple;
 
-namespace Xtensive.Sql.Drivers.SqlServer.v10
+namespace Xtensive.Sql.Drivers.SqlServer.v10;
+
+internal class TypeMapper(SqlDriver driver) : v09.TypeMapper(driver)
 {
-  internal class TypeMapper(SqlDriver driver) : v09.TypeMapper(driver)
+  public const string
+    LongListTypeName = "_DO_LongList",
+    GuidListTypeName = "_DO_GuidList",
+    StringListTypeName = "_DO_StringList";
+
+  public override void BindDateTime(DbParameter parameter, object value)
   {
-    public const string
-      LongListTypeName = "_DO_LongList",
-      GuidListTypeName = "_DO_GuidList",
-      StringListTypeName = "_DO_StringList";
-
-    public override void BindDateTime(DbParameter parameter, object value)
-    {
-      parameter.DbType = DbType.DateTime2;
-      parameter.Value = value ?? DBNull.Value;
-    }
-
-    public override DateTime ReadDateTime(DbDataReader reader, int index)
-    {
-      string type = reader.GetDataTypeName(index);
-      if (type=="time") {
-        var time = (TimeSpan) reader.GetValue(index);
-        return new DateTime(time.Ticks / 100);
-      }
-      return base.ReadDateTime(reader, index);
-    }
-
-    private static void BindList(DbParameter parameter, object value, SqlDbType sqlDbType)
-    {
-      var sqlParameter = (SqlParameter) parameter;
-      sqlParameter.SqlDbType = SqlDbType.Structured;
-      sqlParameter.Value = new SqlDataRecordList((List<Tuple>) value, sqlDbType) switch { var o => o.IsEmpty ? null : o };
-      sqlParameter.TypeName =
-        sqlDbType switch {
-          SqlDbType.BigInt => LongListTypeName,
-          SqlDbType.UniqueIdentifier => GuidListTypeName,
-          _ => StringListTypeName
-        };
-    }
-
-    public override void BindLongList(DbParameter parameter, object value) => BindList(parameter, value, SqlDbType.BigInt);
-    public override void BindGuidList(DbParameter parameter, object value) => BindList(parameter, value, SqlDbType.UniqueIdentifier);
-    public override void BindStringList(DbParameter parameter, object value) => BindList(parameter, value, SqlDbType.NVarChar);
+    parameter.DbType = DbType.DateTime2;
+    parameter.Value = value ?? DBNull.Value;
   }
+
+  public override DateTime ReadDateTime(DbDataReader reader, int index)
+  {
+    string type = reader.GetDataTypeName(index);
+    if (type=="time") {
+      var time = (TimeSpan) reader.GetValue(index);
+      return new DateTime(time.Ticks / 100);
+    }
+    return base.ReadDateTime(reader, index);
+  }
+
+  private static void BindList(DbParameter parameter, object value, SqlDbType sqlDbType)
+  {
+    var sqlParameter = (SqlParameter) parameter;
+    sqlParameter.SqlDbType = SqlDbType.Structured;
+    sqlParameter.Value = new SqlDataRecordList((List<Tuple>) value, sqlDbType) switch { var o => o.IsEmpty ? null : o };
+    sqlParameter.TypeName =
+      sqlDbType switch {
+        SqlDbType.BigInt => LongListTypeName,
+        SqlDbType.UniqueIdentifier => GuidListTypeName,
+        _ => StringListTypeName
+      };
+  }
+
+  public override void BindLongList(DbParameter parameter, object value) => BindList(parameter, value, SqlDbType.BigInt);
+  public override void BindGuidList(DbParameter parameter, object value) => BindList(parameter, value, SqlDbType.UniqueIdentifier);
+  public override void BindStringList(DbParameter parameter, object value) => BindList(parameter, value, SqlDbType.NVarChar);
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Include.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Include.cs
@@ -39,7 +39,7 @@ namespace Xtensive.Orm.Providers
             && tableValuedParametersSupported
             && provider.FilteredColumnsExtractionTransform.Descriptor.Count == 1) {
         var fieldType = provider.FilteredColumnsExtractionTransform.Descriptor[0];
-        if (fieldType == WellKnownTypes.Int64 || fieldType == WellKnownTypes.Int32 || fieldType == WellKnownTypes.String) {
+        if (WellKnownTypes.TypesWithTvpSupport.Contains(fieldType)) {
           tvpType = fieldType;
         }
       }
@@ -104,9 +104,10 @@ namespace Xtensive.Orm.Providers
       Type tableValuedParameterType,
       bool enforceTvp)
     {
-      var tvpMapping = Driver.GetTypeMapping(tableValuedParameterType == WellKnownTypes.String
-        ? typeof(List<string>)
-        : typeof(List<long>));
+      var tvpMapping = Driver.GetTypeMapping(
+        tableValuedParameterType == WellKnownTypes.String ? typeof(List<string>)
+          : tableValuedParameterType == WellKnownTypes.Guid ? typeof(List<Guid>)
+          : typeof(List<long>));
       QueryRowFilterParameterBinding binding = new(mappings, valueAccessor, tvpMapping, enforceTvp);
       return (SqlDml.TvpDynamicFilter(binding, provider.FilteredColumns.Select(index => sourceColumns[index]).ToArray()), binding);
     }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Include.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Include.cs
@@ -39,7 +39,7 @@ namespace Xtensive.Orm.Providers
             && tableValuedParametersSupported
             && provider.FilteredColumnsExtractionTransform.Descriptor.Count == 1) {
         var fieldType = provider.FilteredColumnsExtractionTransform.Descriptor[0];
-        if (WellKnownTypes.TypesWithTvpSupport.Contains(fieldType)) {
+        if (TypeHelper.TypesWithTvpSupport.Contains(fieldType)) {
           tvpType = fieldType;
         }
       }

--- a/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
+++ b/Orm/Xtensive.Orm/Reflection/TypeHelper.cs
@@ -6,6 +6,7 @@
 
 using System.Collections;
 using System.Collections.Concurrent;
+using System.Collections.Frozen;
 using System.Diagnostics;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -1280,5 +1281,8 @@ namespace Xtensive.Reflection
     }
 
     #endregion
+
+
+    public static readonly FrozenSet<Type> TypesWithTvpSupport = [typeof(int), typeof(long), typeof(Guid), typeof(string)];
   }
 }

--- a/Orm/Xtensive.Orm/Reflection/WellKnownTypes.cs
+++ b/Orm/Xtensive.Orm/Reflection/WellKnownTypes.cs
@@ -2,16 +2,14 @@
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.Collections.Frozen;
 using System.Linq.Expressions;
 using System.Reflection;
 using Xtensive.Orm.Linq;
 
 namespace Xtensive.Reflection
 {
-  internal static class WellKnownTypes
+  public static class WellKnownTypes
   {
     public static readonly Type Object = typeof(object);
     public static readonly Type Array = typeof(Array);
@@ -84,5 +82,7 @@ namespace Xtensive.Reflection
 
     public static readonly Type ReadOnlySpanOfT = typeof(ReadOnlySpan<>);
     public static readonly Type SpanOfT = typeof(Span<>);
+
+    public static readonly FrozenSet<Type> TypesWithTvpSupport = [typeof(int), typeof(long), typeof(Guid), typeof(string)];
   }
 }

--- a/Orm/Xtensive.Orm/Reflection/WellKnownTypes.cs
+++ b/Orm/Xtensive.Orm/Reflection/WellKnownTypes.cs
@@ -2,14 +2,13 @@
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
-using System.Collections.Frozen;
 using System.Linq.Expressions;
 using System.Reflection;
 using Xtensive.Orm.Linq;
 
 namespace Xtensive.Reflection
 {
-  public static class WellKnownTypes
+  internal static class WellKnownTypes
   {
     public static readonly Type Object = typeof(object);
     public static readonly Type Array = typeof(Array);
@@ -82,7 +81,5 @@ namespace Xtensive.Reflection
 
     public static readonly Type ReadOnlySpanOfT = typeof(ReadOnlySpan<>);
     public static readonly Type SpanOfT = typeof(Span<>);
-
-    public static readonly FrozenSet<Type> TypesWithTvpSupport = [typeof(int), typeof(long), typeof(Guid), typeof(string)];
   }
 }

--- a/Orm/Xtensive.Orm/Sql/ValueTypeMapping/TypeMapper.cs
+++ b/Orm/Xtensive.Orm/Sql/ValueTypeMapping/TypeMapper.cs
@@ -172,8 +172,9 @@ namespace Xtensive.Sql
       parameter.Value = value ?? DBNull.Value;
     }
 
-    public virtual void BindLongList(DbParameter parameter, object value) => throw new NotSupportedException("Table-Valued Paramenters not supported");
-    public virtual void BindStringList(DbParameter parameter, object value) => throw new NotSupportedException("Table-Valued Paramenters not supported");
+    public virtual void BindLongList(DbParameter parameter, object value) => throw new NotSupportedException("Table-Valued Parameters not supported");
+    public virtual void BindGuidList(DbParameter parameter, object value) => throw new NotSupportedException("Table-Valued Parameters not supported");
+    public virtual void BindStringList(DbParameter parameter, object value) => throw new NotSupportedException("Table-Valued Parameters not supported");
 
     #endregion
 

--- a/Version.props
+++ b/Version.props
@@ -2,8 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.2.189</DoVersion>
-    <DoVersionSuffix>servicetitan</DoVersionSuffix>
+    <DoVersion>7.2.190</DoVersion>
+    <DoVersionSuffix>servicetitan-test</DoVersionSuffix>
 </PropertyGroup>
 
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -3,7 +3,7 @@
 
 <PropertyGroup>
     <DoVersion>7.2.190</DoVersion>
-    <DoVersionSuffix>servicetitan-test</DoVersionSuffix>
+    <DoVersionSuffix>servicetitan</DoVersionSuffix>
 </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
We have TVP support of `IEnumerable<long>`  & `IEnumerable<string>`  in `.In()` expressions.

This change adds `IEnumerable<Guid>` support, as filtering by GUID list is used in a few places in the App