### PR TITLE
Optimize `CollectionBaseSlim`

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Configuration/AppConfigTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Configuration/AppConfigTest.cs
@@ -115,11 +115,11 @@ namespace Xtensive.Orm.Tests.Configuration
 
       var bad1 = configuration.Clone();
       bad1.DefaultDatabase = null;
-      AssertEx.ThrowsInvalidOperationException(bad1.Lock);
+      AssertEx.ThrowsInvalidOperationException(() => bad1.Lock());
 
       var bad2 = configuration.Clone();
       bad2.DefaultSchema = null;
-      AssertEx.ThrowsInvalidOperationException(bad2.Lock);
+      AssertEx.ThrowsInvalidOperationException(() => bad2.Lock());
 
       var good = configuration.Clone();
       good.DefaultDatabase = null;

--- a/Orm/Xtensive.Orm/Collections/CollectionBaseSlim.cs
+++ b/Orm/Xtensive.Orm/Collections/CollectionBaseSlim.cs
@@ -4,136 +4,107 @@
 // Created by: Alexey Kochetov
 // Created:    2007.09.24
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Diagnostics;
 using Xtensive.Core;
 
-namespace Xtensive.Collections
+namespace Xtensive.Collections;
+
+/// <summary>
+/// Lightweight base class for any collection.
+/// </summary>
+[Serializable]
+[DebuggerDisplay("Count = {Count}")]
+public class CollectionBaseSlim<TItem> : List<TItem>, ILockable
 {
+  /// <inheritdoc/>
+  public bool IsLocked { [DebuggerStepThrough] get; private set; }
+
+  [MethodImpl(MethodImplOptions.NoInlining)]
+  private static void ThrowInstanceIsLockedException() => throw new InstanceIsLockedException(Strings.ExInstanceIsLocked);
+
   /// <summary>
-  /// Lightweight base class for any collection.
+  /// Ensures the object is not locked (see <see cref="ILockable.Lock()"/>) yet.
   /// </summary>
-  [Serializable]
-  [DebuggerDisplay("Count = {Count}")]
-  public class CollectionBaseSlim<TItem>: LockableBase,
-    ICollection<TItem>, IReadOnlyList<TItem>
+  /// <exception cref="InstanceIsLockedException">The instance is locked.</exception>
+  public void EnsureNotLocked()
   {
-    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-    private readonly List<TItem> items;
-
-    /// <inheritdoc/>
-    public virtual bool IsReadOnly {
-      [DebuggerStepThrough]
-      get => IsLocked;
+    if (IsLocked) {
+      ThrowInstanceIsLockedException();
     }
+  }
 
-    /// <inheritdoc/>
-    public int Count
-    {
-      [DebuggerStepThrough]
-      get => items.Count;
-    }
+  /// <inheritdoc/>
+  public virtual void Lock(bool recursive = true) => IsLocked = true;
 
-    /// <inheritdoc/>
-    public virtual TItem this[int index]
-    {
-      [DebuggerStepThrough]
-      get => items[index];
-    }
-
-    /// <inheritdoc/>
+  /// <inheritdoc/>
+  public virtual bool IsReadOnly {
     [DebuggerStepThrough]
-    public virtual bool Contains(TItem item)
-      => items.Contains(item);
+    get => IsLocked;
+  }
 
-    /// <inheritdoc/>
-    [DebuggerStepThrough]
-    public virtual void CopyTo(TItem[] array, int arrayIndex)
-      => items.CopyTo(array, arrayIndex);
+  /// <inheritdoc/>
+  [DebuggerStepThrough]
+  public new virtual bool Contains(TItem item) => base.Contains(item);
 
-    #region GetEnumerator<...> methods
+  #region Modification methods: Add, Remove, etc.
 
-    /// <inheritdoc/>
-    [DebuggerStepThrough]
-    public List<TItem>.Enumerator GetEnumerator()
-      => items.GetEnumerator();
+  /// <inheritdoc/>
+  public new virtual void Add(TItem item)
+  {
+    EnsureNotLocked();
+    base.Add(item);
+  }
 
-    /// <inheritdoc/>
-    [DebuggerStepThrough]
-    IEnumerator<TItem> IEnumerable<TItem>.GetEnumerator()
-      => items.GetEnumerator();
-    
-    /// <inheritdoc/>
-    [DebuggerStepThrough]
-    IEnumerator IEnumerable.GetEnumerator()
-      => items.GetEnumerator();
+  /// <summary>
+  /// Adds the elements of the specified collection to the end of the <see cref="CollectionBaseSlim{TItem}"/>.
+  /// </summary>
+  /// <param name="collection">The collection whose elements should be added to the end of the <see cref="CollectionBaseSlim{TItem}"/>. The collection itself cannot be null, but it can contain elements that are null, if type T is a reference type.</param>
+  /// <exception cref="T:System.ArgumentNullException">collection is null.</exception>
+  public new virtual void AddRange(IEnumerable<TItem> collection)
+  {
+    EnsureNotLocked();
+    base.AddRange(collection);
+  }
 
-    #endregion
+  /// <inheritdoc/>
+  public new virtual bool Remove(TItem item)
+  {
+    EnsureNotLocked();
+    return base.Remove(item);
+  }
 
-    #region Modification methods: Add, Remove, etc.
+  /// <inheritdoc/>
+  public new virtual void Clear()
+  {
+    EnsureNotLocked();
+    base.Clear();
+  }
 
-    /// <inheritdoc/>
-    public virtual void Add(TItem item)
-    {
-      EnsureNotLocked();
-      items.Add(item);
-    }
+  #endregion
 
-    /// <summary>
-    /// Adds the elements of the specified collection to the end of the <see cref="CollectionBaseSlim{TItem}"/>.
-    /// </summary>
-    /// <param name="collection">The collection whose elements should be added to the end of the <see cref="CollectionBaseSlim{TItem}"/>. The collection itself cannot be null, but it can contain elements that are null, if type T is a reference type.</param>
-    /// <exception cref="T:System.ArgumentNullException">collection is null.</exception>
-    public virtual void AddRange(IEnumerable<TItem> collection)
-    {
-      EnsureNotLocked();
-      items.AddRange(collection);
-    }
+  // Constructors
 
-    /// <inheritdoc/>
-    public virtual bool Remove(TItem item)
-    {
-      EnsureNotLocked();
-      return items.Remove(item);
-    }
+  /// <summary>
+  /// Initializes a new instance of this type.
+  /// </summary>
+  public CollectionBaseSlim()
+  {
+  }
 
-    /// <inheritdoc/>
-    public virtual void Clear()
-    {
-      EnsureNotLocked();
-      items.Clear();
-    }
+  /// <summary>
+  /// Initializes a new instance of this type.
+  /// </summary>
+  /// <param name="capacity">The capacity.</param>
+  public CollectionBaseSlim(int capacity) : base(capacity)
+  {
+  }
 
-    #endregion
-
-    // Constructors
-
-    /// <summary>
-    /// Initializes a new instance of this type.
-    /// </summary>
-    public CollectionBaseSlim()
-    {
-      items = new List<TItem>();
-    }
-
-    /// <summary>
-    /// Initializes a new instance of this type.
-    /// </summary>
-    /// <param name="capacity">The capacity.</param>
-    public CollectionBaseSlim(int capacity)
-    {
-      items = new List<TItem>(capacity);
-    }
-
-    /// <summary>
-    /// Initializes a new instance of this type.
-    /// </summary>
-    /// <param name="collection">The collection.</param>
-    public CollectionBaseSlim(IEnumerable<TItem> collection)
-    {
-      items = new List<TItem>(collection);
-    }
+  /// <summary>
+  /// Initializes a new instance of this type.
+  /// </summary>
+  /// <param name="collection">The collection.</param>
+  public CollectionBaseSlim(IEnumerable<TItem> collection) : base(collection)
+  {
   }
 }

--- a/Orm/Xtensive.Orm/Collections/ExtensionCollection.cs
+++ b/Orm/Xtensive.Orm/Collections/ExtensionCollection.cs
@@ -92,7 +92,7 @@ namespace Xtensive.Collections
     }
 
     /// <inheritdoc/>
