### PR TITLE
PERF-407: Optimization: get rid of `.ToArray(n)` & `.ToList(n)` usages

### DIFF
--- a/Orm/Xtensive.Orm.Firebird/Sql.Drivers.Firebird/v2_5/Compiler.cs
+++ b/Orm/Xtensive.Orm.Firebird/Sql.Drivers.Firebird/v2_5/Compiler.cs
@@ -208,7 +208,7 @@ namespace Xtensive.Sql.Drivers.Firebird.v2_5
 
       switch (node.FunctionType) {
         case SqlFunctionType.Concat:
-          Visit(SqlDml.Concat(arguments.ToArray(node.Arguments.Count)));
+          Visit(SqlDml.Concat(arguments.ToArray()));
           return;
         case SqlFunctionType.DateTimeTruncate:
           Visit(SqlDml.Cast(arguments[0], new SqlValueType("Date")));

--- a/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/v5_0/Compiler.cs
+++ b/Orm/Xtensive.Orm.MySql/Sql.Drivers.MySql/v5_0/Compiler.cs
@@ -152,7 +152,7 @@ namespace Xtensive.Sql.Drivers.MySql.v5_0
           SqlDml.FunctionCall("TRUNCATE", arguments[0], SqlDml.Literal(0)).AcceptVisitor(this);
           return;
         case SqlFunctionType.Concat:
-          Visit(SqlDml.Concat(arguments.ToArray(node.Arguments.Count)));
+          Visit(SqlDml.Concat(arguments.ToArray()));
           return;
         case SqlFunctionType.CharLength:
           SqlDml.FunctionCall(translator.TranslateToString(SqlFunctionType.CharLength), node.Arguments[0]).AcceptVisitor(this);

--- a/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm.PostgreSql/Orm.Providers.PostgreSql/SqlCompiler.cs
@@ -37,7 +37,7 @@ namespace Xtensive.Orm.Providers.PostgreSql
       var query = queryAndBindings.Query;
       var table = Mapping[realPrimaryIndex.ReflectedType];
       var fromTable = SqlDml.FreeTextTable(table, searchCriteriaBinding.ParameterReference,
-        table.Columns.Select(column => column.Name).Append(rankColumnName).ToArray(table.Columns.Count + 1));
+        table.Columns.Select(column => column.Name).Append(rankColumnName).ToArray());
       var fromTableRef = SqlDml.QueryRef(fromTable);
       foreach (var column in query.Columns) {
         select.Columns.Add(fromTableRef.Columns[column.Name] ?? column);

--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/ErrorMessageParser.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/ErrorMessageParser.cs
@@ -190,7 +190,7 @@ namespace Xtensive.Sql.Drivers.SqlServer
       }
 
       CollectLastChunk(regexBuilder, template, offset);
-      return new PreparedTemplate(regexBuilder.ToString(), Enumerable.Range(1, count).ToArray(count));
+      return new PreparedTemplate(regexBuilder.ToString(), Enumerable.Range(1, count).ToArray());
     }
 
     private static PreparedTemplate PrepareNonEnglishTemplate(string template)

--- a/Orm/Xtensive.Orm/Core/AssociateProvider.cs
+++ b/Orm/Xtensive.Orm/Core/AssociateProvider.cs
@@ -305,7 +305,7 @@ namespace Xtensive.Core
       typeSuffixes = (string[]) info.GetValue(nameof(typeSuffixes), typeof(string[]));
 
       var highPriorityLocationsSerializable = (List<(string, string)>) info.GetValue(nameof(highPriorityLocations), typeof(List<(string, string)>));
-      highPriorityLocations = highPriorityLocationsSerializable.SelectToList(ls => (Assembly.Load(ls.Item1), ls.Item2));
+      highPriorityLocations = highPriorityLocationsSerializable.Select(ls => (Assembly.Load(ls.Item1), ls.Item2)).ToList();
     }
 
     /// <summary>
@@ -333,7 +333,7 @@ namespace Xtensive.Core
       info.AddValue(nameof(constructorParams), constructorParamsExceptThis, constructorParams.GetType());
       info.AddValue(nameof(typeSuffixes), typeSuffixes, typeSuffixes.GetType());
 
-      var highPriorityLocationsSerializable = HighPriorityLocations.SelectToList(l => (l.Item1.FullName, l.Item2));
+      var highPriorityLocationsSerializable = HighPriorityLocations.Select(l => (l.Item1.FullName, l.Item2)).ToList();
       info.AddValue(nameof(highPriorityLocations), highPriorityLocationsSerializable, highPriorityLocationsSerializable.GetType());
     }
   }

