### PR TITLE
Optimize `.Query.All<>`  implementation

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Domain.cs
+++ b/Orm/Xtensive.Orm/Orm/Domain.cs
@@ -4,12 +4,8 @@
 // Created by: Dmitri Maximov
 // Created:    2007.08.03
 
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Runtime.ExceptionServices;
-using System.Threading;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Xtensive.Caching;
 using Xtensive.Collections;
@@ -131,8 +127,6 @@ namespace Xtensive.Orm
     internal ConcurrentDictionary<TypeInfo, IReadOnlyList<PrefetchFieldDescriptor>> PrefetchFieldDescriptorCache { get; } = new();
 
     internal FastConcurrentLruCache<QueryKey, (QueryKey Key, ParameterizedQuery Query)> QueryCache { get; }
-
-    internal static ConcurrentDictionary<Type, System.Linq.Expressions.MethodCallExpression> RootCallExpressionsCache { get; } = new();
 
     /// <summary>
     /// Caches uncompiled queries used by <see cref="PrefetchManager"/> to fetch certain entities.

--- a/Orm/Xtensive.Orm/Orm/Domain.cs
+++ b/Orm/Xtensive.Orm/Orm/Domain.cs
@@ -132,7 +132,7 @@ namespace Xtensive.Orm
 
     internal FastConcurrentLruCache<QueryKey, (QueryKey Key, ParameterizedQuery Query)> QueryCache { get; }
 
-    internal ConcurrentDictionary<Type, System.Linq.Expressions.MethodCallExpression> RootCallExpressionsCache { get; } = new();
+    internal static ConcurrentDictionary<Type, System.Linq.Expressions.MethodCallExpression> RootCallExpressionsCache { get; } = new();
 
     /// <summary>
     /// Caches uncompiled queries used by <see cref="PrefetchManager"/> to fetch certain entities.

--- a/Orm/Xtensive.Orm/Orm/Linq/QueryHelper.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/QueryHelper.cs
@@ -4,10 +4,6 @@
 // Created by: Denis Krjuchkov
 // Created:    2009.04.02
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Xtensive.Core;
@@ -66,10 +62,8 @@ namespace Xtensive.Orm.Linq
       return FastExpression.Lambda<Func<Tuple, bool>>(filterExpression, TupleParameters);
     }
 
-    private static Expression CreateEntityQuery(Type elementType, Domain domain)
-    {
-      return domain.RootCallExpressionsCache.GetOrAdd(elementType, (t) => Expression.Call(null, WellKnownMembers.Query.All.MakeGenericMethod(elementType)));
-    }
+    internal static Expression CreateEntityQuery(Type elementType) =>
+      Domain.RootCallExpressionsCache.GetOrAdd(elementType, static t => Expression.Call(null, WellKnownMembers.Query.All.MakeGenericMethod(t)));
 
     public static bool IsDirectEntitySetQuery(Expression entitySet)
     {
@@ -134,7 +128,7 @@ namespace Xtensive.Orm.Linq
           );
         return Expression.Call(
           WellKnownMembers.Queryable.Where.CachedMakeGenericMethod(elementType),
-          CreateEntityQuery(elementType, domain),
+          CreateEntityQuery(elementType),
           FastExpression.Lambda(whereExpression, whereParameter)
           );
       }
@@ -159,7 +153,7 @@ namespace Xtensive.Orm.Linq
 
       var outerQuery = Expression.Call(
         WellKnownMembers.Queryable.Where.CachedMakeGenericMethod(connectorType),
-        CreateEntityQuery(connectorType, domain),
+        CreateEntityQuery(connectorType),
         FastExpression.Lambda(filterExpression, filterParameter)
         );
 
@@ -171,7 +165,7 @@ namespace Xtensive.Orm.Linq
       var innerSelector = FastExpression.Lambda(innerSelectorParameter, innerSelectorParameter);
       var resultSelector = FastExpression.Lambda(innerSelectorParameter, outerSelectorParameter, innerSelectorParameter);
 