-    public override void Lock(bool recursive)
+    public override void Lock(bool recursive = true)
     {
       base.Lock(recursive);
       if (extensions!=null)

--- a/Orm/Xtensive.Orm/Core/Interfaces/ILockable.cs
+++ b/Orm/Xtensive.Orm/Core/Interfaces/ILockable.cs
@@ -23,14 +23,9 @@ namespace Xtensive.Core
     bool IsLocked { get; }
 
     /// <summary>
-    /// Locks the instance recursively.
-    /// </summary>
-    void Lock() => Lock(true);
-
-    /// <summary>
     /// Locks the instance and (possibly) all dependent objects.
     /// </summary>
     /// <param name="recursive"><see langword="True"/> if all dependent objects should be locked as well.</param>
-    void Lock(bool recursive);
+    void Lock(bool recursive = true);
   }
 }

--- a/Orm/Xtensive.Orm/Core/LockableBase.cs
+++ b/Orm/Xtensive.Orm/Core/LockableBase.cs
@@ -33,8 +33,5 @@ public abstract class LockableBase(bool isLocked = false) : ILockable
   }
 
   /// <inheritdoc/>
-  public void Lock() => Lock(true);
-
-  /// <inheritdoc/>
-  public virtual void Lock(bool recursive) => IsLocked = true;
+  public virtual void Lock(bool recursive = true) => IsLocked = true;
 }