--- a/Orm/Xtensive.Orm/Core/Extensions/CollectionExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/CollectionExtensions.cs
@@ -17,18 +17,6 @@ namespace Xtensive.Core
   /// </summary>
   public static class CollectionExtensionsEx
   {
-    /// <summary>
-    /// Converts <paramref name="source"/> collection to an array.
-    /// </summary>
-    /// <typeparam name="TItem">The type of collection items.</typeparam>
-    /// <param name="source">Collection to convert.</param>
-    /// <returns>An array containing all the items from the <paramref name="source"/>.</returns>
-    public static TItem[] ToArray<TItem>(this ICollection<TItem> source)
-    {
-      var items = new TItem[source.Count];
-      source.Copy(items, 0);
-      return items;
-    }
 
     /// <summary>
     /// Copies the items from <paramref name="source"/> collection
@@ -137,62 +125,6 @@ namespace Xtensive.Core
         if (collection.Contains(item))
           return true;
       return false;
-    }
-
-    /// <summary>Projects each element of a sequence into a new form.</summary>
-    /// <param name="source">A collection of values to invoke a transform function on.</param>
-    /// <param name="selector">A transform function to apply to each element.</param>
-    /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
-    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector" />.</typeparam>
-    /// <returns>An <see cref="T:System.Array`1" /> whose elements are the result of invoking the transform function on each element of <paramref name="source" />.</returns>
-    /// <exception cref="T:System.ArgumentNullException">
-    /// <paramref name="source" /> or <paramref name="selector" /> is <see langword="null" />.</exception>
-    public static TResult[] SelectToArray<TSource, TResult>(
-      this ICollection<TSource> source, Func<TSource, TResult> selector)
-    {
-      return source.Select(selector).ToArray(source.Count);
-    }
-
-    /// <summary>Projects each element of a sequence into a new form by incorporating the element's index.</summary>
-    /// <param name="source">A collection of values to invoke a transform function on.</param>
-    /// <param name="selector">A transform function to apply to each source element; the second parameter of the function represents the index of the source element.</param>
-    /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
-    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector" />.</typeparam>
-    /// <returns>An <see cref="T:System.Array`1" /> whose elements are the result of invoking the transform function on each element of <paramref name="source" />.</returns>
-    /// <exception cref="T:System.ArgumentNullException">
-    /// <paramref name="source" /> or <paramref name="selector" /> is <see langword="null" />.</exception>
-    public static TResult[] SelectToArray<TSource, TResult>(
-      this ICollection<TSource> source, Func<TSource, int, TResult> selector)
-    {
-      return source.Select(selector).ToArray(source.Count);
-    }
-
-    /// <summary>Projects each element of a sequence into a new form.</summary>
-    /// <param name="source">A collection of values to invoke a transform function on.</param>
-    /// <param name="selector">A transform function to apply to each element.</param>
-    /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
-    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector" />.</typeparam>
-    /// <returns>An <see cref="T:System.Collections.Generic.List`1" /> whose elements are the result of invoking the transform function on each element of <paramref name="source" />.</returns>
-    /// <exception cref="T:System.ArgumentNullException">
-    /// <paramref name="source" /> or <paramref name="selector" /> is <see langword="null" />.</exception>
-    public static List<TResult> SelectToList<TSource, TResult>(
-      this ICollection<TSource> source, Func<TSource, TResult> selector)
-    {
-      return source.Select(selector).ToList(source.Count);
-    }
-
-    /// <summary>Projects each element of a sequence into a new form by incorporating the element's index.</summary>
-    /// <param name="source">A collection of values to invoke a transform function on.</param>
-    /// <param name="selector">A transform function to apply to each source element; the second parameter of the function represents the index of the source element.</param>
-    /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
-    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector" />.</typeparam>
-    /// <returns>An <see cref="T:System.Collections.Generic.List`1" /> whose elements are the result of invoking the transform function on each element of <paramref name="source" />.</returns>
-    /// <exception cref="T:System.ArgumentNullException">
-    /// <paramref name="source" /> or <paramref name="selector" /> is <see langword="null" />.</exception>
-    public static List<TResult> SelectToList<TSource, TResult>(
-      this ICollection<TSource> source, Func<TSource, int, TResult> selector)
-    {
-      return source.Select(selector).ToList(source.Count);
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
@@ -580,7 +580,7 @@ namespace Xtensive.Core
           if (edgeTester.Invoke(left.Value, right.Value))
             new Edge(left, right);
       var result = TopologicalSorter.Sort(graph);
-      return result.HasLoops ? null : result.SortedNodes.SelectToList(node => node.Value);
+      return result.HasLoops ? null : result.SortedNodes.Select(node => node.Value).ToList();
     }
 
     internal static IReadOnlyList<T> ToReadOnlyList<T>(this IEnumerable<T> seq) =>

--- a/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
+++ b/Orm/Xtensive.Orm/Core/Extensions/EnumerableExtensions.cs
@@ -246,7 +246,7 @@ namespace Xtensive.Core
     /// <typeparam name="T">The sequence element type.</typeparam>
     /// <returns>The resulting array.</returns>
     /// <exception cref="ArgumentException"><paramref name="length"/> is negative.</exception>
