### PR TITLE
PERF-392: Avoid closure allocation in `.GetCompiler()`

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Linq/MemberCompilerProviderTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/MemberCompilerProviderTest.cs
@@ -189,7 +189,7 @@ namespace Xtensive.Orm.Tests.Linq
         .GetProperty("InternalProperty", BindingFlags.Instance | BindingFlags.NonPublic);
       Assert.IsNotNull(property);
       var result = provider.GetCompiler(property);
-      Assert.IsNull(result);
+      Assert.IsTrue(result.IsNull);
     }
 
     [Test]

--- a/Orm/Xtensive.Orm.Tests/Linq/MemberCompilerProviderTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/MemberCompilerProviderTest.cs
@@ -20,7 +20,7 @@ namespace Xtensive.Orm.Tests.Linq
   {
     private readonly string[] dummy = new string[10];
     
-    private static Func<string, string[],string> GetCompilerForMethod(
+    private static IMemberCompilerProvider<string>.BoundCompiler GetCompilerForMethod(
       IMemberCompilerProvider<string> provider, Type source, string methodName)
     {
       if (source.IsGenericTypeDefinition)
@@ -31,11 +31,11 @@ namespace Xtensive.Orm.Tests.Linq
       if (mi.IsGenericMethodDefinition)
         mi = mi.MakeGenericMethod(typeof(object));
       var result = provider.GetCompiler(mi);
-      Assert.IsNotNull(result);
+      Assert.IsFalse(result.IsNull);
       return result;
     }
 
-    private static Func<string, string[], string> GetCompilerForCtor(
+    private static IMemberCompilerProvider<string>.BoundCompiler GetCompilerForCtor(
       IMemberCompilerProvider<string> provider, Type source)
     {
       if (source.IsGenericTypeDefinition)
@@ -43,11 +43,11 @@ namespace Xtensive.Orm.Tests.Linq
 
       var ci = source.GetConstructors().First();
       var result = provider.GetCompiler(ci);
-      Assert.IsNotNull(result);
+      Assert.IsFalse(result.IsNull);
       return result;
     }
 
-    private static Func<string, string[], string> GetCompilerForField(
+    private static IMemberCompilerProvider<string>.BoundCompiler GetCompilerForField(
       IMemberCompilerProvider<string> provider, Type source, string fieldName)
     {
       if (source.IsGenericTypeDefinition)
@@ -56,7 +56,7 @@ namespace Xtensive.Orm.Tests.Linq
       var fi = source.GetField(fieldName);
       Assert.IsNotNull(fi);
       var result = provider.GetCompiler(fi);
-      Assert.IsNotNull(result);
+      Assert.IsFalse(result.IsNull);
       return result;
     }
 
@@ -71,7 +71,7 @@ namespace Xtensive.Orm.Tests.Linq
           foreach (string s2 in new[]{"Generic", "NonGeneric"}) {
             string method = s1 + s2 + "Method";
             var d = GetCompilerForMethod(provider, t, method);
-            Assert.AreEqual(t.Name + "." + method, d(null, dummy));
+            Assert.AreEqual(t.Name + "." + method, d.Invoke(null, dummy));
           }
     }
 
@@ -86,7 +86,7 @@ namespace Xtensive.Orm.Tests.Linq
           foreach (string s2 in new[] { "InstanceProperty", "StaticProperty", "Item" }) {
             string method = s1 + s2;
             var d = GetCompilerForMethod(provider, t, method);
-            Assert.AreEqual(t.Name + "." + method, d(null, dummy));
+            Assert.AreEqual(t.Name + "." + method, d.Invoke(null, dummy));
           }
     }
 
@@ -99,7 +99,7 @@ namespace Xtensive.Orm.Tests.Linq
       foreach (var t in new[]{typeof(NonGenericTarget), typeof(GenericTarget<>)})
         foreach (string s in new[] {"InstanceField", "StaticField"}) {
           var d = GetCompilerForField(provider, t, s);
-          Assert.AreEqual(t.Name + "." + s, d(null, dummy));
+          Assert.AreEqual(t.Name + "." + s, d.Invoke(null, dummy));
         }
     }
 
@@ -110,7 +110,7 @@ namespace Xtensive.Orm.Tests.Linq
       provider.RegisterCompilers(typeof(CtorCompiler));
       foreach (var t in new[]{typeof(NonGenericTarget), typeof(GenericTarget<>)}) {
         var d = GetCompilerForCtor(provider, t);
-        Assert.AreEqual(t.Name + Reflection.WellKnown.CtorName, d(null, dummy));
+        Assert.AreEqual(t.Name + Reflection.WellKnown.CtorName, d.Invoke(null, dummy));
       }
     }
 
