### PR TITLE
Optimization: Cache `DomainHandlerGetProviderCompilerContainers()` results

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Providers/DomainHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/DomainHandler.cs
@@ -122,7 +122,11 @@ namespace Xtensive.Orm.Providers
     /// Gets compiler containers specific to current storage provider.
     /// </summary>
     /// <returns>Compiler containers for current provider.</returns>
-    protected virtual IEnumerable<Type> GetProviderCompilerContainers()
+    protected virtual IEnumerable<Type> GetProviderCompilerContainers() => ProviderCompilerContainers;
+
+    private static IReadOnlyList<Type> ProviderCompilerContainers => field ??= GetProviderCompilerContainersImpl();
+
+    private static IReadOnlyList<Type> GetProviderCompilerContainersImpl()
     {
       IEnumerable<Type> basicCompilerContainers = new[] {
         typeof (NullableCompilers),
@@ -140,11 +144,10 @@ namespace Xtensive.Orm.Providers
         
       };
       var result = basicCompilerContainers;
-      var defaultLoadedAssemblies = AssemblyLoadContext.Default.Assemblies;
-      var currentLoadedAssemblies = AssemblyLoadContext.CurrentContextualReflectionContext.Assemblies;
+      var defaultLoadedAssemblies = AssemblyLoadContext.Default.Assemblies.ToList();
       // dynamic registration to not cause assembly loading
-      if (defaultLoadedAssemblies.Any(static a => a.GetName().Name.Equals("FSharp.Core", StringComparison.OrdinalIgnoreCase))
-        || defaultLoadedAssemblies.Any(static a => a.GetName().Name.Equals("FSharp.Core", StringComparison.OrdinalIgnoreCase))) {
+      if (defaultLoadedAssemblies.Any(static a => a.GetName().Name?.Equals("FSharp.Core", StringComparison.OrdinalIgnoreCase) == true)
+        || defaultLoadedAssemblies.Any(static a => a.GetName().Name?.Equals("FSharp.Core", StringComparison.OrdinalIgnoreCase) == true)) {
         result = result.Concat(new[] {
           typeof (FSharpMathOperationsCompilers),
           typeof (FSharpOperatorsCompilers),
@@ -162,7 +165,7 @@ namespace Xtensive.Orm.Providers
         });
       }
 
-      return result;
+      return result.ToList();
     }
 
     protected virtual SearchConditionCompiler CreateSearchConditionVisitor()

--- a/Orm/Xtensive.Orm/Orm/Providers/DomainHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/DomainHandler.cs
@@ -118,13 +118,14 @@ namespace Xtensive.Orm.Providers
         ? new CompositePostCompiler([new SqlSelectCorrector(Handlers.ProviderInfo), new SqlProviderPreparer(Handlers)])
         : new CompositePostCompiler([new SqlSelectCorrector(Handlers.ProviderInfo)]);
 
+    private static IReadOnlyList<Type> providerCompilerContainers;
+
     /// <summary>
     /// Gets compiler containers specific to current storage provider.
     /// </summary>
     /// <returns>Compiler containers for current provider.</returns>
-    protected virtual IEnumerable<Type> GetProviderCompilerContainers() => ProviderCompilerContainers;
-
-    private static IReadOnlyList<Type> ProviderCompilerContainers => field ??= GetProviderCompilerContainersImpl();
+    protected virtual IEnumerable<Type> GetProviderCompilerContainers() =>
+      providerCompilerContainers ??= GetProviderCompilerContainersImpl();
 
     private static IReadOnlyList<Type> GetProviderCompilerContainersImpl()
     {

--- a/Orm/Xtensive.Orm/Orm/Providers/DomainHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/DomainHandler.cs
@@ -157,8 +157,8 @@ namespace Xtensive.Orm.Providers
         });
       }
 
-      if (defaultLoadedAssemblies.Any(static a => a.GetName().Name.Equals("Microsoft.VisualBasic", StringComparison.OrdinalIgnoreCase))
-        || defaultLoadedAssemblies.Any(static a => a.GetName().Name.Equals("Microsoft.VisualBasic", StringComparison.OrdinalIgnoreCase))) {
+      if (defaultLoadedAssemblies.Any(static a => a.GetName()?.Name.Equals("Microsoft.VisualBasic", StringComparison.OrdinalIgnoreCase) == true)
+        || defaultLoadedAssemblies.Any(static a => a.GetName()?.Name.Equals("Microsoft.VisualBasic", StringComparison.OrdinalIgnoreCase) == true)) {
         result = result.Concat(new[] {
           typeof (VbConversionsCompilers),
           typeof (VbStringsCompilers),

--- a/Orm/Xtensive.Orm/Orm/Providers/DomainHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/DomainHandler.cs
@@ -124,11 +124,11 @@ namespace Xtensive.Orm.Providers
     /// Gets compiler containers specific to current storage provider.
     /// </summary>
     /// <returns>Compiler containers for current provider.</returns>
-    protected virtual IEnumerable<Type> GetProviderCompilerContainers() =>
-      providerCompilerContainers ??= GetProviderCompilerContainersImpl();
-
-    private static IReadOnlyList<Type> GetProviderCompilerContainersImpl()
+    protected virtual IEnumerable<Type> GetProviderCompilerContainers()
     {
+      if (providerCompilerContainers != null) {
+        return providerCompilerContainers;
+      }
       IEnumerable<Type> basicCompilerContainers = new[] {
         typeof (NullableCompilers),
         typeof (StringCompilers),
@@ -166,7 +166,7 @@ namespace Xtensive.Orm.Providers
         });
       }
 
-      return result.ToList();
+      return providerCompilerContainers = result.ToList();
     }
 
     protected virtual SearchConditionCompiler CreateSearchConditionVisitor()

--- a/Orm/Xtensive.Orm/Orm/Providers/DomainHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/DomainHandler.cs
@@ -166,7 +166,7 @@ namespace Xtensive.Orm.Providers
         });
       }
 
-      return providerCompilerContainers = result.ToList();
+      return providerCompilerContainers = result.ToArray();
     }
 
     protected virtual SearchConditionCompiler CreateSearchConditionVisitor()

--- a/Version.props
+++ b/Version.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.3.13</DoVersion>
+    <DoVersion>7.3.14</DoVersion>
     <DoVersionSuffix>servicetitan</DoVersionSuffix>
 </PropertyGroup>
 


### PR DESCRIPTION
This method invoked multiple times in tests, as we build the Domain multiple times.

Also:
* Add Null-checking. Test fail with NRE here https://teamcity.st.dev/buildConfiguration/Services_ServiceTitan_TestBackend/10330465?expandBuildDeploymentsSection=false&hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildTestsSection=true&expandMatrixBuildSection=true

This is a new code from Xtensive https://github.com/servicetitan/dataobjects-net/commit/bbdcd801a1434f85cec18b7474aacab99e48b3ea#diff-ff3699d85aae77e164ca8b89c02b04059e27e23357e96ef891f291431142d483
Unstable yet