-    public static T[] ToArray<T>(this IEnumerable<T> sequence, int length)
+    internal static T[] ToArray<T>(this IEnumerable<T> sequence, int length)
     {
       ArgumentOutOfRangeException.ThrowIfNegative(length);
 
@@ -270,7 +270,7 @@ namespace Xtensive.Core
     /// <param name="capacity">The number of elements that the new list can initially store.</param>
     /// <typeparam name="TItem">The type of the elements of <paramref name="source" />.</typeparam>
     /// <returns>A <see cref="T:System.Collections.Generic.List`1" /> that contains elements from the input sequence.</returns>
-    public static List<TItem> ToList<TItem>(this IEnumerable<TItem> source, int capacity)
+    internal static List<TItem> ToList<TItem>(this IEnumerable<TItem> source, int capacity)
     {
       ArgumentOutOfRangeException.ThrowIfNegative(capacity);
 

--- a/Orm/Xtensive.Orm/Modelling/Actions/CreateNodeAction.cs
+++ b/Orm/Xtensive.Orm/Modelling/Actions/CreateNodeAction.cs
@@ -102,8 +102,8 @@ namespace Xtensive.Modelling.Actions
     protected Node TryConstructor(IModel model, params object[] arguments)
     {
       if (parameters!=null)
-        arguments = arguments.Concat(parameters.Select(p => PathNodeReference.Resolve(model, p))).ToArray(arguments.Length + parameters.Length);
-      var argTypes = arguments.SelectToArray(a => a.GetType());
+        arguments = arguments.Concat(parameters.Select(p => PathNodeReference.Resolve(model, p))).ToArray();
+      var argTypes = arguments.Select(a => a.GetType()).ToArray();
       var ci = type.GetConstructor(argTypes);
       if (ci==null)
         return null;

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.ClassTable.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/IndexBuilder.ClassTable.cs
@@ -97,7 +97,7 @@ namespace Xtensive.Orm.Building.Builders
       if (untypedIndexes.Contains(primaryIndex) && primaryIndex.ReflectedType == root) {
         primaryIndex = type.Indexes.Single(i => i.DeclaringIndex == primaryIndex.DeclaringIndex && i.IsTyped);
       }
-      var filterByTypes = type.AllDescendants.Append(type).ToList(type.AllDescendants.Count + 1);
+      var filterByTypes = type.AllDescendants.Append(type).ToList();
 
       // Build virtual primary index
       if (ancestors.Count > 0) {

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/TypeBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/TypeBuilder.cs
@@ -489,8 +489,7 @@ namespace Xtensive.Orm.Building.Builders
         .Select(static field => field.Column)
         .ToArray();
 
-      var keyTupleDescriptor = TupleDescriptor.Create(
-        keyColumns.Select(static c => c.ValueType).ToArray(keyColumns.Length));
+      var keyTupleDescriptor = TupleDescriptor.Create(keyColumns.Select(static c => c.ValueType).ToArray());
       var typeIdColumnIndex = -1;
       if (hierarchyDef.IncludeTypeId) {
         for (var i = 0; i < keyColumns.Length; i++) {

--- a/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
+++ b/Orm/Xtensive.Orm/Orm/EntitySetBase.cs
@@ -941,16 +941,15 @@ namespace Xtensive.Orm
             .ToList()
         : CollectionUtils.ColNumRange(targetDescriptor.Count);
 
-      var keyFieldCount = ownerDescriptor.Count + itemColumnOffsets.Count;
       var keyFieldTypes = ownerDescriptor
         .Concat(itemColumnOffsets.Select(i => targetDescriptor[i]))
-        .ToArray(keyFieldCount);
+        .ToArray();
       var keyDescriptor = TupleDescriptor.Create(keyFieldTypes);
 
       var map = Enumerable.Range(0, ownerDescriptor.Count)
         .Select(i => ((ColNum)0, (ColNum) i))
         .Concat(itemColumnOffsets.Select(i => ((ColNum)1, i)))
-        .ToArray(keyFieldCount);
+        .ToArray();
       var seekTransform = new MapTransform(true, keyDescriptor, map);
 
       Func<Tuple, Entity> itemCtor = null;

--- a/Orm/Xtensive.Orm/Orm/Internals/KeyFactory.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/KeyFactory.cs
@@ -137,7 +137,7 @@ namespace Xtensive.Orm.Internals
       var descriptor = typeInfo.Key.TupleDescriptor;
       var keyTypeName = string.Format(GenericKeyNameFormat, WellKnownOrmTypes.KeyOfT.Namespace, WellKnownOrmTypes.Key.Name, descriptor.Count);
       var keyType = WellKnownOrmTypes.Key.Assembly.GetType(keyTypeName);
-      keyType = keyType.MakeGenericType(descriptor.ToArray(descriptor.Count));
+      keyType = keyType.MakeGenericType(descriptor.ToArray());
       var defaultConstructor = DelegateHelper.CreateDelegate<Func<string, TypeInfo, Tuple, TypeReferenceAccuracy, Key>>(
         null, keyType, "Create", Array.Empty<Type>());
       var keyIndexBasedConstructor = DelegateHelper.CreateDelegate<Func<string, TypeInfo, Tuple, TypeReferenceAccuracy, IReadOnlyList<ColNum>, Key>>(

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntitySetTask.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/EntitySetTask.cs
@@ -207,7 +207,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       AddResultColumnIndexes(resultColumns, primaryTargetIndex, 0);
       var association = cachingKey.ReferencingField.Associations.Last();
       var field = association.Reversed.OwnerField;
-      var keyColumnTypes = field.Columns.SelectToArray(column => column.ValueType);
+      var keyColumnTypes = field.Columns.Select(column => column.ValueType).ToArray();
       return primaryTargetIndex
         .GetQuery()
         .Filter(QueryHelper.BuildFilterLambda(field.MappingInfo.Offset, keyColumnTypes, ownerParameter));

--- a/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/SetNode.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/Prefetch/Nodes/SetNode.cs
@@ -27,7 +27,7 @@ namespace Xtensive.Orm.Internals.Prefetch
       var entity = (Entity) target;
       var entitySet = (EntitySetBase) entity.GetFieldValue(Field);
       var fetchedKeys = entitySet.State.FetchedKeys;
-      return fetchedKeys.ToArray(fetchedKeys.Count);
+      return fetchedKeys.ToArray();
     }
 
     public IHasNestedNodes ReplaceNestedNodes(IReadOnlyList<BaseFieldNode> nestedNodes) =>

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ConstructorExpression.cs
@@ -37,7 +37,7 @@ namespace Xtensive.Orm.Linq
         Bindings.ToDictionary(kvp => kvp.Key, kvp => genericBinder(kvp.Value)),
         NativeBindings.ToDictionary(kvp=>kvp.Key, kvp => genericBinder(kvp.Value)),
         Constructor,
-        ConstructorArguments.Select(genericBinder).ToArray(ConstructorArguments.Count));
+        ConstructorArguments.Select(genericBinder).ToArray());
     }
 
     public override Expression RemoveOuterParameter(Dictionary<Expression, Expression> processedExpressions)

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/KeyExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/KeyExpression.cs
@@ -107,7 +107,7 @@ namespace Xtensive.Orm.Linq.Expressions
       FieldExpression CreateField(ColumnInfo c) => FieldExpression.CreateField(c.Field, offset);
 
       var fields = entityType.IsLocked
-        ? entityType.Key.Columns.Select(CreateField).ToArray(entityType.Key.Columns.Count)
+        ? entityType.Key.Columns.Select(CreateField).ToArray()
         : entityType.Columns
           .Where(c => c.IsPrimaryKey)
           .OrderBy(c => c.Field.MappingInfo.Offset)

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/OwnerRemover.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/OwnerRemover.cs
@@ -47,7 +47,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       var oldConstructorArguments = expression.ConstructorArguments;
       var newConstructorArguments = VisitExpressionList(oldConstructorArguments);
 
-      var oldBindings = expression.Bindings.Values.ToArray(expression.Bindings.Count);
+      var oldBindings = expression.Bindings.Values.ToArray();
       var newBindings = VisitExpressionList(oldBindings);
 
       var oldNativeBindings = expression.NativeBindings.Select(b => b.Value).ToArray().AsSafeWrapper();

--- a/Orm/Xtensive.Orm/Orm/Linq/ItemToTupleConverter{TItem}.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/ItemToTupleConverter{TItem}.cs
@@ -245,7 +245,7 @@ namespace Xtensive.Orm.Linq
       Expression = IsPersistableType(itemType)
         ? BuildField(itemType, ref index, types)
         : BuildLocalCollectionExpression(itemType, new HashSet<Type>(), ref index, null, types, sourceExpression);
-      TupleDescriptor = TupleDescriptor.Create(types.ToArray(types.Count));
+      TupleDescriptor = TupleDescriptor.Create(types.ToArray());
 
       return delegate(TItem item) {
         var tuple = Tuple.Create(TupleDescriptor);

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -1119,19 +1119,17 @@ namespace Xtensive.Orm.Linq
       expression = expression.StripCasts();
       if (expression is IEntityExpression iEntityExpression) {
         var keyFields = iEntityExpression.Key.KeyFields;
-        return keyFields
-          .Cast<Expression>()
-          .ToArray(keyFields.Count);
+        return keyFields.Cast<Expression>().ToArray();
       }
       if (expression.IsNull()) {
         return keyFieldTypes
           .Select(type => (Expression) Expression.Constant(null, type.ToNullable()))
-          .ToArray(keyFieldTypes.Count);
+          .ToArray();
       }
       if (IsConditionalOrWellknown(expression)) {
         return keyFieldTypes
           .Select((type, index) => GetConditionalKeyField(expression, type, index))
-          .ToArray(keyFieldTypes.Count);
+          .ToArray();
       }
 
       var nullEntityExpression = Expression.Constant(null, expression.Type);
@@ -1179,14 +1177,14 @@ namespace Xtensive.Orm.Linq
         return keyExpression
           .KeyFields
           .Cast<Expression>()
-          .ToArray(keyExpression.KeyFields.Count);
+          .ToArray();
       }
 
       if (expression.IsNull())
         return keyFields
           .Select(f => f.Type)
           .Select(type => (Expression) Expression.Constant(null, type.ToNullable()))
-          .ToArray(keyFields.Count);
+          .ToArray();
 
       var nullExpression = Expression.Constant(null, expression.Type);
       var isNullExpression = Expression.Equal(expression, nullExpression);
@@ -1205,7 +1203,7 @@ namespace Xtensive.Orm.Linq
           _ = State.NonVisitableExpressions.Add(checkForNulls);
           return checkForNulls;
         })
-        .ToArray(keyFields.Count);
+        .ToArray();
     }
 
     private Expression ProcessProjectionElement(Expression body)