@@ -128,8 +128,8 @@ namespace Xtensive.Orm.Tests.Linq
         .MakeGenericMethod(typeof(string));
 
       var d = provider.GetCompiler(mi);
-      Assert.IsNotNull(d);
-      Assert.AreEqual("OK", d(null, dummy));
+      Assert.IsFalse(d.IsNull);
+      Assert.AreEqual("OK", d.Invoke(null, dummy));
     }
 
     [Test]
@@ -160,7 +160,7 @@ namespace Xtensive.Orm.Tests.Linq
       provider.RegisterCompilers(typeof(ConflictCompiler1));
       provider.RegisterCompilers(typeof(ConflictCompiler2), ConflictHandlingMethod.KeepOld);
       var d = GetCompilerForMethod(provider, typeof(ConflictTarget), "ConflictMethod");
-      Assert.AreEqual("Compiler1", d(null, dummy));
+      Assert.AreEqual("Compiler1", d.Invoke(null, dummy));
     }
 
     [Test]
@@ -170,7 +170,7 @@ namespace Xtensive.Orm.Tests.Linq
       provider.RegisterCompilers(typeof(ConflictCompiler1));
       provider.RegisterCompilers(typeof(ConflictCompiler2), ConflictHandlingMethod.Overwrite);
       var d = GetCompilerForMethod(provider, typeof(ConflictTarget), "ConflictMethod");
-      Assert.AreEqual("Compiler2", d(null, dummy));
+      Assert.AreEqual("Compiler2", d.Invoke(null, dummy));
     }
 
     [Test]

--- a/Orm/Xtensive.Orm/Orm/Linq/MemberCompilation/Interfaces/IMemberCompilerProvider{T}.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/MemberCompilation/Interfaces/IMemberCompilerProvider{T}.cs
@@ -4,8 +4,6 @@
 // Created by: Denis Krjuchkov
 // Created:    2009.02.09
 
-using System;
-using System.Collections.Generic;
 using System.Reflection;
 
 namespace Xtensive.Orm.Linq.MemberCompilation
@@ -36,12 +34,29 @@ namespace Xtensive.Orm.Linq.MemberCompilation
     /// <param name="conflictHandlingMethod">Conflict handling method.</param>
     void RegisterCompilers(IEnumerable<KeyValuePair<MemberInfo, Func<MemberInfo, T, T[], T>>> compilerDefinitions, ConflictHandlingMethod conflictHandlingMethod);
 
+    public readonly struct BoundCompiler
+    {
+      private readonly Func<MemberInfo, T, T[], T> compiler;
+      private readonly MemberInfo memberInfo;
+
+      public bool IsNull => compiler == null;
+
+      public T Invoke(T arg2, T[] arg3) => compiler(memberInfo, arg2, arg3);
+
+      public BoundCompiler(Func<MemberInfo, T, T[], T> compiler, MemberInfo memberInfo)
+      {
+        ArgumentNullException.ThrowIfNull(compiler);
+        this.compiler = compiler;
+        this.memberInfo = memberInfo;
+      }
+    }
+
     /// <summary>
     /// Finds compiler for specified <see cref="MemberInfo"/>.
     /// </summary>
     /// <param name="target"><see cref="MemberInfo"/> to search compiler for.</param>
     /// <returns>compiler associated with <see cref="MethodInfo"/>
     /// or <see langword="null"/> if compiler is not found.</returns>
