### PR TITLE
Optimize Async enumeration

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Queryable.cs
@@ -41,7 +41,7 @@ namespace Xtensive.Orm.Linq
     /// <inheritdoc/>
     public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
     {
-      var result = (await provider.ExecuteSequenceAsync<T>(expression, cancellationToken).ConfigureAwaitFalse());
+      var result = await provider.ExecuteSequenceAsync<T>(expression, cancellationToken).ConfigureAwaitFalse();
       await using var enumerator = result.GetAsyncEnumerator();
       while (await enumerator.MoveNextAsync()) {
         cancellationToken.ThrowIfCancellationRequested();

--- a/Orm/Xtensive.Orm/Orm/Linq/Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Queryable.cs
@@ -69,7 +69,7 @@ namespace Xtensive.Orm.Linq
     internal Queryable(QueryProvider provider, QueryEndpoint.ExpressionOfTypeQueryable<T> expression)
     {
       this.provider = provider;
-      this.expression = expression.Expression;
+      this.expression = expression.Value;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Queryable.cs
@@ -4,13 +4,8 @@
 // Created by: Alexis Kochetov
 // Created:    2009.07.01
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Threading;
-using System.Threading.Tasks;
 using Xtensive.Core;
 
 namespace Xtensive.Orm.Linq
@@ -46,10 +41,11 @@ namespace Xtensive.Orm.Linq
     /// <inheritdoc/>
     public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
     {
-      var result = await provider.ExecuteSequenceAsync<T>(expression, cancellationToken).ConfigureAwaitFalse();
-      var asyncSource = result.AsAsyncEnumerable().WithCancellation(cancellationToken).ConfigureAwaitFalse();
-      await foreach (var element in asyncSource) {
-        yield return element;
+      var result = (await provider.ExecuteSequenceAsync<T>(expression, cancellationToken).ConfigureAwaitFalse());
+      await using var enumerator = result.GetAsyncEnumerator();
+      while (await enumerator.MoveNextAsync()) {
+        cancellationToken.ThrowIfCancellationRequested();
+        yield return enumerator.Current;
       }
     }
 
@@ -68,6 +64,12 @@ namespace Xtensive.Orm.Linq
 
       this.provider = provider;
       this.expression = expression;
+    }
+
+    internal Queryable(QueryProvider provider, QueryEndpoint.ExpressionOfTypeQueryable<T> expression)
+    {
+      this.provider = provider;
+      this.expression = expression.Expression;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Queryable.cs
@@ -43,7 +43,7 @@ namespace Xtensive.Orm.Linq
     {
       var result = await provider.ExecuteSequenceAsync<T>(expression, cancellationToken).ConfigureAwaitFalse();
       await using var enumerator = result.GetAsyncEnumerator();
-      while (await enumerator.MoveNextAsync()) {
+      while (await enumerator.MoveNextAsync().ConfigureAwaitFalse()) {
         cancellationToken.ThrowIfCancellationRequested();
         yield return enumerator.Current;
       }

--- a/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
@@ -45,10 +45,12 @@ namespace Xtensive.Orm
 
     public override int GetHashCode() => HashCode.Combine(Provider, RootBuilder);
 
+    internal readonly record struct ExpressionOfTypeQueryable<T>(MethodCallExpression Expression);
+
     private static class Traits<T>
     {
-      public static readonly MethodCallExpression RootCallExpression =
-        Expression.Call(null, WellKnownMembers.Query.All.MakeGenericMethod(typeof(T)));
+      public static readonly ExpressionOfTypeQueryable<T> RootCallExpression =
+        new(Expression.Call(null, WellKnownMembers.Query.All.MakeGenericMethod(typeof(T))));
     }
 
   /// <summary>
@@ -62,9 +64,9 @@ namespace Xtensive.Orm
     /// of type <typeparamref name="T"/>.
     /// </returns>
     public IQueryable<T> All<T>() where T : class, IEntity =>
-      Provider.CreateQuery<T>(RootBuilder != null
-        ? RootBuilder.BuildRootExpression(typeof(T))
-        : Traits<T>.RootCallExpression);
+      RootBuilder != null
+        ? Provider.CreateQuery<T>(RootBuilder.BuildRootExpression(typeof(T)))
+        : new Queryable<T>(Provider, Traits<T>.RootCallExpression);
 
     /// <summary>
     /// The "starting point" for dynamic LINQ query -

--- a/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
@@ -45,9 +45,7 @@ namespace Xtensive.Orm
 
     public override int GetHashCode() => HashCode.Combine(Provider, RootBuilder);
 
-    internal readonly record struct ExpressionOfTypeQueryable<T>(MethodCallExpression Expression);
-
-    private static class Traits<T>
+    internal readonly record struct ExpressionOfTypeQueryable<T>(MethodCallExpression Value)
     {
       public static readonly ExpressionOfTypeQueryable<T> RootCallExpression =
         new(Expression.Call(null, WellKnownMembers.Query.All.MakeGenericMethod(typeof(T))));
@@ -66,7 +64,7 @@ namespace Xtensive.Orm
     public IQueryable<T> All<T>() where T : class, IEntity =>
       RootBuilder != null
         ? Provider.CreateQuery<T>(RootBuilder.BuildRootExpression(typeof(T)))
-        : new Queryable<T>(Provider, Traits<T>.RootCallExpression);
+        : new Queryable<T>(Provider, ExpressionOfTypeQueryable<T>.RootCallExpression);
 
     /// <summary>
     /// The "starting point" for dynamic LINQ query -

--- a/Orm/Xtensive.Orm/Orm/QueryResult.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryResult.cs
@@ -49,16 +49,20 @@ namespace Xtensive.Orm
       return reader.AsEnumerator();
     }
 
+    internal IAsyncEnumerator<TItem> GetAsyncEnumerator()
+    {
+      EnsureResultsAlive();
+      return reader.AsAsyncEnumerator();
+    }
+
     /// <summary>
     /// Transforms <see cref="QueryResult{TItem}"/> to an <see cref="IAsyncEnumerable{T}"/> sequence.
     /// </summary>
     public async IAsyncEnumerable<TItem> AsAsyncEnumerable()
     {
-      EnsureResultsAlive();
-      await using (var enumerator = reader.AsAsyncEnumerator()) {
-        while (await enumerator.MoveNextAsync().ConfigureAwaitFalse()) {
-          yield return enumerator.Current;
-        }
+      await using var enumerator = GetAsyncEnumerator();
+      while (await enumerator.MoveNextAsync().ConfigureAwaitFalse()) {
+        yield return enumerator.Current;
       }
     }
 


### PR DESCRIPTION
Avoid redundant conversions between I`AsyncEnumerable` and `IAsyncEnumerator`

Also:
* Add simplified `Queriable` constructor with static type-checking