@@ -1343,7 +1341,7 @@ namespace Xtensive.Orm.Linq
           .Select((methodInfo, index) => (methodInfo.Name, Argument: newExpression.Arguments[index]))
           .OrderBy(a => a.Name)
           .Select(a => a.Argument);
-        return arguments.ToArray(newExpression.Members.Count);
+        return arguments.ToArray();
       }
 
       if (expression.NodeType == ExpressionType.Constant) {
@@ -1358,7 +1356,7 @@ namespace Xtensive.Orm.Linq
 
           return orderedProps1
             .Select(p => (Expression) Expression.MakeMemberAccess(constantExpression, p))
-            .ToArray(orderedProps1.Length);
+            .ToArray();
         }
       }
 
@@ -1369,7 +1367,7 @@ namespace Xtensive.Orm.Linq
 
       return orderedProps
         .Select(p => (Expression) Expression.MakeMemberAccess(expression, p))
-        .ToArray(orderedProps.Length);
+        .ToArray();
 
       static int CompareProps(PropertyInfo p1, PropertyInfo p2)
       {
@@ -1795,7 +1793,7 @@ namespace Xtensive.Orm.Linq
       var tupleDescriptor = itemToTupleConverter.TupleDescriptor;
       Column[] columns = tupleDescriptor
         .Select(x => new SystemColumn(translatorContext.GetNextColumnAlias(), 0, x))
-        .ToArray(tupleDescriptor.Count);
+        .ToArray();
       var rsHeader = new RecordSetHeader(tupleDescriptor, columns);
       var rawProvider = new RawProvider(rsHeader, itemToTupleConverter.GetEnumerable());
       var recordset = new StoreProvider(rawProvider);

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -826,7 +826,7 @@ namespace Xtensive.Orm.Linq
             var aggregateDescriptors = groupingDataSource.AggregateColumns
               .Select(c => c.Descriptor)
               .Append(aggregateDescriptor)
-              .ToArray(groupingDataSource.AggregateColumns.Length + 1);
+              .ToArray();
 
             resultDataSource = new AggregateProvider(
               commonOriginDataSource,

--- a/Orm/Xtensive.Orm/Orm/Model/IndexInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/IndexInfo.cs
@@ -341,14 +341,14 @@ namespace Xtensive.Orm.Model
     private void CreateTupleDescriptors()
     {
       tupleDescriptor = TupleDescriptor.Create(
-        Columns.Select(static c => c.ValueType).ToArray(Columns.Count));
+        Columns.Select(static c => c.ValueType).ToArray());
       keyTupleDescriptor = TupleDescriptor.Create(
-        KeyColumns.Select(static c => c.Key.ValueType).ToArray(KeyColumns.Count));
+        KeyColumns.Select(static c => c.Key.ValueType).ToArray());
     }
 
     private void CreateColumns()
     {
-      Columns = KeyColumns.Select(static pair => pair.Key).Concat(ValueColumns).ToArray(KeyColumns.Count + ValueColumns.Count).AsSafeWrapper();
+      Columns = KeyColumns.Select(static pair => pair.Key).Concat(ValueColumns).ToArray().AsSafeWrapper();
     }
 
     /// Unsubscribe ColumnInfoCollections from FieldInfo events to avoid memory leak.

--- a/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeInfo.cs
@@ -808,11 +808,10 @@ namespace Xtensive.Orm.Model
 
     private void CreateTupleDescriptor()
     {
-      var orderedColumns = columns.OrderBy(c => c.Field.MappingInfo.Offset).ToList(columns.Count);
+      var orderedColumns = columns.OrderBy(c => c.Field.MappingInfo.Offset).ToList();
       columns.Clear();                    // To prevent event handler leak
       columns.AddRange(orderedColumns);
-      TupleDescriptor = TupleDescriptor.Create(
-        Columns.Select(c => c.ValueType).ToArray(Columns.Count));
+      TupleDescriptor = TupleDescriptor.Create(Columns.Select(c => c.ValueType).ToArray());
     }
 
     private void BuildTuplePrototype()
@@ -876,8 +875,8 @@ namespace Xtensive.Orm.Model
         VersionExtractor = null;
         return;
       }
-      var types = versionColumns.Select(c => c.ValueType).ToArray(versionColumnsCount);
-      var map = versionColumns.Select(c => c.Field.MappingInfo.Offset).ToArray(versionColumnsCount);
+      var types = versionColumns.Select(c => c.ValueType).ToArray();
+      var map = versionColumns.Select(c => c.Field.MappingInfo.Offset).ToArray();
       var versionTupleDescriptor = TupleDescriptor.Create(types);
       VersionExtractor = new MapTransform(true, versionTupleDescriptor, map);
     }

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
@@ -419,7 +419,7 @@ namespace Xtensive.Orm.Providers
       if (mc.AsTupleAccess(activeParameters) != null)
         return VisitTupleAccess(mc);
 
-      var arguments = mc.Arguments.SelectToArray(a => Visit(a));
+      var arguments = mc.Arguments.Select(a => Visit(a)).ToArray();
       var mi = mc.Method;
 
       if (mc.Object!=null && mc.Object.Type!=mi.ReflectedType) {
@@ -467,14 +467,14 @@ namespace Xtensive.Orm.Providers
 
     protected override SqlExpression VisitNew(NewExpression n)
     {
-      return CompileMember(n.Constructor, null, n.Arguments.SelectToArray(a => Visit(a)));
+      return CompileMember(n.Constructor, null, n.Arguments.Select(a => Visit(a)).ToArray());
     }
 
     protected override SqlExpression VisitNewArray(NewArrayExpression expression)
     {
       if (expression.NodeType!=ExpressionType.NewArrayInit)
         throw new NotSupportedException();
-      var expressions = expression.Expressions.SelectToArray(e => Visit(e));
+      var expressions = expression.Expressions.Select(e => Visit(e)).ToArray();
       return SqlDml.Container(expressions);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/PartialIndexFilterCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/PartialIndexFilterCompiler.cs
@@ -25,7 +25,7 @@ namespace Xtensive.Orm.Providers
       IReadOnlyList<SqlExpression> columns = filter.Fields
         .Select(field => field.Column.Name)
         .Select((name, i) => SqlDml.ColumnRef(table.Columns[i], name))
-        .ToArray(fieldsCount);
+        .ToArray();
 
       var processor = new ExpressionProcessor(filter.Expression, handlers, null, true, columns);
       var fragment = SqlDml.Fragment(processor.Translate());

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Aggregate.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Aggregate.cs
@@ -28,7 +28,7 @@ namespace Xtensive.Orm.Providers
       var columnNames = columns.Select((c, i) =>
         i >= sqlSelect.Columns.Count
           ? sqlSelect.From.Columns[i].Name
-          : sqlSelect.Columns[i].Name).ToArray(columns.Count);
+          : sqlSelect.Columns[i].Name).ToArray();
       sqlSelect.Columns.Clear();
 
       var groupColumnIndexes = provider.GroupColumnIndexes;

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Helpers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Helpers.cs
@@ -84,7 +84,7 @@ namespace Xtensive.Orm.Providers
     }
 
     protected IReadOnlyList<SqlExpression> ExtractColumnExpressions(SqlSelect query) =>