-    Func<T, T[], T> GetCompiler(MemberInfo target);
+    BoundCompiler GetCompiler(MemberInfo target);
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/MemberCompilation/Interfaces/IMemberCompilerProvider{T}.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/MemberCompilation/Interfaces/IMemberCompilerProvider{T}.cs
@@ -34,7 +34,7 @@ namespace Xtensive.Orm.Linq.MemberCompilation
     /// <param name="conflictHandlingMethod">Conflict handling method.</param>
     void RegisterCompilers(IEnumerable<KeyValuePair<MemberInfo, Func<MemberInfo, T, T[], T>>> compilerDefinitions, ConflictHandlingMethod conflictHandlingMethod);
 
-    public readonly struct BoundCompiler(Func<MemberInfo, T, T[], T> compiler, MemberInfo memberInfo)
+    readonly struct BoundCompiler(Func<MemberInfo, T, T[], T> compiler, MemberInfo memberInfo)
     {
       public bool IsNull => compiler == null;
 

--- a/Orm/Xtensive.Orm/Orm/Linq/MemberCompilation/Interfaces/IMemberCompilerProvider{T}.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/MemberCompilation/Interfaces/IMemberCompilerProvider{T}.cs
@@ -34,21 +34,11 @@ namespace Xtensive.Orm.Linq.MemberCompilation
     /// <param name="conflictHandlingMethod">Conflict handling method.</param>
     void RegisterCompilers(IEnumerable<KeyValuePair<MemberInfo, Func<MemberInfo, T, T[], T>>> compilerDefinitions, ConflictHandlingMethod conflictHandlingMethod);
 
-    public readonly struct BoundCompiler
+    public readonly struct BoundCompiler(Func<MemberInfo, T, T[], T> compiler, MemberInfo memberInfo)
     {
-      private readonly Func<MemberInfo, T, T[], T> compiler;
-      private readonly MemberInfo memberInfo;
-
       public bool IsNull => compiler == null;
 
       public T Invoke(T arg2, T[] arg3) => compiler(memberInfo, arg2, arg3);
-
-      public BoundCompiler(Func<MemberInfo, T, T[], T> compiler, MemberInfo memberInfo)
-      {
-        ArgumentNullException.ThrowIfNull(compiler);
-        this.compiler = compiler;
-        this.memberInfo = memberInfo;
-      }
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Linq/MemberCompilation/MemberCompilerProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/MemberCompilation/MemberCompilerProvider.cs
@@ -4,9 +4,7 @@
 // Created by: Denis Krjuchkov
 // Created:    2009.02.09
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.Collections.Frozen;
 using System.Reflection;
 using Xtensive.Core;
 using Xtensive.Reflection;
@@ -36,23 +34,24 @@ namespace Xtensive.Orm.Linq.MemberCompilation
       }
     }
 
-    private readonly Dictionary<CompilerKey, Delegate> compilers
-      = new Dictionary<CompilerKey, Delegate>();
+    private IDictionary<CompilerKey, Delegate> compilers = new Dictionary<CompilerKey, Delegate>();
 
     public Type ExpressionType => typeof(T);
+
+    public override void Lock(bool recursive)
+    {
+      base.Lock(recursive);
+      compilers = compilers.ToFrozenDictionary();
+    }
 
     public Delegate GetUntypedCompiler(MemberInfo target)
     {
       ArgumentNullException.ThrowIfNull(target);
-
-      return compilers.GetValueOrDefault(GetCompilerKey(target));
+      return compilers.TryGetValue(GetCompilerKey(target), out var v) ? v : null;
     }
 
