### PR TITLE
Optimize `PackedFieldAccessor.GetValue<>()`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -4,9 +4,7 @@
 // Created by: Vakhtina Elena
 // Created:    2009.02.13
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.Buffers;
 using Xtensive.Collections;
 using Xtensive.Core;
 using Xtensive.Orm.Configuration;
@@ -339,13 +337,17 @@ namespace Xtensive.Orm.Providers
       var columnIndexes = provider.ColumnIndexes;
 
       var newIndex = 0;
-      var newColumns = new SqlColumn[columnIndexes.Count];
+      var n = columnIndexes.Count;
+      PooledArray<SqlColumn> pooledArray = new(n);
+      var newColumns = pooledArray.Array;
       foreach (var index in columnIndexes) {
         newColumns[newIndex++] = queryColumns[index];
       }
-
       queryColumns.Clear();
-      queryColumns.AddRange(newColumns);
+      queryColumns.EnsureCapacity(n);
+      for (var i = 0; i < n; ++i) {
+        queryColumns.Add(newColumns[i]);
+      }
 
       return CreateProvider(query, provider, compiledSource);
     }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -344,7 +344,6 @@ namespace Xtensive.Orm.Providers
         newColumns[newIndex++] = queryColumns[index];
       }
       queryColumns.Clear();
-      queryColumns.EnsureCapacity(n);
       for (var i = 0; i < n; ++i) {
         queryColumns.Add(newColumns[i]);
       }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -337,16 +337,13 @@ namespace Xtensive.Orm.Providers
       var columnIndexes = provider.ColumnIndexes;
 
       var n = columnIndexes.Count;
-      using PooledArray<SqlColumn> pooledArray = new(n);
-      var newColumns = pooledArray.Array;
       var newIndex = 0;
+      var newColumns = new SqlColumn[columnIndexes.Count];
       foreach (var index in columnIndexes) {
         newColumns[newIndex++] = queryColumns[index];
       }
       queryColumns.Clear();
-      for (var i = 0; i < n; ++i) {
-        queryColumns.Add(newColumns[i]);
-      }
+      queryColumns.AddRange(newColumns);
 
       return CreateProvider(query, provider, compiledSource);
     }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -336,10 +336,10 @@ namespace Xtensive.Orm.Providers
       var queryColumns = query.Columns;
       var columnIndexes = provider.ColumnIndexes;
 
-      var newIndex = 0;
       var n = columnIndexes.Count;
       using PooledArray<SqlColumn> pooledArray = new(n);
       var newColumns = pooledArray.Array;
+      var newIndex = 0;
       foreach (var index in columnIndexes) {
         newColumns[newIndex++] = queryColumns[index];
       }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -338,7 +338,7 @@ namespace Xtensive.Orm.Providers
 
       var newIndex = 0;
       var n = columnIndexes.Count;
