### PR TITLE
Trim trailing spaces for TVP string values

### DIFF
--- a/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/SqlDataRecordList.cs
+++ b/Orm/Xtensive.Orm.SqlServer/Sql.Drivers.SqlServer/v10/SqlDataRecordList.cs
@@ -62,7 +62,7 @@ public class SqlDataRecordList(IReadOnlyList<Tuple> tuples, SqlDbType sqlDbType)
         SqlDataRecord record = new(metaData);
         HashSet<string> added = new(StringComparer.OrdinalIgnoreCase);
         foreach (var valueObj in tuples.Select(t => t.GetValueOrDefault(0)).Where(o => o != null)) {
-          string castValue = (string) valueObj;
+          var castValue = ((string) valueObj).TrimEnd();
           if (added.Add(castValue)) {
             record.SetSqlString(0, castValue);
             yield return record;


### PR DESCRIPTION
See https://mskb.pkisolutions.com/kb/316626
SQL Unique Constraint does not allow two NVARCHAR keys differing by trailing spaces

We have an issue because of this: https://servicetitan.atlassian.net/browse/STCRM-2615?focusedCommentId=2397077
```
SQL error details 'Type: UniqueConstraintViolation; Table: @p0_1; Value: (2134462427 );
```
Note the space after phone number `"2134462427 "`