-    public Func<T, T[], T> GetCompiler(MemberInfo target)
-    {
-      var compiler = (Func<MemberInfo, T, T[], T>) GetUntypedCompiler(target);
-      return compiler.Bind(target);
-    }
+    public IMemberCompilerProvider<T>.BoundCompiler GetCompiler(MemberInfo target) =>
+      new((Func<MemberInfo, T, T[], T>) GetUntypedCompiler(target), target);
 
     public void RegisterCompilers(Type compilerContainer)
     {

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -361,18 +361,18 @@ namespace Xtensive.Orm.Linq
       // Reflected type doesn't have custom compiler defined, so falling back to base class compiler
       var declaringType = memberInfo.DeclaringType;
       var reflectedType = memberInfo.ReflectedType;
-      if (customCompiler == null && declaringType != reflectedType && declaringType.IsAssignableFrom(reflectedType)) {
+      if (customCompiler.IsNull && declaringType != reflectedType && declaringType.IsAssignableFrom(reflectedType)) {
         var root = declaringType;
         var current = reflectedType;
-        while (current != root && customCompiler == null) {
+        while (current != root && customCompiler.IsNull) {
           current = current.BaseType;
           var member = current.GetProperty(memberInfo.Name, BindingFlags.Instance|BindingFlags.Public|BindingFlags.NonPublic);
           customCompiler = context.CustomCompilerProvider.GetCompiler(member);
         }
       }
 
-      if (customCompiler != null) {
-        var expression = customCompiler.Invoke(sourceExpression, Array.Empty<Expression>());
+      if (!customCompiler.IsNull) {
+        var expression = customCompiler.Invoke(sourceExpression, []);
         if (expression == null) {
           if (reflectedType.IsInterface)
             return Visit(BuildInterfaceExpression(ma));
@@ -435,7 +435,7 @@ namespace Xtensive.Orm.Linq
       using (CreateScope(new TranslatorState(State) { IsTailMethod = mc == context.Query && mc.IsQuery() })) {
         var method = mc.Method;
         var customCompiler = context.CustomCompilerProvider.GetCompiler(method);
-        if (customCompiler != null) {
+        if (!customCompiler.IsNull) {
           return Visit(customCompiler.Invoke(mc.Object, mc.Arguments.ToArray()));
         }
 
@@ -1841,7 +1841,7 @@ namespace Xtensive.Orm.Linq
       Expression current = Expression.Constant(defaultValue, propertyType);
       foreach (var field in fields) {
         var compiler = context.CustomCompilerProvider.GetCompiler(field);
-        if (compiler == null)
+        if (compiler.IsNull)
           continue;
         var expression = compiler.Invoke(Expression.TypeAs(ma.Expression, field.ReflectedType), null);
         current = Expression.Condition(Expression.TypeIs(ma.Expression, field.ReflectedType), expression, current);

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.Helpers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.Helpers.cs
@@ -201,8 +201,10 @@ namespace Xtensive.Orm.Providers
 
     private SqlExpression CompileMember(MemberInfo member, SqlExpression instance, params SqlExpression[] arguments)
     {
-      var memberCompiler = memberCompilerProvider.GetCompiler(member)
-        ?? throw new NotSupportedException(string.Format(Strings.ExMemberXIsNotSupported, member.GetFullName(true)));
+      var memberCompiler = memberCompilerProvider.GetCompiler(member);
+      if (memberCompiler.IsNull) {
+        throw new NotSupportedException(string.Format(Strings.ExMemberXIsNotSupported, member.GetFullName(true)));
+      }
       return memberCompiler.Invoke(instance, arguments);
     }
 


### PR DESCRIPTION
Instead of calling `.Bind()` to allocate a closure we can use `readonly struct` with the bound argument as a field.
These `BoundCompiler` instances are short-living

Also:
* Freeze `CompilerProvider.compilers` dictionary on locking