### PR TITLE
Optimization: Avoid iterators

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Building/Builders/DatabaseDependencyBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Building/Builders/DatabaseDependencyBuilder.cs
@@ -136,9 +136,8 @@ namespace Xtensive.Orm.Building.Builders
 
     private void Visit(string database)
     {
-      if (visited.Contains(database))
+      if (!visited.Add(database))
         return;
-      visited.Add(database);
       var references = referenceRegistry.Keys
         .Where(r => r.OwnerDatabase==database);
       foreach (var reference in references) {

--- a/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/IncludeFilterMappingGatherer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Expressions/Visitors/IncludeFilterMappingGatherer.cs
@@ -40,7 +40,7 @@ namespace Xtensive.Orm.Linq.Expressions.Visitors
     {    
       var visitor = new IncludeFilterMappingGatherer(filterDataTuple, filteredTuple, mapping);
       _ = visitor.Visit(filterExpression);
-      if (mapping.Contains(null))
+      if (mapping.IndexOf(null) >= 0)
         throw Exceptions.InternalError("Failed to gather mappings for IncludeProvider", OrmLog.Instance);
     }
 


### PR DESCRIPTION
`.IndexOf()` is faster for `ArraySegment<>`

Also:
* Avoid redundant `.Contains()`