### PR TITLE
Optimize `VisitSetOperations()`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/ItemProjectorExpression.cs
@@ -42,7 +42,7 @@ namespace Xtensive.Orm.Linq.Expressions
       }
     }
 
-    public IReadOnlyList<ColNum> GetColumns(ColumnExtractionModes columnExtractionModes) =>
+    public ColNum[] GetColumns(ColumnExtractionModes columnExtractionModes) =>
       ColumnGatherer.GetColumns(Item, columnExtractionModes);
 
     public IReadOnlyList<(ColNum, Expression)> GetColumnsAndExpressions(ColumnExtractionModes columnExtractionModes) =>

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ColumnGatherer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/ColumnGatherer.cs
@@ -57,7 +57,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
       return ordered.ToArray();
     }
     
-    public static IReadOnlyList<ColNum> GetColumns(Expression expression, ColumnExtractionModes columnExtractionModes)
+    public static ColNum[] GetColumns(Expression expression, ColumnExtractionModes columnExtractionModes)
     {
       var gatherer = new ColumnGatherer(columnExtractionModes);
       gatherer.Visit(expression);

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Materialization.cs
@@ -86,7 +86,7 @@ namespace Xtensive.Orm.Linq
     {
       var originProvider = origin.ItemProjector.DataSource;
 
-      var usedColumns = origin.ItemProjector
+      IReadOnlyList<ColNum> usedColumns = origin.ItemProjector
         .GetColumns(ColumnExtractionModes.KeepSegment | ColumnExtractionModes.KeepTypeId | ColumnExtractionModes.OmitLazyLoad);
 
       if (usedColumns.Count == 0)

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -1637,21 +1637,11 @@ namespace Xtensive.Orm.Linq
 
       var outerItemProjector = outer.ItemProjector.RemoveOwner();
       var innerItemProjector = inner.ItemProjector.RemoveOwner();
-      var outerColumnList = outerItemProjector.GetColumns(ColumnExtractionModes.Distinct);
-      var innerColumnList = innerItemProjector.GetColumns(ColumnExtractionModes.Distinct);
-      ColNum[] outerColumns, innerColumns;
-      if (!outerColumnList.Except(innerColumnList).Any() && outerColumnList.Count == innerColumnList.Count) {
-        var outerColumnListCopy = outerColumnList.ToArray();
-        Array.Sort(outerColumnListCopy);
-        outerColumns = outerColumnListCopy;
-
-        var innerColumnListCopy = innerColumnList.ToArray();
-        Array.Sort(innerColumnListCopy);
-        innerColumns = innerColumnListCopy;
-      }
-      else {
-        outerColumns = outerColumnList.ToArray();
-        innerColumns = innerColumnList.ToArray();
+      var outerColumns = outerItemProjector.GetColumns(ColumnExtractionModes.Distinct);
+      var innerColumns = innerItemProjector.GetColumns(ColumnExtractionModes.Distinct);
+      if (outerColumns.ToHashSet().SetEquals(innerColumns)) {
+        Array.Sort(outerColumns);
+        Array.Sort(innerColumns);
       }
 
       var outerRecordSet = ShouldWrapDataSourceWithSelect(outerItemProjector, outerColumns)


### PR DESCRIPTION
Avoid redundant `.ToArray()` conversions
`.GetColumns()` always returns a fresh allocated array instance.

Also simplify set comparison: Use standard LINQ `.SetEquals()`  extension