-      query.Columns.Select(ExtractColumnExpression).ToArray(query.Columns.Count);
+      query.Columns.Select(ExtractColumnExpression).ToArray();
 
     protected SqlExpression ExtractColumnExpression(SqlColumn column)
     {

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Include.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Include.cs
@@ -46,7 +46,7 @@ namespace Xtensive.Orm.Providers
 
       Func<ParameterContext, object> parameterAccessor;
       var filterTupleDescriptor = provider.FilteredColumnsExtractionTransform.Descriptor;
-      var mappings = filterTupleDescriptor.Select(type => Driver.GetTypeMapping(type)).ToArray(filterTupleDescriptor.Count).AsSafeWrapper();
+      var mappings = filterTupleDescriptor.Select(type => Driver.GetTypeMapping(type)).ToArray().AsSafeWrapper();
       switch (algorithm) {
         case IncludeAlgorithm.Auto:
           if (tvpType != null) {
@@ -119,7 +119,7 @@ namespace Xtensive.Orm.Providers
       var filterTupleDescriptor = provider.FilteredColumnsExtractionTransform.Descriptor;
       var filteredColumns = provider.FilteredColumns
         .Select(index => sourceColumns[index])
-        .ToArray(provider.FilteredColumns.Count);
+        .ToArray();
       tableDescriptor = DomainHandler.TemporaryTableManager
         .BuildDescriptor(Mapping, Guid.NewGuid().ToString(), filterTupleDescriptor);
       var filterQuery = tableDescriptor.QueryStatement.ShallowClone();

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Index.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Index.cs
@@ -223,11 +223,11 @@ namespace Xtensive.Orm.Providers
         }
         else {
           var values = filterByTypes
-            .Select(t => GetDiscriminatorValue(discriminatorMap, t.TypeDiscriminatorValue)).ToArray(filterByTypesCount);
+            .Select(t => GetDiscriminatorValue(discriminatorMap, t.TypeDiscriminatorValue)).ToArray();
           filter = SqlDml.In(discriminatorColumn, SqlDml.Array(values));
           if (containsDefault) {
             var allValues = discriminatorMap
-              .Select(p => GetDiscriminatorValue(discriminatorMap, p.Item1)).ToArray(discriminatorMap.Count);
+              .Select(p => GetDiscriminatorValue(discriminatorMap, p.Item1)).ToArray();
             filter |= SqlDml.NotIn(discriminatorColumn, SqlDml.Array(allValues));
           }
         }
@@ -239,7 +239,7 @@ namespace Xtensive.Orm.Providers
           filter = filterByTypes.Count == 1
             ? typeIdColumn == TypeIdRegistry[filterByTypes.First()]
             : SqlDml.In(typeIdColumn,
-                SqlDml.Array(filterByTypes.Select(t => TypeIdRegistry[t]).ToArray(filterByTypes.Count)));
+                SqlDml.Array(filterByTypes.Select(t => TypeIdRegistry[t]).ToArray()));
         }
         else {
           if (filterByTypes.Count == 1) {
@@ -254,7 +254,7 @@ namespace Xtensive.Orm.Providers
                 bindings.Add(binding);
                 return binding.ParameterReference;
               })
-              .ToArray(filterByTypes.Count);
+              .ToArray();
             filter = SqlDml.In(typeIdColumn, SqlDml.Array(typeIdParameters));
           }
         }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -308,7 +308,7 @@ namespace Xtensive.Orm.Providers
         pair => ((MappedColumn) headerColumns[pair.Key]).ColumnInfoRef.ColumnName!=typeIdColumnName;
       var keyColumns = provider.Header.Order
         .Where(filterNonTypeId)
