### PR TITLE
Optimize `HashCodeCalculator` operations

### DIFF
--- a/Orm/Xtensive.Orm/Linq/Internals/ExpressionHashCodeCalculator.cs
+++ b/Orm/Xtensive.Orm/Linq/Internals/ExpressionHashCodeCalculator.cs
@@ -101,11 +101,12 @@ namespace Xtensive.Linq
 
     #region Private / internal methods
 
-    private int HashExpressionSequence(IEnumerable<Expression> expressions)
+    private int HashExpressionSequence(IReadOnlyList<Expression> expressions)
     {
       HashCode hashCode = new();
-      foreach (var e in expressions)
-        hashCode.Add(Visit(e));
+      for (int i = 0, n = expressions.Count; i < n; ++i) {
+        hashCode.Add(Visit(expressions[i]));
+      }
       return hashCode.ToHashCode();
     }
 

--- a/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlConcat.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/Expressions/SqlConcat.cs
@@ -20,9 +20,10 @@ namespace Xtensive.Sql.Dml
         return (SqlConcat)value;
       }
 
-      var expressionsClone = new List<SqlExpression>(expressions.Count);
+      var expressionsClone = new SqlExpression[expressions.Count];
+      int i = 0;
       foreach (var e in expressions)
-        expressionsClone.Add(e.Clone(context));
+        expressionsClone[i++] = e.Clone(context);
 
       var clone = new SqlConcat(expressionsClone);
       return clone;


### PR DESCRIPTION
Use `IReadOnlyList.Count`  to avoid allocating Enumerator

I see this place in  stack traces:
```
00007FC8176120D0 00007FD78E87CDEF System.Dynamic.Utils.ListProvider`1[[System.__Canon, System.Private.CoreLib]].GetEnumerator()
00007FC817612100 00007FD79FE2CB8A Xtensive.Linq.ExpressionHashCodeCalculator.HashExpressionSequence(System.Collections.Generic.IEnumerable`1<System.Linq.Expressions.Expression>)
```