### PR TITLE
Use covariant types in  `BindParameter()`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnExpression.cs
@@ -32,10 +32,8 @@ namespace Xtensive.Orm.Linq.Expressions
       return new ColumnExpression(Type, newMapping, OuterParameter, DefaultIfEmpty);
     }
 
-    public Expression BindParameter(ParameterExpression parameter)
-    {
-      return BindParameter(parameter, new Dictionary<Expression, Expression>());
-    }
+    public ColumnExpression BindParameter(ParameterExpression parameter) =>
+      BindParameter(parameter, new Dictionary<Expression, Expression>());
 
     public override ColumnExpression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ColumnExpression.cs
@@ -40,10 +40,8 @@ namespace Xtensive.Orm.Linq.Expressions
       return new ColumnExpression(Type, Mapping, parameter, DefaultIfEmpty);
     }
 
-    public override Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
-    {
-      return new ColumnExpression(Type, Mapping, null, DefaultIfEmpty);
-    }
+    public override ColumnExpression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions) =>
+      new(Type, Mapping, null, DefaultIfEmpty);
 
     public static ColumnExpression Create(Type type, ColNum columnIndex)
     {

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
@@ -28,7 +28,7 @@ namespace Xtensive.Orm.Linq
 
     public IReadOnlyList<Expression> ConstructorArguments { get; }
 
-    public override Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
+    public override ParameterizedExpression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
       GenericExpressionVisitor<IMappedExpression> genericVisitor = new(mapped => mapped.BindParameter(parameter, processedExpressions));
       var genericBinder = genericVisitor.Process;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityExpression.cs
@@ -96,13 +96,13 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
+    public override EntityExpression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
     {
       if (processedExpressions.TryGetValue(this, out var value)) {
-        return value;
+        return (EntityExpression) value;
       }
 
-      var keyExpression = (KeyExpression) Key.RemoveOuterParameter(processedExpressions);
+      var keyExpression = Key.RemoveOuterParameter(processedExpressions);
       var result = new EntityExpression(PersistentType, keyExpression, null, DefaultIfEmpty);
       result.IsNullable = IsNullable;
       processedExpressions.Add(this, result);

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityExpression.cs
@@ -76,13 +76,13 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
+    public override EntityExpression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
       if (processedExpressions.TryGetValue(this, out var value)) {
-        return value;
+        return (EntityExpression) value;
       }
 
-      var keyExpression = (KeyExpression) Key.BindParameter(parameter, processedExpressions);
+      var keyExpression = Key.BindParameter(parameter, processedExpressions);
       var result = new EntityExpression(PersistentType, keyExpression, parameter, DefaultIfEmpty);
       result.IsNullable = IsNullable;
       processedExpressions.Add(this, result);
@@ -177,7 +177,7 @@ namespace Xtensive.Orm.Linq.Expressions
       result.SetFields(fields);
       return entityFieldExpression.OuterParameter == null
         ? result
-        : (EntityExpression) result.BindParameter(
+        : result.BindParameter(
           entityFieldExpression.OuterParameter, new Dictionary<Expression, Expression>());
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityFieldExpression.cs
@@ -109,8 +109,8 @@ namespace Xtensive.Orm.Linq.Expressions
         // Do not convert to LINQ. We want to avoid a closure creation here.
         newFields[i++] = (PersistentFieldExpression) field.BindParameter(parameter, processedExpressions);
       }
-      var keyExpression = (KeyExpression) Key.BindParameter(parameter, processedExpressions);
-      var entity = (EntityExpression) Entity?.BindParameter(parameter, processedExpressions);
+      var keyExpression = Key.BindParameter(parameter, processedExpressions);
+      var entity = Entity?.BindParameter(parameter, processedExpressions);
       var result = new EntityFieldExpression(
         PersistentType, Field, newFields, Mapping, keyExpression, entity, parameter, DefaultIfEmpty);
       if (Owner == null) {

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntityFieldExpression.cs
@@ -4,8 +4,6 @@
 // Created by: Alexis Kochetov
 // Created:    2009.05.06
 
-using System;
-using System.Collections.Generic;
 using System.Linq.Expressions;
 using Xtensive.Core;
 using Xtensive.Orm.Model;
@@ -103,11 +101,11 @@ namespace Xtensive.Orm.Linq.Expressions
         return (EntityFieldExpression)r;
       }
 
-      var newFields = new PersistentFieldExpression[fields.Count];
-      int i = 0;
-      foreach (var field in fields) {
+      var n = fields.Count;
+      var newFields = new PersistentFieldExpression[n];
+      for (int i = 0; i < n; ++i) {
         // Do not convert to LINQ. We want to avoid a closure creation here.
-        newFields[i++] = (PersistentFieldExpression) field.BindParameter(parameter, processedExpressions);
+        newFields[i] = (PersistentFieldExpression) fields[i].BindParameter(parameter, processedExpressions);
       }
       var keyExpression = Key.BindParameter(parameter, processedExpressions);
       var entity = Entity?.BindParameter(parameter, processedExpressions);
@@ -122,20 +120,21 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
+    public override EntityFieldExpression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
     {
-      if (processedExpressions.TryGetValue(this, out var result)) {
-        return result;
+      if (processedExpressions.TryGetValue(this, out var value)) {
+        return (EntityFieldExpression) value;
       }
 
-      var newFields = new List<PersistentFieldExpression>(fields.Count);
+      var newFields = new PersistentFieldExpression[fields.Count];
+      int i = 0;
       foreach (var field in fields) {
         // Do not convert to LINQ. We want to avoid a closure creation here.
-        newFields.Add((PersistentFieldExpression) field.RemoveOuterParameter(processedExpressions));
+        newFields[i++] = (PersistentFieldExpression) field.RemoveOuterParameter(processedExpressions);
       }
-      var keyExpression = (KeyExpression) Key.RemoveOuterParameter(processedExpressions);
-      var entity = (EntityExpression) Entity?.RemoveOuterParameter(processedExpressions);
-      result = new EntityFieldExpression(
+      var keyExpression = Key.RemoveOuterParameter(processedExpressions);
+      var entity = Entity?.RemoveOuterParameter(processedExpressions);
+      var result = new EntityFieldExpression(
         PersistentType, Field, newFields, Mapping, keyExpression, entity, null, DefaultIfEmpty);
       if (Owner == null) {
         return result;

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntitySetExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/EntitySetExpression.cs
@@ -87,12 +87,11 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
+    public override EntitySetExpression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
     {
-      Expression result;
-      if (processedExpressions.TryGetValue(this, out result))
-        return result;
-      result = new EntitySetExpression(Field, null, DefaultIfEmpty);
+      if (processedExpressions.TryGetValue(this, out var value))
+        return (EntitySetExpression) value;
+      var result = new EntitySetExpression(Field, null, DefaultIfEmpty);
       if (base.Owner==null)
         return result;
       processedExpressions.Add(this, result);

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/FieldExpression.cs
@@ -90,13 +90,13 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
+    public override FieldExpression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
     {
-      if (processedExpressions.TryGetValue(this, out var result)) {
-        return result;
+      if (processedExpressions.TryGetValue(this, out var value)) {
+        return (FieldExpression) value;
       }
 
-      result = new FieldExpression(ExtendedExpressionType.Field, Field, Mapping, null, DefaultIfEmpty);
+      var result = new FieldExpression(ExtendedExpressionType.Field, Field, Mapping, null, DefaultIfEmpty);
       if (owner == null) {
         return result;
       }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/FullTextExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/FullTextExpression.cs
@@ -24,14 +24,14 @@ namespace Xtensive.Orm.Linq.Expressions
 
     public EntityExpression EntityExpression { get; private set; }
 
-    public override Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
+    public override ParameterizedExpression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
       Expression result;
       if (processedExpressions.TryGetValue(this, out result))
-        return result;
+        return (ParameterizedExpression) result;
 
-      var entityExpression = (EntityExpression) EntityExpression.BindParameter(parameter, processedExpressions);
-      var rankExpression = (ColumnExpression) RankExpression.BindParameter(parameter, processedExpressions);
+      var entityExpression = EntityExpression.BindParameter(parameter, processedExpressions);
+      var rankExpression = RankExpression.BindParameter(parameter, processedExpressions);
       return new FullTextExpression(FullTextIndex, entityExpression, rankExpression, parameter);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/FullTextExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/FullTextExpression.cs
@@ -41,8 +41,8 @@ namespace Xtensive.Orm.Linq.Expressions
       if (processedExpressions.TryGetValue(this, out result))
         return result;
 
-      var entityExpression = (EntityExpression) EntityExpression.RemoveOuterParameter(processedExpressions);
-      var rankExpression = (ColumnExpression) RankExpression.RemoveOuterParameter(processedExpressions);
+      var entityExpression = EntityExpression.RemoveOuterParameter(processedExpressions);
+      var rankExpression = RankExpression.RemoveOuterParameter(processedExpressions);
       return new FullTextExpression(FullTextIndex, entityExpression, rankExpression, null);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/GroupingExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/GroupingExpression.cs
@@ -42,16 +42,14 @@ namespace Xtensive.Orm.Linq.Expressions
 
     public SelectManyGroupingInfo SelectManyInfo { get; private set; }
 
-    public override Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
+    public override ParameterizedExpression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
-      Expression result;
-      if (processedExpressions.TryGetValue(this, out result))
-        return result;
-      var mappedKey = KeyExpression as IMappedExpression;
-      if (mappedKey==null)
+      if (processedExpressions.TryGetValue(this, out var value))
+        return (ParameterizedExpression) value;
+      if (!(KeyExpression is IMappedExpression mappedKey))
         return this;
       var processedKey = mappedKey.BindParameter(parameter, processedExpressions);
-      result = new GroupingExpression(Type, OuterParameter, DefaultIfEmpty, ProjectionExpression, ApplyParameter, processedKey, SelectManyInfo);
+      var result = new GroupingExpression(Type, OuterParameter, DefaultIfEmpty, ProjectionExpression, ApplyParameter, processedKey, SelectManyInfo);
       processedExpressions.Add(this, result);
       return result;
     }

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Interfaces/IMappedExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Interfaces/IMappedExpression.cs
@@ -12,7 +12,7 @@ namespace Xtensive.Orm.Linq.Expressions
 {
   internal interface IMappedExpression
   {
-    Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions);
+    ParameterizedExpression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions);
     Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions);
     Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions);
     Expression Remap(ColumnMap map, Dictionary<Expression, Expression> processedExpressions);

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/KeyExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/KeyExpression.cs
@@ -25,13 +25,6 @@ namespace Xtensive.Orm.Linq.Expressions
     {
       if (TryProcessed<KeyExpression>(processedExpressions, out var value))
         return value;
-      return RemapWithNoCheck(offset, processedExpressions);
-    }
-
-    // Having this code as a separate method helps to avoid closure allocation during Remap call
-    // in case processedExpressions dictionary already contains a result.
-    private KeyExpression RemapWithNoCheck(ColNum offset, Dictionary<Expression, Expression> processedExpressions)
-    {
       var newMapping = new Segment<ColNum>((ColNum)(Mapping.Offset + offset), Mapping.Length);
 
       var n = KeyFields.Count;
@@ -90,23 +83,16 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
+    public override KeyExpression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
     {
       if (processedExpressions.TryGetValue(this, out var value)) {
-        return value;
+        return (KeyExpression) value;
       }
 
-      return RemoveOuterParameterWithNoCheck(processedExpressions);
-    }
-
-    // Having this code as a separate method helps to avoid closure allocation during RemoveOuterParameter call
-    // in case processedExpressions dictionary already contains a result.
-    private Expression RemoveOuterParameterWithNoCheck(Dictionary<Expression, Expression> processedExpressions)
-    {
       var n = KeyFields.Count;
       var fields = new FieldExpression[n];
       for (int i = 0; i < n; ++i) {
-        fields[i] = (FieldExpression) KeyFields[i].RemoveOuterParameter(processedExpressions);
+        fields[i] = KeyFields[i].RemoveOuterParameter(processedExpressions);
       }
       var result = new KeyExpression(EntityType, fields, Mapping, UnderlyingProperty, null, DefaultIfEmpty);
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/KeyExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/KeyExpression.cs
@@ -79,14 +79,6 @@ namespace Xtensive.Orm.Linq.Expressions
         return (KeyExpression)value;
       }
 
-      return BindParameterWithNoCheck(parameter, processedExpressions);
-    }
-
-    // Having this code as a separate method helps to avoid closure allocation during BindParameter call
-    // in case processedExpressions dictionary already contains a result.
-    private KeyExpression BindParameterWithNoCheck(
-      ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
-    {
       var n = KeyFields.Count;
       var fields = new FieldExpression[n];
       for (int i = 0; i < n; ++i) {

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/LocalCollectionExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/LocalCollectionExpression.cs
@@ -54,10 +54,10 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
+    public override ParameterizedExpression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
       if (processedExpressions.TryGetValue(this, out var value))
-        return value;
+        return (ParameterizedExpression) value;
 
       var result = new LocalCollectionExpression(Type, MemberInfo, expressionAsString);
       processedExpressions.Add(this, result);

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ParameterizedExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ParameterizedExpression.cs
@@ -4,8 +4,6 @@
 // Created by: Alexis Kochetov
 // Created:    2009.05.18
 
-using System;
-using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace Xtensive.Orm.Linq.Expressions

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ParameterizedExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ParameterizedExpression.cs
@@ -42,7 +42,7 @@ namespace Xtensive.Orm.Linq.Expressions
       return false;
     }
 
-    public abstract Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions);
+    public abstract ParameterizedExpression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions);
     public abstract Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions);
     public abstract Expression Remap(ColNum offset, Dictionary<Expression, Expression> processedExpressions);
     public abstract Expression Remap(ColumnMap map, Dictionary<Expression, Expression> processedExpressions);

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureExpression.cs
@@ -88,10 +88,10 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
+    public override ParameterizedExpression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
     {
       if (processedExpressions.TryGetValue(this, out var value)) {
-        return value;
+        return (ParameterizedExpression) value;
       }
 
       var result = new StructureExpression(PersistentType, Mapping);

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureFieldExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/StructureFieldExpression.cs
@@ -4,9 +4,6 @@
 // Created by: Alexis Kochetov
 // Created:    2009.05.05
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using Xtensive.Core;
 using Xtensive.Orm.Model;
@@ -120,10 +117,10 @@ namespace Xtensive.Orm.Linq.Expressions
       return result;
     }
 
-    public override Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
+    public override StructureFieldExpression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
     {
       if (processedExpressions.TryGetValue(this, out var value)) {
-        return value;
+        return (StructureFieldExpression) value;
       }
 
       var result = new StructureFieldExpression(PersistentType, Field, Mapping, OuterParameter, DefaultIfEmpty);

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/SubQueryExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/SubQueryExpression.cs
@@ -22,10 +22,8 @@ namespace Xtensive.Orm.Linq.Expressions
 
     public ApplyParameter ApplyParameter { get; }
 
-    public override Expression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions)
-    {
-      return this;
-    }
+    public override ParameterizedExpression BindParameter(ParameterExpression parameter, Dictionary<Expression, Expression> processedExpressions) =>
+      this;
 
     public override Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)
     {

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -1704,7 +1704,7 @@ namespace Xtensive.Orm.Linq
         var result = EntityExpression.Create(targetTypeInfo, offset, false);
         result.IsNullable = true;
         if (parameter != currentParameter) {
-          result = (EntityExpression) result.BindParameter(parameter, new Dictionary<Expression, Expression>());
+          result = result.BindParameter(parameter, new Dictionary<Expression, Expression>());
         }
 
         return result;

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -847,7 +847,7 @@ namespace Xtensive.Orm.Linq
 
             var resultColumn = ColumnExpression.Create(columnType, (ColNum) (resultDataSource.Header.Length - 1));
             if (isSubqueryParameter) {
-              resultColumn = (ColumnExpression) resultColumn.BindParameter(groupingParameter);
+              resultColumn = resultColumn.BindParameter(groupingParameter);
             }
             return convertResultColumn ? Expression.Convert(resultColumn, resultType) : (Expression) resultColumn;
           }


### PR DESCRIPTION
To reduce number of explicit castings