-        .ToList(provider.Header.Order.Count);
+        .ToList();
 
       parameterBindings.Capacity = keyColumns.Count;
       for (int i = 0, count = keyColumns.Count; i < count; i++) {

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlProvider.cs
@@ -96,7 +96,7 @@ namespace Xtensive.Orm.Providers
     /// <param name="provider">The provider.</param>
     /// <param name="permanentReference">The permanent reference.</param>
     public SqlProvider(SqlProvider provider, SqlTable permanentReference)
-      : base(provider.Origin, provider.Sources.Cast<ExecutableProvider>().ToArray(provider.Sources.Count))
+      : base(provider.Origin, provider.Sources.Cast<ExecutableProvider>().ToArray())
     {
       this.permanentReference = permanentReference;
       handlers = provider.handlers;

--- a/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/ColumnCollection.cs
@@ -65,7 +65,7 @@ public readonly struct ColumnCollection
   public ColumnCollection Alias(string alias)
   {
     ArgumentException.ThrowIfNullOrEmpty(alias);
-    return new ColumnCollection(Columns.Select(column => column.Clone(alias + "." + column.Name)).ToArray(Count));
+    return new ColumnCollection(Columns.Select(column => column.Clone(alias + "." + column.Name)).ToArray());
   }
 
   // Constructors

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ContainsTableProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/ContainsTableProvider.cs
@@ -56,7 +56,7 @@ namespace Xtensive.Orm.Rse.Providers
       FullFeatured = fullFeatured;
       PrimaryIndex = new IndexInfoRef(index.PrimaryIndex);
       TargetColumns = targetColumns.Select(tc => index.Columns.First(c => c.Column == tc))
-        .ToArray(targetColumns.Count)
+        .ToArray()
         .AsSafeWrapper();
       TopN = topNByRank;
       if (FullFeatured) {
@@ -72,12 +72,12 @@ namespace Xtensive.Orm.Rse.Providers
         var fieldTypes = primaryIndexKeyColumns
           .Select(static columnInfo => columnInfo.Key.ValueType)
           .Append(WellKnownTypes.Double)
-          .ToArray(primaryIndexKeyColumns.Count + 1);
+          .ToArray();
         var tupleDescriptor = TupleDescriptor.Create(fieldTypes);
         var columns = primaryIndexKeyColumns
           .Select(static (c, i) => (Column) new MappedColumn("KEY", (ColNum) i, c.Key.ValueType))
           .Append(new MappedColumn("RANK", tupleDescriptor.Count, WellKnownTypes.Double))
-          .ToArray(primaryIndexKeyColumns.Count + 1);;
+          .ToArray();;
         indexHeader = new RecordSetHeader(tupleDescriptor, columns);
       }
       Initialize();

--- a/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/FreeTextProvider.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Providers/Compilable/FreeTextProvider.cs
@@ -65,12 +65,12 @@ namespace Xtensive.Orm.Rse.Providers
         var fieldTypes = primaryIndexKeyColumns
           .Select(static columnInfo => columnInfo.Key.ValueType)
           .Append(WellKnownTypes.Double)
-          .ToArray(primaryIndexKeyColumns.Count + 1);
+          .ToArray();
         var tupleDescriptor = TupleDescriptor.Create(fieldTypes);
         var columns = primaryIndexKeyColumns
           .Select(static (c, i) => (Column) new MappedColumn("KEY", (ColNum) i, c.Key.ValueType))
           .Append(new MappedColumn("RANK", tupleDescriptor.Count, WellKnownTypes.Double))
-          .ToArray(primaryIndexKeyColumns.Count + 1);
+          .ToArray();
         indexHeader = new RecordSetHeader(tupleDescriptor, columns);
       }
       Initialize();

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -186,14 +186,14 @@ namespace Xtensive.Orm.Rse
         .Where(g => g.Keys.All(k => columnsMap[k] >= 0))
         .Select(g => new ColumnGroup(
             g.TypeInfoRef,
-            g.Keys.Select(k => columnsMap[k]).ToArray(g.Keys.Count),
+            g.Keys.Select(k => columnsMap[k]).ToArray(),
             g.Columns
               .Select(c => columnsMap[c])
               .Where(static c => c >= 0).ToList()));
 
       return new RecordSetHeader(
-        TupleDescriptor.CreateFromNormalized(columns.Select(i => TupleDescriptor[i]).ToArray(columns.Count)),
-        columns.Select((oldIndex, newIndex) => Columns[oldIndex].Clone((ColNum) newIndex)).ToArray(columns.Count),
+        TupleDescriptor.CreateFromNormalized(columns.Select(i => TupleDescriptor[i]).ToArray()),
+        columns.Select((oldIndex, newIndex) => Columns[oldIndex].Clone((ColNum) newIndex)).ToArray(),
         resultGroups.ToArray(),
         null,
         resultOrder);
@@ -230,7 +230,7 @@ namespace Xtensive.Orm.Rse
       var indexInfoColumns = indexInfo.Columns;
       var indexInfoKeyColumns = indexInfo.KeyColumns;
 
-      var resultFieldTypes = indexInfoColumns.Select(columnInfo => columnInfo.ValueType).ToArray(indexInfoColumns.Count);
+      var resultFieldTypes = indexInfoColumns.Select(columnInfo => columnInfo.ValueType).ToArray();
       var resultTupleDescriptor = TupleDescriptor.Create(resultFieldTypes);
 
       var keyOrderEnumerable = indexInfoKeyColumns.Select(static (p, i) => new KeyValuePair<ColNum, Direction>((ColNum) i, p.Value));
@@ -245,13 +245,12 @@ namespace Xtensive.Orm.Rse
       }
       var order = new DirectionCollection<ColNum>(keyOrderEnumerable);
 
-      var keyFieldTypes = indexInfoKeyColumns
-        .SelectToArray(static columnInfo => columnInfo.Key.ValueType);
+      var keyFieldTypes = indexInfoKeyColumns.Select(static columnInfo => columnInfo.Key.ValueType).ToArray();
       var keyDescriptor = TupleDescriptor.Create(keyFieldTypes);
 
       var resultColumns = indexInfoColumns
         .Select(static (c,i) => (Column) new MappedColumn(new ColumnInfoRef(c), (ColNum) i, c.ValueType))
-        .ToArray(indexInfoColumns.Count);
+        .ToArray();
       var resultGroups = new[]{indexInfo.Group};
 
       return new RecordSetHeader(

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/ColumnMappingInspector.cs
@@ -49,7 +49,7 @@ namespace Xtensive.Orm.Rse.Transformation
       }
       var filteredColumns = provider.FilteredColumns
         .Select(el => (ColNum) mappings[provider].IndexOf(el))
-        .ToArray(provider.FilteredColumns.Count);
+        .ToArray();
       return new IncludeProvider(source, provider.Algorithm, provider.IsInlined,
         provider.FilterDataSource, provider.ResultColumnName, filteredColumns);
     }
@@ -59,7 +59,7 @@ namespace Xtensive.Orm.Rse.Transformation
       var requiredColumns = mappings[provider];
       var remappedColumns = requiredColumns
         .Select(c => provider.ColumnIndexes[c])
-        .ToList(requiredColumns.Count);
+        .ToList();
 
       mappings[provider.Source] = remappedColumns;
       var source = VisitCompilable(provider.Source);
@@ -262,7 +262,7 @@ namespace Xtensive.Orm.Rse.Transformation
       using ColumnMap sourceMap = new(mappings[provider.Source]);
       var currentMap = mappings[provider];
 
-      mappings[provider] = provider.Header.Columns.Columns.Select(c => c.Index).ToList(provider.Header.Columns.Count);
+      mappings[provider] = provider.Header.Columns.Columns.Select(c => c.Index).ToList();
 
       if (source == provider.Source) {
         return provider;
@@ -279,7 +279,7 @@ namespace Xtensive.Orm.Rse.Transformation
 
       var groupColumnIndexes = provider.GroupColumnIndexes
         .Select(index => (ColNum)sourceMap.IndexOf(index))
-        .ToArray(provider.GroupColumnIndexes.Count);
+        .ToArray();
 
       return new AggregateProvider(source, groupColumnIndexes, columns);
     }
@@ -408,7 +408,7 @@ namespace Xtensive.Orm.Rse.Transformation
 
       var columns = expectedColumns
         .Select(originalIndex => (OriginalIndex: originalIndex, NewIndex: (ColNum) returningColumns.IndexOf(originalIndex)))
-        .Select(x => x.NewIndex < 0 ? x.OriginalIndex : x.NewIndex).ToArray(expectedColumns.Count);
+        .Select(x => x.NewIndex < 0 ? x.OriginalIndex : x.NewIndex).ToArray();
       return new SelectProvider(provider, columns);
     }
 
@@ -443,7 +443,7 @@ namespace Xtensive.Orm.Rse.Transformation
       foreach (var r in right) {
         _ = hs.Add(r);
       }
-      var resultList = hs.ToList(hs.Count);
+      var resultList = hs.ToList();
       resultList.Sort();
       return resultList;
     }
