### PR TITLE
Optimize `ContainerNode.FlushBuffer()`

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Linq/CustomExpressionCompilers.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/CustomExpressionCompilers.cs
@@ -161,7 +161,7 @@ namespace Xtensive.Orm.Tests.Linq
         new Assignment() {Active = true, Start = new DateTime(2009, 11, 23), End = null};
         new Assignment() {Active = false, Start = new DateTime(2009, 10, 3), End = null};
         new Assignment() {Active = false, Start = new DateTime(2020, 01, 10), End = new DateTime(2044, 12, 3)};
-        new Assignment() {Active = true, Start = new DateTime(2026, 01, 10), End = new DateTime(2045, 11, 3)};
+        new Assignment() {Active = true, Start = new DateTime(2040, 01, 10), End = new DateTime(2045, 11, 3)};
         new Assignment() {Active = true, Start = new DateTime(2010, 01, 10), End = new DateTime(2035, 11, 3)};
 
         var currentCount = session.Query.All<Assignment>().Count(a => a.Current);

--- a/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/ContainerNode.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/ContainerNode.cs
@@ -2,11 +2,8 @@
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Text;
 using Xtensive.Sql.Model;
 

--- a/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/ContainerNode.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/ContainerNode.cs
@@ -167,7 +167,7 @@ namespace Xtensive.Sql.Compiler
         var s = stringBuilder.ToString();
         children.Add(TextNode.Create(s));
         lastNodeIsText = true;
-        lastChar = s[len-1];
+        lastChar = s[len - 1];
         _ = stringBuilder.Clear();
         lastCharIsPunctuation = false;
       }

--- a/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/ContainerNode.cs
+++ b/Orm/Xtensive.Orm/Sql/Compiler/Internals/Nodes/ContainerNode.cs
@@ -163,10 +163,11 @@ namespace Xtensive.Sql.Compiler
 
     internal void FlushBuffer()
     {
-      if (stringBuilder.Length > 0) {
-        children.Add(TextNode.Create(stringBuilder.ToString()));
+      if (stringBuilder.Length is > 0 and var len) {
+        var s = stringBuilder.ToString();
+        children.Add(TextNode.Create(s));
         lastNodeIsText = true;
-        lastChar = stringBuilder[^1];
+        lastChar = s[len-1];
         _ = stringBuilder.Clear();
         lastCharIsPunctuation = false;
       }


### PR DESCRIPTION
Indexing string is more efficient than indexing `StringBuffer`

Also:
* Fix current year-dependent test