### PR TITLE
Optimize `StorageDriver.Compile()`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.cs
@@ -4,13 +4,8 @@
 // Created by: Denis Krjuchkov
 // Created:    2009.08.14
 
-using System;
-using System.Collections.Generic;
 using System.Data.Common;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Reflection;
 using Xtensive.Core;
 using Xtensive.Linq;
@@ -43,6 +38,7 @@ namespace Xtensive.Orm.Providers
     private readonly TypeMappingRegistry allMappings;
     private readonly bool isLoggingEnabled;
     private readonly bool hasSavepoints;
+    private readonly SqlCompilerConfiguration options;
 
     private readonly IReadOnlyDictionary<Type, Func<IDbConnectionAccessor>> connectionAccessorFactories;
 
@@ -83,15 +79,7 @@ namespace Xtensive.Orm.Providers
       return result;
     }
 
-    public SqlCompilationResult Compile(ISqlCompileUnit statement)
-    {
-      var options = new SqlCompilerConfiguration {
-        DatabaseQualifiedObjects = configuration.IsMultidatabase,
-        ParametrizeSchemaNames = configuration.ShareQueryCacheOverNodes,
-        CommentLocation = configuration.TagsLocation.ToCommentLocation(),
-      };
-      return underlyingDriver.Compile(statement, options);
-    }
+    public SqlCompilationResult Compile(ISqlCompileUnit statement) => underlyingDriver.Compile(statement, options);
 
     public DbDataReaderAccessor GetDataReaderAccessor(in TupleDescriptor descriptor)
     {
@@ -274,6 +262,13 @@ namespace Xtensive.Orm.Providers
       isLoggingEnabled = SqlLog.IsLogged(LogLevel.Info); // Just to cache this value
       ServerInfo = underlyingDriver.ServerInfo;
       connectionAccessorFactories = factoryCache;
+
+      options = new SqlCompilerConfiguration {
+        DatabaseQualifiedObjects = configuration.IsMultidatabase,
+        ParametrizeSchemaNames = configuration.ShareQueryCacheOverNodes,
+        CommentLocation = configuration.TagsLocation.ToCommentLocation(),
+      };
+      underlyingDriver.ValidateCompilerConfiguration(options);
     }
   }
 }

--- a/Orm/Xtensive.Orm/Sql/SqlDriver.cs
+++ b/Orm/Xtensive.Orm/Sql/SqlDriver.cs
@@ -2,11 +2,6 @@
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Xtensive.Core;
 using Xtensive.Orm;
 using Xtensive.Orm.Model;
@@ -72,11 +67,8 @@ namespace Xtensive.Sql
     /// <param name="configuration">The options of compilation.</param>
     /// <param name="typeIdRegistry">TypeId registry.</param>
     /// <returns>Result of compilation.</returns>
-    public SqlCompilationResult Compile(ISqlCompileUnit statement, in SqlCompilerConfiguration configuration, TypeIdRegistry typeIdRegistry = null)
-    {
-      ValidateCompilerConfiguration(configuration);
-      return CreateCompiler().Compile(statement, configuration);
-    }
+    public SqlCompilationResult Compile(ISqlCompileUnit statement, in SqlCompilerConfiguration configuration, TypeIdRegistry typeIdRegistry = null) =>
+      CreateCompiler().Compile(statement, configuration);
 
     /// <summary>
     /// Gets <see cref="DefaultSchemaInfo"/> for the specified <paramref name="connection"/>.
@@ -469,7 +461,7 @@ namespace Xtensive.Sql
       return extractor;
     }
 
-    private void ValidateCompilerConfiguration(in SqlCompilerConfiguration configuration)
+    internal void ValidateCompilerConfiguration(in SqlCompilerConfiguration configuration)
     {
       var supported = ServerInfo.Query.Features.Supports(QueryFeatures.MultidatabaseQueries);
       var requested = configuration.DatabaseQualifiedObjects;


### PR DESCRIPTION
Don't invoke `ValidateCompilerConfiguration(options)` on every `.Compile()` invocation, because the `options` are the same.
Validate them once in the `StorageDriver` constructor.
Assume the `DomainConfiguration` does not change at run time


