### PR TITLE
Optimization: avoid LINQ in `ExpressionProcessor` constructor

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
@@ -516,8 +516,12 @@ namespace Xtensive.Orm.Providers
 
       if (lambda.Parameters.Count != sourceColumns.Length)
         throw Exceptions.InternalError(Strings.ExParametersCountIsNotSameAsSourceColumnListsCount, OrmLog.Instance);
-      if (sourceColumns.Any(list => list.Any(c => c is null)))
-        throw Exceptions.InternalError(Strings.ExSourceColumnListContainsNullValues, OrmLog.Instance);
+      foreach (var list in sourceColumns) {
+        foreach (var c in list) {
+          if (c is null)
+            throw Exceptions.InternalError(Strings.ExSourceColumnListContainsNullValues, OrmLog.Instance);
+        }
+      }
 
       this.compiler = compiler; // This might be null, check before use!
       this.lambda = lambda;

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Index.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Index.cs
@@ -48,7 +48,7 @@ namespace Xtensive.Orm.Providers
     {
       var index = provider.Index.Resolve(Handlers.Domain.Model);
       var queryAndBindings = BuildProviderQuery(index);
-      return CreateProvider(queryAndBindings.Query, queryAndBindings.Bindings.ToArray(), provider);
+      return CreateProvider(queryAndBindings.Query, queryAndBindings.Bindings, provider);
     }
 
     protected QueryAndBindings BuildProviderQuery(IndexInfo index)


### PR DESCRIPTION
Also:
* Remove redundant `.ToArray()`