@@ -522,9 +522,9 @@ namespace Xtensive.Orm.Rse.Transformation
       ref List<ColNum> rightMapping, ref CompilableProvider right, bool skipSort)
     {
       if (!skipSort) {
-        leftMapping = leftMapping.Distinct().ToList(leftMapping.Count);
+        leftMapping = leftMapping.Distinct().ToList();
         leftMapping.Sort();
-        rightMapping = rightMapping.Distinct().ToList(rightMapping.Count);
+        rightMapping = rightMapping.Distinct().ToList();
         rightMapping.Sort();
       }
 

--- a/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyProviderCorrectorRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/Transformation/Internals/ApplyProviderCorrectorRewriter.cs
@@ -399,8 +399,8 @@ namespace Xtensive.Orm.Rse.Transformation
     private static CalculateProvider RecreateCalculate(CalculateProvider provider, CompilableProvider source)
     {
       var ccds = provider.CalculatedColumns
-        .SelectToArray(
-          column => new CalculatedColumnDescriptor(column.Name, column.Type, column.Expression));
+        .Select(column => new CalculatedColumnDescriptor(column.Name, column.Type, column.Expression))
+        .ToArray();
       return source.Calculate(ccds);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryBuilder.cs
@@ -49,7 +49,7 @@ namespace Xtensive.Orm.Services
       if (request.ParameterBindings is ICollection<Providers.QueryParameterBinding> bindingCollection) {
         return new QueryTranslationResult(
           request.Statement,
-          bindingCollection.SelectToArray(b => new QueryParameterBinding(b)));
+          bindingCollection.Select(b => new QueryParameterBinding(b)).ToArray());
       }
       else
         return new QueryTranslationResult(request.Statement,

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/HintGenerator.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/HintGenerator.cs
@@ -76,7 +76,7 @@ namespace Xtensive.Orm.Upgrade
       var upgradedTypesMapping = reverseTypeMapping
         .ToDictionary(item => item.Key.UnderlyingType, item => item.Value.UnderlyingType);
 
-      return new HintGenerationResult(hints.ToList(hints.Count), schemaHints, upgradedTypesMapping);
+      return new HintGenerationResult(hints.ToList(), schemaHints, upgradedTypesMapping);
     }
 
     #region Hint generation
@@ -510,14 +510,15 @@ namespace Xtensive.Orm.Upgrade
           string.Format(Strings.ExPairedIdentityColumnsForTypesXAndXNotFound, removedType, updatedType));
 
       var sourceTablePath = GetTablePath(updatedType);
-      var identities = pairedIdentityColumns.SelectToList(pair =>
-        CreateIdentityPair(removedType, updatedType, pair));
+      var identities = pairedIdentityColumns
+        .Select(pair => CreateIdentityPair(removedType, updatedType, pair))
+        .ToList();
       if (removedType.Hierarchy.InheritanceSchema != InheritanceSchema.ConcreteTable) {
         identities.Add(CreateIdentityPair(removedType, removedType));
       }
 
       var updatedColumns = pairedIdentityColumns
-        .SelectToList(pair => (GetColumnPath(updatedType, pair.Item2), (object) null));
+        .Select(pair => (GetColumnPath(updatedType, pair.Item2), (object) null)).ToList();
 
       if (association.ConnectorType == null) {
         schemaHints.Add(new UpdateDataHint(sourceTablePath, identities, updatedColumns));
@@ -826,15 +827,13 @@ namespace Xtensive.Orm.Upgrade
 
     private static StoredTypeInfo[] GetAffectedMappedTypesAsArray(StoredTypeInfo type, bool includeInheritors)
     {
-      var count = 1;
       IEnumerable<StoredTypeInfo> result = [type];
       if (includeInheritors) {
         result = result.Concat(type.AllDescendants);
-        count += type.AllDescendants.Length;
       }
       return type.Hierarchy.InheritanceSchema == InheritanceSchema.ConcreteTable
         ? result.Where(t => !t.IsAbstract).ToArray()
-        : result.ToArray(count);
+        : result.ToArray();
     }
 
     private IdentityPair CreateIdentityPair(StoredTypeInfo removedType, StoredTypeInfo updatedType, int? typeIdOverride = null)
@@ -961,8 +960,7 @@ namespace Xtensive.Orm.Upgrade
           tasks.Enqueue(newTask);
         }
       }
-      return result
-        .SelectToArray(mapping => (mapping.Item1.MappingName, mapping.Item2.MappingName));
+      return result.Select(mapping => (mapping.Item1.MappingName, mapping.Item2.MappingName)).ToArray();
     }
 
     #endregion

--- a/Orm/Xtensive.Orm/Orm/Upgrade/Internals/UpgradeHintsProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Upgrade/Internals/UpgradeHintsProcessor.cs
@@ -189,7 +189,7 @@ namespace Xtensive.Orm.Upgrade.Internals
         var newGenericDefType = hint.TargetType;
         if (genericTypeDefLookup.TryGetValue(newGenericDefType, out var instanceGroup)) {
           foreach (var triplet in instanceGroup.Instances) {
-            var newGenericArguments = triplet.Item3.SelectToArray(pair => pair.Item2);
+            var newGenericArguments = triplet.Item3.Select(pair => pair.Item2).ToArray();
             rewrittenHints.Add(new RenameFieldHint(newGenericDefType.MakeGenericType(newGenericArguments),
               hint.OldFieldName, hint.NewFieldName));
           }
@@ -528,10 +528,8 @@ namespace Xtensive.Orm.Upgrade.Internals
         let type = association.ConnectorType
         where type != null
         select type
-        ).ToHashSet();
-      return model.Types
-        .Where(type => !connectorTypes.Contains(type))
-        .ToArray(model.Types.Length - connectorTypes.Count);
+        );
+      return model.Types.Except(connectorTypes).ToArray();
     }
 
     public static ClassifiedCollection<string, (string, string[])> GetGenericTypes(StoredDomainModel model)