-      var innerQuery = CreateEntityQuery(elementType, domain);
+      var innerQuery = CreateEntityQuery(elementType);
       var joinMethodInfo = WellKnownMembers.Queryable.Join
         .MakeGenericMethod(new[] {
           connectorType,

--- a/Orm/Xtensive.Orm/Orm/Linq/QueryHelper.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/QueryHelper.cs
@@ -4,6 +4,7 @@
 // Created by: Denis Krjuchkov
 // Created:    2009.04.02
 
+using System.Collections.Concurrent;
 using System.Linq.Expressions;
 using System.Reflection;
 using Xtensive.Core;
@@ -62,8 +63,10 @@ namespace Xtensive.Orm.Linq
       return FastExpression.Lambda<Func<Tuple, bool>>(filterExpression, TupleParameters);
     }
 
+    private static readonly ConcurrentDictionary<Type, MethodCallExpression> RootCallExpressionsCache = new();
+
     internal static Expression CreateEntityQuery(Type elementType) =>
-      Domain.RootCallExpressionsCache.GetOrAdd(elementType, static t => Expression.Call(null, WellKnownMembers.Query.All.MakeGenericMethod(t)));
+      RootCallExpressionsCache.GetOrAdd(elementType, static t => Expression.Call(null, WellKnownMembers.Query.All.MakeGenericMethod(t)));
 
     public static bool IsDirectEntitySetQuery(Expression entitySet)
     {

--- a/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
@@ -47,7 +47,7 @@ namespace Xtensive.Orm
 
     private static class Traits<T>
     {
-      public static readonly MethodCallExpression AllExpression =
+      public static readonly MethodCallExpression RootCallExpression =
         Expression.Call(null, WellKnownMembers.Query.All.MakeGenericMethod(typeof(T)));
     }
 
@@ -64,7 +64,7 @@ namespace Xtensive.Orm
     public IQueryable<T> All<T>() where T : class, IEntity =>
       Provider.CreateQuery<T>(RootBuilder != null
         ? RootBuilder.BuildRootExpression(typeof(T))
-        : Traits<T>.AllExpression);
+        : Traits<T>.RootCallExpression);
 
     /// <summary>
     /// The "starting point" for dynamic LINQ query -

--- a/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
@@ -2,19 +2,13 @@
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Xtensive.Core;
 using Xtensive.Orm.FullTextSearchCondition.Interfaces;
 using Xtensive.Orm.FullTextSearchCondition.Nodes;
 using Xtensive.Orm.Internals;
-using Xtensive.Orm.Internals.Prefetch;
 using Xtensive.Orm.Linq;
 using Xtensive.Reflection;
 using Tuple = Xtensive.Tuples.Tuple;
@@ -51,7 +45,13 @@ namespace Xtensive.Orm
 
     public override int GetHashCode() => HashCode.Combine(Provider, RootBuilder);
 
-    /// <summary>
+    private static class Traits<T>
+    {
+      public static readonly MethodCallExpression AllExpression =
+        Expression.Call(null, WellKnownMembers.Query.All.MakeGenericMethod(typeof(T)));
+    }
+
+  /// <summary>
     /// The "starting point" for any LINQ query -
     /// a <see cref="IQueryable{T}"/> enumerating all the instances
     /// of type <typeparamref name="T"/>.
@@ -61,11 +61,10 @@ namespace Xtensive.Orm
     /// An <see cref="IQueryable{T}"/> enumerating all the instances
     /// of type <typeparamref name="T"/>.
     /// </returns>
-    public IQueryable<T> All<T>()
-      where T : class, IEntity
-    {
-      return Provider.CreateQuery<T>(BuildRootExpression(typeof(T)));
-    }
+    public IQueryable<T> All<T>() where T : class, IEntity =>
+      Provider.CreateQuery<T>(RootBuilder != null
+        ? RootBuilder.BuildRootExpression(typeof(T))
+        : Traits<T>.AllExpression);
 
     /// <summary>
     /// The "starting point" for dynamic LINQ query -
@@ -77,10 +76,11 @@ namespace Xtensive.Orm
     /// An <see cref="IQueryable"/> enumerating all the instances
     /// of type <paramref name="elementType"/>.
     /// </returns>
-    public IQueryable All(Type elementType)
-    {
-      return ((IQueryProvider) Provider).CreateQuery(BuildRootExpression(elementType));
-    }
+    public IQueryable All(Type elementType) =>
+      ((IQueryProvider) Provider).CreateQuery(RootBuilder != null
+        ? RootBuilder.BuildRootExpression(elementType)
+        : QueryHelper.CreateEntityQuery(elementType)
+      );
 
     #region Full-text related
 
@@ -970,13 +970,6 @@ namespace Xtensive.Orm
       return Key.Create(session.Domain, session.StorageNodeId, session.Domain.Model.Types[typeof(T)], TypeReferenceAccuracy.BaseType, keyValues);
     }
 
-    private Expression BuildRootExpression(Type elementType)
-    {
-      return RootBuilder!=null
-        ? RootBuilder.BuildRootExpression(elementType)
-        : Session.Domain.RootCallExpressionsCache.GetOrAdd(elementType, (t) => Expression.Call(null, WellKnownMembers.Query.All.MakeGenericMethod(t)));
-    }
-
     private static void ThrowKeyNotFoundException(Key key) =>
         throw new KeyNotFoundException(String.Format(Strings.EntityWithKeyXDoesNotExist, key));
 
@@ -987,7 +980,6 @@ namespace Xtensive.Orm
 
     internal QueryEndpoint(QueryProvider provider)
     {
-      ArgumentNullException.ThrowIfNull(provider);
       Provider = provider;
     }
 


### PR DESCRIPTION
Generic form  `.Query.All<>`  can be implemented on generic `Traits<T>.RootCallExpression` instead of cache lookup

Also:
* Make the `RootCallExpressionsCache` static as it is domain-independent
* Remove `provider` null-checking. It is already ensured by the caller