### PR TITLE
Convert `LinqExtensionRegistration` to readonly struct

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Configuration/LinqExtensionRegistration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/LinqExtensionRegistration.cs
@@ -4,33 +4,30 @@
 // Created by: Denis Krjuchkov
 // Created:    2011.10.27
 
-using System;
 using System.Linq.Expressions;
 using System.Reflection;
-using Xtensive.Core;
-
 
 namespace Xtensive.Orm.Configuration
 {
   /// <summary>
   /// Registration entry for LINQ extension.
   /// </summary>
-  public sealed class LinqExtensionRegistration
+  public readonly struct LinqExtensionRegistration
   {
     /// <summary>
     /// Gets member this extension is intended for.
     /// </summary>
-    public MemberInfo Member { get; private set; }
+    public MemberInfo Member { get; }
 
     /// <summary>
     /// Gets substitution that is performed when LINQ translator encouters <see cref="Member"/> access.
     /// </summary>
-    public LambdaExpression Substitution { get; private set; }
+    public LambdaExpression Substitution { get; }
 
     /// <summary>
     /// Gets action that is performed when LINQ translator encouters <see cref="Member"/> access.
     /// </summary>
-    public Func<MemberInfo, Expression, Expression[], Expression> Compiler { get; private set; }
+    public Func<MemberInfo, Expression, Expression[], Expression> Compiler { get; }
 
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/Linq/MemberCompilation/MemberCompilerProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/MemberCompilation/MemberCompilerProvider.cs
@@ -22,8 +22,7 @@ namespace Xtensive.Orm.Linq.MemberCompilation
       private readonly Module module;
       private readonly int metadataToken;
 
-      public bool Equals(CompilerKey other) => metadataToken == other.metadataToken
-        && (ReferenceEquals(module, other.module) || module == other.module);
+      public bool Equals(CompilerKey other) => metadataToken == other.metadataToken && module == other.module;
 
       public override bool Equals(object obj) => obj is CompilerKey other && Equals(other);
 


### PR DESCRIPTION
Also:
* Remove redundant `ReferenceEquals()` as module comparison also does it