--- a/Orm/Xtensive.Orm/Orm/Building/Builders/DomainBuilderConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/DomainBuilderConfiguration.cs
@@ -100,7 +100,7 @@ namespace Xtensive.Orm.Building.Builders
       }
     }
 
-    public override void Lock(bool recursive)
+    public override void Lock(bool recursive = true)
     {
       base.Lock(recursive);
       if (recycledDefinitions!=null)

--- a/Orm/Xtensive.Orm/Orm/Configuration/ConfigurationBase.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/ConfigurationBase.cs
@@ -26,7 +26,7 @@ namespace Xtensive.Orm.Configuration
     }
 
     /// <inheritdoc/>
-    public override void Lock(bool recursive)
+    public override void Lock(bool recursive = true)
     {
       Validate();
       base.Lock(recursive);

--- a/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/DomainConfiguration.cs
@@ -708,7 +708,7 @@ namespace Xtensive.Orm.Configuration
     /// Locks the instance and (possible) all dependent objects.
     /// </summary>
     /// <param name="recursive"><see langword="True"/> if all dependent objects should be locked as well.</param>
-    public override void Lock(bool recursive)
+    public override void Lock(bool recursive = true)
     {
       var multischema = GetIsMultischema();
       var multidatabase = GetIsMultidatabase();

--- a/Orm/Xtensive.Orm/Orm/Configuration/NodeConfiguration.cs
+++ b/Orm/Xtensive.Orm/Orm/Configuration/NodeConfiguration.cs
@@ -84,7 +84,7 @@ namespace Xtensive.Orm.Configuration
     /// </summary>
     public NameMappingCollection DatabaseMapping { get; init; }  = new();
 
-    public override void Lock(bool recursive)
+    public override void Lock(bool recursive = true)
     {
       base.Lock(recursive);
 

--- a/Orm/Xtensive.Orm/Orm/Model/IndexInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/IndexInfo.cs
@@ -317,7 +317,7 @@ namespace Xtensive.Orm.Model
     }
 
     /// <inheritdoc/>
-    public override void Lock(bool recursive)
+    public override void Lock(bool recursive = true)
     {
       base.Lock(recursive);
       if (!recursive)

--- a/Orm/Xtensive.Orm/Orm/Model/NodeCollection.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/NodeCollection.cs
@@ -153,7 +153,7 @@ namespace Xtensive.Orm.Model
     }
 
     /// <inheritdoc/>
-    public override void Lock(bool recursive)
+    public override void Lock(bool recursive = true)
     {
       base.Lock(recursive);
       NameIndex = NameIndex.ToFrozenDictionary();

--- a/Orm/Xtensive.Orm/Orm/Model/PartialIndexFilterInfo.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/PartialIndexFilterInfo.cs
@@ -48,7 +48,7 @@ namespace Xtensive.Orm.Model
     }
 
     /// <inheritdoc/>
-    public override void Lock(bool recursive)
+    public override void Lock(bool recursive = true)
     {
       if (IsLocked)
         return;

--- a/Orm/Xtensive.Orm/Orm/Model/TypeIdRegistry.cs
+++ b/Orm/Xtensive.Orm/Orm/Model/TypeIdRegistry.cs
@@ -146,7 +146,7 @@ namespace Xtensive.Orm.Model
       reverseMapping[typeId] = type;
     }
 
-    public override void Lock(bool recursive)
+    public override void Lock(bool recursive = true)
     {
       base.Lock(recursive);
       mapping = mapping?.ToFrozenDictionary();


### PR DESCRIPTION
Inherit `CollectionBaseSlim` from `List<>` instead of keeping `List<> items` field.
This will save 24 bytes per instance. And our typical process may have >100K instances
That should save >2MB RAM
Also one indirection less is better for the performance.

Also:
* Consolidate `Lock(bool recursive)` and `Lock()` into single method with default parameter to simplify