--- a/Orm/Xtensive.Orm/Sorting/TopologicalSorter.cs
+++ b/Orm/Xtensive.Orm/Sorting/TopologicalSorter.cs
@@ -295,8 +295,8 @@ namespace Xtensive.Sorting
     {
       var (sorted, count) = SortInternal(nodes, out removedEdges, removeWholeNode);
       return (count == 0)
-        ? Array.Empty<TNodeItem>()
-        : sorted.ToArray(count);
+        ? []
+        : sorted.ToArray();
     }
 
     private static (IEnumerable<TNodeItem> sorted, int count) SortInternal<TNodeItem, TConnectionItem>(

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCustomFunctionCall.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlCustomFunctionCall.cs
@@ -30,7 +30,7 @@ namespace Xtensive.Sql.Dml
 
     internal override SqlCustomFunctionCall Clone(SqlNodeCloneContext context) =>
       context.GetOrAdd(this, static (t, c) =>
-        new(t.FunctionType, t.Arguments.Select(o => o.Clone(c)).ToArray(t.Arguments.Count)));
+        new(t.FunctionType, t.Arguments.Select(o => o.Clone(c)).ToArray()));
 
     public override void AcceptVisitor(ISqlVisitor visitor) => visitor.Visit(this);
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlFunctionCall.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlFunctionCall.cs
@@ -27,7 +27,7 @@ namespace Xtensive.Sql.Dml
 
     internal override SqlFunctionCall Clone(SqlNodeCloneContext context) =>
       context.GetOrAdd(this, static (t, c) =>
-        new(t.FunctionType, t.Arguments.Select(o => o.Clone(c)).ToArray(t.Arguments.Count)));
+        new(t.FunctionType, t.Arguments.Select(o => o.Clone(c)).ToArray()));
 
     public override void AcceptVisitor(ISqlVisitor visitor) => visitor.Visit(this);
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlUserFunctionCall.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlUserFunctionCall.cs
@@ -27,7 +27,7 @@ namespace Xtensive.Sql.Dml
 
     internal override SqlUserFunctionCall Clone(SqlNodeCloneContext context) =>
       context.GetOrAdd(this, static (t, c) =>
-        new(t.Name, t.Arguments.Select(o => o.Clone(c)).ToArray(t.Arguments.Count)));
+        new(t.Name, t.Arguments.Select(o => o.Clone(c)).ToArray()));
 
     internal SqlUserFunctionCall(string name, IReadOnlyList<SqlExpression> arguments)
       : base(SqlFunctionType.UserDefined, arguments)

--- a/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlForceJoinOrderHint.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Hints/SqlForceJoinOrderHint.cs
@@ -19,7 +19,7 @@ namespace Xtensive.Sql.Dml
 
     internal override SqlForceJoinOrderHint Clone(SqlNodeCloneContext context) =>
       context.GetOrAdd(this, static (t, c) =>
-        new(t.Tables?.Select(table => (SqlTable) table.Clone()).ToArray(t.Tables.Count)));
+        new(t.Tables?.Select(table => (SqlTable) table.Clone()).ToArray()));
 
     public override void AcceptVisitor(ISqlVisitor visitor)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlContainsTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlContainsTable.cs
@@ -85,15 +85,13 @@ namespace Xtensive.Sql.Dml
       TargetTable = SqlDml.TableRef(dataTable);
       SearchCondition = searchCondition;
       TopNByRank = topNByRank;
-      var targetColumnCount = targetColumnNames.Count;
-      if (targetColumnCount == 0) {
-        TargetColumns = new SqlTableColumnCollection([Asterisk]);
-      }
-      else {
-        TargetColumns = new SqlTableColumnCollection(targetColumnNames.Select(columnName => SqlDml.TableColumn(this, columnName)).ToArray(targetColumnCount));
-      }
+      TargetColumns = new SqlTableColumnCollection(
+        targetColumnNames.Count == 0
+          ? [Asterisk]
+          : targetColumnNames.Select(columnName => SqlDml.TableColumn(this, columnName)).ToArray()
+        );
 
-      columns = new SqlTableColumnCollection(columnNames.Select(columnName => SqlDml.TableColumn(this, columnName)).ToArray(columnNames.Count));
+      columns = new SqlTableColumnCollection(columnNames.Select(columnName => SqlDml.TableColumn(this, columnName)).ToArray());
     }
   }
 }

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlFreeTextTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlFreeTextTable.cs
@@ -90,15 +90,14 @@ namespace Xtensive.Sql.Dml
       TargetTable = SqlDml.TableRef(dataTable);
       FreeText = freeText;
       TopNByRank = topNByRank;
-      var targetColumnCount = targetColumnNames.Count;
-      if (targetColumnCount == 0) {
+      if (targetColumnNames.Count == 0) {
         TargetColumns = new SqlTableColumnCollection([Asterisk]);
       }
       else {
-        TargetColumns = new SqlTableColumnCollection(targetColumnNames.Select(columnName => SqlDml.TableColumn(this, columnName)).ToArray(targetColumnCount));
+        TargetColumns = new SqlTableColumnCollection(targetColumnNames.Select(columnName => SqlDml.TableColumn(this, columnName)).ToArray());
       }
 
-      columns = new SqlTableColumnCollection(columnNames.Select(columnName => SqlDml.TableColumn(this, columnName)).ToArray(columnNames.Count));
+      columns = new SqlTableColumnCollection(columnNames.Select(columnName => SqlDml.TableColumn(this, columnName)).ToArray());
     }
   }
 }

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlJoinedTable.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlJoinedTable.cs
@@ -60,7 +60,7 @@ namespace Xtensive.Sql.Dml
       var allLeftColumns = joinExpression.Left.Columns;
       var allRightColumns = joinExpression.Right.Columns;
 
-      columns = new SqlTableColumnCollection(allLeftColumns.Concat(allRightColumns).ToArray(allLeftColumns.Count + allRightColumns.Count));
+      columns = new SqlTableColumnCollection(allLeftColumns.Concat(allRightColumns).ToArray());
 
       AliasedColumns = new(leftColumns.Concat(rightColumns));
     }

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlTableRef.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlTableRef.cs
@@ -40,7 +40,7 @@ namespace Xtensive.Sql.Dml
       var clone = new SqlTableRef {Name = Name, DataTable = DataTable};
       context.NodeMapping[this] = clone;
 
-      clone.columns = new SqlTableColumnCollection(columns.Select(column => (SqlTableColumn) column.Clone(context)).ToArray(columns.Count));
+      clone.columns = new SqlTableColumnCollection(columns.Select(column => (SqlTableColumn) column.Clone(context)).ToArray());
 
       return clone;
     }
@@ -65,8 +65,8 @@ namespace Xtensive.Sql.Dml
     {
       DataTable = dataTable;
       var  tableColumns = columnNames.Length == 0
-        ? dataTable.Columns.Select(column => SqlDml.TableColumn(this, column.Name)).ToArray(dataTable.Columns.Count)
-        : columnNames.Select(columnName => SqlDml.TableColumn(this, columnName)).ToArray(columnNames.Length);
+        ? dataTable.Columns.Select(column => SqlDml.TableColumn(this, column.Name)).ToArray()
+        : columnNames.Select(columnName => SqlDml.TableColumn(this, columnName)).ToArray();
       columns = new SqlTableColumnCollection(tableColumns);
     }
   }

--- a/Orm/Xtensive.Orm/Sql/SqlDriverConfiguration.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlDriverConfiguration.cs
@@ -45,7 +45,7 @@ namespace Xtensive.Sql
       // no deep cloning
       var accessors = (DbConnectionAccessors.Count == 0)
         ? Array.Empty<IDbConnectionAccessor>()
-        : DbConnectionAccessors.ToArray(DbConnectionAccessors.Count);
+        : DbConnectionAccessors.ToArray();
 
       return new SqlDriverConfiguration(accessors) {
         ForcedServerVersion = ForcedServerVersion,


### PR DESCRIPTION
.NET10 optimizes standard LINQ better

Also:
* Make them `internal`