-      PooledArray<SqlColumn> pooledArray = new(n);
+      using PooledArray<SqlColumn> pooledArray = new(n);
       var newColumns = pooledArray.Array;
       foreach (var index in columnIndexes) {
         newColumns[newIndex++] = queryColumns[index];

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -335,7 +335,6 @@ namespace Xtensive.Orm.Providers
       var queryColumns = query.Columns;
       var columnIndexes = provider.ColumnIndexes;
 
-      var n = columnIndexes.Count;
       var newIndex = 0;
       var newColumns = new SqlColumn[columnIndexes.Count];
       foreach (var index in columnIndexes) {

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -4,7 +4,6 @@
 // Created by: Vakhtina Elena
 // Created:    2009.02.13
 
-using System.Buffers;
 using Xtensive.Collections;
 using Xtensive.Core;
 using Xtensive.Orm.Configuration;

--- a/Orm/Xtensive.Orm/Sql/Dml/Collections/SqlColumnCollection.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Collections/SqlColumnCollection.cs
@@ -36,6 +36,8 @@ namespace Xtensive.Sql.Dml
     public void Add(SqlExpression expression) =>
       base.Add(expression as SqlColumn ?? SqlDml.ColumnRef(SqlDml.Column(expression)));
 
+    public void Add(SqlColumn column) => base.Add(column);
+
     /// <summary>
     /// Builds a <see cref="SqlColumnRef"/> by the specified <paramref name="expression"/> and
     /// <paramref name="alias"/>; then adds it to the end of the <see cref="SqlColumnCollection"/>.

--- a/Orm/Xtensive.Orm/Sql/Dml/Collections/SqlColumnCollection.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Collections/SqlColumnCollection.cs
@@ -36,7 +36,7 @@ namespace Xtensive.Sql.Dml
     public void Add(SqlExpression expression) =>
       base.Add(expression as SqlColumn ?? SqlDml.ColumnRef(SqlDml.Column(expression)));
 
-    public void Add(SqlColumn column) => base.Add(column);
+    public new void Add(SqlColumn column) => base.Add(column);
 
     /// <summary>
     /// Builds a <see cref="SqlColumnRef"/> by the specified <paramref name="expression"/> and

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedFieldAccessor.cs
@@ -4,7 +4,6 @@
 // Created by: Denis Krjuchkov
 // Created:    2013.01.22
 
-using System;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using Xtensive.Sql;
@@ -38,16 +37,10 @@ namespace Xtensive.Tuples.Packed
     /// </summary>
     protected Delegate NullableSetter;
 
-    public readonly int Rank;
-    public readonly int ValueBitCount;
+    public readonly byte ValueBitCount;
     protected readonly long ValueBitMask;
     public readonly byte Index;
-
-    public bool IsObjectAccessor
-    {
-      [MethodImpl(MethodImplOptions.AggressiveInlining)]
-      get => Rank < 0;
-    }
+    public readonly bool IsObjectAccessor;
 
     public readonly CounterIncrementer CounterIncrementer;
     public readonly PositionUpdater PositionUpdater;
@@ -65,21 +58,18 @@ namespace Xtensive.Tuples.Packed
     public virtual void SetValue(PackedTuple tuple, PackedFieldDescriptor descriptor, MapperReader mr) =>
       throw new NotSupportedException($"{this} does not support reading from DbDataReader");
 
-    public T GetValue<T>(PackedTuple tuple, PackedFieldDescriptor descriptor, bool isNullable, out TupleFieldState fieldState)
+    public T GetValue<T>(PackedTuple tuple, PackedFieldDescriptor descriptor, out TupleFieldState fieldState)
     {
+      var isNullable = null == default(T); // Is nullable value type or class
       if ((isNullable ? NullableGetter : Getter) is GetValueDelegate<T> getter) {
         return getter.Invoke(tuple, descriptor, out fieldState);
       }
-      var targetType = typeof(T);
 
-      //Dirty hack of nullable enum reading
-      if (isNullable) {
-        targetType = Nullable.GetUnderlyingType(targetType) ?? targetType;
-      }
-      if (targetType.IsEnum) {
-        return (T) Enum.ToObject(targetType, GetUntypedValue(tuple, descriptor, out fieldState));
-      }
-      return (T) GetUntypedValue(tuple, descriptor, out fieldState);
+      var targetType = isNullable
+        ? Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T)    //Dirty hack of nullable enum reading
+        : typeof(T);
+      var untypedValue = GetUntypedValue(tuple, descriptor, out fieldState);
+      return (T) (targetType.IsEnum ? Enum.ToObject(targetType, untypedValue) : untypedValue);
     }
 
     public abstract object GetUntypedValue(PackedTuple tuple, PackedFieldDescriptor descriptor, out TupleFieldState fieldState);
@@ -103,13 +93,13 @@ namespace Xtensive.Tuples.Packed
 
     protected PackedFieldAccessor(int rank, byte index)
     {
-      Rank = rank;
       Index = index;
       if (All[Index] != null) {
         throw new IndexOutOfRangeException($"Duplicated Index {Index} of PackedFieldAccessor instance");
       }
       All[Index] = this;
-      ValueBitCount = 1 << Rank;
+      ValueBitCount = (byte)(1 << rank);
+      IsObjectAccessor = rank < 0;
 
       // What we want here is to shift 1L by ValueBitCount to left and then subtract 1
       // This gives us a mask. For example if bit count = 4 then
@@ -124,7 +114,7 @@ namespace Xtensive.Tuples.Packed
       // 1000_0000 << 1 = 0000_0000
       ValueBitMask = (1L << (ValueBitCount - 1) << 1) - 1;
 
-      CounterIncrementer = Rank switch {
+      CounterIncrementer = rank switch {
         0 => (ref Counters counters) => counters.Val001Counter++,
         3 => (ref Counters counters) => counters.Val008Counter++,
         4 => (ref Counters counters) => counters.Val016Counter++,
@@ -134,7 +124,7 @@ namespace Xtensive.Tuples.Packed
         _ => (ref Counters counters) => throw new NotSupportedException(),
       };
 
-      PositionUpdater = Rank switch {
+      PositionUpdater = rank switch {
         0 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val001Counter),
         3 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val008Counter),
         4 => (ref PackedFieldDescriptor descriptor, ref Counters counters) => UpdateDescriptorPosition(ref descriptor, ref counters.Val016Counter),
@@ -188,16 +178,10 @@ namespace Xtensive.Tuples.Packed
     { }
   }
 
-  internal abstract class ValueFieldAccessor : PackedFieldAccessor
+  internal abstract class ValueFieldAccessor(int bitCount, byte index)
+    : PackedFieldAccessor(BitOperations.Log2((uint)bitCount), index)
   {
     public Type FieldType { get; protected set; }
-
-    private static int GetRank(int bitSize) =>
-      BitOperations.Log2((uint)bitSize);
-
-    protected ValueFieldAccessor(int bitCount, byte index)
-      : base(GetRank(bitCount), index)
-    {}
   }
 
   internal abstract class ValueFieldAccessor<T> : ValueFieldAccessor

--- a/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
+++ b/Orm/Xtensive.Orm/Tuples/Packed/PackedTuple.cs
@@ -97,9 +97,8 @@ namespace Xtensive.Tuples.Packed
 
     public override T GetValue<T>(int fieldIndex, out TupleFieldState fieldState)
     {
-      var isNullable = null == default(T); // Is nullable value type or class
       var descriptor = PackedDescriptor.FieldDescriptors[fieldIndex];
-      return descriptor.Accessor.GetValue<T>(this, descriptor, isNullable, out fieldState);
+      return descriptor.Accessor.GetValue<T>(this, descriptor, out fieldState);
     }
 
     public override void SetValue(int fieldIndex, object fieldValue)


### PR DESCRIPTION
Remove `isNullable` parameter. It can be calculated at compile time and compile can apply some optimizations knowing it.

Also:
* Remove `PackedFieldAccessor.Rank` field as unused
* Change type of `PackedFieldAccessor.Index` to byte to reduce this class size
* Use `PooedArray` in `VisitSelect()`