### PR TITLE
Get rid of obsolete `.GetLeftJoin()` extension

### DIFF
--- a/Orm/Xtensive.Orm.Tests.FSharp/Xtensive.Orm.Tests.FSharp.fsproj
+++ b/Orm/Xtensive.Orm.Tests.FSharp/Xtensive.Orm.Tests.FSharp.fsproj
@@ -6,7 +6,7 @@
     <Configurations>Debug;Release;Debug-NET8;Release-NET8;Debug-NET10;Release-NET10</Configurations>
   </PropertyGroup>
   <PropertyGroup>
-    <LangVersion>4.7</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(OrmKeyFile)</AssemblyOriginatorKeyFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueGithub0114_QueryRootReuseCauseNoRefJoin.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueGithub0114_QueryRootReuseCauseNoRefJoin.cs
@@ -2389,7 +2389,7 @@ namespace Xtensive.Orm.Tests.Issues
           .Select(promo => new {
             promo,
             notifications = session.Query.All<Notification>()
-              .LeftJoin(session.Query.All<User>(), n => n.TriggeredBy.Id, u => u.Id, (n, u) => new { n, u })
+              .LeftOuterJoin(session.Query.All<User>(), n => n.TriggeredBy.Id, u => u.Id, (n, u) => new { n, u })
           })
           .Select(anon => new {
             contacted = anon.notifications.Select(c => c.n.Recipient.User.Id)
@@ -2401,9 +2401,9 @@ namespace Xtensive.Orm.Tests.Issues
           .Select(promo => new { promo })
           .Select(anon => new {
             contacted = session.Query.All<Notification>()
-                .LeftJoin(session.Query.All<User>(), n => n.TriggeredBy.Id, u => u.Id, (n, u) => new { n, u }).Select(c => c.n.Recipient.User.Id)
+                .LeftOuterJoin(session.Query.All<User>(), n => n.TriggeredBy.Id, u => u.Id, (n, u) => new { n, u }).Select(c => c.n.Recipient.User.Id)
               .Concat(session.Query.All<Notification>()
-                .LeftJoin(session.Query.All<User>(), n => n.TriggeredBy.Id, u => u.Id, (n, u) => new { n, u }).Select(c => c.n.Recipient.User.Id)),
+                .LeftOuterJoin(session.Query.All<User>(), n => n.TriggeredBy.Id, u => u.Id, (n, u) => new { n, u }).Select(c => c.n.Recipient.User.Id)),
             promo = anon.promo
           }).ToArray();
 

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueGithub0171_ReadDateTimeOffsetFromPackedTuple.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueGithub0171_ReadDateTimeOffsetFromPackedTuple.cs
@@ -78,7 +78,7 @@ namespace Xtensive.Orm.Tests.Issues
         var loadWithCargo = new CargoLoad(session, cargo);
 
         var query = session.Query.All<CargoLoad>()
-          .LeftJoin(session.Query.All<Cargo>(),
+          .LeftOuterJoin(session.Query.All<Cargo>(),
             cl => cl.Cargo,
             c => c,
             (cl, c) => new { CargoLoad = cl, Cargo = c })
@@ -102,7 +102,7 @@ namespace Xtensive.Orm.Tests.Issues
         var loadWithCargo = new CargoLoad(session, cargo);
 
         var query = session.Query.All<CargoLoad>()
-          .LeftJoin(session.Query.All<Cargo>(),
+          .LeftOuterJoin(session.Query.All<Cargo>(),
             cl => cl.Cargo,
             c => c,
             (cl, c) => new { CargoLoad = cl, Cargo = c })

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0553_IncorrectLeftJoinOnNotNullEntityField.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0553_IncorrectLeftJoinOnNotNullEntityField.cs
@@ -136,7 +136,7 @@ namespace Xtensive.Orm.Tests.Issues
       using (var session = Domain.OpenSession())
       using (var t = session.OpenTransaction()) {
         var badResult = session.Query.All<Employee>()
-          .LeftJoin(
+          .LeftOuterJoin(
             session.Query.All<EmployeeWithCar>(),
             e => e.Id,
             ewc => ewc.Id,
@@ -155,7 +155,7 @@ namespace Xtensive.Orm.Tests.Issues
       using (var session = Domain.OpenSession())
       using (var transaction = session.OpenTransaction()) {
         var goodResult = session.Query.All<Employee>()
-          .LeftJoin(
+          .LeftOuterJoin(
             session.Query.All<EmployeeWithCar>(),
             e => e.Id,
             ewc => ewc.Id,
@@ -173,7 +173,7 @@ namespace Xtensive.Orm.Tests.Issues
       using (var session = Domain.OpenSession())
       using (var transaction = session.OpenTransaction()) {
         var wordaround = session.Query.All<Employee>()
-          .LeftJoin(
+          .LeftOuterJoin(
             session.Query.All<EmployeeWithCar>(),
               e => e.Id,
               ewc => ewc.Id,
@@ -181,7 +181,7 @@ namespace Xtensive.Orm.Tests.Issues
                 e.Id,
                 CarId = ewc.Car.Id
               })
-          .LeftJoin(
+          .LeftOuterJoin(
             session.Query.All<Car>(),
             e => e.CarId,
             c => c.Id,

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0584_IncorrectMappingOfColumnInQuery.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0584_IncorrectMappingOfColumnInQuery.cs
@@ -526,8 +526,8 @@ namespace Xtensive.Orm.Tests.Issues
 
         var usefulColumns = masterCredit.Union(masterDebit);
         var readyForFilterQuery = from joinResult in usefulColumns
-          .LeftJoin(priceCalculation, a => a.SlaveAccount, a => a.Account, (pp, ps) => new {pp, ps})
-          .LeftJoin(priceCalculation, a => a.pp.MasterAccount, a => a.Account, (a, pm) => new {a.pp, a.ps, pm})
+          .LeftOuterJoin(priceCalculation, a => a.SlaveAccount, a => a.Account, (pp, ps) => new {pp, ps})
+          .LeftOuterJoin(priceCalculation, a => a.pp.MasterAccount, a => a.Account, (a, pm) => new {a.pp, a.ps, pm})
           let item = joinResult.pp
           select new CustomPosting() {
             Id = item.Id,
@@ -609,8 +609,8 @@ namespace Xtensive.Orm.Tests.Issues
 
         var usefulColumns = masterCredit.Union(masterDebit);
         var readyForFilterQuery = from joinResult in usefulColumns
-          .LeftJoin(priceCalculation, a => a.SlaveAccount, a => a.Account, (pp, ps) => new {pp, ps})
-          .LeftJoin(priceCalculation, a => a.pp.MasterAccount, a => a.Account, (a, pm) => new {a.pp, a.ps, pm})
+          .LeftOuterJoin(priceCalculation, a => a.SlaveAccount, a => a.Account, (pp, ps) => new {pp, ps})
+          .LeftOuterJoin(priceCalculation, a => a.pp.MasterAccount, a => a.Account, (a, pm) => new {a.pp, a.ps, pm})
           let item = joinResult.pp
           select new CustomPosting {
             Id = item.Id,
@@ -692,8 +692,8 @@ namespace Xtensive.Orm.Tests.Issues
 
         var usefulColumns = masterCredit.Union(masterDebit);
         var readyForFilterQuery = from joinResult in usefulColumns
-          .LeftJoin(priceCalculation, a => a.SlaveAccount, a => a.Account, (pp, ps) => new {pp, ps})
-          .LeftJoin(priceCalculation, a => a.pp.MasterAccount, a => a.Account, (a, pm) => new {a.pp, a.ps, pm})
+          .LeftOuterJoin(priceCalculation, a => a.SlaveAccount, a => a.Account, (pp, ps) => new {pp, ps})
+          .LeftOuterJoin(priceCalculation, a => a.pp.MasterAccount, a => a.Account, (a, pm) => new {a.pp, a.ps, pm})
           let item = joinResult.pp
           select new CustomPosting {
             Id = item.Id,
@@ -776,8 +776,8 @@ namespace Xtensive.Orm.Tests.Issues
 
         var usefulColumns = masterCredit.Union(masterDebit);
         var readyForFilterQuery = from joinResult in usefulColumns
-          .LeftJoin(priceCalculation, a => a.SlaveAccount, a => a.Account, (pp, ps) => new {pp, ps})
-          .LeftJoin(priceCalculation, a => a.pp.MasterAccount, a => a.Account, (a, pm) => new {a.pp, a.ps, pm})
+          .LeftOuterJoin(priceCalculation, a => a.SlaveAccount, a => a.Account, (pp, ps) => new {pp, ps})
+          .LeftOuterJoin(priceCalculation, a => a.pp.MasterAccount, a => a.Account, (a, pm) => new {a.pp, a.ps, pm})
           let item = joinResult.pp
           select new CustomPosting {
             Id = item.Id,
@@ -859,8 +859,8 @@ namespace Xtensive.Orm.Tests.Issues
 
         var usefulColumns = masterCredit.Union(masterDebit);
         var readyForFilterQuery = from joinResult in usefulColumns
-          .LeftJoin(priceCalculation, a => a.SlaveAccount, a => a.Account, (pp, ps) => new {pp, ps})
-          .LeftJoin(priceCalculation, a => a.pp.MasterAccount, a => a.Account, (a, pm) => new {a.pp, a.ps, pm})
+          .LeftOuterJoin(priceCalculation, a => a.SlaveAccount, a => a.Account, (pp, ps) => new {pp, ps})
+          .LeftOuterJoin(priceCalculation, a => a.pp.MasterAccount, a => a.Account, (a, pm) => new {a.pp, a.ps, pm})
           let item = joinResult.pp
           select new CustomPosting {
             Id = item.Id,
@@ -1029,7 +1029,7 @@ namespace Xtensive.Orm.Tests.Issues
         var result =
           from r in
             preResult.Join(tp.Distinct(), a => a.MasterAccount, a => a.Account, (a, pm) => new {pp = a, pm})
-              .LeftJoin(Query.All<TablePartBase.FinToolKind>(), a => a.pm.FinToolKind, a => a.Id, (a, b) => new {pp = a.pp, pm = a.pm, fk = b})
+              .LeftOuterJoin(Query.All<TablePartBase.FinToolKind>(), a => a.pm.FinToolKind, a => a.Id, (a, b) => new {pp = a.pp, pm = a.pm, fk = b})
           let q = r.pp
           select
             new {

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0586_AnonymousTypeComparisonBug.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0586_AnonymousTypeComparisonBug.cs
@@ -108,7 +108,7 @@ namespace Xtensive.Orm.Tests.Issues
 
         var masterCredit = Query.All<PacioliPosting>();
 
-        var join = from r in masterCredit.LeftJoin(
+        var join = from r in masterCredit.LeftOuterJoin(
           tableParts,
           a => a.CreditAccount.Id,
           a => a.Account.Id,

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0617_IncorrectRemoveOfRedundantColumns.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0617_IncorrectRemoveOfRedundantColumns.cs
@@ -68,8 +68,8 @@ namespace Xtensive.Orm.Tests.Issues
 
         var usefulColumns = masterCredit.Union(masterDebit);
         var readyForFilterQuery = from joinResult in usefulColumns
-          .LeftJoin(priceCalculation, a => a.SlaveAccount, a => a.Account, (pp, ps) => new {pp, ps})
-          .LeftJoin(priceCalculation, a => a.pp.MasterAccount, a => a.Account, (a, pm) => new {a.pp, a.ps, pm})
+          .LeftOuterJoin(priceCalculation, a => a.SlaveAccount, a => a.Account, (pp, ps) => new {pp, ps})
+          .LeftOuterJoin(priceCalculation, a => a.pp.MasterAccount, a => a.Account, (a, pm) => new {a.pp, a.ps, pm})
           let item = joinResult.pp
           select new CustomPosting() {
             Id = item.Id,
@@ -149,8 +149,8 @@ namespace Xtensive.Orm.Tests.Issues
 
         var usefulColumns = masterCredit.Union(masterDebit);
         var readyForFilterQuery = from joinResult in usefulColumns
-          .LeftJoin(priceCalculation, a => a.SlaveAccount, a => a.Account, (pp, ps) => new {pp, ps})
-          .LeftJoin(priceCalculation, a => a.pp.MasterAccount, a => a.Account, (a, pm) => new {a.pp, a.ps, pm})
+          .LeftOuterJoin(priceCalculation, a => a.SlaveAccount, a => a.Account, (pp, ps) => new {pp, ps})
+          .LeftOuterJoin(priceCalculation, a => a.pp.MasterAccount, a => a.Account, (a, pm) => new {a.pp, a.ps, pm})
           let item = joinResult.pp
           select new CustomPosting {
             Id = item.Id,
@@ -230,8 +230,8 @@ namespace Xtensive.Orm.Tests.Issues
 
         var usefulColumns = masterCredit.Union(masterDebit);
         var readyForFilterQuery = from joinResult in usefulColumns
-          .LeftJoin(priceCalculation, a => a.SlaveAccount, a => a.Account, (pp, ps) => new {pp, ps})
-          .LeftJoin(priceCalculation, a => a.pp.MasterAccount, a => a.Account, (a, pm) => new {a.pp, a.ps, pm})
+          .LeftOuterJoin(priceCalculation, a => a.SlaveAccount, a => a.Account, (pp, ps) => new {pp, ps})
+          .LeftOuterJoin(priceCalculation, a => a.pp.MasterAccount, a => a.Account, (a, pm) => new {a.pp, a.ps, pm})
           let item = joinResult.pp
           select new CustomPosting {
             Id = item.Id,
@@ -312,8 +312,8 @@ namespace Xtensive.Orm.Tests.Issues
 
         var usefulColumns = masterCredit.Union(masterDebit);
         var readyForFilterQuery = from joinResult in usefulColumns
-          .LeftJoin(priceCalculation, a => a.SlaveAccount, a => a.Account, (pp, ps) => new {pp, ps})
-          .LeftJoin(priceCalculation, a => a.pp.MasterAccount, a => a.Account, (a, pm) => new {a.pp, a.ps, pm})
+          .LeftOuterJoin(priceCalculation, a => a.SlaveAccount, a => a.Account, (pp, ps) => new {pp, ps})
+          .LeftOuterJoin(priceCalculation, a => a.pp.MasterAccount, a => a.Account, (a, pm) => new {a.pp, a.ps, pm})
           let item = joinResult.pp
           select new CustomPosting {
             Id = item.Id,
@@ -393,8 +393,8 @@ namespace Xtensive.Orm.Tests.Issues
 
         var usefulColumns = masterCredit.Union(masterDebit);
         var readyForFilterQuery = from joinResult in usefulColumns
-          .LeftJoin(priceCalculation, a => a.SlaveAccount, a => a.Account, (pp, ps) => new {pp, ps})
-          .LeftJoin(priceCalculation, a => a.pp.MasterAccount, a => a.Account, (a, pm) => new {a.pp, a.ps, pm})
+          .LeftOuterJoin(priceCalculation, a => a.SlaveAccount, a => a.Account, (pp, ps) => new {pp, ps})
+          .LeftOuterJoin(priceCalculation, a => a.pp.MasterAccount, a => a.Account, (a, pm) => new {a.pp, a.ps, pm})
           let item = joinResult.pp
           select new CustomPosting {
             Id = item.Id,
@@ -562,7 +562,7 @@ namespace Xtensive.Orm.Tests.Issues
         var result =
           from r in
             preResult.Join(tp.Distinct(), a => a.MasterAccount, a => a.Account, (a, pm) => new {pp = a, pm})
-              .LeftJoin(Query.All<TablePartBase.FinToolKind>(), a => a.pm.FinToolKind, a => a.Id, (a, b) => new {pp = a.pp, pm = a.pm, fk = b})
+              .LeftOuterJoin(Query.All<TablePartBase.FinToolKind>(), a => a.pm.FinToolKind, a => a.Id, (a, b) => new {pp = a.pp, pm = a.pm, fk = b})
           let q = r.pp
           select
             new {

--- a/Orm/Xtensive.Orm.Tests/Issues/IssueJira0803_ReuseOfJoiningExpressionCausesWrongTranslation.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueJira0803_ReuseOfJoiningExpressionCausesWrongTranslation.cs
@@ -66,7 +66,7 @@ namespace Xtensive.Orm.Tests.Issues
       using (var tx = session.OpenTransaction()) {
 
         var leftJoinWithExpression = session.Query.All<TestEntity>()
-          .LeftJoin(session.Query.All<TestEntity>().Where(it => it.Description == null),
+          .LeftOuterJoin(session.Query.All<TestEntity>().Where(it => it.Description == null),
             o => o.Id,
             key,
             (o, i) => o)
@@ -78,7 +78,7 @@ namespace Xtensive.Orm.Tests.Issues
         Assert.That(leftJoinWithExpression.Count, Is.EqualTo(3));
 
         leftJoinWithExpression = session.Query.All<TestEntity>()
-          .LeftJoin(session.Query.All<TestEntity>().Where(it => it.Description == null),
+          .LeftOuterJoin(session.Query.All<TestEntity>().Where(it => it.Description == null),
             key,
             i => i.Id,
             (o, i) => o)
@@ -101,7 +101,7 @@ namespace Xtensive.Orm.Tests.Issues
 
         var ex = Assert.Throws<QueryTranslationException>(() =>
           _ = session.Query.All<TestEntity>()
-          .LeftJoin(session.Query.All<TestEntity>().Where(it => it.Description == null),
+          .LeftOuterJoin(session.Query.All<TestEntity>().Where(it => it.Description == null),
             key,
             key,
             (o, i) => o)

--- a/Orm/Xtensive.Orm.Tests/Linq/DynamicallyDefinedFields.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/DynamicallyDefinedFields.cs
@@ -1265,7 +1265,7 @@ namespace Xtensive.Orm.Tests.Linq
       using (session.Activate())
       using (var transction = session.OpenTransaction()) {
         Assert.DoesNotThrow(() => {
-          session.Query.All<Area>().LeftJoin(session.Query.All<Group>(), area => (Group)area[testData.GroupFieldName],
+          session.Query.All<Area>().LeftOuterJoin(session.Query.All<Group>(), area => (Group)area[testData.GroupFieldName],
             group => group, (area, @group) => new { Area = area, Group = group });
         });
       }

--- a/Orm/Xtensive.Orm.Tests/Linq/InTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/InTest.cs
@@ -76,7 +76,7 @@ namespace Xtensive.Orm.Tests.Linq
     public void MartinTest()
     {
       _ = Session.Query.All<Customer>()
-        .LeftJoin(Session.Query.All<Invoice>(), c => c, i => i.Customer, (c, i) => new { Customer = c, Invoice = i })
+        .LeftOuterJoin(Session.Query.All<Invoice>(), c => c, i => i.Customer, (c, i) => new { Customer = c, Invoice = i })
         .GroupBy(i => new { i.Customer.FirstName, i.Customer.LastName })
         .Select(g => new { Key = g.Key, Count = g.Count(j => j.Invoice != null) })
         .ToList();

--- a/Orm/Xtensive.Orm.Tests/Linq/JoinTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/JoinTest.cs
@@ -143,7 +143,7 @@ namespace Xtensive.Orm.Tests.Linq
     {
       var traclCount = Session.Query.All<Track>().Count();
       var result = Session.Query.All<Track>()
-        .LeftJoin(Session.Query.All<Album>(),
+        .LeftOuterJoin(Session.Query.All<Album>(),
           track => track.Album.AlbumId,
           album => album.AlbumId,
           (track, album) => new {track.Name, album.Title, album.AlbumId});
@@ -159,7 +159,7 @@ namespace Xtensive.Orm.Tests.Linq
       Session.Current.SaveChanges();
       var tracks = Session.Query.All<Track>();
       var albums = Session.Query.All<Album>();
-      var result = tracks.LeftJoin(
+      var result = tracks.LeftOuterJoin(
         albums,
         track => track.Album,
         album => album,
@@ -179,7 +179,7 @@ namespace Xtensive.Orm.Tests.Linq
       Session.Current.SaveChanges();
       var tracks = Session.Query.All<Track>();
       var albums = Session.Query.All<Album>();
-      var result = tracks.LeftJoin(
+      var result = tracks.LeftOuterJoin(
         albums,
         track => track.Album.AlbumId,
         album => album.AlbumId,

--- a/Orm/Xtensive.Orm.Tests/Linq/TagTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/TagTest.cs
@@ -331,7 +331,7 @@ namespace Xtensive.Orm.Tests.Linq
         var inner = session.Query.All<BusinessUnit>().Tag("inner");
         var outer = session.Query.All<Property>().Tag("outer");
 
-        var query = outer.LeftJoin(inner, o => o.Owner.Id, i => i.Id, (i, o) => new { i, o });
+        var query = outer.LeftOuterJoin(inner, o => o.Owner.Id, i => i.Id, (i, o) => new { i, o });
 
         var queryFormatter = session.Services.Demand<QueryFormatter>();
         var queryString = queryFormatter.ToSqlString(query);
@@ -589,7 +589,7 @@ namespace Xtensive.Orm.Tests.Linq
           .Tag("AfterSelect")
           .Where(g => g.Items.Count() >= 0)
           .Tag("AfterWhere")
-          .LeftJoin(session.Query.All<BusinessUnit>().Tag("WithinJoin"), g => g.Key, bu => bu.Id, (g, bu) => new { Key = bu, Items = g.Items });
+          .LeftOuterJoin(session.Query.All<BusinessUnit>().Tag("WithinJoin"), g => g.Key, bu => bu.Id, (g, bu) => new { Key = bu, Items = g.Items });
 
         using (var tagScope = session.Tag("sessionTag6")) {
           session.Events.DbCommandExecuting += SqlCapturer;

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -516,7 +516,7 @@ namespace Xtensive.Orm.Linq
         // Visit Queryable extensions.
         if (methodDeclaringType == typeof(QueryableExtensions)) {
           return methodName switch {
-            Reflection.WellKnown.QueryableExtensions.LeftJoin => VisitLeftJoin(mc),
+            Reflection.WellKnown.QueryableExtensions.LeftOuterJoin => VisitLeftJoin(mc),
             Reflection.WellKnown.QueryableExtensions.In => VisitIn(mc),
             Reflection.WellKnown.QueryableExtensions.Lock => VisitLock(mc),
             Reflection.WellKnown.QueryableExtensions.Take => VisitTake(mc.Arguments[0], mc.Arguments[1]),

--- a/Orm/Xtensive.Orm/Orm/Linq/WellknownMembers.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/WellknownMembers.Queryable.cs
@@ -122,7 +122,7 @@ namespace Xtensive.Orm.Linq
 
       // Queryable extensions
       public static readonly MethodInfo ExtensionCount = GetQueryableExtensionsMethod(nameof(QueryableExtensions.Count), 0, 1);
-      public static readonly MethodInfo ExtensionLeftJoin = GetQueryableExtensionsMethod(nameof(QueryableExtensions.LeftJoin), 4, 5);
+      public static readonly MethodInfo ExtensionLeftJoin = GetQueryableExtensionsMethod(nameof(QueryableExtensions.LeftOuterJoin), 4, 5);
       public static readonly MethodInfo ExtensionLock = GetQueryableExtensionsMethod(nameof(QueryableExtensions.Lock), 1, 3);
       public static readonly MethodInfo ExtensionTake = GetQueryableExtensionsMethod(nameof(QueryableExtensions.Take), 1, 2);
       public static readonly MethodInfo ExtensionSkip = GetQueryableExtensionsMethod(nameof(QueryableExtensions.Skip), 1, 2);

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
@@ -313,10 +313,6 @@ namespace Xtensive.Orm
       values == null ? false : values.Contains(source);
 #pragma warning restore IDE0060 // Remove unused parameter
 
-    [Obsolete("Use '.LeftOuterJoin()' extension instead.")]
-    public static IQueryable<TResult> LeftJoin<TOuter, TInner, TKey, TResult>(this IQueryable<TOuter> outer, IEnumerable<TInner> inner, Expression<Func<TOuter, TKey>> outerKeySelector, Expression<Func<TInner, TKey>> innerKeySelector, Expression<Func<TOuter, TInner, TResult>> resultSelector) =>
-      LeftOuterJoin(outer, inner, outerKeySelector, innerKeySelector, resultSelector);
-
     /// <summary>
     /// Correlates the elements of two sequences based on matching keys.
     /// </summary>

--- a/Orm/Xtensive.Orm/Reflection/WellKnown.QueryableExtensions.cs
+++ b/Orm/Xtensive.Orm/Reflection/WellKnown.QueryableExtensions.cs
@@ -12,7 +12,7 @@ namespace Xtensive.Reflection
     public static class QueryableExtensions
     {
       public const string Count = nameof(Orm.QueryableExtensions.Count);
-      public const string LeftJoin = nameof(Orm.QueryableExtensions.LeftJoin);
+      public const string LeftOuterJoin = nameof(Orm.QueryableExtensions.LeftOuterJoin);
       public const string Lock = nameof(Orm.QueryableExtensions.Lock);
       public const string Take = nameof(Orm.QueryableExtensions.Take);
       public const string Skip = nameof(Orm.QueryableExtensions.Skip);


### PR DESCRIPTION
To avoid ambiguity with LINQ `.LeftJoin()` in .NET10