### PR TITLE
Convert `ServiceRegistration` to readonly struct

### DIFF
--- a/Orm/Xtensive.Orm/IoC/ServiceRegistration.cs
+++ b/Orm/Xtensive.Orm/IoC/ServiceRegistration.cs
@@ -4,12 +4,9 @@
 // Created by: Dmitri Maximov
 // Created:    2009.10.12
 
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using Xtensive.Core;
 using Xtensive.Reflection;
-using ServiceRegistrationKey = System.ValueTuple<System.Type, bool>;
 
 namespace Xtensive.IoC
 {
@@ -19,10 +16,9 @@ namespace Xtensive.IoC
   /// Describes single service mapping entry for <see cref="ServiceContainer"/>.
   /// </summary>
   [Serializable]
-  public sealed class ServiceRegistration
+  public readonly struct ServiceRegistration
   {
-    private static readonly ConcurrentDictionary<ServiceRegistrationKey, Lazy<ServiceRegistration[]>> serviceRegistrationsByType =
-      new ConcurrentDictionary<ServiceRegistrationKey, Lazy<ServiceRegistration[]>>();
+    private static readonly ConcurrentDictionary<ServiceRegistrationKey, Lazy<ServiceRegistration[]>> serviceRegistrationsByType = new();
 
     private static readonly Func<ServiceRegistrationKey, Lazy<ServiceRegistration[]>> ServiceRegistrationsExtractor = ServiceRegistrationsExtractorImpl;
 
@@ -34,22 +30,22 @@ namespace Xtensive.IoC
     /// <summary>
     /// Gets the name of the service.
     /// </summary>
-    public string Name { get; private set; }
+    public string Name { get; }
 
     /// <summary>
     /// Gets the type it is mapped to.
     /// </summary>
-    public Type MappedType { get; private set; }
+    public Type MappedType { get; }
 
     /// <summary>
     /// Gets the instance it is mapped to.
     /// </summary>
-    public object MappedInstance { get; private set; }
+    public object MappedInstance { get; }
 
     /// <summary>
     /// Gets a value indicating whether this service is singleton.
     /// </summary>
-    public bool Singleton { get; private set; }
+    public bool Singleton { get; }
 
 
     // Static constructor-like methods

--- a/Orm/Xtensive.Orm/IoC/ServiceRegistration.cs
+++ b/Orm/Xtensive.Orm/IoC/ServiceRegistration.cs
@@ -18,9 +18,7 @@ namespace Xtensive.IoC
   [Serializable]
   public readonly struct ServiceRegistration
   {
-    private static readonly ConcurrentDictionary<ServiceRegistrationKey, Lazy<ServiceRegistration[]>> serviceRegistrationsByType = new();
-
-    private static readonly Func<ServiceRegistrationKey, Lazy<ServiceRegistration[]>> ServiceRegistrationsExtractor = ServiceRegistrationsExtractorImpl;
+    private static readonly ConcurrentDictionary<ServiceRegistrationKey, ServiceRegistration[]> serviceRegistrationsByType = new();
 
     /// <summary>
     /// Gets the type of the service.
@@ -74,26 +72,24 @@ namespace Xtensive.IoC
     /// An array of <see cref="ServiceRegistration"/> objects.
     /// </returns>
     public static ServiceRegistration[] CreateAll(Type type, bool defaultOnly) =>
-      serviceRegistrationsByType.GetOrAdd(new ServiceRegistrationKey(type, defaultOnly), ServiceRegistrationsExtractor).Value;
-
-    private static Lazy<ServiceRegistration[]> ServiceRegistrationsExtractorImpl(ServiceRegistrationKey key) =>
-      new Lazy<ServiceRegistration[]>(() => {
-        (var type, var defaultOnly) = key;
-        ArgumentNullException.ThrowIfNull(type);
-        if (type.IsAbstract) {
-          return Array.Empty<ServiceRegistration>();
-        }
-
-        var attributes = type.GetAttributes<ServiceAttribute>(AttributeSearchOptions.InheritNone);
-        var registrations = new List<ServiceRegistration>(attributes.Count);
-        foreach (var sa in attributes) {
-          if (!defaultOnly || sa.Default) {
-            registrations.Add(new ServiceRegistration(sa.Type, sa.Name.IsNullOrEmpty() ? null : sa.Name, type, sa.Singleton));
+      serviceRegistrationsByType.GetOrAdd(new ServiceRegistrationKey(type, defaultOnly),
+        static key => {
+          (var type, var defaultOnly) = key;
+          ArgumentNullException.ThrowIfNull(type);
+          if (type.IsAbstract) {
+            return Array.Empty<ServiceRegistration>();
           }
-        }
-        return registrations.ToArray();
-      });
 
+          var attributes = type.GetAttributes<ServiceAttribute>(AttributeSearchOptions.InheritNone);
+          var registrations = new List<ServiceRegistration>(attributes.Count);
+          foreach (var sa in attributes) {
+            if (!defaultOnly || sa.Default) {
+              registrations.Add(new ServiceRegistration(sa.Type, sa.Name.IsNullOrEmpty() ? null : sa.Name, type, sa.Singleton));
+            }
+          }
+
+          return registrations.ToArray();
+        });
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/IoC/ServiceRegistration.cs
+++ b/Orm/Xtensive.Orm/IoC/ServiceRegistration.cs
@@ -77,7 +77,7 @@ namespace Xtensive.IoC
           (var type, var defaultOnly) = key;
           ArgumentNullException.ThrowIfNull(type);
           if (type.IsAbstract) {
-            return Array.Empty<ServiceRegistration>();
+            return [];
           }
 
           var attributes = type.GetAttributes<ServiceAttribute>(AttributeSearchOptions.InheritNone);

--- a/Orm/Xtensive.Orm/IoC/ServiceRegistration.cs
+++ b/Orm/Xtensive.Orm/IoC/ServiceRegistration.cs
@@ -25,7 +25,7 @@ namespace Xtensive.IoC
     /// <summary>
     /// Gets the type of the service.
     /// </summary>
-    public Type Type { get; private set; }
+    public Type Type { get; }
 
     /// <summary>
     /// Gets the name of the service.


### PR DESCRIPTION
A few `ServiceRegistration` instances are created in the `Session` constructor.
We can reduce the GC work by making them structs.

Also:
* Remove unnecessary `Lazy<>` in `ServiceRegistration.CreateAll()` - that is static cache. Even if some `ServiceRegistration[]` was generated twice on of the copies will be garbage-collected.
* We are optimizing most frequent case: reading from the cache, and `Lazy` adds an "indirection overhead"