### PR TITLE
PERF-434: add SqlColumnPruner to reduce SQL text size

### DIFF
--- a/.github/actions/mssql-fts/Dockerfile
+++ b/.github/actions/mssql-fts/Dockerfile
@@ -4,10 +4,10 @@ USER root
 ENV ACCEPT_EULA=Y \
     MSSQL_SA_PASSWORD=dbatools.I0
 
-RUN apt-get update \
+RUN apt-get update --fix-missing \
     && apt-get -qq install -y gnupg curl \
     && curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg \
     && echo >>/etc/apt/sources.list.d/mssql-release.list 'deb [arch=amd64,armhf,arm64] https://packages.microsoft.com/ubuntu/22.04/mssql-server-2022 jammy main' \
-    && apt-get update
+    && apt-get update --fix-missing
 
-RUN apt-get install -y apt-utils mssql-server-fts
+RUN apt-get install -y --fix-missing apt-utils mssql-server-fts

--- a/Orm/Xtensive.Orm.Tests.Sql/SqlColumnPrunerTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/SqlColumnPrunerTest.cs
@@ -1,0 +1,866 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Xtensive.Orm.Providers;
+using Xtensive.Sql;
+using Xtensive.Sql.Dml;
+using Xtensive.Sql.Model;
+
+namespace Xtensive.Orm.Tests.Sql
+{
+  [TestFixture]
+  public class SqlColumnPrunerTest
+  {
+    private Table table1;
+    private Table table2;
+
+    [OneTimeSetUp]
+    public void SetUp()
+    {
+      var catalog = new Catalog("test");
+      var schema = catalog.CreateSchema("dbo");
+
+      table1 = schema.CreateTable("table1");
+      _ = table1.CreateColumn("Col0", new SqlValueType(SqlType.Int32));
+      _ = table1.CreateColumn("Col1", new SqlValueType(SqlType.VarChar));
+      _ = table1.CreateColumn("Col2", new SqlValueType(SqlType.VarChar));
+      _ = table1.CreateColumn("Col3", new SqlValueType(SqlType.VarChar));
+      _ = table1.CreateColumn("Col4", new SqlValueType(SqlType.VarChar));
+
+      table2 = schema.CreateTable("table2");
+      _ = table2.CreateColumn("Id", new SqlValueType(SqlType.Int32));
+      _ = table2.CreateColumn("Name", new SqlValueType(SqlType.VarChar));
+      _ = table2.CreateColumn("Value", new SqlValueType(SqlType.VarChar));
+    }
+
+    #region Basic pruning
+
+    [Test]
+    public void PrunesUnusedColumns()
+    {
+      // Before: SELECT q.Col0, q.Col2 FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      // After:  SELECT q.Col0, q.Col2 FROM (SELECT t.Col0, t.Col2 FROM table1 t) q
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+      outerSelect.Columns.Add(queryRef[2]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col2");
+      AssertSelectColumnCount(innerSelect, 2);
+    }
+
+    [Test]
+    public void DoesNotPruneWhenAllColumnsUsed()
+    {
+      // SELECT q.Col0, q.Col1, q.Col2, q.Col3, q.Col4
+      // FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      // All 5 columns used → no pruning expected
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      for (int i = 0; i < queryRef.Columns.Count; i++) {
+        outerSelect.Columns.Add(queryRef[i]);
+      }
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col1", "Col2", "Col3", "Col4");
+      AssertSelectColumnCount(innerSelect, 5);
+    }
+
+    [Test]
+    public void PrunesSingleColumnToOne()
+    {
+      // Before: SELECT q.Col3 FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      // After:  SELECT q.Col3 FROM (SELECT t.Col3 FROM table1 t) q
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[3]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col3");
+      AssertSelectColumnCount(innerSelect, 1);
+    }
+
+    [Test]
+    public void PreservesColumnIdentityAfterPruning()
+    {
+      // Before: SELECT q.Col0, q.Col4 FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      // After:  SELECT q.Col0, q.Col4 FROM (SELECT t.Col0, t.Col4 FROM table1 t) q
+      // SqlTableColumn object references must survive pruning (identity, not just name)
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+
+      var col0Ref = queryRef[0];
+      var col4Ref = queryRef[4];
+      outerSelect.Columns.Add(col0Ref);
+      outerSelect.Columns.Add(col4Ref);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col4");
+      Assert.That(queryRef.Columns[0], Is.SameAs(col0Ref));
+      Assert.That(queryRef.Columns[1], Is.SameAs(col4Ref));
+    }
+
+    #endregion
+
+    #region Column references in clauses
+
+    [Test]
+    public void ColumnsReferencedInWhereArePreserved()
+    {
+      // Before: SELECT q.Col0 FROM (SELECT …5 cols…) q WHERE q.Col3 = 'test'
+      // After:  SELECT q.Col0 FROM (SELECT t.Col0, t.Col3 …) q WHERE q.Col3 = 'test'
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+      outerSelect.Where = queryRef[3] == SqlDml.Literal("test");
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col3");
+      AssertSelectColumnCount(innerSelect, 2);
+    }
+
+    [Test]
+    public void ColumnsReferencedInOrderByArePreserved()
+    {
+      // Before: SELECT q.Col0 FROM (SELECT …5 cols…) q ORDER BY q.Col4
+      // After:  SELECT q.Col0 FROM (SELECT t.Col0, t.Col4 …) q ORDER BY q.Col4
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+      outerSelect.OrderBy.Add(queryRef[4]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col4");
+      AssertSelectColumnCount(innerSelect, 2);
+    }
+
+    [Test]
+    public void ColumnsReferencedInGroupByArePreserved()
+    {
+      // Before: SELECT COUNT(*) FROM (SELECT …5 cols…) q GROUP BY q.Col1
+      // After:  SELECT COUNT(*) FROM (SELECT t.Col1 …) q GROUP BY q.Col1
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(SqlDml.Count());
+      outerSelect.GroupBy.Add(queryRef[1]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col1");
+      AssertSelectColumnCount(innerSelect, 1);
+    }
+
+    [Test]
+    public void ColumnsReferencedInHavingArePreserved()
+    {
+      // Before: SELECT q.Col0 FROM (SELECT …5 cols…) q GROUP BY q.Col0 HAVING COUNT(q.Col2) > 1
+      // After:  SELECT q.Col0 FROM (SELECT t.Col0, t.Col2 …) q GROUP BY q.Col0 HAVING COUNT(q.Col2) > 1
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+      outerSelect.GroupBy.Add(queryRef[0]);
+      outerSelect.Having = SqlDml.Count(queryRef[2]) > SqlDml.Literal(1);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col2");
+      AssertSelectColumnCount(innerSelect, 2);
+    }
+
+    [Test]
+    public void ComplexWhereWithAndOrPreservesAllReferencedColumns()
+    {
+      // Before: SELECT q.Col0 FROM (SELECT …5 cols…) q WHERE q.Col1 = 'a' AND q.Col3 IS NOT NULL
+      // After:  SELECT q.Col0 FROM (SELECT t.Col0, t.Col1, t.Col3 …) q WHERE …
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+      outerSelect.Where = queryRef[1] == SqlDml.Literal("a")
+                           & queryRef[3] != SqlDml.Null;
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col1", "Col3");
+      AssertSelectColumnCount(innerSelect, 3);
+    }
+
+    #endregion
+
+    #region Expressions
+
+    [Test]
+    public void CaseExpressionPreservesAllBranches()
+    {
+      // Before: SELECT CASE q.Col1 WHEN 'a' THEN q.Col2 ELSE q.Col3 END
+      //         FROM (SELECT …5 cols…) q
+      // After:  SELECT CASE q.Col1 WHEN 'a' THEN q.Col2 ELSE q.Col3 END
+      //         FROM (SELECT t.Col1, t.Col2, t.Col3 FROM table1 t) q
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+
+      var caseExpr = SqlDml.Case(queryRef[1]);
+      caseExpr[SqlDml.Literal("a")] = queryRef[2];
+      caseExpr.Else = queryRef[3];
+      outerSelect.Columns.Add(caseExpr);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col1", "Col2", "Col3");
+      AssertSelectColumnCount(innerSelect, 3);
+    }
+
+    [Test]
+    public void CaseExpressionWithMultipleBranches()
+    {
+      // SELECT CASE WHEN q.Col0 > 0 THEN q.Col1
+      //             WHEN q.Col0 < 0 THEN q.Col2
+      //             ELSE q.Col3 END
+      // FROM (SELECT …5 cols…) q
+      // → inner pruned to Col0, Col1, Col2, Col3
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+
+      var caseExpr = SqlDml.Case();
+      caseExpr[queryRef[0] > SqlDml.Literal(0)] = queryRef[1];
+      caseExpr[queryRef[0] < SqlDml.Literal(0)] = queryRef[2];
+      caseExpr.Else = queryRef[3];
+      outerSelect.Columns.Add(caseExpr);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col1", "Col2", "Col3");
+      AssertSelectColumnCount(innerSelect, 4);
+    }
+
+    [Test]
+    public void CastExpressionPreservesOperand()
+    {
+      // Before: SELECT CAST(q.Col2 AS INT) FROM (SELECT …5 cols…) q
+      // After:  SELECT CAST(q.Col2 AS INT) FROM (SELECT t.Col2 FROM table1 t) q
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(SqlDml.Cast(queryRef[2], SqlType.Int32));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col2");
+      AssertSelectColumnCount(innerSelect, 1);
+    }
+
+    [Test]
+    public void CoalescePreservesAllArguments()
+    {
+      // Before: SELECT COALESCE(q.Col1, q.Col4) FROM (SELECT …5 cols…) q
+      // After:  SELECT COALESCE(q.Col1, q.Col4) FROM (SELECT t.Col1, t.Col4 FROM table1 t) q
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(SqlDml.Coalesce(queryRef[1], queryRef[4]));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col1", "Col4");
+      AssertSelectColumnCount(innerSelect, 2);
+    }
+
+    [Test]
+    public void AggregatePreservesInnerExpression()
+    {
+      // Before: SELECT q.Col1, SUM(q.Col3) FROM (SELECT …5 cols…) q GROUP BY q.Col1
+      // After:  SELECT q.Col1, SUM(q.Col3) FROM (SELECT t.Col1, t.Col3 FROM table1 t) q GROUP BY q.Col1
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[1]);
+      outerSelect.Columns.Add(SqlDml.Sum(queryRef[3]));
+      outerSelect.GroupBy.Add(queryRef[1]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col1", "Col3");
+      AssertSelectColumnCount(innerSelect, 2);
+    }
+
+    [Test]
+    public void LikeExpressionPreservesAllParts()
+    {
+      // Before: SELECT q.Col0 FROM (SELECT …5 cols…) q WHERE q.Col1 LIKE q.Col2
+      // After:  SELECT q.Col0 FROM (SELECT t.Col0, t.Col1, t.Col2 …) q WHERE q.Col1 LIKE q.Col2
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+      outerSelect.Where = SqlDml.Like(queryRef[1], queryRef[2]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col1", "Col2");
+      AssertSelectColumnCount(innerSelect, 3);
+    }
+
+    [Test]
+    public void BetweenExpressionPreservesAllParts()
+    {
+      // Before: SELECT q.Col0 FROM (SELECT …5 cols…) q WHERE q.Col1 BETWEEN q.Col2 AND q.Col3
+      // After:  SELECT q.Col0 FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3 …) q WHERE …
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+      outerSelect.Where = SqlDml.Between(queryRef[1], queryRef[2], queryRef[3]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col1", "Col2", "Col3");
+      AssertSelectColumnCount(innerSelect, 4);
+    }
+
+    [Test]
+    public void ArithmeticExpressionPreservesOperands()
+    {
+      // Before: SELECT q.Col0 + q.Col3 FROM (SELECT …5 cols…) q
+      // After:  SELECT q.Col0 + q.Col3 FROM (SELECT t.Col0, t.Col3 FROM table1 t) q
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0] + queryRef[3]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col3");
+      AssertSelectColumnCount(innerSelect, 2);
+    }
+
+    [Test]
+    public void UnaryExpressionPreservesOperand()
+    {
+      // Before: SELECT -q.Col0 FROM (SELECT …5 cols…) q
+      // After:  SELECT -q.Col0 FROM (SELECT t.Col0 FROM table1 t) q
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(-queryRef[0]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0");
+      AssertSelectColumnCount(innerSelect, 1);
+    }
+
+    [Test]
+    public void RowNumberInSelectPreservesOrderByColumns()
+    {
+      // Before: SELECT q.Col0, ROW_NUMBER() OVER(ORDER BY q.Col2)
+      //         FROM (SELECT …5 cols…) q
+      // After:  SELECT q.Col0, ROW_NUMBER() OVER(ORDER BY q.Col2)
+      //         FROM (SELECT t.Col0, t.Col2 FROM table1 t) q
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+
+      var rn = SqlDml.RowNumber();
+      rn.OrderBy.Add(queryRef[2]);
+      outerSelect.Columns.Add(rn);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col2");
+      AssertSelectColumnCount(innerSelect, 2);
+    }
+
+    [Test]
+    public void MixedSelectAndWhereExpressions()
+    {
+      // Before: SELECT COALESCE(q.Col1, q.Col2), CAST(q.Col0 AS VARCHAR)
+      //         FROM (SELECT …5 cols…) q
+      //         WHERE q.Col3 > 0
+      //         ORDER BY q.Col4
+      // After:  SELECT COALESCE(q.Col1, q.Col2), CAST(q.Col0 AS VARCHAR)
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      //         WHERE q.Col3 > 0
+      //         ORDER BY q.Col4
+      // All 5 columns referenced → no pruning
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(SqlDml.Coalesce(queryRef[1], queryRef[2]));
+      outerSelect.Columns.Add(SqlDml.Cast(queryRef[0], SqlType.VarChar));
+      outerSelect.Where = queryRef[3] > SqlDml.Literal(0);
+      outerSelect.OrderBy.Add(queryRef[4]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col1", "Col2", "Col3", "Col4");
+      AssertSelectColumnCount(innerSelect, 5);
+    }
+
+    [Test]
+    public void MixedExpressionsWithPruning()
+    {
+      // Before: SELECT COALESCE(q.Col1, 'N/A'), q.Col0 * 2
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      //         WHERE q.Col3 IS NOT NULL
+      // After:  SELECT COALESCE(q.Col1, 'N/A'), q.Col0 * 2
+      //         FROM (SELECT t.Col0, t.Col1, t.Col3 FROM table1 t) q
+      //         WHERE q.Col3 IS NOT NULL
+      // Col2, Col4 pruned
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(SqlDml.Coalesce(queryRef[1], SqlDml.Literal("N/A")));
+      outerSelect.Columns.Add(queryRef[0] * SqlDml.Literal(2));
+      outerSelect.Where = queryRef[3] != SqlDml.Null;
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col1", "Col3");
+      AssertSelectColumnCount(innerSelect, 3);
+    }
+
+    #endregion
+
+    #region Subqueries
+
+    [Test]
+    public void CorrelatedSubqueryInSelectList()
+    {
+      // Before: SELECT q.Col0, (SELECT COUNT(*) FROM table2 t2 WHERE t2.Id = q.Col3)
+      //         FROM (SELECT …5 cols…) q
+      // After:  SELECT q.Col0, (SELECT COUNT(*) FROM table2 t2 WHERE t2.Id = q.Col3)
+      //         FROM (SELECT t.Col0, t.Col3 FROM table1 t) q
+      // Col3 referenced only in correlated subquery — must not be pruned
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var subquerySelect = SqlDml.Select(t2);
+      subquerySelect.Columns.Add(SqlDml.Count());
+      subquerySelect.Where = t2["Id"] == queryRef[3];
+      var subquery = SqlDml.SubQuery(subquerySelect);
+
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+      outerSelect.Columns.Add(subquery);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col3");
+      AssertSelectColumnCount(innerSelect, 2);
+    }
+
+    [Test]
+    public void ExistsSubqueryInWhere()
+    {
+      // Before: SELECT q.Col0 FROM (SELECT …5 cols…) q
+      //         WHERE EXISTS (SELECT 1 FROM table2 t2 WHERE t2.Id = q.Col4)
+      // After:  SELECT q.Col0 FROM (SELECT t.Col0, t.Col4 FROM table1 t) q
+      //         WHERE EXISTS (…)
+      // Col4 referenced in EXISTS — must not be pruned
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var existsSelect = SqlDml.Select(t2);
+      existsSelect.Columns.Add(SqlDml.Literal(1));
+      existsSelect.Where = t2["Id"] == queryRef[4];
+
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+      outerSelect.Where = SqlDml.Exists(existsSelect);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col4");
+      AssertSelectColumnCount(innerSelect, 2);
+    }
+
+    [Test]
+    public void CorrelatedSubqueryAlsoPrunedInternally()
+    {
+      // The correlated subquery itself may have a SqlQueryRef FROM that can be pruned.
+      // Before: SELECT q.Col0,
+      //           (SELECT s.Name FROM (SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) s
+      //            WHERE s.Id = q.Col3)
+      //         FROM (SELECT …5 cols…) q
+      // After:  SELECT q.Col0,
+      //           (SELECT s.Name FROM (SELECT t2.Id, t2.Name FROM table2 t2) s
+      //            WHERE s.Id = q.Col3)
+      //         FROM (SELECT t.Col0, t.Col3 FROM table1 t) q
+      // Both outer and inner subquery pruned
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var subInner = SqlDml.Select(t2);
+      subInner.Columns.Add(t2["Id"]);
+      subInner.Columns.Add(t2["Name"]);
+      subInner.Columns.Add(t2["Value"]);
+
+      var subRef = SqlDml.QueryRef(subInner, "s");
+      var subOuter = SqlDml.Select(subRef);
+      subOuter.Columns.Add(subRef["Name"]);
+      subOuter.Where = subRef["Id"] == queryRef[3];
+
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+      outerSelect.Columns.Add(SqlDml.SubQuery(subOuter));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      // Outer query pruned to Col0, Col3
+      AssertColumnNames(queryRef, "Col0", "Col3");
+      AssertSelectColumnCount(innerSelect, 2);
+      // Subquery inner pruned to Id, Name (Value removed)
+      AssertColumnNames(subRef, "Id", "Name");
+      AssertSelectColumnCount(subInner, 2);
+    }
+
+    #endregion
+
+    #region Nesting
+
+    [Test]
+    public void NestedSubqueriesCascadePruning()
+    {
+      // Before: SELECT o.Col0, o.Col4
+      //         FROM (SELECT m.Col0, m.Col2, m.Col4
+      //               FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) m
+      //              ) o
+      // After:  SELECT o.Col0, o.Col4
+      //         FROM (SELECT m.Col0, m.Col4
+      //               FROM (SELECT t.Col0, t.Col4 FROM table1 t) m
+      //              ) o
+      // Cascading: outer prunes middle to 2 cols, middle prunes inner to 2 cols
+      var innermostSelect = CreateInnerSelect();
+      var innerRef = SqlDml.QueryRef(innermostSelect, "m");
+
+      var middleSelect = SqlDml.Select(innerRef);
+      middleSelect.Columns.Add(innerRef[0]);
+      middleSelect.Columns.Add(innerRef[2]);
+      middleSelect.Columns.Add(innerRef[4]);
+
+      var outerRef = SqlDml.QueryRef(middleSelect, "o");
+      var outerSelect = SqlDml.Select(outerRef);
+      outerSelect.Columns.Add(outerRef[0]);
+      outerSelect.Columns.Add(outerRef[2]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(outerRef, "Col0", "Col4");
+      AssertSelectColumnCount(middleSelect, 2);
+
+      AssertColumnNames(innerRef, "Col0", "Col4");
+      AssertSelectColumnCount(innermostSelect, 2);
+    }
+
+    [Test]
+    public void ThreeLevelNestingWithFilterAtMiddle()
+    {
+      // Before: SELECT o.Col0
+      //         FROM (SELECT m.Col0, m.Col1, m.Col2, m.Col3, m.Col4
+      //               FROM (SELECT …5 cols…) m
+      //               WHERE m.Col2 = 'x'
+      //              ) o
+      // After:  SELECT o.Col0
+      //         FROM (SELECT m.Col0
+      //               FROM (SELECT t.Col0, t.Col2 FROM table1 t) m
+      //               WHERE m.Col2 = 'x'
+      //              ) o
+      // Outer prunes middle to Col0; middle still references Col2 in WHERE → inner keeps Col0, Col2
+      var innermostSelect = CreateInnerSelect();
+      var innerRef = SqlDml.QueryRef(innermostSelect, "m");
+
+      var middleSelect = SqlDml.Select(innerRef);
+      for (int i = 0; i < innerRef.Columns.Count; i++) {
+        middleSelect.Columns.Add(innerRef[i]);
+      }
+      middleSelect.Where = innerRef["Col2"] == SqlDml.Literal("x");
+
+      var outerRef = SqlDml.QueryRef(middleSelect, "o");
+      var outerSelect = SqlDml.Select(outerRef);
+      outerSelect.Columns.Add(outerRef[0]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      // Outer prunes middle to just Col0
+      AssertColumnNames(outerRef, "Col0");
+      AssertSelectColumnCount(middleSelect, 1);
+
+      // But middle still references Col2 in its WHERE, so inner keeps Col0 + Col2
+      AssertColumnNames(innerRef, "Col0", "Col2");
+      AssertSelectColumnCount(innermostSelect, 2);
+    }
+
+    #endregion
+
+    #region Set operations and edge cases
+
+    [Test]
+    public void DoesNotPruneSetOperations()
+    {
+      // SELECT u.Col0
+      // FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t
+      //       UNION ALL
+      //       SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) u
+      // UNION requires matched column counts → no pruning on the SqlQueryRef
+      var t = SqlDml.TableRef(table1);
+      var selectA = SqlDml.Select(t);
+      selectA.Columns.AddRange(t.Columns.ToArray<SqlColumn>());
+
+      var selectB = SqlDml.Select(t);
+      selectB.Columns.AddRange(t.Columns.ToArray<SqlColumn>());
+
+      var union = selectA.UnionAll(selectB);
+      var queryRef = SqlDml.QueryRef(union, "u");
+
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+
+      var originalColumnCount = queryRef.Columns.Count;
+      SqlColumnPruner.Process(outerSelect);
+
+      Assert.That(queryRef.Columns.Count, Is.EqualTo(originalColumnCount));
+    }
+
+    [Test]
+    public void HandlesNoFromSource()
+    {
+      // SELECT 1  — no FROM clause, nothing to prune, should not throw
+      var select = SqlDml.Select();
+      select.Columns.Add(SqlDml.Literal(1));
+
+      Assert.DoesNotThrow(() => SqlColumnPruner.Process(select));
+    }
+
+    [Test]
+    public void HandlesDirectTableRef()
+    {
+      // SELECT t.Col0, t.Col2 FROM table1 t
+      // FROM is a physical table, not a subquery — nothing to prune
+      var t = SqlDml.TableRef(table1);
+      var select = SqlDml.Select(t);
+      select.Columns.Add(t[0]);
+      select.Columns.Add(t[2]);
+
+      Assert.DoesNotThrow(() => SqlColumnPruner.Process(select));
+      Assert.That(select.Columns.Count, Is.EqualTo(2));
+    }
+
+    #endregion
+
+    #region ORM-like patterns (typical compiler output)
+
+    [Test]
+    public void PagingPatternWithRowNumber()
+    {
+      // Simulates the typical paging wrapper produced by the ORM compiler:
+      // Before: SELECT p.Col0, p.Col1 FROM (
+      //           SELECT q.Col0, q.Col1, q.Col2, q.Col3, q.Col4,
+      //                  ROW_NUMBER() OVER(ORDER BY q.Col0) AS rn
+      //           FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      //         ) p WHERE p.rn > 10 AND p.rn <= 20
+      // After:  SELECT p.Col0, p.Col1 FROM (
+      //           SELECT q.Col0, q.Col1, ROW_NUMBER() OVER(ORDER BY q.Col0) AS rn
+      //           FROM (SELECT t.Col0, t.Col1 FROM table1 t) q
+      //         ) p WHERE p.rn > 10 AND p.rn <= 20
+      var baseSelect = CreateInnerSelect();
+      var baseRef = SqlDml.QueryRef(baseSelect, "q");
+
+      // Middle: wraps in subquery, adds all columns + ROW_NUMBER
+      var middleSelect = SqlDml.Select(baseRef);
+      for (int i = 0; i < baseRef.Columns.Count; i++) {
+        middleSelect.Columns.Add(baseRef[i]);
+      }
+      var rn = SqlDml.RowNumber();
+      rn.OrderBy.Add(baseRef[0]);
+      middleSelect.Columns.Add(rn, "rn");
+
+      // Outer: selects only Col0, Col1 and filters on rn
+      var middleRef = SqlDml.QueryRef(middleSelect, "p");
+      var outerSelect = SqlDml.Select(middleRef);
+      outerSelect.Columns.Add(middleRef["Col0"]);
+      outerSelect.Columns.Add(middleRef["Col1"]);
+      outerSelect.Where = middleRef["rn"] > SqlDml.Literal(10)
+                           & middleRef["rn"] <= SqlDml.Literal(20);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      // Middle should have Col0, Col1, rn (3 cols)
+      AssertColumnNames(middleRef, "Col0", "Col1", "rn");
+      AssertSelectColumnCount(middleSelect, 3);
+
+      // Base should have Col0, Col1 (2 cols) — Col2-Col4 pruned
+      AssertColumnNames(baseRef, "Col0", "Col1");
+      AssertSelectColumnCount(baseSelect, 2);
+    }
+
+    [Test]
+    public void SelectWithComputedColumnsAndAlias()
+    {
+      // Before: SELECT q.Col0, q.Col1 || ' ' || q.Col2 AS FullName
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      // After:  SELECT q.Col0, q.Col1 || ' ' || q.Col2 AS FullName
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2 FROM table1 t) q
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+      outerSelect.Columns.Add(
+        SqlDml.Concat(queryRef[1], SqlDml.Literal(" "), queryRef[2]),
+        "FullName");
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col1", "Col2");
+      AssertSelectColumnCount(innerSelect, 3);
+    }
+
+    [Test]
+    public void GroupByAggregateMultipleColumns()
+    {
+      // Before: SELECT q.Col1, COUNT(q.Col0), MAX(q.Col3)
+      //         FROM (SELECT …5 cols…) q GROUP BY q.Col1
+      // After:  SELECT q.Col1, COUNT(q.Col0), MAX(q.Col3)
+      //         FROM (SELECT t.Col0, t.Col1, t.Col3 FROM table1 t) q GROUP BY q.Col1
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[1]);
+      outerSelect.Columns.Add(SqlDml.Count(queryRef[0]));
+      outerSelect.Columns.Add(SqlDml.Max(queryRef[3]));
+      outerSelect.GroupBy.Add(queryRef[1]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col1", "Col3");
+      AssertSelectColumnCount(innerSelect, 3);
+    }
+
+    [Test]
+    public void JoinFromSidesRecurseIndependently()
+    {
+      // When FROM is a join, the pruner recurses into each join side.
+      // Before: SELECT …
+      //         FROM (SELECT t1.Col0, t1.Col1, t1.Col2 FROM table1 t1) l
+      //         JOIN (SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) r ON l.Col0 = r.Id
+      // The inner selects of l and r are visited for their own FROM pruning.
+      // The join sides themselves are not pruned (no parent SqlQueryRef wraps them),
+      // but the test verifies no exceptions and that inner FROM sources are processed.
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var leftInner = SqlDml.Select(t1);
+      leftInner.Columns.Add(t1["Col0"]);
+      leftInner.Columns.Add(t1["Col1"]);
+      leftInner.Columns.Add(t1["Col2"]);
+
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var rightInner = SqlDml.Select(t2);
+      rightInner.Columns.Add(t2["Id"]);
+      rightInner.Columns.Add(t2["Name"]);
+      rightInner.Columns.Add(t2["Value"]);
+
+      var leftRef = SqlDml.QueryRef(leftInner, "l");
+      var rightRef = SqlDml.QueryRef(rightInner, "r");
+
+      var joined = leftRef.InnerJoin(rightRef, leftRef["Col0"] == rightRef["Id"]);
+      var outerSelect = SqlDml.Select(joined);
+      outerSelect.Columns.Add(leftRef["Col0"]);
+      outerSelect.Columns.Add(rightRef["Name"]);
+
+      Assert.DoesNotThrow(() => SqlColumnPruner.Process(outerSelect));
+      // Join sides themselves are not pruned (FROM is a join, not a SqlQueryRef),
+      // but inner selects of the join sides are visited without error.
+      Assert.That(leftInner.Columns.Count, Is.EqualTo(3));
+      Assert.That(rightInner.Columns.Count, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void WrappedJoinResultPrunedThroughQueryRef()
+    {
+      // When the join result is wrapped in a SqlQueryRef (common ORM pattern):
+      // Before: SELECT w.Col0, w.Name
+      //         FROM (SELECT l.Col0, l.Col1, l.Col2, r.Id, r.Name, r.Value
+      //               FROM l JOIN r ON l.Col0 = r.Id) w
+      // After:  SELECT w.Col0, w.Name
+      //         FROM (SELECT l.Col0, r.Name
+      //               FROM l JOIN r ON l.Col0 = r.Id) w
+      // The wrapping subquery is pruned from 6 to 2 columns.
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var t2 = SqlDml.TableRef(table2, "t2");
+
+      var joined = t1.InnerJoin(t2, t1["Col0"] == t2["Id"]);
+      var joinSelect = SqlDml.Select(joined);
+      joinSelect.Columns.Add(t1["Col0"]);
+      joinSelect.Columns.Add(t1["Col1"]);
+      joinSelect.Columns.Add(t1["Col2"]);
+      joinSelect.Columns.Add(t2["Id"]);
+      joinSelect.Columns.Add(t2["Name"]);
+      joinSelect.Columns.Add(t2["Value"]);
+
+      var wrapRef = SqlDml.QueryRef(joinSelect, "w");
+      var outerSelect = SqlDml.Select(wrapRef);
+      outerSelect.Columns.Add(wrapRef["Col0"]);
+      outerSelect.Columns.Add(wrapRef["Name"]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(wrapRef, "Col0", "Name");
+      AssertSelectColumnCount(joinSelect, 2);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private SqlSelect CreateInnerSelect()
+    {
+      var t = SqlDml.TableRef(table1);
+      var select = SqlDml.Select(t);
+      for (int i = 0; i < t.Columns.Count; i++) {
+        select.Columns.Add(t[i]);
+      }
+      return select;
+    }
+
+    private static void AssertColumnNames(SqlQueryRef queryRef, params string[] expectedNames)
+    {
+      var actualNames = Enumerable.Range(0, queryRef.Columns.Count)
+        .Select(i => queryRef.Columns[i].Name)
+        .ToArray();
+      Assert.That(actualNames, Is.EqualTo(expectedNames),
+        $"QueryRef columns: expected [{string.Join(", ", expectedNames)}] " +
+        $"but was [{string.Join(", ", actualNames)}]");
+    }
+
+    private static void AssertSelectColumnCount(SqlSelect select, int expectedCount)
+    {
+      Assert.That(select.Columns.Count, Is.EqualTo(expectedCount),
+        $"Inner SELECT column count: expected {expectedCount} but was {select.Columns.Count}");
+    }
+
+    #endregion
+  }
+}

--- a/Orm/Xtensive.Orm.Tests.Sql/SqlColumnPrunerTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/SqlColumnPrunerTest.cs
@@ -441,6 +441,58 @@ namespace Xtensive.Orm.Tests.Sql
       AssertSelectColumnCount(innerSelect, 3);
     }
 
+    [Test]
+    public void MetadataWrappedColumnPreservesReference()
+    {
+      // SqlMetadata wraps an inner Expression (used by BooleanExpressionConverter).
+      // The pruner must recurse into it to detect column references.
+      // Before: SELECT q.Col0, METADATA(q.Col3 = 1, tag)
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      // After:  SELECT q.Col0, METADATA(q.Col3 = 1, tag)
+      //         FROM (SELECT t.Col0, t.Col3 FROM table1 t) q
+      // Col3 is only referenced inside the SqlMetadata wrapper — must not be pruned.
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+
+      var metadataExpr = SqlDml.Metadata(SqlDml.Equals(queryRef[3], SqlDml.Literal(1)), new object());
+
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+      outerSelect.Columns.Add(metadataExpr);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col3");
+      AssertSelectColumnCount(innerSelect, 2);
+    }
+
+    [Test]
+    public void NestedMetadataInsideCastPreservesReference()
+    {
+      // Mirrors the BooleanToInt pattern: METADATA(CAST(CASE WHEN q.Col2 THEN 1 ELSE 0 END AS bit), tag)
+      // Before: SELECT q.Col0, METADATA(CAST(CASE WHEN q.Col2 ... END AS int), tag)
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      // After:  SELECT q.Col0, METADATA(CAST(CASE WHEN q.Col2 ... END AS int), tag)
+      //         FROM (SELECT t.Col0, t.Col2 FROM table1 t) q
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+
+      var caseExpr = SqlDml.Case();
+      caseExpr.Add(queryRef[2], SqlDml.Literal(1));
+      caseExpr.Else = SqlDml.Literal(0);
+      var castExpr = SqlDml.Cast(caseExpr, new SqlValueType(SqlType.Int32));
+      var metadataExpr = SqlDml.Metadata(castExpr, new object());
+
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+      outerSelect.Columns.Add(metadataExpr);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col2");
+      AssertSelectColumnCount(innerSelect, 2);
+    }
+
     #endregion
 
     #region Subqueries
@@ -928,6 +980,89 @@ namespace Xtensive.Orm.Tests.Sql
       // Right join side pruned from 3 to 2 (Id for join condition, Name for select)
       AssertColumnNames(rightRef, "Id", "Name");
       AssertSelectColumnCount(rightInner, 2);
+    }
+
+    [Test]
+    public void OuterApplyCorrelatedReferencePreservesColumns()
+    {
+      // OUTER APPLY subqueries reference columns from a sibling join side.
+      // The pruner must not remove columns referenced by correlated siblings.
+      // Before: SELECT a.Col0, a.Col1, b.Name
+      //         FROM (SELECT t1.Col0, t1.Col1, t1.Col2, t1.Col3, t1.Col4 FROM table1 t1) a
+      //         OUTER APPLY (SELECT t2.Name FROM table2 t2 WHERE t2.Id = a.Col3) b
+      // After:  SELECT a.Col0, a.Col1, b.Name
+      //         FROM (SELECT t1.Col0, t1.Col1, t1.Col3 FROM table1 t1) a
+      //         OUTER APPLY (SELECT t2.Name FROM table2 t2 WHERE t2.Id = a.Col3) b
+      // Col3 is not in the outer SELECT but IS referenced by the APPLY's WHERE → must be kept.
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var innerA = SqlDml.Select(t1);
+      for (int i = 0; i < t1.Columns.Count; i++) {
+        innerA.Columns.Add(t1[i]);
+      }
+      var aRef = SqlDml.QueryRef(innerA, "a");
+
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var innerB = SqlDml.Select(t2);
+      innerB.Columns.Add(t2["Name"]);
+      innerB.Where = t2["Id"] == aRef["Col3"];
+      var bRef = SqlDml.QueryRef(innerB, "b");
+
+      var applied = aRef.LeftOuterApply(bRef);
+      var outerSelect = SqlDml.Select(applied);
+      outerSelect.Columns.Add(aRef["Col0"]);
+      outerSelect.Columns.Add(aRef["Col1"]);
+      outerSelect.Columns.Add(bRef["Name"]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      // Col3 preserved because the APPLY subquery references it
+      AssertColumnNames(aRef, "Col0", "Col1", "Col3");
+      AssertSelectColumnCount(innerA, 3);
+    }
+
+    [Test]
+    public void MultipleOuterApplyCorrelatedReferences()
+    {
+      // Multiple OUTER APPLY subqueries each reference different columns from [a].
+      // Before: SELECT a.Col0, b.Name, c.Value
+      //         FROM (SELECT t1.Col0, t1.Col1, t1.Col2, t1.Col3, t1.Col4 FROM table1 t1) a
+      //         OUTER APPLY (SELECT t2.Name FROM table2 t2 WHERE t2.Id = a.Col2) b
+      //         OUTER APPLY (SELECT t2.Value FROM table2 t2 WHERE t2.Id = a.Col4) c
+      // After:  SELECT a.Col0, b.Name, c.Value
+      //         FROM (SELECT t1.Col0, t1.Col2, t1.Col4 FROM table1 t1) a
+      //         OUTER APPLY (SELECT t2.Name FROM table2 t2 WHERE t2.Id = a.Col2) b
+      //         OUTER APPLY (SELECT t2.Value FROM table2 t2 WHERE t2.Id = a.Col4) c
+      // Col2 and Col4 are each referenced by one APPLY sibling — both must be kept.
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var innerA = SqlDml.Select(t1);
+      for (int i = 0; i < t1.Columns.Count; i++) {
+        innerA.Columns.Add(t1[i]);
+      }
+      var aRef = SqlDml.QueryRef(innerA, "a");
+
+      var t2b = SqlDml.TableRef(table2, "t2b");
+      var innerB = SqlDml.Select(t2b);
+      innerB.Columns.Add(t2b["Name"]);
+      innerB.Where = t2b["Id"] == aRef["Col2"];
+      var bRef = SqlDml.QueryRef(innerB, "b");
+
+      var t2c = SqlDml.TableRef(table2, "t2c");
+      var innerC = SqlDml.Select(t2c);
+      innerC.Columns.Add(t2c["Value"]);
+      innerC.Where = t2c["Id"] == aRef["Col4"];
+      var cRef = SqlDml.QueryRef(innerC, "c");
+
+      var applied = aRef.LeftOuterApply(bRef).LeftOuterApply(cRef);
+      var outerSelect = SqlDml.Select(applied);
+      outerSelect.Columns.Add(aRef["Col0"]);
+      outerSelect.Columns.Add(bRef["Name"]);
+      outerSelect.Columns.Add(cRef["Value"]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      // Col0 from outer SELECT, Col2 from [b]'s WHERE, Col4 from [c]'s WHERE
+      AssertColumnNames(aRef, "Col0", "Col2", "Col4");
+      AssertSelectColumnCount(innerA, 3);
     }
 
     [Test]

--- a/Orm/Xtensive.Orm.Tests.Sql/SqlColumnPrunerTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/SqlColumnPrunerTest.cs
@@ -620,19 +620,24 @@ namespace Xtensive.Orm.Tests.Sql
     #region Set operations and edge cases
 
     [Test]
-    public void DoesNotPruneSetOperations()
+    public void PrunesUnionWrappedInQueryRef()
     {
-      // SELECT u.Col0
-      // FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t
-      //       UNION ALL
-      //       SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) u
-      // UNION requires matched column counts → no pruning on the SqlQueryRef
-      var t = SqlDml.TableRef(table1);
-      var selectA = SqlDml.Select(t);
-      selectA.Columns.AddRange(t.Columns.ToArray<SqlColumn>());
+      // Before: SELECT u.Col0
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t
+      //               UNION ALL
+      //               SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) u
+      // After:  SELECT u.Col0
+      //         FROM (SELECT t.Col0 FROM table1 t
+      //               UNION ALL
+      //               SELECT t.Col0 FROM table1 t) u
+      // Both sides of the UNION are pruned to the same column indices.
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var selectA = SqlDml.Select(t1);
+      selectA.Columns.AddRange(t1.Columns.ToArray<SqlColumn>());
 
-      var selectB = SqlDml.Select(t);
-      selectB.Columns.AddRange(t.Columns.ToArray<SqlColumn>());
+      var t2 = SqlDml.TableRef(table1, "t2");
+      var selectB = SqlDml.Select(t2);
+      selectB.Columns.AddRange(t2.Columns.ToArray<SqlColumn>());
 
       var union = selectA.UnionAll(selectB);
       var queryRef = SqlDml.QueryRef(union, "u");
@@ -640,10 +645,44 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(queryRef);
       outerSelect.Columns.Add(queryRef[0]);
 
-      var originalColumnCount = queryRef.Columns.Count;
       SqlColumnPruner.Process(outerSelect);
 
-      Assert.That(queryRef.Columns.Count, Is.EqualTo(originalColumnCount));
+      Assert.That(queryRef.Columns.Count, Is.EqualTo(1));
+      Assert.That(selectA.Columns.Count, Is.EqualTo(1));
+      Assert.That(selectB.Columns.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void PrunesUnionDistinctWrappedInQueryRef()
+    {
+      // Before: SELECT u.Col0
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t
+      //               UNION
+      //               SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) u
+      // After:  SELECT u.Col0
+      //         FROM (SELECT t.Col0 FROM table1 t
+      //               UNION
+      //               SELECT t.Col0 FROM table1 t) u
+      // Same as UNION ALL — both sides pruned to the same column indices.
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var selectA = SqlDml.Select(t1);
+      selectA.Columns.AddRange(t1.Columns.ToArray<SqlColumn>());
+
+      var t2 = SqlDml.TableRef(table1, "t2");
+      var selectB = SqlDml.Select(t2);
+      selectB.Columns.AddRange(t2.Columns.ToArray<SqlColumn>());
+
+      var union = selectA.Union(selectB);
+      var queryRef = SqlDml.QueryRef(union, "u");
+
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      Assert.That(queryRef.Columns.Count, Is.EqualTo(1));
+      Assert.That(selectA.Columns.Count, Is.EqualTo(1));
+      Assert.That(selectB.Columns.Count, Is.EqualTo(1));
     }
 
     [Test]
@@ -763,13 +802,15 @@ namespace Xtensive.Orm.Tests.Sql
     [Test]
     public void JoinFromSidesRecurseIndependently()
     {
-      // When FROM is a join, the pruner recurses into each join side.
-      // Before: SELECT …
+      // When FROM is a join with SqlQueryRef sides, the pruner prunes each side independently.
+      // Before: SELECT l.Col0, r.Name
       //         FROM (SELECT t1.Col0, t1.Col1, t1.Col2 FROM table1 t1) l
       //         JOIN (SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) r ON l.Col0 = r.Id
-      // The inner selects of l and r are visited for their own FROM pruning.
-      // The join sides themselves are not pruned (no parent SqlQueryRef wraps them),
-      // but the test verifies no exceptions and that inner FROM sources are processed.
+      // After:  SELECT l.Col0, r.Name
+      //         FROM (SELECT t1.Col0 FROM table1 t1) l
+      //         JOIN (SELECT t2.Id, t2.Name FROM table2 t2) r ON l.Col0 = r.Id
+      // Left side pruned from 3 to 1 (only Col0 used in select + join condition).
+      // Right side pruned from 3 to 2 (Id used in join condition, Name in select).
       var t1 = SqlDml.TableRef(table1, "t1");
       var leftInner = SqlDml.Select(t1);
       leftInner.Columns.Add(t1["Col0"]);
@@ -790,11 +831,12 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(leftRef["Col0"]);
       outerSelect.Columns.Add(rightRef["Name"]);
 
-      Assert.DoesNotThrow(() => SqlColumnPruner.Process(outerSelect));
-      // Join sides themselves are not pruned (FROM is a join, not a SqlQueryRef),
-      // but inner selects of the join sides are visited without error.
-      Assert.That(leftInner.Columns.Count, Is.EqualTo(3));
-      Assert.That(rightInner.Columns.Count, Is.EqualTo(3));
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(leftRef, "Col0");
+      AssertSelectColumnCount(leftInner, 1);
+      AssertColumnNames(rightRef, "Id", "Name");
+      AssertSelectColumnCount(rightInner, 2);
     }
 
     [Test]
@@ -829,6 +871,140 @@ namespace Xtensive.Orm.Tests.Sql
 
       AssertColumnNames(wrapRef, "Col0", "Name");
       AssertSelectColumnCount(joinSelect, 2);
+    }
+
+    [Test]
+    public void JoinSidesWithQueryRefsPrunedThroughWrapper()
+    {
+      // Pruning cascades through a wrapping SqlQueryRef into inner join sides.
+      // Before: SELECT x.Col0, x.Name
+      //         FROM (SELECT l.Col0, l.Col1, l.Col2, r.Id, r.Name, r.Value
+      //               FROM (SELECT t1.Col0, t1.Col1, t1.Col2 FROM table1 t1) l
+      //               JOIN (SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) r ON l.Col0 = r.Id) x
+      // After:  SELECT x.Col0, x.Name
+      //         FROM (SELECT l.Col0, r.Name
+      //               FROM (SELECT t1.Col0 FROM table1 t1) l
+      //               JOIN (SELECT t2.Id, t2.Name FROM table2 t2) r ON l.Col0 = r.Id) x
+      // Three-level pruning: outer wrapper → join wrapper → join sides.
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var leftInner = SqlDml.Select(t1);
+      leftInner.Columns.Add(t1["Col0"]);
+      leftInner.Columns.Add(t1["Col1"]);
+      leftInner.Columns.Add(t1["Col2"]);
+
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var rightInner = SqlDml.Select(t2);
+      rightInner.Columns.Add(t2["Id"]);
+      rightInner.Columns.Add(t2["Name"]);
+      rightInner.Columns.Add(t2["Value"]);
+
+      var leftRef = SqlDml.QueryRef(leftInner, "l");
+      var rightRef = SqlDml.QueryRef(rightInner, "r");
+
+      var joined = leftRef.InnerJoin(rightRef, leftRef["Col0"] == rightRef["Id"]);
+      var joinSelect = SqlDml.Select(joined);
+      joinSelect.Columns.Add(leftRef["Col0"]);
+      joinSelect.Columns.Add(leftRef["Col1"]);
+      joinSelect.Columns.Add(leftRef["Col2"]);
+      joinSelect.Columns.Add(rightRef["Id"]);
+      joinSelect.Columns.Add(rightRef["Name"]);
+      joinSelect.Columns.Add(rightRef["Value"]);
+
+      var wrapRef = SqlDml.QueryRef(joinSelect, "x");
+      var outerSelect = SqlDml.Select(wrapRef);
+      outerSelect.Columns.Add(wrapRef["Col0"]);
+      outerSelect.Columns.Add(wrapRef["Name"]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      // Outer wrapper pruned from 6 to 2 columns
+      AssertColumnNames(wrapRef, "Col0", "Name");
+      AssertSelectColumnCount(joinSelect, 2);
+
+      // Left join side pruned from 3 to 1 (only Col0 used in select + join condition)
+      AssertColumnNames(leftRef, "Col0");
+      AssertSelectColumnCount(leftInner, 1);
+
+      // Right join side pruned from 3 to 2 (Id for join condition, Name for select)
+      AssertColumnNames(rightRef, "Id", "Name");
+      AssertSelectColumnCount(rightInner, 2);
+    }
+
+    [Test]
+    public void UnionFromDifferentTablesPrunedThroughQueryRef()
+    {
+      // UNION sides with different source tables are pruned by index.
+      // Before: SELECT u.Col0, u.Col2
+      //         FROM (SELECT t1.Col0, t1.Col1, t1.Col2 FROM table1 t1
+      //               UNION ALL
+      //               SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) u
+      // After:  SELECT u.Col0, u.Col2
+      //         FROM (SELECT t1.Col0, t1.Col2 FROM table1 t1
+      //               UNION ALL
+      //               SELECT t2.Id, t2.Value FROM table2 t2) u
+      // Column index 1 removed from both sides.
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var selectA = SqlDml.Select(t1);
+      selectA.Columns.Add(t1["Col0"]);
+      selectA.Columns.Add(t1["Col1"]);
+      selectA.Columns.Add(t1["Col2"]);
+
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var selectB = SqlDml.Select(t2);
+      selectB.Columns.Add(t2["Id"]);
+      selectB.Columns.Add(t2["Name"]);
+      selectB.Columns.Add(t2["Value"]);
+
+      var union = selectA.UnionAll(selectB);
+      var queryRef = SqlDml.QueryRef(union, "u");
+
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+      outerSelect.Columns.Add(queryRef[2]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      Assert.That(queryRef.Columns.Count, Is.EqualTo(2));
+      Assert.That(selectA.Columns.Count, Is.EqualTo(2));
+      Assert.That(selectB.Columns.Count, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void UnionDistinctFromDifferentTablesPrunedThroughQueryRef()
+    {
+      // Before: SELECT u.Col0, u.Col2
+      //         FROM (SELECT t1.Col0, t1.Col1, t1.Col2 FROM table1 t1
+      //               UNION
+      //               SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) u
+      // After:  SELECT u.Col0, u.Col2
+      //         FROM (SELECT t1.Col0, t1.Col2 FROM table1 t1
+      //               UNION
+      //               SELECT t2.Id, t2.Value FROM table2 t2) u
+      // Column index 1 removed from both sides.
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var selectA = SqlDml.Select(t1);
+      selectA.Columns.Add(t1["Col0"]);
+      selectA.Columns.Add(t1["Col1"]);
+      selectA.Columns.Add(t1["Col2"]);
+
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var selectB = SqlDml.Select(t2);
+      selectB.Columns.Add(t2["Id"]);
+      selectB.Columns.Add(t2["Name"]);
+      selectB.Columns.Add(t2["Value"]);
+
+      var union = selectA.Union(selectB);
+      var queryRef = SqlDml.QueryRef(union, "u");
+
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+      outerSelect.Columns.Add(queryRef[2]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      Assert.That(queryRef.Columns.Count, Is.EqualTo(2));
+      Assert.That(selectA.Columns.Count, Is.EqualTo(2));
+      Assert.That(selectB.Columns.Count, Is.EqualTo(2));
     }
 
     #endregion

--- a/Orm/Xtensive.Orm.Tests.Sql/SqlColumnPrunerTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/SqlColumnPrunerTest.cs
@@ -591,6 +591,115 @@ namespace Xtensive.Orm.Tests.Sql
       AssertSelectColumnCount(subInner, 2);
     }
 
+    [Test]
+    public void DeeplyNestedCorrelatedSubqueryPreservesColumns()
+    {
+      // A correlated reference to the outer table [l] is buried two levels deep
+      // inside a subquery's own FROM tree.
+      // Before: SELECT l.Col0,
+      //           (SELECT SUM(g.Id) FROM
+      //             (SELECT s.Id FROM (SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) s
+      //              WHERE s.Id = l.Col3 AND s.Name = l.Col4) g) AS agg
+      //         FROM (SELECT t1.Col0, t1.Col1, t1.Col2, t1.Col3, t1.Col4 FROM table1 t1) l
+      //         JOIN table2 r ON l.Col0 = r.Id
+      // After:  SELECT l.Col0,
+      //           (SELECT SUM(g.Id) FROM
+      //             (SELECT s.Id FROM (SELECT t2.Id, t2.Name FROM table2 t2) s
+      //              WHERE s.Id = l.Col3 AND s.Name = l.Col4) g) AS agg
+      //         FROM (SELECT t1.Col0, t1.Col3, t1.Col4 FROM table1 t1) l
+      //         JOIN table2 r ON l.Col0 = r.Id
+      // Col3 and Col4 are only referenced inside the subquery's nested FROM, not
+      // in the immediate subquery SELECT — the pruner must scan the entire subtree.
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var innerL = SqlDml.Select(t1);
+      for (int i = 0; i < t1.Columns.Count; i++) {
+        innerL.Columns.Add(t1[i]);
+      }
+      var lRef = SqlDml.QueryRef(innerL, "l");
+
+      var t2s = SqlDml.TableRef(table2, "t2s");
+      var innerS = SqlDml.Select(t2s);
+      innerS.Columns.Add(t2s["Id"]);
+      innerS.Columns.Add(t2s["Name"]);
+      innerS.Columns.Add(t2s["Value"]);
+      var sRef = SqlDml.QueryRef(innerS, "s");
+
+      var innerG = SqlDml.Select(sRef);
+      innerG.Columns.Add(sRef["Id"]);
+      innerG.Where = sRef["Id"] == lRef["Col3"] & sRef["Name"] == lRef["Col4"];
+      var gRef = SqlDml.QueryRef(innerG, "g");
+
+      var subqSelect = SqlDml.Select(gRef);
+      subqSelect.Columns.Add(SqlDml.Sum(gRef["Id"]));
+
+      var rTable = SqlDml.TableRef(table2, "r");
+      var joined = lRef.InnerJoin(rTable, lRef["Col0"] == rTable["Id"]);
+      var outerSelect = SqlDml.Select(joined);
+      outerSelect.Columns.Add(lRef["Col0"]);
+      outerSelect.Columns.Add(SqlDml.SubQuery(subqSelect));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      // Col0 from outer SELECT + join, Col3 and Col4 from deep inside the subquery
+      AssertColumnNames(lRef, "Col0", "Col3", "Col4");
+      AssertSelectColumnCount(innerL, 3);
+      // The subquery's inner [s] should also be pruned (Value removed)
+      AssertColumnNames(sRef, "Id", "Name");
+      AssertSelectColumnCount(innerS, 2);
+    }
+
+    [Test]
+    public void CorrelatedSubqueryWithGroupByReferencesOuterTable()
+    {
+      // Mirrors the real ORM pattern: a GROUP BY subquery joined with a table,
+      // and correlated subqueries in the SELECT list referencing the grouped alias.
+      // Before: SELECT f.Col0,
+      //           (SELECT COUNT(*) FROM
+      //             (SELECT t2.Id FROM table2 t2
+      //              WHERE t2.Id = g.Col0 AND t2.Name = g.Col1) h) AS cnt
+      //         FROM (SELECT t1.Col0, t1.Col1, t1.Col2
+      //               FROM table1 t1 GROUP BY t1.Col0, t1.Col1, t1.Col2) g
+      //         JOIN table1 f ON g.Col0 = f.Col0
+      // After:  SELECT f.Col0,
+      //           (SELECT COUNT(*) FROM
+      //             (SELECT t2.Id FROM table2 t2
+      //              WHERE t2.Id = g.Col0 AND t2.Name = g.Col1) h) AS cnt
+      //         FROM (SELECT t1.Col0, t1.Col1
+      //               FROM table1 t1 GROUP BY t1.Col0, t1.Col1, t1.Col2) g
+      //         JOIN table1 f ON g.Col0 = f.Col0
+      // g.Col1 is only referenced deep inside the correlated subquery — must be kept.
+      var t1g = SqlDml.TableRef(table1, "t1g");
+      var innerG = SqlDml.Select(t1g);
+      innerG.Columns.Add(t1g["Col0"]);
+      innerG.Columns.Add(t1g["Col1"]);
+      innerG.Columns.Add(t1g["Col2"]);
+      innerG.GroupBy.Add(t1g["Col0"]);
+      innerG.GroupBy.Add(t1g["Col1"]);
+      innerG.GroupBy.Add(t1g["Col2"]);
+      var gRef = SqlDml.QueryRef(innerG, "g");
+
+      var t2h = SqlDml.TableRef(table2, "t2h");
+      var innerH = SqlDml.Select(t2h);
+      innerH.Columns.Add(t2h["Id"]);
+      innerH.Where = t2h["Id"] == gRef["Col0"] & t2h["Name"] == gRef["Col1"];
+      var hRef = SqlDml.QueryRef(innerH, "h");
+
+      var subqSelect = SqlDml.Select(hRef);
+      subqSelect.Columns.Add(SqlDml.Count());
+
+      var fTable = SqlDml.TableRef(table1, "f");
+      var joined = gRef.InnerJoin(fTable, gRef["Col0"] == fTable["Col0"]);
+      var outerSelect = SqlDml.Select(joined);
+      outerSelect.Columns.Add(fTable["Col0"]);
+      outerSelect.Columns.Add(SqlDml.SubQuery(subqSelect));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      // Col0 from join condition, Col1 from deep inside the subquery — Col2 pruned
+      AssertColumnNames(gRef, "Col0", "Col1");
+      AssertSelectColumnCount(innerG, 2);
+    }
+
     #endregion
 
     #region Nesting

--- a/Orm/Xtensive.Orm.Tests.Sql/SqlColumnPrunerTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/SqlColumnPrunerTest.cs
@@ -2,6 +2,7 @@
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -17,6 +18,7 @@ namespace Xtensive.Orm.Tests.Sql
   {
     private Table table1;
     private Table table2;
+    private ProviderInfo providerInfo;
 
     [OneTimeSetUp]
     public void SetUp()
@@ -35,6 +37,20 @@ namespace Xtensive.Orm.Tests.Sql
       _ = table2.CreateColumn("Id", new SqlValueType(SqlType.Int32));
       _ = table2.CreateColumn("Name", new SqlValueType(SqlType.VarChar));
       _ = table2.CreateColumn("Value", new SqlValueType(SqlType.VarChar));
+
+      // Minimal ProviderInfo for invoking SqlSelectProcessor.
+      // Column pruning logic itself does not consult any provider feature flags,
+      // so ProviderFeatures.None is sufficient.
+      providerInfo = new ProviderInfo(
+        providerName: "test",
+        storageVersion: new Version(1, 0),
+        providerFeatures: ProviderFeatures.None,
+        maxIdentifierLength: 128,
+        constantPrimaryIndexName: "PK",
+        defaultDatabase: "test",
+        defaultSchema: "dbo",
+        supportedTypes: Enumerable.Empty<Type>(),
+        maxQueryParameterCount: 1000);
     }
 
     #region Basic pruning
@@ -50,7 +66,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(queryRef[0]);
       outerSelect.Columns.Add(queryRef[2]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col2");
       AssertSelectColumnCount(innerSelect, 2);
@@ -69,7 +85,7 @@ namespace Xtensive.Orm.Tests.Sql
         outerSelect.Columns.Add(queryRef[i]);
       }
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col1", "Col2", "Col3", "Col4");
       AssertSelectColumnCount(innerSelect, 5);
@@ -85,7 +101,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(queryRef);
       outerSelect.Columns.Add(queryRef[3]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col3");
       AssertSelectColumnCount(innerSelect, 1);
@@ -106,7 +122,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(col0Ref);
       outerSelect.Columns.Add(col4Ref);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col4");
       Assert.That(queryRef.Columns[0], Is.SameAs(col0Ref));
@@ -128,7 +144,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(queryRef[0]);
       outerSelect.Where = queryRef[3] == SqlDml.Literal("test");
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col3");
       AssertSelectColumnCount(innerSelect, 2);
@@ -145,7 +161,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(queryRef[0]);
       outerSelect.OrderBy.Add(queryRef[4]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col4");
       AssertSelectColumnCount(innerSelect, 2);
@@ -162,7 +178,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(SqlDml.Count());
       outerSelect.GroupBy.Add(queryRef[1]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col1");
       AssertSelectColumnCount(innerSelect, 1);
@@ -180,7 +196,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.GroupBy.Add(queryRef[0]);
       outerSelect.Having = SqlDml.Count(queryRef[2]) > SqlDml.Literal(1);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col2");
       AssertSelectColumnCount(innerSelect, 2);
@@ -198,7 +214,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Where = queryRef[1] == SqlDml.Literal("a")
                            & queryRef[3] != SqlDml.Null;
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col1", "Col3");
       AssertSelectColumnCount(innerSelect, 3);
@@ -224,7 +240,7 @@ namespace Xtensive.Orm.Tests.Sql
       caseExpr.Else = queryRef[3];
       outerSelect.Columns.Add(caseExpr);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col1", "Col2", "Col3");
       AssertSelectColumnCount(innerSelect, 3);
@@ -248,7 +264,7 @@ namespace Xtensive.Orm.Tests.Sql
       caseExpr.Else = queryRef[3];
       outerSelect.Columns.Add(caseExpr);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col1", "Col2", "Col3");
       AssertSelectColumnCount(innerSelect, 4);
@@ -264,7 +280,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(queryRef);
       outerSelect.Columns.Add(SqlDml.Cast(queryRef[2], SqlType.Int32));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col2");
       AssertSelectColumnCount(innerSelect, 1);
@@ -280,7 +296,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(queryRef);
       outerSelect.Columns.Add(SqlDml.Coalesce(queryRef[1], queryRef[4]));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col1", "Col4");
       AssertSelectColumnCount(innerSelect, 2);
@@ -298,7 +314,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(SqlDml.Sum(queryRef[3]));
       outerSelect.GroupBy.Add(queryRef[1]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col1", "Col3");
       AssertSelectColumnCount(innerSelect, 2);
@@ -315,7 +331,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(queryRef[0]);
       outerSelect.Where = SqlDml.Like(queryRef[1], queryRef[2]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col1", "Col2");
       AssertSelectColumnCount(innerSelect, 3);
@@ -332,7 +348,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(queryRef[0]);
       outerSelect.Where = SqlDml.Between(queryRef[1], queryRef[2], queryRef[3]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col1", "Col2", "Col3");
       AssertSelectColumnCount(innerSelect, 4);
@@ -348,7 +364,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(queryRef);
       outerSelect.Columns.Add(queryRef[0] + queryRef[3]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col3");
       AssertSelectColumnCount(innerSelect, 2);
@@ -364,7 +380,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(queryRef);
       outerSelect.Columns.Add(-queryRef[0]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0");
       AssertSelectColumnCount(innerSelect, 1);
@@ -386,7 +402,7 @@ namespace Xtensive.Orm.Tests.Sql
       rn.OrderBy.Add(queryRef[2]);
       outerSelect.Columns.Add(rn);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col2");
       AssertSelectColumnCount(innerSelect, 2);
@@ -412,7 +428,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Where = queryRef[3] > SqlDml.Literal(0);
       outerSelect.OrderBy.Add(queryRef[4]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col1", "Col2", "Col3", "Col4");
       AssertSelectColumnCount(innerSelect, 5);
@@ -435,7 +451,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(queryRef[0] * SqlDml.Literal(2));
       outerSelect.Where = queryRef[3] != SqlDml.Null;
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col1", "Col3");
       AssertSelectColumnCount(innerSelect, 3);
@@ -460,7 +476,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(queryRef[0]);
       outerSelect.Columns.Add(metadataExpr);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col3");
       AssertSelectColumnCount(innerSelect, 2);
@@ -487,7 +503,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(queryRef[0]);
       outerSelect.Columns.Add(metadataExpr);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col2");
       AssertSelectColumnCount(innerSelect, 2);
@@ -518,7 +534,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(queryRef[0]);
       outerSelect.Columns.Add(subquery);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col3");
       AssertSelectColumnCount(innerSelect, 2);
@@ -544,7 +560,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(queryRef[0]);
       outerSelect.Where = SqlDml.Exists(existsSelect);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col4");
       AssertSelectColumnCount(innerSelect, 2);
@@ -581,7 +597,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(queryRef[0]);
       outerSelect.Columns.Add(SqlDml.SubQuery(subOuter));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       // Outer query pruned to Col0, Col3
       AssertColumnNames(queryRef, "Col0", "Col3");
@@ -638,7 +654,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(lRef["Col0"]);
       outerSelect.Columns.Add(SqlDml.SubQuery(subqSelect));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       // Col0 from outer SELECT + join, Col3 and Col4 from deep inside the subquery
       AssertColumnNames(lRef, "Col0", "Col3", "Col4");
@@ -693,7 +709,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(fTable["Col0"]);
       outerSelect.Columns.Add(SqlDml.SubQuery(subqSelect));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       // Col0 from join condition, Col1 from deep inside the subquery — Col2 pruned
       AssertColumnNames(gRef, "Col0", "Col1");
@@ -729,7 +745,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(outerRef[0]);
       outerSelect.Columns.Add(outerRef[2]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(outerRef, "Col0", "Col4");
       AssertSelectColumnCount(middleSelect, 2);
@@ -765,7 +781,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(outerRef);
       outerSelect.Columns.Add(outerRef[0]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       // Outer prunes middle to just Col0
       AssertColumnNames(outerRef, "Col0");
@@ -806,7 +822,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(queryRef);
       outerSelect.Columns.Add(queryRef[0]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       Assert.That(queryRef.Columns.Count, Is.EqualTo(1));
       Assert.That(selectA.Columns.Count, Is.EqualTo(1));
@@ -827,7 +843,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(queryRef);
       outerSelect.Columns.Add(queryRef[0]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       Assert.That(queryRef.Columns.Count, Is.EqualTo(5));
       AssertSelectColumnCount(innerSelect, 5);
@@ -859,7 +875,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(queryRef);
       outerSelect.Columns.Add(queryRef[0]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       // DISTINCT select is NOT pruned (still 3 columns)
       Assert.That(queryRef.Columns.Count, Is.EqualTo(3));
@@ -894,7 +910,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(queryRef[0]);
 
       var originalColumnCount = queryRef.Columns.Count;
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       Assert.That(queryRef.Columns.Count, Is.EqualTo(originalColumnCount));
       Assert.That(selectA.Columns.Count, Is.EqualTo(5));
@@ -908,7 +924,7 @@ namespace Xtensive.Orm.Tests.Sql
       var select = SqlDml.Select();
       select.Columns.Add(SqlDml.Literal(1));
 
-      Assert.DoesNotThrow(() => SqlColumnPruner.Process(select));
+      Assert.DoesNotThrow(() => RunSelectCorrector(select));
     }
 
     [Test]
@@ -921,7 +937,7 @@ namespace Xtensive.Orm.Tests.Sql
       select.Columns.Add(t[0]);
       select.Columns.Add(t[2]);
 
-      Assert.DoesNotThrow(() => SqlColumnPruner.Process(select));
+      Assert.DoesNotThrow(() => RunSelectCorrector(select));
       Assert.That(select.Columns.Count, Is.EqualTo(2));
     }
 
@@ -962,7 +978,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Where = middleRef["rn"] > SqlDml.Literal(10)
                            & middleRef["rn"] <= SqlDml.Literal(20);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       // Middle should have Col0, Col1, rn (3 cols)
       AssertColumnNames(middleRef, "Col0", "Col1", "rn");
@@ -988,7 +1004,7 @@ namespace Xtensive.Orm.Tests.Sql
         SqlDml.Concat(queryRef[1], SqlDml.Literal(" "), queryRef[2]),
         "FullName");
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col1", "Col2");
       AssertSelectColumnCount(innerSelect, 3);
@@ -1009,7 +1025,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(SqlDml.Max(queryRef[3]));
       outerSelect.GroupBy.Add(queryRef[1]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col1", "Col3");
       AssertSelectColumnCount(innerSelect, 3);
@@ -1047,7 +1063,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(leftRef["Col0"]);
       outerSelect.Columns.Add(rightRef["Name"]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(leftRef, "Col0");
       AssertSelectColumnCount(leftInner, 1);
@@ -1083,7 +1099,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(wrapRef["Col0"]);
       outerSelect.Columns.Add(wrapRef["Name"]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(wrapRef, "Col0", "Name");
       AssertSelectColumnCount(joinSelect, 2);
@@ -1131,7 +1147,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(wrapRef["Col0"]);
       outerSelect.Columns.Add(wrapRef["Name"]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       // Outer wrapper pruned from 6 to 2 columns
       AssertColumnNames(wrapRef, "Col0", "Name");
@@ -1177,7 +1193,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(aRef["Col1"]);
       outerSelect.Columns.Add(bRef["Name"]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       // Col3 preserved because the APPLY subquery references it
       AssertColumnNames(aRef, "Col0", "Col1", "Col3");
@@ -1222,7 +1238,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(bRef["Name"]);
       outerSelect.Columns.Add(cRef["Value"]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       // Col0 from outer SELECT, Col2 from [b]'s WHERE, Col4 from [c]'s WHERE
       AssertColumnNames(aRef, "Col0", "Col2", "Col4");
@@ -1261,7 +1277,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(queryRef[0]);
       outerSelect.Columns.Add(queryRef[2]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       Assert.That(queryRef.Columns.Count, Is.EqualTo(2));
       Assert.That(selectA.Columns.Count, Is.EqualTo(2));
@@ -1293,7 +1309,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(queryRef[0]);
 
       var originalColumnCount = queryRef.Columns.Count;
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       Assert.That(queryRef.Columns.Count, Is.EqualTo(originalColumnCount));
       Assert.That(selectA.Columns.Count, Is.EqualTo(3));
@@ -1340,7 +1356,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(queryRef);
       outerSelect.Columns.Add(queryRef[0]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       // UNION column list is NOT pruned (still 2 per side)
       Assert.That(queryRef.Columns.Count, Is.EqualTo(2));
@@ -1394,7 +1410,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(queryRef);
       outerSelect.Columns.Add(queryRef[0]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       Assert.That(queryRef.Columns.Count, Is.EqualTo(1));
       Assert.That(selectA.Columns.Count, Is.EqualTo(1));
@@ -1433,7 +1449,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(queryRef[0]);
 
       var originalColumnCount = queryRef.Columns.Count;
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       Assert.That(queryRef.Columns.Count, Is.EqualTo(originalColumnCount));
       Assert.That(selectA.Columns.Count, Is.EqualTo(3));
@@ -1472,7 +1488,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(queryRef[0]);
 
       var originalColumnCount = queryRef.Columns.Count;
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       Assert.That(queryRef.Columns.Count, Is.EqualTo(originalColumnCount));
       Assert.That(selectA.Columns.Count, Is.EqualTo(3));
@@ -1517,7 +1533,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(dRef["Col0"]);
       outerSelect.Columns.Add(iRef["Id"]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       // Col3 preserved because it's referenced deep inside the APPLY
       AssertColumnNames(dRef, "Col0", "Col3");
@@ -1569,7 +1585,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(bRef["Name"]);
       outerSelect.Columns.Add(iRef["Id"]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       // Col0 from outer SELECT, Col2 from [b]'s WHERE, Col4 from deep inside [i]
       AssertColumnNames(dRef, "Col0", "Col2", "Col4");
@@ -1592,7 +1608,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(queryRef);
       outerSelect.Columns.Add(SqlDml.Trim(queryRef[1]));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col1");
       AssertSelectColumnCount(innerSelect, 1);
@@ -1610,7 +1626,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(queryRef);
       outerSelect.Columns.Add(SqlDml.Extract(SqlDateTimePart.Year, queryRef[0]));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0");
       AssertSelectColumnCount(innerSelect, 1);
@@ -1630,7 +1646,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(
         SqlDml.Round(queryRef[0], queryRef[3], TypeCode.Decimal, MidpointRounding.AwayFromZero));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col3");
       AssertSelectColumnCount(innerSelect, 2);
@@ -1652,7 +1668,7 @@ namespace Xtensive.Orm.Tests.Sql
         var outerSelect = SqlDml.Select(queryRef);
         outerSelect.Columns.Add(SqlDml.Collate(queryRef[1], collation));
 
-        SqlColumnPruner.Process(outerSelect);
+        RunSelectCorrector(outerSelect);
 
         AssertColumnNames(queryRef, "Col1");
         AssertSelectColumnCount(innerSelect, 1);
@@ -1675,7 +1691,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(queryRef);
       outerSelect.Columns.Add(SqlDml.Variant("v1", queryRef[1], queryRef[3]));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col1", "Col3");
       AssertSelectColumnCount(innerSelect, 2);
@@ -1697,7 +1713,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(queryRef[0]);
       outerSelect.Where = SqlDml.DynamicFilter("df1", new SqlExpression[] { queryRef[2], queryRef[4] });
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col2", "Col4");
       AssertSelectColumnCount(innerSelect, 3);
@@ -1716,7 +1732,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(queryRef);
       outerSelect.Columns.Add(SqlDml.ColumnStub(queryRef[2]));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col2");
       AssertSelectColumnCount(innerSelect, 1);
@@ -1738,7 +1754,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(queryRef[0]);
       outerSelect.Where = SqlDml.In(queryRef[3], SqlDml.Row(queryRef[1], queryRef[4]));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col1", "Col3", "Col4");
       AssertSelectColumnCount(innerSelect, 4);
@@ -1760,7 +1776,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(queryRef[0]);
       outerSelect.Where = SqlDml.Like(queryRef[1], queryRef[2], queryRef[3]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col1", "Col2", "Col3");
       AssertSelectColumnCount(innerSelect, 4);
@@ -1779,7 +1795,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(queryRef);
       outerSelect.Columns.Add(SqlDml.Column(queryRef[3] + queryRef[4]));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col3", "Col4");
       AssertSelectColumnCount(innerSelect, 2);
@@ -1818,7 +1834,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(t1);
       outerSelect.Columns.Add(caseExpr);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(subRef, "Id");
       AssertSelectColumnCount(subInner, 1);
@@ -1847,7 +1863,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(t1);
       outerSelect.Columns.Add(SqlDml.Cast(SqlDml.SubQuery(subOuter), SqlType.Int32));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(subRef, "Id");
       AssertSelectColumnCount(subInner, 1);
@@ -1879,7 +1895,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(
         SqlDml.Coalesce(SqlDml.SubQuery(subOuter), SqlDml.Literal("default")));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(subRef, "Name");
       AssertSelectColumnCount(subInner, 1);
@@ -1908,7 +1924,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(t1);
       outerSelect.Columns.Add(SqlDml.Column(SqlDml.SubQuery(subOuter)));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(subRef, "Value");
       AssertSelectColumnCount(subInner, 1);
@@ -1938,7 +1954,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(t1["Col0"]);
       outerSelect.Where = SqlDml.Like(t1["Col1"], SqlDml.SubQuery(subOuter));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(subRef, "Name");
       AssertSelectColumnCount(subInner, 1);
@@ -1968,7 +1984,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(t1["Col0"]);
       outerSelect.Where = SqlDml.Between(t1["Col0"], SqlDml.SubQuery(subOuter), SqlDml.Literal(100));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(subRef, "Id");
       AssertSelectColumnCount(subInner, 1);
@@ -1997,7 +2013,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(t1);
       outerSelect.Columns.Add(SqlDml.Trim(SqlDml.SubQuery(subOuter)));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(subRef, "Name");
       AssertSelectColumnCount(subInner, 1);
@@ -2026,7 +2042,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(t1);
       outerSelect.Columns.Add(SqlDml.Extract(SqlDateTimePart.Year, SqlDml.SubQuery(subOuter)));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(subRef, "Id");
       AssertSelectColumnCount(subInner, 1);
@@ -2058,7 +2074,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(
         SqlDml.Variant("v1", SqlDml.SubQuery(subOuter), SqlDml.Literal("fallback")));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(subRef, "Name");
       AssertSelectColumnCount(subInner, 1);
@@ -2092,7 +2108,7 @@ namespace Xtensive.Orm.Tests.Sql
       rn.OrderBy.Add(SqlDml.SubQuery(subOuter));
       outerSelect.Columns.Add(rn);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(subRef, "Id");
       AssertSelectColumnCount(subInner, 1);
@@ -2123,7 +2139,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(t1);
       outerSelect.Columns.Add(SqlDml.Metadata(SqlDml.SubQuery(subOuter), new object()));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(subRef, "Value");
       AssertSelectColumnCount(subInner, 1);
@@ -2160,7 +2176,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.GroupBy.Add(t1["Col0"]);
       outerSelect.Having = SqlDml.Count() > SqlDml.SubQuery(subOuter);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(subRef, "Id");
       AssertSelectColumnCount(subInner, 1);
@@ -2190,7 +2206,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(t1["Col0"]);
       outerSelect.OrderBy.Add(SqlDml.SubQuery(subOuter));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(subRef, "Name");
       AssertSelectColumnCount(subInner, 1);
@@ -2220,7 +2236,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(t1["Col0"]);
       outerSelect.GroupBy.Add(SqlDml.SubQuery(subOuter));
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(subRef, "Id");
       AssertSelectColumnCount(subInner, 1);
@@ -2273,10 +2289,57 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(dRef["Col0"]);
       outerSelect.Columns.Add(iRef["Id"]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(dRef, "Col0", "Col3", "Col4");
       AssertSelectColumnCount(innerD, 3);
+    }
+
+    [Test]
+    public void CorrelatedReferenceInsideUnionWrappedInScalarSubQueryPreservesColumns()
+    {
+      // Variant of CorrelatedReferenceInsideUnionSiblingPreservesColumns where
+      // the UNION is the body of a scalar SqlSubQuery expression instead of a
+      // SqlQueryRef in the FROM clause. This exercises the SqlSubQuery dispatch
+      // arm of CollectUsedColumns, whose .Query may be either SqlSelect or
+      // SqlQueryExpression; only the SqlSelect arm is currently handled, so the
+      // correlated references inside the union sides are silently invisible to
+      // the collector and Col3/Col4 get incorrectly pruned away.
+      // Before: SELECT a.Col0,
+      //                (SELECT t2L.Id FROM table2 t2L WHERE t2L.Id = a.Col3
+      //                 UNION ALL
+      //                 SELECT t2R.Id FROM table2 t2R WHERE t2R.Id = a.Col4)
+      //         FROM (SELECT t1.Col0, t1.Col1, t1.Col2, t1.Col3, t1.Col4 FROM table1 t1) a
+      // After:  SELECT a.Col0, (...)
+      //         FROM (SELECT t1.Col0, t1.Col3, t1.Col4 FROM table1 t1) a
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var innerA = SqlDml.Select(t1);
+      for (int i = 0; i < t1.Columns.Count; i++) {
+        innerA.Columns.Add(t1[i]);
+      }
+      var aRef = SqlDml.QueryRef(innerA, "a");
+
+      var t2L = SqlDml.TableRef(table2, "t2L");
+      var unionLeft = SqlDml.Select(t2L);
+      unionLeft.Columns.Add(t2L["Id"]);
+      unionLeft.Where = t2L["Id"] == aRef["Col3"];
+
+      var t2R = SqlDml.TableRef(table2, "t2R");
+      var unionRight = SqlDml.Select(t2R);
+      unionRight.Columns.Add(t2R["Id"]);
+      unionRight.Where = t2R["Id"] == aRef["Col4"];
+
+      var union = unionLeft.UnionAll(unionRight);
+      var scalarSub = SqlDml.SubQuery(union);
+
+      var outerSelect = SqlDml.Select(aRef);
+      outerSelect.Columns.Add(aRef["Col0"]);
+      outerSelect.Columns.Add(scalarSub);
+
+      RunSelectCorrector(outerSelect);
+
+      AssertColumnNames(aRef, "Col0", "Col3", "Col4");
+      AssertSelectColumnCount(innerA, 3);
     }
 
     [Test]
@@ -2313,7 +2376,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(dRef["Col0"]);
       outerSelect.Columns.Add(iRef["Name"]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(dRef, "Col0", "Col2");
       AssertSelectColumnCount(innerD, 2);
@@ -2352,7 +2415,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(queryRef[0]);
 
       var originalColumnCount = queryRef.Columns.Count;
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       Assert.That(queryRef.Columns.Count, Is.EqualTo(originalColumnCount));
       Assert.That(selectA.Columns.Count, Is.EqualTo(3));
@@ -2378,7 +2441,7 @@ namespace Xtensive.Orm.Tests.Sql
       outerSelect.Columns.Add(sharedExpr);
       outerSelect.Where = sharedExpr > SqlDml.Literal(0);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       AssertColumnNames(queryRef, "Col0", "Col2");
       AssertSelectColumnCount(innerSelect, 2);
@@ -2426,7 +2489,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(queryRef);
       outerSelect.Columns.Add(queryRef[0]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       // INTERSECT not pruned — still 2 columns per side
       Assert.That(queryRef.Columns.Count, Is.EqualTo(2));
@@ -2451,7 +2514,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(queryRef);
       outerSelect.Columns.Add(SqlDml.Literal(1));
 
-      Assert.DoesNotThrow(() => SqlColumnPruner.Process(outerSelect));
+      Assert.DoesNotThrow(() => RunSelectCorrector(outerSelect));
     }
 
     [Test]
@@ -2462,7 +2525,7 @@ namespace Xtensive.Orm.Tests.Sql
       var select = SqlDml.Select();
       select.Columns.Add(SqlDml.Literal(42));
 
-      Assert.DoesNotThrow(() => SqlColumnPruner.Process(select));
+      Assert.DoesNotThrow(() => RunSelectCorrector(select));
     }
 
     [Test]
@@ -2521,7 +2584,7 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(queryRef);
       outerSelect.Columns.Add(queryRef[0]);
 
-      SqlColumnPruner.Process(outerSelect);
+      RunSelectCorrector(outerSelect);
 
       // Inner subqueries pruned from 3 to 1 (only Col0 needed)
       AssertColumnNames(aRef, "Col0");
@@ -2530,6 +2593,186 @@ namespace Xtensive.Orm.Tests.Sql
       AssertSelectColumnCount(innerB, 1);
       AssertColumnNames(cRef, "Col0");
       AssertSelectColumnCount(innerC, 1);
+    }
+
+    #endregion
+
+    #region Regressions for issues discovered during the SqlColumnPruner / SqlSelectProcessor merge
+
+    [Test]
+    public void NullWhereClauseDoesNotDisablePruning()
+    {
+      // Before: SELECT q.Col0, q.Col2
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      //         /* no WHERE clause */
+      // After:  SELECT q.Col0, q.Col2
+      //         FROM (SELECT t.Col0, t.Col2 FROM table1 t) q
+      //
+      // Regression: in the original SqlColumnPruner, the guard against null clauses
+      // used `if (expr == null) return;`. SqlExpression overloads `operator ==` to
+      // construct a SqlBinary (returning a non-null reference) and `operator true`
+      // returns false, so `if (expr == null)` never enters the body — `expr` then
+      // falls through to the switch statement's `default` branch, which conservatively
+      // marks all target-table columns as used. The net effect: any SqlSelect whose
+      // Where clause was null disabled pruning of its FROM source.
+      //
+      // The fix replaces `== null` with `is null`, which is a true reference null
+      // check that cannot be intercepted by user-defined operators.
+      //
+      // This test pins the correct behavior: when Where is null and only Col0/Col2
+      // are referenced in the SELECT list, the inner subquery must be pruned to
+      // those two columns.
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+      outerSelect.Columns.Add(queryRef[2]);
+
+      Assert.That(outerSelect.Where, Is.Null,
+        "Test precondition: outer SELECT must have a null Where clause to exercise the regression.");
+
+      RunSelectCorrector(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col2");
+      AssertSelectColumnCount(innerSelect, 2);
+    }
+
+    [Test]
+    public void NullHavingClauseDoesNotDisablePruning()
+    {
+      // Before: SELECT COUNT(*)
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      //         GROUP BY q.Col1
+      //         /* no HAVING clause */
+      // After:  SELECT COUNT(*)
+      //         FROM (SELECT t.Col1 FROM table1 t) q
+      //         GROUP BY q.Col1
+      //
+      // Companion regression to NullWhereClauseDoesNotDisablePruning — the same
+      // faulty null-check also affected the Having clause path. With Having=null
+      // and only Col1 referenced (in GROUP BY), the inner subquery must still be
+      // pruned to one column.
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(SqlDml.Count());
+      outerSelect.GroupBy.Add(queryRef[1]);
+
+      Assert.That(outerSelect.Having, Is.Null,
+        "Test precondition: outer SELECT must have a null Having clause to exercise the regression.");
+
+      RunSelectCorrector(outerSelect);
+
+      AssertColumnNames(queryRef, "Col1");
+      AssertSelectColumnCount(innerSelect, 1);
+    }
+
+    [Test]
+    public void NullOrderByExpressionDoesNotDisablePruning()
+    {
+      // Before: SELECT q.Col0
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      //         ORDER BY q.Col3
+      //         /* no WHERE / HAVING clauses; ORDER BY entries with null Expression
+      //            are tolerated by the same `is null` guard */
+      // After:  SELECT q.Col0
+      //         FROM (SELECT t.Col0, t.Col3 FROM table1 t) q
+      //         ORDER BY q.Col3
+      //
+      // SqlOrder.Expression can in principle be null (defensive coverage of the
+      // same `is null` guard exercised inside CollectUsedColumns). The pruner
+      // must continue scanning sibling order-by entries and other clauses
+      // without bailing out or marking all columns as used.
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+      outerSelect.OrderBy.Add(queryRef[3]);
+
+      RunSelectCorrector(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col3");
+      AssertSelectColumnCount(innerSelect, 2);
+    }
+
+    [Test]
+    public void SubqueryInsideVariantAlternativeBranchIsPruned()
+    {
+      // Before: SELECT VARIANT(
+      //                  'primary',
+      //                  (SELECT s.Value FROM (SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) s))
+      //         FROM table1 t1
+      // After:  SELECT VARIANT(
+      //                  'primary',
+      //                  (SELECT s.Value FROM (SELECT t2.Value FROM table2 t2) s))
+      //         FROM table1 t1
+      //
+      // Regression: Visit(SqlVariant) in SqlSelectProcessor used to be an empty
+      // method, so subqueries embedded in either branch of a SqlVariant were
+      // never visited and therefore never pruned. The fix routes the visitor
+      // into both Main and Alternative.
+      //
+      // SubqueryInsideVariantIsPruned already covers the Main branch; this test
+      // pins the Alternative branch independently (subquery in Alternative,
+      // literal in Main) so a future regression affecting only one side cannot
+      // slip through.
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var subInner = SqlDml.Select(t2);
+      subInner.Columns.Add(t2["Id"]);
+      subInner.Columns.Add(t2["Name"]);
+      subInner.Columns.Add(t2["Value"]);
+      var subRef = SqlDml.QueryRef(subInner, "s");
+      var subOuter = SqlDml.Select(subRef);
+      subOuter.Columns.Add(subRef["Value"]);
+
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var outerSelect = SqlDml.Select(t1);
+      outerSelect.Columns.Add(
+        SqlDml.Variant("v1", SqlDml.Literal("primary"), SqlDml.SubQuery(subOuter)));
+
+      RunSelectCorrector(outerSelect);
+
+      AssertColumnNames(subRef, "Value");
+      AssertSelectColumnCount(subInner, 1);
+    }
+
+    [Test]
+    public void SubqueryInsideCaseWhenConditionIsPruned()
+    {
+      // Regression: Visit(SqlCase) in SqlSelectProcessor used to visit only Value
+      // and Else, skipping the When/Then key/value pairs entirely. A subquery
+      // embedded in a WHEN condition (the key) therefore was never visited and
+      // never pruned. The fix iterates over the case's key/value pairs as well.
+      //
+      // Before: SELECT CASE WHEN
+      //                  (SELECT s.Id FROM (SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) s)
+      //                  IS NOT NULL THEN 1 ELSE 0 END
+      //         FROM table1 t1
+      // After:  SELECT CASE WHEN
+      //                  (SELECT s.Id FROM (SELECT t2.Id FROM table2 t2) s)
+      //                  IS NOT NULL THEN 1 ELSE 0 END
+      //         FROM table1 t1
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var subInner = SqlDml.Select(t2);
+      subInner.Columns.Add(t2["Id"]);
+      subInner.Columns.Add(t2["Name"]);
+      subInner.Columns.Add(t2["Value"]);
+      var subRef = SqlDml.QueryRef(subInner, "s");
+      var subOuter = SqlDml.Select(subRef);
+      subOuter.Columns.Add(subRef["Id"]);
+
+      var caseExpr = SqlDml.Case();
+      caseExpr[SqlDml.IsNotNull(SqlDml.SubQuery(subOuter))] = SqlDml.Literal(1);
+      caseExpr.Else = SqlDml.Literal(0);
+
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var outerSelect = SqlDml.Select(t1);
+      outerSelect.Columns.Add(caseExpr);
+
+      RunSelectCorrector(outerSelect);
+
+      AssertColumnNames(subRef, "Id");
+      AssertSelectColumnCount(subInner, 1);
     }
 
     #endregion
@@ -2544,6 +2787,20 @@ namespace Xtensive.Orm.Tests.Sql
         select.Columns.Add(t[i]);
       }
       return select;
+    }
+
+    /// <summary>
+    /// Runs the production post-compilation pipeline through
+    /// <see cref="SqlSelectCorrector"/>, the same entry point production code
+    /// reaches via <see cref="IPostCompiler"/>. Tests deliberately go through
+    /// the corrector rather than its inner mechanics so that internal
+    /// refactorings (e.g. moving column pruning between <c>SqlSelectProcessor</c>
+    /// and <c>SqlColumnPruner</c>) do not break the suite — only end-to-end
+    /// pruning behavior is asserted.
+    /// </summary>
+    private void RunSelectCorrector(SqlSelect rootSelect)
+    {
+      new SqlSelectCorrector(providerInfo).Process(rootSelect);
     }
 
     private static void AssertColumnNames(SqlQueryRef queryRef, params string[] expectedNames)

--- a/Orm/Xtensive.Orm.Tests.Sql/SqlColumnPrunerTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/SqlColumnPrunerTest.cs
@@ -1371,6 +1371,1058 @@ namespace Xtensive.Orm.Tests.Sql
       Assert.That(selectC.Columns.Count, Is.EqualTo(3));
     }
 
+    [Test]
+    public void DeeplyNestedOuterApplyCorrelatedReferencePreservesColumns()
+    {
+      // A correlated reference to [d].[Col3] appears two levels deep:
+      // inside [h], which is nested inside [i]'s FROM clause.
+      // Before: SELECT d.Col0, i.Id
+      //         FROM (SELECT t1.Col0, t1.Col1, t1.Col2, t1.Col3, t1.Col4 FROM table1 t1) d
+      //         OUTER APPLY (SELECT h.Id FROM
+      //           (SELECT t2.Id, t2.Name FROM table2 t2 WHERE t2.Id = d.Col3) h) i
+      // After:  SELECT d.Col0, i.Id
+      //         FROM (SELECT t1.Col0, t1.Col3 FROM table1 t1) d
+      //         OUTER APPLY (SELECT h.Id FROM
+      //           (SELECT t2.Id, t2.Name FROM table2 t2 WHERE t2.Id = d.Col3) h) i
+      // Col3 is NOT in the outer SELECT but IS referenced deep inside the APPLY.
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var innerD = SqlDml.Select(t1);
+      for (int i = 0; i < t1.Columns.Count; i++) {
+        innerD.Columns.Add(t1[i]);
+      }
+      var dRef = SqlDml.QueryRef(innerD, "d");
+
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var innerH = SqlDml.Select(t2);
+      innerH.Columns.Add(t2["Id"]);
+      innerH.Columns.Add(t2["Name"]);
+      innerH.Where = t2["Id"] == dRef["Col3"];
+      var hRef = SqlDml.QueryRef(innerH, "h");
+
+      var innerI = SqlDml.Select(hRef);
+      innerI.Columns.Add(hRef["Id"]);
+      var iRef = SqlDml.QueryRef(innerI, "i");
+
+      var applied = SqlDml.Join(SqlJoinType.LeftOuterApply, dRef, iRef);
+      var outerSelect = SqlDml.Select(applied);
+      outerSelect.Columns.Add(dRef["Col0"]);
+      outerSelect.Columns.Add(iRef["Id"]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      // Col3 preserved because it's referenced deep inside the APPLY
+      AssertColumnNames(dRef, "Col0", "Col3");
+      AssertSelectColumnCount(innerD, 2);
+    }
+
+    [Test]
+    public void TriplyNestedOuterApplyCorrelatedReferencePreservesColumns()
+    {
+      // A correlated reference appears three levels deep inside an APPLY chain.
+      // [i] wraps a select whose FROM is a join containing [h],
+      // and [h] wraps a select whose WHERE references [d].[Col4].
+      // Before: SELECT d.Col0, b.Name, i.Id
+      //         FROM (SELECT t1.Col0, t1.Col1, t1.Col2, t1.Col3, t1.Col4 FROM table1 t1) d
+      //         OUTER APPLY (SELECT t2.Name FROM table2 t2 WHERE t2.Id = d.Col2) b
+      //         OUTER APPLY (SELECT h.Id FROM
+      //           (SELECT t2.Id FROM table2 t2 WHERE t2.Id = d.Col4) h) i
+      // After:  SELECT d.Col0, b.Name, i.Id
+      //         FROM (SELECT t1.Col0, t1.Col2, t1.Col4 FROM table1 t1) d
+      //         OUTER APPLY (...) b
+      //         OUTER APPLY (...) i
+      // Col2 referenced by [b]'s WHERE; Col4 referenced deep inside [i].
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var innerD = SqlDml.Select(t1);
+      for (int i = 0; i < t1.Columns.Count; i++) {
+        innerD.Columns.Add(t1[i]);
+      }
+      var dRef = SqlDml.QueryRef(innerD, "d");
+
+      var t2b = SqlDml.TableRef(table2, "t2b");
+      var innerB = SqlDml.Select(t2b);
+      innerB.Columns.Add(t2b["Name"]);
+      innerB.Where = t2b["Id"] == dRef["Col2"];
+      var bRef = SqlDml.QueryRef(innerB, "b");
+
+      var t2h = SqlDml.TableRef(table2, "t2h");
+      var innerH = SqlDml.Select(t2h);
+      innerH.Columns.Add(t2h["Id"]);
+      innerH.Where = t2h["Id"] == dRef["Col4"];
+      var hRef = SqlDml.QueryRef(innerH, "h");
+
+      var innerI = SqlDml.Select(hRef);
+      innerI.Columns.Add(hRef["Id"]);
+      var iRef = SqlDml.QueryRef(innerI, "i");
+
+      var applied = dRef.LeftOuterApply(bRef).LeftOuterApply(iRef);
+      var outerSelect = SqlDml.Select(applied);
+      outerSelect.Columns.Add(dRef["Col0"]);
+      outerSelect.Columns.Add(bRef["Name"]);
+      outerSelect.Columns.Add(iRef["Id"]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      // Col0 from outer SELECT, Col2 from [b]'s WHERE, Col4 from deep inside [i]
+      AssertColumnNames(dRef, "Col0", "Col2", "Col4");
+      AssertSelectColumnCount(innerD, 3);
+    }
+
+    #endregion
+
+    #region CollectUsedColumns — expression type coverage
+
+    [Test]
+    public void TrimExpressionPreservesColumn()
+    {
+      // Before: SELECT TRIM(q.Col1)
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      // After:  SELECT TRIM(q.Col1)
+      //         FROM (SELECT t.Col1 FROM table1 t) q
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(SqlDml.Trim(queryRef[1]));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col1");
+      AssertSelectColumnCount(innerSelect, 1);
+    }
+
+    [Test]
+    public void ExtractExpressionPreservesColumn()
+    {
+      // Before: SELECT EXTRACT(YEAR FROM q.Col0)
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      // After:  SELECT EXTRACT(YEAR FROM q.Col0)
+      //         FROM (SELECT t.Col0 FROM table1 t) q
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(SqlDml.Extract(SqlDateTimePart.Year, queryRef[0]));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0");
+      AssertSelectColumnCount(innerSelect, 1);
+    }
+
+    [Test]
+    public void RoundExpressionPreservesBothArguments()
+    {
+      // Before: SELECT ROUND(q.Col0, q.Col3)
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      // After:  SELECT ROUND(q.Col0, q.Col3)
+      //         FROM (SELECT t.Col0, t.Col3 FROM table1 t) q
+      // Both Argument and Length operands must be preserved.
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(
+        SqlDml.Round(queryRef[0], queryRef[3], TypeCode.Decimal, MidpointRounding.AwayFromZero));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col3");
+      AssertSelectColumnCount(innerSelect, 2);
+    }
+
+    [Test]
+    public void CollateExpressionPreservesColumn()
+    {
+      // Before: SELECT q.Col1 COLLATE Latin1_General_CI_AS
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      // After:  SELECT q.Col1 COLLATE Latin1_General_CI_AS
+      //         FROM (SELECT t.Col1 FROM table1 t) q
+      var catalog = table1.Schema.Catalog;
+      var schema = table1.Schema;
+      var collation = schema.CreateCollation("Latin1_General_CI_AS");
+      try {
+        var innerSelect = CreateInnerSelect();
+        var queryRef = SqlDml.QueryRef(innerSelect, "q");
+        var outerSelect = SqlDml.Select(queryRef);
+        outerSelect.Columns.Add(SqlDml.Collate(queryRef[1], collation));
+
+        SqlColumnPruner.Process(outerSelect);
+
+        AssertColumnNames(queryRef, "Col1");
+        AssertSelectColumnCount(innerSelect, 1);
+      }
+      finally {
+        schema.Collations.Remove(collation);
+      }
+    }
+
+    [Test]
+    public void VariantExpressionPreservesBothBranches()
+    {
+      // Before: SELECT VARIANT(q.Col1, q.Col3)
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      // After:  SELECT VARIANT(q.Col1, q.Col3)
+      //         FROM (SELECT t.Col1, t.Col3 FROM table1 t) q
+      // Both Main and Alternative branches must be preserved.
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(SqlDml.Variant("v1", queryRef[1], queryRef[3]));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col1", "Col3");
+      AssertSelectColumnCount(innerSelect, 2);
+    }
+
+    [Test]
+    public void DynamicFilterPreservesColumns()
+    {
+      // Before: SELECT q.Col0
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      //         WHERE DynamicFilter(q.Col2, q.Col4)
+      // After:  SELECT q.Col0
+      //         FROM (SELECT t.Col0, t.Col2, t.Col4 FROM table1 t) q
+      //         WHERE DynamicFilter(q.Col2, q.Col4)
+      // Columns inside the DynamicFilter expression list must be preserved.
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+      outerSelect.Where = SqlDml.DynamicFilter("df1", new SqlExpression[] { queryRef[2], queryRef[4] });
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col2", "Col4");
+      AssertSelectColumnCount(innerSelect, 3);
+    }
+
+    [Test]
+    public void ColumnStubPreservesReferencedColumn()
+    {
+      // Before: SELECT ColumnStub(q.Col2)
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      // After:  SELECT ColumnStub(q.Col2)
+      //         FROM (SELECT t.Col2 FROM table1 t) q
+      // SqlColumnStub wraps a column reference that must be tracked through.
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(SqlDml.ColumnStub(queryRef[2]));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col2");
+      AssertSelectColumnCount(innerSelect, 1);
+    }
+
+    [Test]
+    public void InWithRowExpressionPreservesColumns()
+    {
+      // Before: SELECT q.Col0
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      //         WHERE q.Col3 IN (q.Col1, q.Col4)
+      // After:  SELECT q.Col0
+      //         FROM (SELECT t.Col0, t.Col1, t.Col3, t.Col4 FROM table1 t) q
+      //         WHERE q.Col3 IN (q.Col1, q.Col4)
+      // The IN expression uses a SqlRow (extends SqlExpressionList) — all elements must be tracked.
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+      outerSelect.Where = SqlDml.In(queryRef[3], SqlDml.Row(queryRef[1], queryRef[4]));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col1", "Col3", "Col4");
+      AssertSelectColumnCount(innerSelect, 4);
+    }
+
+    [Test]
+    public void LikeWithEscapePreservesAllThreeParts()
+    {
+      // Before: SELECT q.Col0
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      //         WHERE q.Col1 LIKE q.Col2 ESCAPE q.Col3
+      // After:  SELECT q.Col0
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3 FROM table1 t) q
+      //         WHERE q.Col1 LIKE q.Col2 ESCAPE q.Col3
+      // All three parts of LIKE (Expression, Pattern, Escape) must be preserved.
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+      outerSelect.Where = SqlDml.Like(queryRef[1], queryRef[2], queryRef[3]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col1", "Col2", "Col3");
+      AssertSelectColumnCount(innerSelect, 4);
+    }
+
+    [Test]
+    public void UserColumnPreservesInnerExpression()
+    {
+      // Before: SELECT (q.Col3 + q.Col4) AS computed
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      // After:  SELECT (q.Col3 + q.Col4) AS computed
+      //         FROM (SELECT t.Col3, t.Col4 FROM table1 t) q
+      // SqlDml.Column(expr) wraps in SqlUserColumn — inner expression must be tracked.
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(SqlDml.Column(queryRef[3] + queryRef[4]));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col3", "Col4");
+      AssertSelectColumnCount(innerSelect, 2);
+    }
+
+    #endregion
+
+    #region FindAndPruneSubqueries — recursion through expression wrappers
+
+    [Test]
+    public void SubqueryInsideCaseExpressionIsPruned()
+    {
+      // Before: SELECT CASE WHEN 1=1
+      //                THEN (SELECT s.Id FROM (SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) s)
+      //                ELSE 0 END
+      //         FROM table1 t1
+      // After:  SELECT CASE WHEN 1=1
+      //                THEN (SELECT s.Id FROM (SELECT t2.Id FROM table2 t2) s)
+      //                ELSE 0 END
+      //         FROM table1 t1
+      // The subquery inside the CASE THEN branch is discovered and its inner pruned (3 → 1).
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var subInner = SqlDml.Select(t2);
+      subInner.Columns.Add(t2["Id"]);
+      subInner.Columns.Add(t2["Name"]);
+      subInner.Columns.Add(t2["Value"]);
+      var subRef = SqlDml.QueryRef(subInner, "s");
+      var subOuter = SqlDml.Select(subRef);
+      subOuter.Columns.Add(subRef["Id"]);
+
+      var caseExpr = SqlDml.Case();
+      caseExpr[SqlDml.Literal(1) == SqlDml.Literal(1)] = SqlDml.SubQuery(subOuter);
+      caseExpr.Else = SqlDml.Literal(0);
+
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var outerSelect = SqlDml.Select(t1);
+      outerSelect.Columns.Add(caseExpr);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(subRef, "Id");
+      AssertSelectColumnCount(subInner, 1);
+    }
+
+    [Test]
+    public void SubqueryInsideCastIsPruned()
+    {
+      // Before: SELECT CAST((SELECT s.Id
+      //                       FROM (SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) s) AS INT)
+      //         FROM table1 t1
+      // After:  SELECT CAST((SELECT s.Id
+      //                       FROM (SELECT t2.Id FROM table2 t2) s) AS INT)
+      //         FROM table1 t1
+      // The subquery inside the CAST is discovered and its inner pruned (3 → 1).
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var subInner = SqlDml.Select(t2);
+      subInner.Columns.Add(t2["Id"]);
+      subInner.Columns.Add(t2["Name"]);
+      subInner.Columns.Add(t2["Value"]);
+      var subRef = SqlDml.QueryRef(subInner, "s");
+      var subOuter = SqlDml.Select(subRef);
+      subOuter.Columns.Add(subRef["Id"]);
+
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var outerSelect = SqlDml.Select(t1);
+      outerSelect.Columns.Add(SqlDml.Cast(SqlDml.SubQuery(subOuter), SqlType.Int32));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(subRef, "Id");
+      AssertSelectColumnCount(subInner, 1);
+    }
+
+    [Test]
+    public void SubqueryInsideFunctionCallIsPruned()
+    {
+      // Before: SELECT COALESCE(
+      //                  (SELECT s.Name FROM (SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) s),
+      //                  'default')
+      //         FROM table1 t1
+      // After:  SELECT COALESCE(
+      //                  (SELECT s.Name FROM (SELECT t2.Name FROM table2 t2) s),
+      //                  'default')
+      //         FROM table1 t1
+      // The subquery inside the COALESCE function call is discovered and its inner pruned (3 → 1).
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var subInner = SqlDml.Select(t2);
+      subInner.Columns.Add(t2["Id"]);
+      subInner.Columns.Add(t2["Name"]);
+      subInner.Columns.Add(t2["Value"]);
+      var subRef = SqlDml.QueryRef(subInner, "s");
+      var subOuter = SqlDml.Select(subRef);
+      subOuter.Columns.Add(subRef["Name"]);
+
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var outerSelect = SqlDml.Select(t1);
+      outerSelect.Columns.Add(
+        SqlDml.Coalesce(SqlDml.SubQuery(subOuter), SqlDml.Literal("default")));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(subRef, "Name");
+      AssertSelectColumnCount(subInner, 1);
+    }
+
+    [Test]
+    public void SubqueryInsideUserColumnIsPruned()
+    {
+      // Before: SELECT (SELECT s.Value
+      //                 FROM (SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) s) AS computed
+      //         FROM table1 t1
+      // After:  SELECT (SELECT s.Value
+      //                 FROM (SELECT t2.Value FROM table2 t2) s) AS computed
+      //         FROM table1 t1
+      // SqlDml.Column(subquery) wraps in SqlUserColumn — the pruner recurses into it (3 → 1).
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var subInner = SqlDml.Select(t2);
+      subInner.Columns.Add(t2["Id"]);
+      subInner.Columns.Add(t2["Name"]);
+      subInner.Columns.Add(t2["Value"]);
+      var subRef = SqlDml.QueryRef(subInner, "s");
+      var subOuter = SqlDml.Select(subRef);
+      subOuter.Columns.Add(subRef["Value"]);
+
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var outerSelect = SqlDml.Select(t1);
+      outerSelect.Columns.Add(SqlDml.Column(SqlDml.SubQuery(subOuter)));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(subRef, "Value");
+      AssertSelectColumnCount(subInner, 1);
+    }
+
+    [Test]
+    public void SubqueryInsideLikePatternIsPruned()
+    {
+      // Before: SELECT t1.Col0 FROM table1 t1
+      //         WHERE t1.Col1 LIKE (SELECT s.Name
+      //           FROM (SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) s)
+      // After:  SELECT t1.Col0 FROM table1 t1
+      //         WHERE t1.Col1 LIKE (SELECT s.Name
+      //           FROM (SELECT t2.Name FROM table2 t2) s)
+      // The subquery used as a LIKE pattern is discovered and its inner pruned (3 → 1).
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var subInner = SqlDml.Select(t2);
+      subInner.Columns.Add(t2["Id"]);
+      subInner.Columns.Add(t2["Name"]);
+      subInner.Columns.Add(t2["Value"]);
+      var subRef = SqlDml.QueryRef(subInner, "s");
+      var subOuter = SqlDml.Select(subRef);
+      subOuter.Columns.Add(subRef["Name"]);
+
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var outerSelect = SqlDml.Select(t1);
+      outerSelect.Columns.Add(t1["Col0"]);
+      outerSelect.Where = SqlDml.Like(t1["Col1"], SqlDml.SubQuery(subOuter));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(subRef, "Name");
+      AssertSelectColumnCount(subInner, 1);
+    }
+
+    [Test]
+    public void SubqueryInsideBetweenIsPruned()
+    {
+      // Before: SELECT t1.Col0 FROM table1 t1
+      //         WHERE t1.Col0 BETWEEN (SELECT s.Id
+      //           FROM (SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) s) AND 100
+      // After:  SELECT t1.Col0 FROM table1 t1
+      //         WHERE t1.Col0 BETWEEN (SELECT s.Id
+      //           FROM (SELECT t2.Id FROM table2 t2) s) AND 100
+      // The subquery inside BETWEEN is discovered and its inner pruned (3 → 1).
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var subInner = SqlDml.Select(t2);
+      subInner.Columns.Add(t2["Id"]);
+      subInner.Columns.Add(t2["Name"]);
+      subInner.Columns.Add(t2["Value"]);
+      var subRef = SqlDml.QueryRef(subInner, "s");
+      var subOuter = SqlDml.Select(subRef);
+      subOuter.Columns.Add(subRef["Id"]);
+
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var outerSelect = SqlDml.Select(t1);
+      outerSelect.Columns.Add(t1["Col0"]);
+      outerSelect.Where = SqlDml.Between(t1["Col0"], SqlDml.SubQuery(subOuter), SqlDml.Literal(100));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(subRef, "Id");
+      AssertSelectColumnCount(subInner, 1);
+    }
+
+    [Test]
+    public void SubqueryInsideTrimIsPruned()
+    {
+      // Before: SELECT TRIM((SELECT s.Name
+      //           FROM (SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) s))
+      //         FROM table1 t1
+      // After:  SELECT TRIM((SELECT s.Name
+      //           FROM (SELECT t2.Name FROM table2 t2) s))
+      //         FROM table1 t1
+      // The subquery inside TRIM is discovered and its inner pruned (3 → 1).
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var subInner = SqlDml.Select(t2);
+      subInner.Columns.Add(t2["Id"]);
+      subInner.Columns.Add(t2["Name"]);
+      subInner.Columns.Add(t2["Value"]);
+      var subRef = SqlDml.QueryRef(subInner, "s");
+      var subOuter = SqlDml.Select(subRef);
+      subOuter.Columns.Add(subRef["Name"]);
+
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var outerSelect = SqlDml.Select(t1);
+      outerSelect.Columns.Add(SqlDml.Trim(SqlDml.SubQuery(subOuter)));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(subRef, "Name");
+      AssertSelectColumnCount(subInner, 1);
+    }
+
+    [Test]
+    public void SubqueryInsideExtractIsPruned()
+    {
+      // Before: SELECT EXTRACT(YEAR FROM (SELECT s.Id
+      //           FROM (SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) s))
+      //         FROM table1 t1
+      // After:  SELECT EXTRACT(YEAR FROM (SELECT s.Id
+      //           FROM (SELECT t2.Id FROM table2 t2) s))
+      //         FROM table1 t1
+      // The subquery inside EXTRACT is discovered and its inner pruned (3 → 1).
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var subInner = SqlDml.Select(t2);
+      subInner.Columns.Add(t2["Id"]);
+      subInner.Columns.Add(t2["Name"]);
+      subInner.Columns.Add(t2["Value"]);
+      var subRef = SqlDml.QueryRef(subInner, "s");
+      var subOuter = SqlDml.Select(subRef);
+      subOuter.Columns.Add(subRef["Id"]);
+
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var outerSelect = SqlDml.Select(t1);
+      outerSelect.Columns.Add(SqlDml.Extract(SqlDateTimePart.Year, SqlDml.SubQuery(subOuter)));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(subRef, "Id");
+      AssertSelectColumnCount(subInner, 1);
+    }
+
+    [Test]
+    public void SubqueryInsideVariantIsPruned()
+    {
+      // Before: SELECT VARIANT(
+      //                  (SELECT s.Name FROM (SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) s),
+      //                  'fallback')
+      //         FROM table1 t1
+      // After:  SELECT VARIANT(
+      //                  (SELECT s.Name FROM (SELECT t2.Name FROM table2 t2) s),
+      //                  'fallback')
+      //         FROM table1 t1
+      // The subquery inside the VARIANT main branch is discovered and its inner pruned (3 → 1).
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var subInner = SqlDml.Select(t2);
+      subInner.Columns.Add(t2["Id"]);
+      subInner.Columns.Add(t2["Name"]);
+      subInner.Columns.Add(t2["Value"]);
+      var subRef = SqlDml.QueryRef(subInner, "s");
+      var subOuter = SqlDml.Select(subRef);
+      subOuter.Columns.Add(subRef["Name"]);
+
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var outerSelect = SqlDml.Select(t1);
+      outerSelect.Columns.Add(
+        SqlDml.Variant("v1", SqlDml.SubQuery(subOuter), SqlDml.Literal("fallback")));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(subRef, "Name");
+      AssertSelectColumnCount(subInner, 1);
+    }
+
+    [Test]
+    public void SubqueryInsideRowNumberOrderByIsPruned()
+    {
+      // Before: SELECT t1.Col0,
+      //                ROW_NUMBER() OVER (ORDER BY
+      //                  (SELECT s.Id FROM (SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) s))
+      //         FROM table1 t1
+      // After:  SELECT t1.Col0,
+      //                ROW_NUMBER() OVER (ORDER BY
+      //                  (SELECT s.Id FROM (SELECT t2.Id FROM table2 t2) s))
+      //         FROM table1 t1
+      // The subquery inside ROW_NUMBER's ORDER BY is discovered and its inner pruned (3 → 1).
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var subInner = SqlDml.Select(t2);
+      subInner.Columns.Add(t2["Id"]);
+      subInner.Columns.Add(t2["Name"]);
+      subInner.Columns.Add(t2["Value"]);
+      var subRef = SqlDml.QueryRef(subInner, "s");
+      var subOuter = SqlDml.Select(subRef);
+      subOuter.Columns.Add(subRef["Id"]);
+
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var outerSelect = SqlDml.Select(t1);
+      outerSelect.Columns.Add(t1["Col0"]);
+      var rn = SqlDml.RowNumber();
+      rn.OrderBy.Add(SqlDml.SubQuery(subOuter));
+      outerSelect.Columns.Add(rn);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(subRef, "Id");
+      AssertSelectColumnCount(subInner, 1);
+    }
+
+    [Test]
+    public void SubqueryInsideMetadataIsPruned()
+    {
+      // Before: SELECT METADATA(
+      //                  (SELECT s.Value FROM (SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) s),
+      //                  tag)
+      //         FROM table1 t1
+      // After:  SELECT METADATA(
+      //                  (SELECT s.Value FROM (SELECT t2.Value FROM table2 t2) s),
+      //                  tag)
+      //         FROM table1 t1
+      // The subquery inside METADATA is discovered and its inner pruned (3 → 1).
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var subInner = SqlDml.Select(t2);
+      subInner.Columns.Add(t2["Id"]);
+      subInner.Columns.Add(t2["Name"]);
+      subInner.Columns.Add(t2["Value"]);
+      var subRef = SqlDml.QueryRef(subInner, "s");
+      var subOuter = SqlDml.Select(subRef);
+      subOuter.Columns.Add(subRef["Value"]);
+
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var outerSelect = SqlDml.Select(t1);
+      outerSelect.Columns.Add(SqlDml.Metadata(SqlDml.SubQuery(subOuter), new object()));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(subRef, "Value");
+      AssertSelectColumnCount(subInner, 1);
+    }
+
+    #endregion
+
+    #region RecurseIntoExpressionSubqueries — clause-level coverage
+
+    [Test]
+    public void SubqueryInHavingClauseIsPruned()
+    {
+      // Before: SELECT t1.Col0 FROM table1 t1
+      //         GROUP BY t1.Col0
+      //         HAVING COUNT(*) > (SELECT s.Id
+      //           FROM (SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) s)
+      // After:  SELECT t1.Col0 FROM table1 t1
+      //         GROUP BY t1.Col0
+      //         HAVING COUNT(*) > (SELECT s.Id
+      //           FROM (SELECT t2.Id FROM table2 t2) s)
+      // The subquery embedded in the HAVING clause is discovered and its inner pruned (3 → 1).
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var subInner = SqlDml.Select(t2);
+      subInner.Columns.Add(t2["Id"]);
+      subInner.Columns.Add(t2["Name"]);
+      subInner.Columns.Add(t2["Value"]);
+      var subRef = SqlDml.QueryRef(subInner, "s");
+      var subOuter = SqlDml.Select(subRef);
+      subOuter.Columns.Add(subRef["Id"]);
+
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var outerSelect = SqlDml.Select(t1);
+      outerSelect.Columns.Add(t1["Col0"]);
+      outerSelect.GroupBy.Add(t1["Col0"]);
+      outerSelect.Having = SqlDml.Count() > SqlDml.SubQuery(subOuter);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(subRef, "Id");
+      AssertSelectColumnCount(subInner, 1);
+    }
+
+    [Test]
+    public void SubqueryInOrderByClauseIsPruned()
+    {
+      // Before: SELECT t1.Col0 FROM table1 t1
+      //         ORDER BY (SELECT s.Name
+      //           FROM (SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) s)
+      // After:  SELECT t1.Col0 FROM table1 t1
+      //         ORDER BY (SELECT s.Name
+      //           FROM (SELECT t2.Name FROM table2 t2) s)
+      // The subquery embedded in the ORDER BY clause is discovered and its inner pruned (3 → 1).
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var subInner = SqlDml.Select(t2);
+      subInner.Columns.Add(t2["Id"]);
+      subInner.Columns.Add(t2["Name"]);
+      subInner.Columns.Add(t2["Value"]);
+      var subRef = SqlDml.QueryRef(subInner, "s");
+      var subOuter = SqlDml.Select(subRef);
+      subOuter.Columns.Add(subRef["Name"]);
+
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var outerSelect = SqlDml.Select(t1);
+      outerSelect.Columns.Add(t1["Col0"]);
+      outerSelect.OrderBy.Add(SqlDml.SubQuery(subOuter));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(subRef, "Name");
+      AssertSelectColumnCount(subInner, 1);
+    }
+
+    [Test]
+    public void SubqueryInGroupByClauseIsPruned()
+    {
+      // Before: SELECT t1.Col0 FROM table1 t1
+      //         GROUP BY (SELECT s.Id
+      //           FROM (SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) s)
+      // After:  SELECT t1.Col0 FROM table1 t1
+      //         GROUP BY (SELECT s.Id
+      //           FROM (SELECT t2.Id FROM table2 t2) s)
+      // The subquery embedded in the GROUP BY clause is discovered and its inner pruned (3 → 1).
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var subInner = SqlDml.Select(t2);
+      subInner.Columns.Add(t2["Id"]);
+      subInner.Columns.Add(t2["Name"]);
+      subInner.Columns.Add(t2["Value"]);
+      var subRef = SqlDml.QueryRef(subInner, "s");
+      var subOuter = SqlDml.Select(subRef);
+      subOuter.Columns.Add(subRef["Id"]);
+
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var outerSelect = SqlDml.Select(t1);
+      outerSelect.Columns.Add(t1["Col0"]);
+      outerSelect.GroupBy.Add(SqlDml.SubQuery(subOuter));
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(subRef, "Id");
+      AssertSelectColumnCount(subInner, 1);
+    }
+
+    #endregion
+
+    #region Correlated subtree scanning
+
+    [Test]
+    public void CorrelatedReferenceInsideUnionSiblingPreservesColumns()
+    {
+      // OUTER APPLY sibling wraps a UNION ALL — the correlated reference is inside
+      // one of the UNION sides, testing CollectUsedColumnsFromEntireSubtree → SqlQueryExpression path.
+      // Before: SELECT d.Col0, i.Id
+      //         FROM (SELECT t1.Col0, t1.Col1, t1.Col2, t1.Col3, t1.Col4 FROM table1 t1) d
+      //         OUTER APPLY (SELECT u.Id FROM (
+      //           SELECT t2.Id FROM table2 t2 WHERE t2.Id = d.Col3
+      //           UNION ALL
+      //           SELECT t2.Id FROM table2 t2 WHERE t2.Id = d.Col4
+      //         ) u) i
+      // After:  SELECT d.Col0, i.Id
+      //         FROM (SELECT t1.Col0, t1.Col3, t1.Col4 FROM table1 t1) d
+      //         OUTER APPLY (...) i
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var innerD = SqlDml.Select(t1);
+      for (int i = 0; i < t1.Columns.Count; i++) {
+        innerD.Columns.Add(t1[i]);
+      }
+      var dRef = SqlDml.QueryRef(innerD, "d");
+
+      var t2a = SqlDml.TableRef(table2, "t2a");
+      var unionLeft = SqlDml.Select(t2a);
+      unionLeft.Columns.Add(t2a["Id"]);
+      unionLeft.Where = t2a["Id"] == dRef["Col3"];
+
+      var t2b = SqlDml.TableRef(table2, "t2b");
+      var unionRight = SqlDml.Select(t2b);
+      unionRight.Columns.Add(t2b["Id"]);
+      unionRight.Where = t2b["Id"] == dRef["Col4"];
+
+      var union = unionLeft.UnionAll(unionRight);
+      var uRef = SqlDml.QueryRef(union, "u");
+      var innerI = SqlDml.Select(uRef);
+      innerI.Columns.Add(uRef["Id"]);
+      var iRef = SqlDml.QueryRef(innerI, "i");
+
+      var applied = SqlDml.Join(SqlJoinType.LeftOuterApply, dRef, iRef);
+      var outerSelect = SqlDml.Select(applied);
+      outerSelect.Columns.Add(dRef["Col0"]);
+      outerSelect.Columns.Add(iRef["Id"]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(dRef, "Col0", "Col3", "Col4");
+      AssertSelectColumnCount(innerD, 3);
+    }
+
+    [Test]
+    public void CorrelatedReferenceInsideNestedJoinInSibling()
+    {
+      // Before: SELECT d.Col0, i.Name
+      //         FROM (SELECT t1.Col0, t1.Col1, t1.Col2, t1.Col3, t1.Col4 FROM table1 t1) d
+      //         OUTER APPLY (SELECT r.Name
+      //           FROM table2 r
+      //           JOIN table2 r2 ON r.Id = r2.Id
+      //           WHERE r.Id = d.Col2) i
+      // After:  SELECT d.Col0, i.Name
+      //         FROM (SELECT t1.Col0, t1.Col2 FROM table1 t1) d
+      //         OUTER APPLY (...) i
+      // Col2 is only referenced in the APPLY sibling's WHERE — must be preserved.
+      // The APPLY's FROM contains a JOIN tree, which the scanner must walk through.
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var innerD = SqlDml.Select(t1);
+      for (int i = 0; i < t1.Columns.Count; i++) {
+        innerD.Columns.Add(t1[i]);
+      }
+      var dRef = SqlDml.QueryRef(innerD, "d");
+
+      var r = SqlDml.TableRef(table2, "r");
+      var r2 = SqlDml.TableRef(table2, "r2");
+      var joinedInner = r.InnerJoin(r2, r["Id"] == r2["Id"]);
+      var innerI = SqlDml.Select(joinedInner);
+      innerI.Columns.Add(r["Name"]);
+      innerI.Where = r["Id"] == dRef["Col2"];
+      var iRef = SqlDml.QueryRef(innerI, "i");
+
+      var applied = SqlDml.Join(SqlJoinType.LeftOuterApply, dRef, iRef);
+      var outerSelect = SqlDml.Select(applied);
+      outerSelect.Columns.Add(dRef["Col0"]);
+      outerSelect.Columns.Add(iRef["Name"]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(dRef, "Col0", "Col2");
+      AssertSelectColumnCount(innerD, 2);
+    }
+
+    #endregion
+
+    #region Edge cases
+
+    [Test]
+    public void DoesNotPruneIntersect()
+    {
+      // Before: SELECT u.Col0
+      //         FROM (SELECT t1.Col0, t1.Col1, t1.Col2 FROM table1 t1
+      //               INTERSECT
+      //               SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) u
+      // After:  (no change — all 3 columns kept on both sides)
+      // INTERSECT uses all projected columns for comparison — removing any column
+      // can change the result set, so no pruning is allowed.
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var selectA = SqlDml.Select(t1);
+      selectA.Columns.Add(t1["Col0"]);
+      selectA.Columns.Add(t1["Col1"]);
+      selectA.Columns.Add(t1["Col2"]);
+
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var selectB = SqlDml.Select(t2);
+      selectB.Columns.Add(t2["Id"]);
+      selectB.Columns.Add(t2["Name"]);
+      selectB.Columns.Add(t2["Value"]);
+
+      var intersect = selectA.Intersect(selectB);
+      var queryRef = SqlDml.QueryRef(intersect, "u");
+
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+
+      var originalColumnCount = queryRef.Columns.Count;
+      SqlColumnPruner.Process(outerSelect);
+
+      Assert.That(queryRef.Columns.Count, Is.EqualTo(originalColumnCount));
+      Assert.That(selectA.Columns.Count, Is.EqualTo(3));
+      Assert.That(selectB.Columns.Count, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void SharedExpressionNodeProcessedSafely()
+    {
+      // Before: SELECT (q.Col0 + q.Col2)
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      //         WHERE (q.Col0 + q.Col2) > 0
+      // After:  SELECT (q.Col0 + q.Col2)
+      //         FROM (SELECT t.Col0, t.Col2 FROM table1 t) q
+      //         WHERE (q.Col0 + q.Col2) > 0
+      // The same expression object appears in both SELECT and WHERE.
+      // The visited-dedup in FindAndPruneSubqueries must handle re-encounters gracefully.
+      var innerSelect = CreateInnerSelect();
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+
+      var sharedExpr = queryRef[0] + queryRef[2];
+      outerSelect.Columns.Add(sharedExpr);
+      outerSelect.Where = sharedExpr > SqlDml.Literal(0);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      AssertColumnNames(queryRef, "Col0", "Col2");
+      AssertSelectColumnCount(innerSelect, 2);
+    }
+
+    [Test]
+    public void QueryRefFromUnionRecursesIntoSidesEvenWithoutPruning()
+    {
+      // Before: SELECT u.Col0
+      //         FROM (SELECT r.Col0, r.Col1
+      //                 FROM (SELECT t.Col0, t.Col1, t.Col2 FROM table1 t) r
+      //               INTERSECT
+      //               SELECT r2.Col0, r2.Col1
+      //                 FROM (SELECT t2.Col0, t2.Col1, t2.Col2 FROM table1 t2) r2) u
+      // After:  SELECT u.Col0
+      //         FROM (SELECT r.Col0, r.Col1
+      //                 FROM (SELECT t.Col0, t.Col1 FROM table1 t) r
+      //               INTERSECT
+      //               SELECT r2.Col0, r2.Col1
+      //                 FROM (SELECT t2.Col0, t2.Col1 FROM table1 t2) r2) u
+      // The INTERSECT itself is NOT pruned (still 2 columns per side),
+      // but the inner subqueries on each side ARE pruned (3 → 2).
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var innerA = SqlDml.Select(t1);
+      innerA.Columns.Add(t1["Col0"]);
+      innerA.Columns.Add(t1["Col1"]);
+      innerA.Columns.Add(t1["Col2"]);
+      var aRef = SqlDml.QueryRef(innerA, "r");
+      var selectA = SqlDml.Select(aRef);
+      selectA.Columns.Add(aRef["Col0"]);
+      selectA.Columns.Add(aRef["Col1"]);
+
+      var t2 = SqlDml.TableRef(table1, "t2");
+      var innerB = SqlDml.Select(t2);
+      innerB.Columns.Add(t2["Col0"]);
+      innerB.Columns.Add(t2["Col1"]);
+      innerB.Columns.Add(t2["Col2"]);
+      var bRef = SqlDml.QueryRef(innerB, "r2");
+      var selectB = SqlDml.Select(bRef);
+      selectB.Columns.Add(bRef["Col0"]);
+      selectB.Columns.Add(bRef["Col1"]);
+
+      var intersect = selectA.Intersect(selectB);
+      var queryRef = SqlDml.QueryRef(intersect, "u");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      // INTERSECT not pruned — still 2 columns per side
+      Assert.That(queryRef.Columns.Count, Is.EqualTo(2));
+
+      // But inner subqueries ARE pruned (3 → 2)
+      AssertColumnNames(aRef, "Col0", "Col1");
+      AssertSelectColumnCount(innerA, 2);
+      AssertColumnNames(bRef, "Col0", "Col1");
+      AssertSelectColumnCount(innerB, 2);
+    }
+
+    [Test]
+    public void EmptyInnerSelectDoesNotThrow()
+    {
+      // Before: SELECT 1 FROM (SELECT FROM table1 t1) q
+      // After:  (no change — zero columns, nothing to prune)
+      // A SqlQueryRef with zero inner columns should be handled gracefully.
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var innerSelect = SqlDml.Select(t1);
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(SqlDml.Literal(1));
+
+      Assert.DoesNotThrow(() => SqlColumnPruner.Process(outerSelect));
+    }
+
+    [Test]
+    public void NullFromSourceDoesNotThrow()
+    {
+      // Before: SELECT 42
+      // After:  (no change — no FROM source, nothing to prune)
+      var select = SqlDml.Select();
+      select.Columns.Add(SqlDml.Literal(42));
+
+      Assert.DoesNotThrow(() => SqlColumnPruner.Process(select));
+    }
+
+    [Test]
+    public void RecursesIntoNestedQueryExpressionSide()
+    {
+      // Before: SELECT u.Col0
+      //         FROM (
+      //           (SELECT a.Col0, a.Col1 FROM (SELECT t.Col0, t.Col1, t.Col2 FROM table1 t) a
+      //            UNION ALL
+      //            SELECT b.Col0, b.Col1 FROM (SELECT t.Col0, t.Col1, t.Col2 FROM table1 t) b)
+      //           UNION ALL
+      //           SELECT c.Col0, c.Col1 FROM (SELECT t.Col0, t.Col1, t.Col2 FROM table1 t) c
+      //         ) u
+      // After:  SELECT u.Col0
+      //         FROM (
+      //           (SELECT a.Col0 FROM (SELECT t.Col0 FROM table1 t) a
+      //            UNION ALL
+      //            SELECT b.Col0 FROM (SELECT t.Col0 FROM table1 t) b)
+      //           UNION ALL
+      //           SELECT c.Col0 FROM (SELECT t.Col0 FROM table1 t) c
+      //         ) u
+      // (A UNION ALL B) UNION ALL C — left side is itself a SqlQueryExpression.
+      // Each leaf's inner subquery is pruned from 3 to 1 column.
+      var t1a = SqlDml.TableRef(table1, "t1a");
+      var innerA = SqlDml.Select(t1a);
+      innerA.Columns.Add(t1a["Col0"]);
+      innerA.Columns.Add(t1a["Col1"]);
+      innerA.Columns.Add(t1a["Col2"]);
+      var aRef = SqlDml.QueryRef(innerA, "a");
+      var selectA = SqlDml.Select(aRef);
+      selectA.Columns.Add(aRef["Col0"]);
+      selectA.Columns.Add(aRef["Col1"]);
+
+      var t1b = SqlDml.TableRef(table1, "t1b");
+      var innerB = SqlDml.Select(t1b);
+      innerB.Columns.Add(t1b["Col0"]);
+      innerB.Columns.Add(t1b["Col1"]);
+      innerB.Columns.Add(t1b["Col2"]);
+      var bRef = SqlDml.QueryRef(innerB, "b");
+      var selectB = SqlDml.Select(bRef);
+      selectB.Columns.Add(bRef["Col0"]);
+      selectB.Columns.Add(bRef["Col1"]);
+
+      var t1c = SqlDml.TableRef(table1, "t1c");
+      var innerC = SqlDml.Select(t1c);
+      innerC.Columns.Add(t1c["Col0"]);
+      innerC.Columns.Add(t1c["Col1"]);
+      innerC.Columns.Add(t1c["Col2"]);
+      var cRef = SqlDml.QueryRef(innerC, "c");
+      var selectC = SqlDml.Select(cRef);
+      selectC.Columns.Add(cRef["Col0"]);
+      selectC.Columns.Add(cRef["Col1"]);
+
+      var union = selectA.UnionAll(selectB).UnionAll(selectC);
+      var queryRef = SqlDml.QueryRef(union, "u");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      // Inner subqueries pruned from 3 to 1 (only Col0 needed)
+      AssertColumnNames(aRef, "Col0");
+      AssertSelectColumnCount(innerA, 1);
+      AssertColumnNames(bRef, "Col0");
+      AssertSelectColumnCount(innerB, 1);
+      AssertColumnNames(cRef, "Col0");
+      AssertSelectColumnCount(innerC, 1);
+    }
+
     #endregion
 
     #region Helpers

--- a/Orm/Xtensive.Orm.Tests.Sql/SqlColumnPrunerTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/SqlColumnPrunerTest.cs
@@ -705,6 +705,63 @@ namespace Xtensive.Orm.Tests.Sql
     }
 
     [Test]
+    public void DoesNotPruneSelectDistinct()
+    {
+      // SELECT DISTINCT uses all projected columns for deduplication.
+      // Removing columns can change the result set — no pruning allowed.
+      // SELECT q.Col0 FROM (SELECT DISTINCT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) q
+      // The inner SELECT DISTINCT must keep all 5 columns.
+      var innerSelect = CreateInnerSelect();
+      innerSelect.Distinct = true;
+      var queryRef = SqlDml.QueryRef(innerSelect, "q");
+
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      Assert.That(queryRef.Columns.Count, Is.EqualTo(5));
+      AssertSelectColumnCount(innerSelect, 5);
+    }
+
+    [Test]
+    public void SelectDistinctInnerSubqueriesStillPruned()
+    {
+      // The DISTINCT select itself is not pruned, but its inner subqueries are.
+      // Before: SELECT q.Col0
+      //         FROM (SELECT DISTINCT r.Col0, r.Col1, r.Col2
+      //               FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) r
+      //              ) q
+      // After:  SELECT q.Col0
+      //         FROM (SELECT DISTINCT r.Col0, r.Col1, r.Col2
+      //               FROM (SELECT t.Col0, t.Col1, t.Col2 FROM table1 t) r
+      //              ) q
+      // The DISTINCT keeps 3 columns, but its inner subquery is pruned from 5 to 3.
+      var baseSelect = CreateInnerSelect();
+      var baseRef = SqlDml.QueryRef(baseSelect, "r");
+
+      var distinctSelect = SqlDml.Select(baseRef);
+      distinctSelect.Columns.Add(baseRef["Col0"]);
+      distinctSelect.Columns.Add(baseRef["Col1"]);
+      distinctSelect.Columns.Add(baseRef["Col2"]);
+      distinctSelect.Distinct = true;
+
+      var queryRef = SqlDml.QueryRef(distinctSelect, "q");
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      // DISTINCT select is NOT pruned (still 3 columns)
+      Assert.That(queryRef.Columns.Count, Is.EqualTo(3));
+      AssertSelectColumnCount(distinctSelect, 3);
+
+      // But the inner subquery IS pruned (from 5 to 3 — only columns used by DISTINCT)
+      AssertColumnNames(baseRef, "Col0", "Col1", "Col2");
+      AssertSelectColumnCount(baseSelect, 3);
+    }
+
+    [Test]
     public void DoesNotPruneUnionDistinct()
     {
       // UNION (without ALL) deduplicates rows using all projected columns,

--- a/Orm/Xtensive.Orm.Tests.Sql/SqlColumnPrunerTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Sql/SqlColumnPrunerTest.cs
@@ -705,17 +705,14 @@ namespace Xtensive.Orm.Tests.Sql
     }
 
     [Test]
-    public void PrunesUnionDistinctWrappedInQueryRef()
+    public void DoesNotPruneUnionDistinct()
     {
-      // Before: SELECT u.Col0
-      //         FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t
-      //               UNION
-      //               SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) u
-      // After:  SELECT u.Col0
-      //         FROM (SELECT t.Col0 FROM table1 t
-      //               UNION
-      //               SELECT t.Col0 FROM table1 t) u
-      // Same as UNION ALL — both sides pruned to the same column indices.
+      // UNION (without ALL) deduplicates rows using all projected columns,
+      // so removing columns can change the result set. No pruning allowed.
+      // SELECT u.Col0
+      // FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t
+      //       UNION
+      //       SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1 t) u
       var t1 = SqlDml.TableRef(table1, "t1");
       var selectA = SqlDml.Select(t1);
       selectA.Columns.AddRange(t1.Columns.ToArray<SqlColumn>());
@@ -730,11 +727,12 @@ namespace Xtensive.Orm.Tests.Sql
       var outerSelect = SqlDml.Select(queryRef);
       outerSelect.Columns.Add(queryRef[0]);
 
+      var originalColumnCount = queryRef.Columns.Count;
       SqlColumnPruner.Process(outerSelect);
 
-      Assert.That(queryRef.Columns.Count, Is.EqualTo(1));
-      Assert.That(selectA.Columns.Count, Is.EqualTo(1));
-      Assert.That(selectB.Columns.Count, Is.EqualTo(1));
+      Assert.That(queryRef.Columns.Count, Is.EqualTo(originalColumnCount));
+      Assert.That(selectA.Columns.Count, Is.EqualTo(5));
+      Assert.That(selectB.Columns.Count, Is.EqualTo(5));
     }
 
     [Test]
@@ -1105,17 +1103,11 @@ namespace Xtensive.Orm.Tests.Sql
     }
 
     [Test]
-    public void UnionDistinctFromDifferentTablesPrunedThroughQueryRef()
+    public void DoesNotPruneExceptOrIntersect()
     {
-      // Before: SELECT u.Col0, u.Col2
-      //         FROM (SELECT t1.Col0, t1.Col1, t1.Col2 FROM table1 t1
-      //               UNION
-      //               SELECT t2.Id, t2.Name, t2.Value FROM table2 t2) u
-      // After:  SELECT u.Col0, u.Col2
-      //         FROM (SELECT t1.Col0, t1.Col2 FROM table1 t1
-      //               UNION
-      //               SELECT t2.Id, t2.Value FROM table2 t2) u
-      // Column index 1 removed from both sides.
+      // EXCEPT and INTERSECT use all projected columns for comparison,
+      // so removing columns can change the result set. No pruning allowed.
+      // SELECT u.Col0 FROM (SELECT ... EXCEPT SELECT ...) u
       var t1 = SqlDml.TableRef(table1, "t1");
       var selectA = SqlDml.Select(t1);
       selectA.Columns.Add(t1["Col0"]);
@@ -1128,18 +1120,198 @@ namespace Xtensive.Orm.Tests.Sql
       selectB.Columns.Add(t2["Name"]);
       selectB.Columns.Add(t2["Value"]);
 
+      var except = selectA.Except(selectB);
+      var queryRef = SqlDml.QueryRef(except, "u");
+
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+
+      var originalColumnCount = queryRef.Columns.Count;
+      SqlColumnPruner.Process(outerSelect);
+
+      Assert.That(queryRef.Columns.Count, Is.EqualTo(originalColumnCount));
+      Assert.That(selectA.Columns.Count, Is.EqualTo(3));
+      Assert.That(selectB.Columns.Count, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void UnionDistinctSidesStillPrunedInternally()
+    {
+      // The UNION itself is not pruned (column list stays intact),
+      // but each side's inner subqueries ARE pruned independently.
+      // Before: SELECT u.Col0 FROM (
+      //           SELECT t.Col0, t.Col1 FROM (SELECT t.Col0, t.Col1, t.Col2, t.Col3, t.Col4 FROM table1) t
+      //           UNION
+      //           SELECT t2.Id, t2.Name FROM (SELECT t2.Id, t2.Name, t2.Value FROM table2) t2) u
+      // After:  SELECT u.Col0 FROM (
+      //           SELECT t.Col0, t.Col1 FROM (SELECT t.Col0, t.Col1 FROM table1) t
+      //           UNION
+      //           SELECT t2.Id, t2.Name FROM (SELECT t2.Id, t2.Name FROM table2) t2) u
+      // The UNION keeps 2 columns per side, but inner subqueries are pruned.
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var innerA = SqlDml.Select(t1);
+      for (int i = 0; i < t1.Columns.Count; i++) {
+        innerA.Columns.Add(t1[i]);
+      }
+      var aRef = SqlDml.QueryRef(innerA, "t");
+      var selectA = SqlDml.Select(aRef);
+      selectA.Columns.Add(aRef["Col0"]);
+      selectA.Columns.Add(aRef["Col1"]);
+
+      var t2 = SqlDml.TableRef(table2, "t2");
+      var innerB = SqlDml.Select(t2);
+      innerB.Columns.Add(t2["Id"]);
+      innerB.Columns.Add(t2["Name"]);
+      innerB.Columns.Add(t2["Value"]);
+      var bRef = SqlDml.QueryRef(innerB, "t2");
+      var selectB = SqlDml.Select(bRef);
+      selectB.Columns.Add(bRef["Id"]);
+      selectB.Columns.Add(bRef["Name"]);
+
       var union = selectA.Union(selectB);
       var queryRef = SqlDml.QueryRef(union, "u");
 
       var outerSelect = SqlDml.Select(queryRef);
       outerSelect.Columns.Add(queryRef[0]);
-      outerSelect.Columns.Add(queryRef[2]);
 
       SqlColumnPruner.Process(outerSelect);
 
+      // UNION column list is NOT pruned (still 2 per side)
       Assert.That(queryRef.Columns.Count, Is.EqualTo(2));
       Assert.That(selectA.Columns.Count, Is.EqualTo(2));
       Assert.That(selectB.Columns.Count, Is.EqualTo(2));
+
+      // But inner subqueries ARE pruned: table1 side from 5 to 2, table2 side from 3 to 2
+      AssertColumnNames(aRef, "Col0", "Col1");
+      AssertSelectColumnCount(innerA, 2);
+      AssertColumnNames(bRef, "Id", "Name");
+      AssertSelectColumnCount(innerB, 2);
+    }
+
+    [Test]
+    public void ChainedUnionAllIsPruned()
+    {
+      // A UNION ALL B UNION ALL C — the entire tree is UNION ALL, so pruning is allowed.
+      // Before: SELECT u.Col0
+      //         FROM (SELECT t.Col0, t.Col1, t.Col2 FROM table1 t
+      //               UNION ALL
+      //               SELECT t.Col0, t.Col1, t.Col2 FROM table1 t
+      //               UNION ALL
+      //               SELECT t.Col0, t.Col1, t.Col2 FROM table1 t) u
+      // After:  SELECT u.Col0
+      //         FROM (SELECT t.Col0 FROM table1 t
+      //               UNION ALL
+      //               SELECT t.Col0 FROM table1 t
+      //               UNION ALL
+      //               SELECT t.Col0 FROM table1 t) u
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var selectA = SqlDml.Select(t1);
+      selectA.Columns.Add(t1["Col0"]);
+      selectA.Columns.Add(t1["Col1"]);
+      selectA.Columns.Add(t1["Col2"]);
+
+      var t2 = SqlDml.TableRef(table1, "t2");
+      var selectB = SqlDml.Select(t2);
+      selectB.Columns.Add(t2["Col0"]);
+      selectB.Columns.Add(t2["Col1"]);
+      selectB.Columns.Add(t2["Col2"]);
+
+      var t3 = SqlDml.TableRef(table1, "t3");
+      var selectC = SqlDml.Select(t3);
+      selectC.Columns.Add(t3["Col0"]);
+      selectC.Columns.Add(t3["Col1"]);
+      selectC.Columns.Add(t3["Col2"]);
+
+      var union = selectA.UnionAll(selectB).UnionAll(selectC);
+      var queryRef = SqlDml.QueryRef(union, "u");
+
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+
+      SqlColumnPruner.Process(outerSelect);
+
+      Assert.That(queryRef.Columns.Count, Is.EqualTo(1));
+      Assert.That(selectA.Columns.Count, Is.EqualTo(1));
+      Assert.That(selectB.Columns.Count, Is.EqualTo(1));
+      Assert.That(selectC.Columns.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void DoesNotPruneUnionAllWithNestedUnionDistinctOnLeft()
+    {
+      // (A UNION B) UNION ALL C — left subtree is UNION (not ALL), so no pruning.
+      // SELECT u.Col0
+      // FROM ((SELECT ... UNION SELECT ...) UNION ALL SELECT ...) u
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var selectA = SqlDml.Select(t1);
+      selectA.Columns.Add(t1["Col0"]);
+      selectA.Columns.Add(t1["Col1"]);
+      selectA.Columns.Add(t1["Col2"]);
+
+      var t2 = SqlDml.TableRef(table1, "t2");
+      var selectB = SqlDml.Select(t2);
+      selectB.Columns.Add(t2["Col0"]);
+      selectB.Columns.Add(t2["Col1"]);
+      selectB.Columns.Add(t2["Col2"]);
+
+      var t3 = SqlDml.TableRef(table1, "t3");
+      var selectC = SqlDml.Select(t3);
+      selectC.Columns.Add(t3["Col0"]);
+      selectC.Columns.Add(t3["Col1"]);
+      selectC.Columns.Add(t3["Col2"]);
+
+      var union = selectA.Union(selectB).UnionAll(selectC);
+      var queryRef = SqlDml.QueryRef(union, "u");
+
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+
+      var originalColumnCount = queryRef.Columns.Count;
+      SqlColumnPruner.Process(outerSelect);
+
+      Assert.That(queryRef.Columns.Count, Is.EqualTo(originalColumnCount));
+      Assert.That(selectA.Columns.Count, Is.EqualTo(3));
+      Assert.That(selectB.Columns.Count, Is.EqualTo(3));
+      Assert.That(selectC.Columns.Count, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void DoesNotPruneUnionAllWithNestedExceptOnRight()
+    {
+      // A UNION ALL (B EXCEPT C) — right subtree is EXCEPT, so no pruning.
+      // SELECT u.Col0
+      // FROM (SELECT ... UNION ALL (SELECT ... EXCEPT SELECT ...)) u
+      var t1 = SqlDml.TableRef(table1, "t1");
+      var selectA = SqlDml.Select(t1);
+      selectA.Columns.Add(t1["Col0"]);
+      selectA.Columns.Add(t1["Col1"]);
+      selectA.Columns.Add(t1["Col2"]);
+
+      var t2 = SqlDml.TableRef(table1, "t2");
+      var selectB = SqlDml.Select(t2);
+      selectB.Columns.Add(t2["Col0"]);
+      selectB.Columns.Add(t2["Col1"]);
+      selectB.Columns.Add(t2["Col2"]);
+
+      var t3 = SqlDml.TableRef(table1, "t3");
+      var selectC = SqlDml.Select(t3);
+      selectC.Columns.Add(t3["Col0"]);
+      selectC.Columns.Add(t3["Col1"]);
+      selectC.Columns.Add(t3["Col2"]);
+
+      var union = selectA.UnionAll(selectB.Except(selectC));
+      var queryRef = SqlDml.QueryRef(union, "u");
+
+      var outerSelect = SqlDml.Select(queryRef);
+      outerSelect.Columns.Add(queryRef[0]);
+
+      var originalColumnCount = queryRef.Columns.Count;
+      SqlColumnPruner.Process(outerSelect);
+
+      Assert.That(queryRef.Columns.Count, Is.EqualTo(originalColumnCount));
+      Assert.That(selectA.Columns.Count, Is.EqualTo(3));
+      Assert.That(selectB.Columns.Count, Is.EqualTo(3));
+      Assert.That(selectC.Columns.Count, Is.EqualTo(3));
     }
 
     #endregion

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlColumnPruner.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlColumnPruner.cs
@@ -191,6 +191,9 @@ namespace Xtensive.Orm.Providers
             }
           }
           break;
+        case SqlMetadata metadata:
+          FindAndPruneSubqueries(metadata.Expression);
+          break;
       }
     }
 
@@ -236,6 +239,7 @@ namespace Xtensive.Orm.Providers
         var usedColumns = new HashSet<SqlTableColumn>(ReferenceEqualityComparer.Instance);
         CollectUsedColumnsFromSelect(select, sideRef, usedColumns);
         CollectUsedColumnsFromJoinConditions(select.From, sideRef, usedColumns);
+        CollectUsedColumnsFromCorrelatedJoinSides(select.From, sideRef, usedColumns);
 
         if (usedColumns.Count >= columnCount) {
           continue;
@@ -274,6 +278,20 @@ namespace Xtensive.Orm.Providers
         CollectUsedColumns(jt.JoinExpression.Expression, targetTable, usedColumns);
         CollectUsedColumnsFromJoinConditions(jt.JoinExpression.Left, targetTable, usedColumns);
         CollectUsedColumnsFromJoinConditions(jt.JoinExpression.Right, targetTable, usedColumns);
+      }
+    }
+
+    private void CollectUsedColumnsFromCorrelatedJoinSides(
+      SqlTable table, SqlTable targetTable, HashSet<SqlTableColumn> usedColumns)
+    {
+      if (table is SqlQueryRef qr) {
+        if (!ReferenceEquals(qr, targetTable) && qr.Query is SqlSelect innerSelect) {
+          CollectUsedColumnsFromSelect(innerSelect, targetTable, usedColumns);
+        }
+      }
+      else if (table is SqlJoinedTable jt) {
+        CollectUsedColumnsFromCorrelatedJoinSides(jt.JoinExpression.Left, targetTable, usedColumns);
+        CollectUsedColumnsFromCorrelatedJoinSides(jt.JoinExpression.Right, targetTable, usedColumns);
       }
     }
 
@@ -397,6 +415,10 @@ namespace Xtensive.Orm.Providers
           }
           break;
 
+        case SqlMetadata metadata:
+          CollectUsedColumns(metadata.Expression, targetTable, usedColumns);
+          break;
+
         // Leaf nodes — no column references to collect
         case SqlNull:
         case SqlLiteral:
@@ -407,7 +429,6 @@ namespace Xtensive.Orm.Providers
         case SqlVariable:
         case SqlCursor:
         case SqlContainer:
-        case SqlMetadata:
           break;
 
         default:

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlColumnPruner.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlColumnPruner.cs
@@ -416,6 +416,7 @@ namespace Xtensive.Orm.Providers
         // Leaf nodes — no column references to collect.
         case SqlNull:
         case SqlLiteral:
+        case SqlArray:
         case SqlParameterRef:
         case SqlNative:
         case SqlPlaceholder:

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlColumnPruner.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlColumnPruner.cs
@@ -285,13 +285,55 @@ namespace Xtensive.Orm.Providers
       SqlTable table, SqlTable targetTable, HashSet<SqlTableColumn> usedColumns)
     {
       if (table is SqlQueryRef qr) {
-        if (!ReferenceEquals(qr, targetTable) && qr.Query is SqlSelect innerSelect) {
-          CollectUsedColumnsFromSelect(innerSelect, targetTable, usedColumns);
+        if (!ReferenceEquals(qr, targetTable)) {
+          CollectUsedColumnsFromEntireSubtree(qr, targetTable, usedColumns);
         }
       }
       else if (table is SqlJoinedTable jt) {
+        CollectUsedColumns(jt.JoinExpression.Expression, targetTable, usedColumns);
         CollectUsedColumnsFromCorrelatedJoinSides(jt.JoinExpression.Left, targetTable, usedColumns);
         CollectUsedColumnsFromCorrelatedJoinSides(jt.JoinExpression.Right, targetTable, usedColumns);
+      }
+    }
+
+    private void CollectUsedColumnsFromEntireSubtree(
+      SqlQueryRef queryRef, SqlTable targetTable, HashSet<SqlTableColumn> usedColumns)
+    {
+      if (queryRef.Query is SqlSelect innerSelect) {
+        CollectUsedColumnsFromSelect(innerSelect, targetTable, usedColumns);
+        if (innerSelect.From != null) {
+          CollectUsedColumnsFromCorrelatedJoinSides(innerSelect.From, targetTable, usedColumns);
+        }
+      }
+      else if (queryRef.Query is SqlQueryExpression queryExpr) {
+        CollectUsedColumnsFromQueryExpressionSubtree(queryExpr, targetTable, usedColumns);
+      }
+    }
+
+    private void CollectUsedColumnsFromQueryExpressionSubtree(
+      SqlQueryExpression queryExpr, SqlTable targetTable, HashSet<SqlTableColumn> usedColumns)
+    {
+      switch (queryExpr.Left) {
+        case SqlSelect leftSelect:
+          CollectUsedColumnsFromSelect(leftSelect, targetTable, usedColumns);
+          if (leftSelect.From != null) {
+            CollectUsedColumnsFromCorrelatedJoinSides(leftSelect.From, targetTable, usedColumns);
+          }
+          break;
+        case SqlQueryExpression leftExpr:
+          CollectUsedColumnsFromQueryExpressionSubtree(leftExpr, targetTable, usedColumns);
+          break;
+      }
+      switch (queryExpr.Right) {
+        case SqlSelect rightSelect:
+          CollectUsedColumnsFromSelect(rightSelect, targetTable, usedColumns);
+          if (rightSelect.From != null) {
+            CollectUsedColumnsFromCorrelatedJoinSides(rightSelect.From, targetTable, usedColumns);
+          }
+          break;
+        case SqlQueryExpression rightExpr:
+          CollectUsedColumnsFromQueryExpressionSubtree(rightExpr, targetTable, usedColumns);
+          break;
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlColumnPruner.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlColumnPruner.cs
@@ -1,0 +1,342 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Xtensive.Sql.Dml;
+
+namespace Xtensive.Orm.Providers
+{
+  /// <summary>
+  /// Post-processing pass that walks the <see cref="SqlSelect"/> AST top-down
+  /// and removes unused columns from inner <see cref="SqlQueryRef"/> subqueries.
+  /// This reduces SQL text size by eliminating column bloat introduced when
+  /// the compiler unconditionally projects all columns through subquery layers.
+  /// </summary>
+  internal sealed class SqlColumnPruner
+  {
+    private readonly HashSet<SqlExpression> visited = new(ReferenceEqualityComparer.Instance);
+
+    public static void Process(SqlSelect rootSelect)
+    {
+      ArgumentNullException.ThrowIfNull(rootSelect);
+      new SqlColumnPruner().PruneSelect(rootSelect);
+    }
+
+    private void PruneSelect(SqlSelect select)
+    {
+      // Prune this level's FROM source first (top-down enables cascading
+      // through multiple nesting levels — the inner select sees the
+      // already-reduced column set).
+      if (select.From is SqlQueryRef queryRef && queryRef.Query is SqlSelect) {
+        TryPruneQueryRef(select, queryRef);
+      }
+
+      // Then recurse into FROM sources to prune deeper levels
+      if (select.From != null) {
+        RecurseIntoTable(select.From);
+      }
+
+      // Finally handle subqueries embedded in expressions
+      RecurseIntoExpressionSubqueries(select);
+    }
+
+    private void RecurseIntoTable(SqlTable table)
+    {
+      switch (table) {
+        case SqlQueryRef queryRef when queryRef.Query is SqlSelect innerSelect:
+          PruneSelect(innerSelect);
+          break;
+        case SqlJoinedTable joined:
+          RecurseIntoTable(joined.JoinExpression.Left);
+          RecurseIntoTable(joined.JoinExpression.Right);
+          break;
+      }
+    }
+
+    private void RecurseIntoExpressionSubqueries(SqlSelect select)
+    {
+      foreach (var col in select.Columns) {
+        FindAndPruneSubqueries(col);
+      }
+      FindAndPruneSubqueries(select.Where);
+      FindAndPruneSubqueries(select.Having);
+      foreach (var col in select.GroupByReadOnly) {
+        FindAndPruneSubqueries(col);
+      }
+      foreach (var order in select.OrderByReadOnly) {
+        if (order.Expression != null) {
+          FindAndPruneSubqueries(order.Expression);
+        }
+      }
+    }
+
+    private void FindAndPruneSubqueries(SqlExpression expr)
+    {
+      if (expr == null || !visited.Add(expr)) {
+        return;
+      }
+
+      switch (expr) {
+        case SqlSubQuery sub:
+          if (sub.Query is SqlSelect innerSelect) {
+            PruneSelect(innerSelect);
+          }
+          break;
+        case SqlBinary bin:
+          FindAndPruneSubqueries(bin.Left);
+          FindAndPruneSubqueries(bin.Right);
+          break;
+        case SqlUnary un:
+          FindAndPruneSubqueries(un.Operand);
+          break;
+        case SqlCase cas:
+          FindAndPruneSubqueries(cas.Value);
+          FindAndPruneSubqueries(cas.Else);
+          foreach (var pair in (IEnumerable<KeyValuePair<SqlExpression, SqlExpression>>) cas) {
+            FindAndPruneSubqueries(pair.Key);
+            FindAndPruneSubqueries(pair.Value);
+          }
+          break;
+        case SqlCast cast:
+          FindAndPruneSubqueries(cast.Operand);
+          break;
+        case SqlUserColumn uc:
+          FindAndPruneSubqueries(uc.Expression);
+          break;
+        case SqlColumnRef cr:
+          FindAndPruneSubqueries(cr.SqlColumn);
+          break;
+        case SqlFunctionCallBase func:
+          foreach (var arg in func.Arguments) {
+            FindAndPruneSubqueries(arg);
+          }
+          break;
+        case SqlAggregate agg:
+          FindAndPruneSubqueries(agg.Expression);
+          break;
+        case SqlLike like:
+          FindAndPruneSubqueries(like.Expression);
+          FindAndPruneSubqueries(like.Pattern);
+          FindAndPruneSubqueries(like.Escape);
+          break;
+        case SqlBetween between:
+          FindAndPruneSubqueries(between.Expression);
+          FindAndPruneSubqueries(between.Left);
+          FindAndPruneSubqueries(between.Right);
+          break;
+        case SqlExpressionList list:
+          for (int i = 0; i < list.Count; i++) {
+            FindAndPruneSubqueries(list[i]);
+          }
+          break;
+        case SqlTrim trim:
+          FindAndPruneSubqueries(trim.Expression);
+          break;
+        case SqlExtract extract:
+          FindAndPruneSubqueries(extract.Operand);
+          break;
+        case SqlRound round:
+          FindAndPruneSubqueries(round.Argument);
+          FindAndPruneSubqueries(round.Length);
+          break;
+        case SqlCollate collate:
+          FindAndPruneSubqueries(collate.Operand);
+          break;
+        case SqlMatch match:
+          FindAndPruneSubqueries(match.Value);
+          FindAndPruneSubqueries(match.SubQuery);
+          break;
+        case SqlVariant variant:
+          FindAndPruneSubqueries(variant.Main);
+          FindAndPruneSubqueries(variant.Alternative);
+          break;
+        case SqlDynamicFilter filter:
+          foreach (var e in filter.Expressions) {
+            FindAndPruneSubqueries(e);
+          }
+          break;
+        case SqlRowNumber rn:
+          foreach (var order in rn.OrderBy) {
+            if (order.Expression != null) {
+              FindAndPruneSubqueries(order.Expression);
+            }
+          }
+          break;
+      }
+    }
+
+    private void TryPruneQueryRef(SqlSelect outerSelect, SqlQueryRef queryRef)
+    {
+      var queryRefColumnCount = queryRef.Columns.Count;
+      if (queryRefColumnCount == 0) {
+        return;
+      }
+
+      var usedColumns = new HashSet<SqlTableColumn>(ReferenceEqualityComparer.Instance);
+      CollectUsedColumnsFromSelect(outerSelect, queryRef, usedColumns);
+
+      if (usedColumns.Count >= queryRefColumnCount) {
+        return;
+      }
+
+      var indicesToKeep = new List<int>(usedColumns.Count);
+      for (int i = 0; i < queryRefColumnCount; i++) {
+        if (usedColumns.Contains(queryRef.Columns[i])) {
+          indicesToKeep.Add(i);
+        }
+      }
+
+      if (indicesToKeep.Count == 0 || indicesToKeep.Count >= queryRefColumnCount) {
+        return;
+      }
+
+      queryRef.PruneColumns(indicesToKeep);
+    }
+
+    private void CollectUsedColumnsFromSelect(
+      SqlSelect select, SqlTable targetTable, HashSet<SqlTableColumn> usedColumns)
+    {
+      foreach (var col in select.Columns) {
+        CollectUsedColumns(col, targetTable, usedColumns);
+      }
+      CollectUsedColumns(select.Where, targetTable, usedColumns);
+      CollectUsedColumns(select.Having, targetTable, usedColumns);
+      foreach (var col in select.GroupByReadOnly) {
+        CollectUsedColumns(col, targetTable, usedColumns);
+      }
+      foreach (var order in select.OrderByReadOnly) {
+        if (order.Expression != null) {
+          CollectUsedColumns(order.Expression, targetTable, usedColumns);
+        }
+      }
+    }
+
+    private void CollectUsedColumns(
+      SqlExpression expr, SqlTable targetTable, HashSet<SqlTableColumn> usedColumns)
+    {
+      if (expr == null) {
+        return;
+      }
+
+      switch (expr) {
+        case SqlTableColumn tc:
+          if (ReferenceEquals(tc.SqlTable, targetTable)) {
+            usedColumns.Add(tc);
+          }
+          break;
+        case SqlColumnRef cr:
+          CollectUsedColumns(cr.SqlColumn, targetTable, usedColumns);
+          break;
+        case SqlColumnStub cs:
+          CollectUsedColumns(cs.Column, targetTable, usedColumns);
+          break;
+        case SqlUserColumn uc:
+          CollectUsedColumns(uc.Expression, targetTable, usedColumns);
+          break;
+        case SqlBinary bin:
+          CollectUsedColumns(bin.Left, targetTable, usedColumns);
+          CollectUsedColumns(bin.Right, targetTable, usedColumns);
+          break;
+        case SqlUnary un:
+          CollectUsedColumns(un.Operand, targetTable, usedColumns);
+          break;
+        case SqlCase cas:
+          CollectUsedColumns(cas.Value, targetTable, usedColumns);
+          CollectUsedColumns(cas.Else, targetTable, usedColumns);
+          foreach (var pair in (IEnumerable<KeyValuePair<SqlExpression, SqlExpression>>) cas) {
+            CollectUsedColumns(pair.Key, targetTable, usedColumns);
+            CollectUsedColumns(pair.Value, targetTable, usedColumns);
+          }
+          break;
+        case SqlCast cast:
+          CollectUsedColumns(cast.Operand, targetTable, usedColumns);
+          break;
+        case SqlFunctionCallBase func:
+          foreach (var arg in func.Arguments) {
+            CollectUsedColumns(arg, targetTable, usedColumns);
+          }
+          break;
+        case SqlAggregate agg:
+          CollectUsedColumns(agg.Expression, targetTable, usedColumns);
+          break;
+        case SqlLike like:
+          CollectUsedColumns(like.Expression, targetTable, usedColumns);
+          CollectUsedColumns(like.Pattern, targetTable, usedColumns);
+          CollectUsedColumns(like.Escape, targetTable, usedColumns);
+          break;
+        case SqlBetween between:
+          CollectUsedColumns(between.Expression, targetTable, usedColumns);
+          CollectUsedColumns(between.Left, targetTable, usedColumns);
+          CollectUsedColumns(between.Right, targetTable, usedColumns);
+          break;
+        case SqlSubQuery sub:
+          if (sub.Query is SqlSelect innerSelect) {
+            CollectUsedColumnsFromSelect(innerSelect, targetTable, usedColumns);
+          }
+          break;
+        case SqlExpressionList list:
+          for (int i = 0; i < list.Count; i++) {
+            CollectUsedColumns(list[i], targetTable, usedColumns);
+          }
+          break;
+        case SqlTrim trim:
+          CollectUsedColumns(trim.Expression, targetTable, usedColumns);
+          break;
+        case SqlExtract extract:
+          CollectUsedColumns(extract.Operand, targetTable, usedColumns);
+          break;
+        case SqlRound round:
+          CollectUsedColumns(round.Argument, targetTable, usedColumns);
+          CollectUsedColumns(round.Length, targetTable, usedColumns);
+          break;
+        case SqlCollate collate:
+          CollectUsedColumns(collate.Operand, targetTable, usedColumns);
+          break;
+        case SqlMatch match:
+          CollectUsedColumns(match.Value, targetTable, usedColumns);
+          CollectUsedColumns(match.SubQuery, targetTable, usedColumns);
+          break;
+        case SqlVariant variant:
+          CollectUsedColumns(variant.Main, targetTable, usedColumns);
+          CollectUsedColumns(variant.Alternative, targetTable, usedColumns);
+          break;
+        case SqlDynamicFilter filter:
+          foreach (var e in filter.Expressions) {
+            CollectUsedColumns(e, targetTable, usedColumns);
+          }
+          break;
+        case SqlRowNumber rn:
+          foreach (var order in rn.OrderBy) {
+            if (order.Expression != null) {
+              CollectUsedColumns(order.Expression, targetTable, usedColumns);
+            }
+          }
+          break;
+
+        // Leaf nodes — no column references to collect
+        case SqlNull:
+        case SqlLiteral:
+        case SqlParameterRef:
+        case SqlNative:
+        case SqlPlaceholder:
+        case SqlDefaultValue:
+        case SqlVariable:
+        case SqlCursor:
+        case SqlContainer:
+        case SqlMetadata:
+          break;
+
+        default:
+          // Unknown expression type — conservatively mark all target columns as used
+          // to prevent incorrect pruning when new expression types are introduced.
+          var targetColumns = targetTable.Columns;
+          for (int i = 0; i < targetColumns.Count; i++) {
+            usedColumns.Add(targetColumns[i]);
+          }
+          break;
+      }
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlColumnPruner.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlColumnPruner.cs
@@ -2,469 +2,418 @@
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Xtensive.Sql;
 using Xtensive.Sql.Dml;
 
 namespace Xtensive.Orm.Providers
 {
   /// <summary>
-  /// Post-processing pass that walks the <see cref="SqlSelect"/> AST top-down
-  /// and removes unused columns from inner <see cref="SqlQueryRef"/> subqueries.
-  /// This reduces SQL text size by eliminating column bloat introduced when
-  /// the compiler unconditionally projects all columns through subquery layers.
+  /// Removes unused columns from <see cref="SqlQueryRef"/> sources in the
+  /// immediate <see cref="SqlSelect.From"/> clause of a SELECT. This shrinks
+  /// generated SQL by eliminating column bloat introduced when the compiler
+  /// unconditionally projects all columns through subquery layers.
   /// </summary>
-  internal sealed class SqlColumnPruner
+  /// <remarks>
+  /// <para>
+  /// Pruning cascades top-down through nested SELECTs because
+  /// <see cref="SqlSelectProcessor"/>'s visitor calls
+  /// <see cref="PruneFromClause"/> at the start of every Visit(SqlSelect) and
+  /// then recurses into the FROM clause via the visitor. By the time an inner
+  /// SELECT's Visit(SqlSelect) runs, its parent has already been reduced.
+  /// </para>
+  /// <para>
+  /// IMPORTANT INVARIANT: nested pruning correctness relies on
+  /// <see cref="SqlSelectProcessor"/> visiting every <see cref="SqlSubQuery"/>,
+  /// every <see cref="ISqlQueryExpression"/> child, and every join subtree.
+  /// If a new node type is added whose visitor does not recurse into nested
+  /// SELECTs, pruning silently stops cascading through that node. The
+  /// <c>Visit(SqlVariant)</c> / <c>Visit(SqlCase)</c> regressions fixed in
+  /// the visitor are the historical evidence of this coupling.
+  /// </para>
+  /// <para>
+  /// IDENTITY-EQUALITY ASSUMPTION: the dictionaries and hash sets below intentionally
+  /// rely on the default <see cref="EqualityComparer{T}"/> for <see cref="SqlTable"/>,
+  /// <see cref="SqlExpression"/>, and <see cref="SqlTableColumn"/>. None of these
+  /// types override <see cref="object.Equals(object)"/> / <see cref="object.GetHashCode"/>
+  /// nor implement <see cref="IEquatable{T}"/>, so the default comparer behaves
+  /// as a reference-equality comparer. If equality semantics are ever introduced
+  /// on those classes, this pruner must be updated to pass an explicit
+  /// <see cref="ReferenceEqualityComparer"/>; otherwise structurally-equal but
+  /// distinct DML nodes would alias and pruning would become incorrect.
+  /// </para>
+  /// </remarks>
+  internal static class SqlColumnPruner
   {
-    private readonly HashSet<SqlExpression> visited = new(ReferenceEqualityComparer.Instance);
-
-    public static void Process(SqlSelect rootSelect)
+    /// <summary>
+    /// Prunes unused columns from any <see cref="SqlQueryRef"/>(s) directly in
+    /// <paramref name="select"/>'s FROM clause. Does NOT recurse into nested
+    /// SELECTs — the caller is expected to drive the rest of the AST walk.
+    /// </summary>
+    internal static void PruneFromClause(SqlSelect select)
     {
-      ArgumentNullException.ThrowIfNull(rootSelect);
-      new SqlColumnPruner().PruneSelect(rootSelect);
+      switch (select.From) {
+        case SqlQueryRef queryRef:
+          TryPruneSingleQueryRef(select, queryRef);
+          break;
+        case SqlJoinedTable joinedRoot:
+          TryPruneJoinTree(select, joinedRoot);
+          break;
+      }
     }
 
-    private void PruneSelect(SqlSelect select)
+    private static void TryPruneSingleQueryRef(SqlSelect outerSelect, SqlQueryRef queryRef)
     {
-      // Prune this level's FROM source first (top-down enables cascading
-      // through multiple nesting levels — the inner select sees the
-      // already-reduced column set).
-      if (select.From is SqlQueryRef queryRef) {
-        TryPruneQueryRef(select, queryRef);
+      var columnCount = queryRef.Columns.Count;
+      if (columnCount == 0) {
+        return;
       }
 
-      // When FROM is a join, prune each side that is a SqlQueryRef
-      if (select.From is SqlJoinedTable) {
-        TryPruneJoinSides(select);
-      }
+      var bucket = new ColumnBucket(queryRef, columnCount);
+      var bucketByTable = new Dictionary<SqlTable, ColumnBucket>(1) {
+        [queryRef] = bucket
+      };
+      var collectVisited = new HashSet<SqlExpression>();
 
-      // Then recurse into FROM sources to prune deeper levels
-      if (select.From != null) {
-        RecurseIntoTable(select.From);
-      }
-
-      // Finally handle subqueries embedded in expressions
-      RecurseIntoExpressionSubqueries(select);
+      CollectUsedColumnsFromSelect(outerSelect, bucketByTable, collectVisited);
+      ApplyPruning(bucket);
     }
 
-    private void RecurseIntoTable(SqlTable table)
+    private static void TryPruneJoinTree(SqlSelect outerSelect, SqlJoinedTable joinedRoot)
+    {
+      // Single-pass collection: enumerate every join-leaf SqlQueryRef into a
+      // bucket dictionary keyed by table identity, then walk the outer SELECT
+      // and the entire join subtree exactly once. SqlTableColumn references
+      // are routed into the appropriate bucket via O(1) dictionary lookup.
+      // Replaces the previous N-times-per-query walk (one per join target).
+      // Typical join trees have a small, bounded number of leaves (2-5).
+      // Pre-sizing avoids the resize/rehash cycles that would otherwise hit
+      // every Add. The capacity is a hint — real depth is discovered during
+      // the walk and growth still works correctly if exceeded.
+      const int initialBucketCapacity = 4;
+      var allBuckets = new List<ColumnBucket>(initialBucketCapacity);
+      var bucketByTable = new Dictionary<SqlTable, ColumnBucket>(initialBucketCapacity);
+      CollectJoinTargets(joinedRoot, allBuckets, bucketByTable);
+      if (allBuckets.Count == 0) {
+        return;
+      }
+
+      var collectVisited = new HashSet<SqlExpression>();
+      CollectUsedColumnsFromSelect(outerSelect, bucketByTable, collectVisited);
+      if (bucketByTable.Count > 0) {
+        CollectUsedColumnsFromJoinSubtrees(joinedRoot, bucketByTable, collectVisited);
+      }
+
+      // CollectionsMarshal.AsSpan exposes the list's backing array directly so
+      // ApplyPruning can take each element by `in` without an intermediate copy
+      // of the (small but not free) ColumnBucket struct.
+      var bucketSpan = CollectionsMarshal.AsSpan(allBuckets);
+      for (int i = 0; i < bucketSpan.Length; i++) {
+        ApplyPruning(in bucketSpan[i]);
+      }
+    }
+
+    private static void CollectJoinTargets(
+      SqlTable table,
+      List<ColumnBucket> allBuckets,
+      Dictionary<SqlTable, ColumnBucket> bucketByTable)
     {
       switch (table) {
-        case SqlQueryRef queryRef:
-          if (queryRef.Query is SqlSelect innerSelect) {
-            PruneSelect(innerSelect);
-          }
-          else if (queryRef.Query is SqlQueryExpression queryExpr) {
-            RecurseIntoQueryExpression(queryExpr);
+        case SqlQueryRef qr:
+          var count = qr.Columns.Count;
+          if (count > 0) {
+            var bucket = new ColumnBucket(qr, count);
+            allBuckets.Add(bucket);
+            bucketByTable[qr] = bucket;
           }
           break;
-        case SqlJoinedTable joined:
-          RecurseIntoTable(joined.JoinExpression.Left);
-          RecurseIntoTable(joined.JoinExpression.Right);
+        case SqlJoinedTable jt:
+          CollectJoinTargets(jt.JoinExpression.Left, allBuckets, bucketByTable);
+          CollectJoinTargets(jt.JoinExpression.Right, allBuckets, bucketByTable);
           break;
       }
     }
 
-    private void RecurseIntoQueryExpression(SqlQueryExpression expr)
+    private static void ApplyPruning(in ColumnBucket bucket)
     {
-      RecurseIntoQueryExpressionSide(expr.Left);
-      RecurseIntoQueryExpressionSide(expr.Right);
-    }
-
-    private void RecurseIntoQueryExpressionSide(ISqlQueryExpression side)
-    {
-      if (side is SqlSelect select) {
-        PruneSelect(select);
-      }
-      else if (side is SqlQueryExpression nested) {
-        RecurseIntoQueryExpression(nested);
-      }
-    }
-
-    private void RecurseIntoExpressionSubqueries(SqlSelect select)
-    {
-      foreach (var col in select.Columns) {
-        FindAndPruneSubqueries(col);
-      }
-      FindAndPruneSubqueries(select.Where);
-      FindAndPruneSubqueries(select.Having);
-      foreach (var col in select.GroupByReadOnly) {
-        FindAndPruneSubqueries(col);
-      }
-      foreach (var order in select.OrderByReadOnly) {
-        if (order.Expression != null) {
-          FindAndPruneSubqueries(order.Expression);
-        }
-      }
-    }
-
-    private void FindAndPruneSubqueries(SqlExpression expr)
-    {
-      if (expr == null || !visited.Add(expr)) {
+      var totalCount = bucket.ColumnCount;
+      var usedCount = bucket.UsedColumns.Count;
+      if (usedCount == 0 || usedCount >= totalCount) {
         return;
       }
 
-      switch (expr) {
-        case SqlSubQuery sub:
-          if (sub.Query is SqlSelect innerSelect) {
-            PruneSelect(innerSelect);
-          }
-          break;
-        case SqlBinary bin:
-          FindAndPruneSubqueries(bin.Left);
-          FindAndPruneSubqueries(bin.Right);
-          break;
-        case SqlUnary un:
-          FindAndPruneSubqueries(un.Operand);
-          break;
-        case SqlCase cas:
-          FindAndPruneSubqueries(cas.Value);
-          FindAndPruneSubqueries(cas.Else);
-          foreach (var pair in (IEnumerable<KeyValuePair<SqlExpression, SqlExpression>>) cas) {
-            FindAndPruneSubqueries(pair.Key);
-            FindAndPruneSubqueries(pair.Value);
-          }
-          break;
-        case SqlCast cast:
-          FindAndPruneSubqueries(cast.Operand);
-          break;
-        case SqlUserColumn uc:
-          FindAndPruneSubqueries(uc.Expression);
-          break;
-        case SqlColumnRef cr:
-          FindAndPruneSubqueries(cr.SqlColumn);
-          break;
-        case SqlFunctionCallBase func:
-          foreach (var arg in func.Arguments) {
-            FindAndPruneSubqueries(arg);
-          }
-          break;
-        case SqlAggregate agg:
-          FindAndPruneSubqueries(agg.Expression);
-          break;
-        case SqlLike like:
-          FindAndPruneSubqueries(like.Expression);
-          FindAndPruneSubqueries(like.Pattern);
-          FindAndPruneSubqueries(like.Escape);
-          break;
-        case SqlBetween between:
-          FindAndPruneSubqueries(between.Expression);
-          FindAndPruneSubqueries(between.Left);
-          FindAndPruneSubqueries(between.Right);
-          break;
-        case SqlExpressionList list:
-          for (int i = 0; i < list.Count; i++) {
-            FindAndPruneSubqueries(list[i]);
-          }
-          break;
-        case SqlTrim trim:
-          FindAndPruneSubqueries(trim.Expression);
-          break;
-        case SqlExtract extract:
-          FindAndPruneSubqueries(extract.Operand);
-          break;
-        case SqlRound round:
-          FindAndPruneSubqueries(round.Argument);
-          FindAndPruneSubqueries(round.Length);
-          break;
-        case SqlCollate collate:
-          FindAndPruneSubqueries(collate.Operand);
-          break;
-        case SqlMatch match:
-          FindAndPruneSubqueries(match.Value);
-          FindAndPruneSubqueries(match.SubQuery);
-          break;
-        case SqlVariant variant:
-          FindAndPruneSubqueries(variant.Main);
-          FindAndPruneSubqueries(variant.Alternative);
-          break;
-        case SqlDynamicFilter filter:
-          foreach (var e in filter.Expressions) {
-            FindAndPruneSubqueries(e);
-          }
-          break;
-        case SqlRowNumber rn:
-          foreach (var order in rn.OrderBy) {
-            if (order.Expression != null) {
-              FindAndPruneSubqueries(order.Expression);
-            }
-          }
-          break;
-        case SqlMetadata metadata:
-          FindAndPruneSubqueries(metadata.Expression);
-          break;
-      }
-    }
-
-    private void TryPruneQueryRef(SqlSelect outerSelect, SqlQueryRef queryRef)
-    {
-      var queryRefColumnCount = queryRef.Columns.Count;
-      if (queryRefColumnCount == 0) {
-        return;
-      }
-
-      var usedColumns = new HashSet<SqlTableColumn>(ReferenceEqualityComparer.Instance);
-      CollectUsedColumnsFromSelect(outerSelect, queryRef, usedColumns);
-
-      if (usedColumns.Count >= queryRefColumnCount) {
-        return;
-      }
-
-      var indicesToKeep = new List<int>(usedColumns.Count);
-      for (int i = 0; i < queryRefColumnCount; i++) {
-        if (usedColumns.Contains(queryRef.Columns[i])) {
+      var indicesToKeep = new List<int>(usedCount);
+      var columns = bucket.QueryRef.Columns;
+      for (int i = 0; i < totalCount; i++) {
+        if (bucket.UsedColumns.Contains(columns[i])) {
           indicesToKeep.Add(i);
         }
       }
 
-      if (indicesToKeep.Count == 0 || indicesToKeep.Count >= queryRefColumnCount) {
+      if (indicesToKeep.Count == 0 || indicesToKeep.Count >= totalCount) {
         return;
       }
 
-      queryRef.PruneColumns(indicesToKeep);
+      bucket.QueryRef.PruneColumns(indicesToKeep);
     }
 
-    private void TryPruneJoinSides(SqlSelect select)
+    // ===== Collection =====
+
+    private static void CollectUsedColumnsFromJoinSubtrees(
+      SqlTable table,
+      Dictionary<SqlTable, ColumnBucket> bucketByTable,
+      HashSet<SqlExpression> collectVisited)
     {
-      var joinQueryRefs = new List<SqlQueryRef>();
-      CollectQueryRefsFromJoinTree(select.From, joinQueryRefs);
-
-      foreach (var sideRef in joinQueryRefs) {
-        var columnCount = sideRef.Columns.Count;
-        if (columnCount == 0) {
-          continue;
-        }
-
-        var usedColumns = new HashSet<SqlTableColumn>(ReferenceEqualityComparer.Instance);
-        CollectUsedColumnsFromSelect(select, sideRef, usedColumns);
-        CollectUsedColumnsFromJoinConditions(select.From, sideRef, usedColumns);
-        CollectUsedColumnsFromCorrelatedJoinSides(select.From, sideRef, usedColumns);
-
-        if (usedColumns.Count >= columnCount) {
-          continue;
-        }
-
-        var indicesToKeep = new List<int>(usedColumns.Count);
-        for (int i = 0; i < columnCount; i++) {
-          if (usedColumns.Contains(sideRef.Columns[i])) {
-            indicesToKeep.Add(i);
-          }
-        }
-
-        if (indicesToKeep.Count == 0 || indicesToKeep.Count >= columnCount) {
-          continue;
-        }
-
-        sideRef.PruneColumns(indicesToKeep);
+      if (bucketByTable.Count == 0) {
+        return;
       }
-    }
-
-    private static void CollectQueryRefsFromJoinTree(SqlTable table, List<SqlQueryRef> result)
-    {
-      if (table is SqlQueryRef qr) {
-        result.Add(qr);
-      }
-      else if (table is SqlJoinedTable jt) {
-        CollectQueryRefsFromJoinTree(jt.JoinExpression.Left, result);
-        CollectQueryRefsFromJoinTree(jt.JoinExpression.Right, result);
-      }
-    }
-
-    private void CollectUsedColumnsFromJoinConditions(
-      SqlTable table, SqlTable targetTable, HashSet<SqlTableColumn> usedColumns)
-    {
-      if (table is SqlJoinedTable jt) {
-        CollectUsedColumns(jt.JoinExpression.Expression, targetTable, usedColumns);
-        CollectUsedColumnsFromJoinConditions(jt.JoinExpression.Left, targetTable, usedColumns);
-        CollectUsedColumnsFromJoinConditions(jt.JoinExpression.Right, targetTable, usedColumns);
-      }
-    }
-
-    private void CollectUsedColumnsFromCorrelatedJoinSides(
-      SqlTable table, SqlTable targetTable, HashSet<SqlTableColumn> usedColumns)
-    {
-      if (table is SqlQueryRef qr) {
-        if (!ReferenceEquals(qr, targetTable)) {
-          CollectUsedColumnsFromEntireSubtree(qr, targetTable, usedColumns);
-        }
-      }
-      else if (table is SqlJoinedTable jt) {
-        CollectUsedColumns(jt.JoinExpression.Expression, targetTable, usedColumns);
-        CollectUsedColumnsFromCorrelatedJoinSides(jt.JoinExpression.Left, targetTable, usedColumns);
-        CollectUsedColumnsFromCorrelatedJoinSides(jt.JoinExpression.Right, targetTable, usedColumns);
-      }
-    }
-
-    private void CollectUsedColumnsFromEntireSubtree(
-      SqlQueryRef queryRef, SqlTable targetTable, HashSet<SqlTableColumn> usedColumns)
-    {
-      if (queryRef.Query is SqlSelect innerSelect) {
-        CollectUsedColumnsFromSelect(innerSelect, targetTable, usedColumns);
-        if (innerSelect.From != null) {
-          CollectUsedColumnsFromCorrelatedJoinSides(innerSelect.From, targetTable, usedColumns);
-        }
-      }
-      else if (queryRef.Query is SqlQueryExpression queryExpr) {
-        CollectUsedColumnsFromQueryExpressionSubtree(queryExpr, targetTable, usedColumns);
-      }
-    }
-
-    private void CollectUsedColumnsFromQueryExpressionSubtree(
-      SqlQueryExpression queryExpr, SqlTable targetTable, HashSet<SqlTableColumn> usedColumns)
-    {
-      switch (queryExpr.Left) {
-        case SqlSelect leftSelect:
-          CollectUsedColumnsFromSelect(leftSelect, targetTable, usedColumns);
-          if (leftSelect.From != null) {
-            CollectUsedColumnsFromCorrelatedJoinSides(leftSelect.From, targetTable, usedColumns);
-          }
+      switch (table) {
+        case SqlQueryRef qr:
+          CollectUsedColumnsFromQuerySubtree(qr, bucketByTable, collectVisited);
           break;
-        case SqlQueryExpression leftExpr:
-          CollectUsedColumnsFromQueryExpressionSubtree(leftExpr, targetTable, usedColumns);
-          break;
-      }
-      switch (queryExpr.Right) {
-        case SqlSelect rightSelect:
-          CollectUsedColumnsFromSelect(rightSelect, targetTable, usedColumns);
-          if (rightSelect.From != null) {
-            CollectUsedColumnsFromCorrelatedJoinSides(rightSelect.From, targetTable, usedColumns);
-          }
-          break;
-        case SqlQueryExpression rightExpr:
-          CollectUsedColumnsFromQueryExpressionSubtree(rightExpr, targetTable, usedColumns);
+        case SqlJoinedTable jt:
+          CollectUsedColumns(jt.JoinExpression.Expression, bucketByTable, collectVisited);
+          CollectUsedColumnsFromJoinSubtrees(jt.JoinExpression.Left, bucketByTable, collectVisited);
+          CollectUsedColumnsFromJoinSubtrees(jt.JoinExpression.Right, bucketByTable, collectVisited);
           break;
       }
     }
 
-    private void CollectUsedColumnsFromSelect(
-      SqlSelect select, SqlTable targetTable, HashSet<SqlTableColumn> usedColumns)
+    private static void CollectUsedColumnsFromQuerySubtree(
+      SqlQueryRef queryRef,
+      Dictionary<SqlTable, ColumnBucket> bucketByTable,
+      HashSet<SqlExpression> collectVisited)
+    {
+      switch (queryRef.Query) {
+        case SqlSelect innerSelect:
+          RecurseIntoSelect(innerSelect, bucketByTable, collectVisited);
+          break;
+        case SqlQueryExpression queryExpr:
+          CollectUsedColumnsFromQueryExpression(queryExpr, bucketByTable, collectVisited);
+          break;
+      }
+    }
+
+    /// <summary>
+    /// Walks a nested <see cref="SqlSelect"/>: collect references from its
+    /// projection/predicate/grouping/ordering, then descend into its FROM clause
+    /// (which may itself be a join subtree) so column usage from join predicates
+    /// of the inner SELECT is also tracked. The FROM walk is skipped when the
+    /// active routing dictionary has already been emptied by saturation.
+    /// </summary>
+    private static void RecurseIntoSelect(
+      SqlSelect select,
+      Dictionary<SqlTable, ColumnBucket> bucketByTable,
+      HashSet<SqlExpression> collectVisited)
+    {
+      CollectUsedColumnsFromSelect(select, bucketByTable, collectVisited);
+      if (select.From != null && bucketByTable.Count > 0) {
+        CollectUsedColumnsFromJoinSubtrees(select.From, bucketByTable, collectVisited);
+      }
+    }
+
+    private static void CollectUsedColumnsFromQueryExpression(
+      SqlQueryExpression queryExpr,
+      Dictionary<SqlTable, ColumnBucket> bucketByTable,
+      HashSet<SqlExpression> collectVisited)
+    {
+      CollectUsedColumnsFromQueryExpressionSide(queryExpr.Left, bucketByTable, collectVisited);
+      if (bucketByTable.Count == 0) {
+        return;
+      }
+      CollectUsedColumnsFromQueryExpressionSide(queryExpr.Right, bucketByTable, collectVisited);
+    }
+
+    private static void CollectUsedColumnsFromQueryExpressionSide(
+      ISqlQueryExpression side,
+      Dictionary<SqlTable, ColumnBucket> bucketByTable,
+      HashSet<SqlExpression> collectVisited)
+    {
+      switch (side) {
+        case SqlSelect sel:
+          RecurseIntoSelect(sel, bucketByTable, collectVisited);
+          break;
+        case SqlQueryExpression nested:
+          CollectUsedColumnsFromQueryExpression(nested, bucketByTable, collectVisited);
+          break;
+      }
+    }
+
+    private static void CollectUsedColumnsFromSelect(
+      SqlSelect select,
+      Dictionary<SqlTable, ColumnBucket> bucketByTable,
+      HashSet<SqlExpression> collectVisited)
     {
       foreach (var col in select.Columns) {
-        CollectUsedColumns(col, targetTable, usedColumns);
+        if (bucketByTable.Count == 0) {
+          return;
+        }
+        CollectUsedColumns(col, bucketByTable, collectVisited);
       }
-      CollectUsedColumns(select.Where, targetTable, usedColumns);
-      CollectUsedColumns(select.Having, targetTable, usedColumns);
-      foreach (var col in select.GroupByReadOnly) {
-        CollectUsedColumns(col, targetTable, usedColumns);
+      if (bucketByTable.Count == 0) {
+        return;
       }
-      foreach (var order in select.OrderByReadOnly) {
-        if (order.Expression != null) {
-          CollectUsedColumns(order.Expression, targetTable, usedColumns);
+      CollectUsedColumns(select.Where, bucketByTable, collectVisited);
+      if (bucketByTable.Count == 0) {
+        return;
+      }
+      CollectUsedColumns(select.Having, bucketByTable, collectVisited);
+      var groupBy = select.GroupByReadOnly;
+      for (int i = 0, n = groupBy.Count; i < n; i++) {
+        if (bucketByTable.Count == 0) {
+          return;
+        }
+        CollectUsedColumns(groupBy[i], bucketByTable, collectVisited);
+      }
+      var orderBy = select.OrderByReadOnly;
+      for (int i = 0, n = orderBy.Count; i < n; i++) {
+        if (bucketByTable.Count == 0) {
+          return;
+        }
+        var orderExpr = orderBy[i].Expression;
+        if (orderExpr != null) {
+          CollectUsedColumns(orderExpr, bucketByTable, collectVisited);
         }
       }
     }
 
-    private void CollectUsedColumns(
-      SqlExpression expr, SqlTable targetTable, HashSet<SqlTableColumn> usedColumns)
+    private static void CollectUsedColumns(
+      SqlExpression expr,
+      Dictionary<SqlTable, ColumnBucket> bucketByTable,
+      HashSet<SqlExpression> collectVisited)
     {
-      if (expr == null) {
+      if (expr is null || bucketByTable.Count == 0 || !collectVisited.Add(expr)) {
         return;
       }
 
       switch (expr) {
         case SqlTableColumn tc:
-          if (ReferenceEquals(tc.SqlTable, targetTable)) {
-            usedColumns.Add(tc);
+          var sqlTable = tc.SqlTable;
+          if (sqlTable != null) {
+            // GetValueRefOrNullRef returns a ref directly into the dictionary's
+            // backing storage instead of copying the 24-byte ColumnBucket struct
+            // onto the stack. This is the hottest dispatch in the entire walk —
+            // every column reference in the SELECT lands here.
+            // Safety: we only Remove() AFTER reading IsSaturated through the
+            // ref, so the dictionary is not mutated while the ref is live.
+            ref var bucket = ref CollectionsMarshal.GetValueRefOrNullRef(bucketByTable, sqlTable);
+            if (!Unsafe.IsNullRef(ref bucket)
+                && bucket.UsedColumns.Add(tc)
+                && bucket.IsSaturated) {
+              bucketByTable.Remove(sqlTable);
+            }
           }
           break;
         case SqlColumnRef cr:
-          CollectUsedColumns(cr.SqlColumn, targetTable, usedColumns);
+          CollectUsedColumns(cr.SqlColumn, bucketByTable, collectVisited);
           break;
         case SqlColumnStub cs:
-          CollectUsedColumns(cs.Column, targetTable, usedColumns);
+          CollectUsedColumns(cs.Column, bucketByTable, collectVisited);
           break;
         case SqlUserColumn uc:
-          CollectUsedColumns(uc.Expression, targetTable, usedColumns);
+          CollectUsedColumns(uc.Expression, bucketByTable, collectVisited);
           break;
         case SqlBinary bin:
-          CollectUsedColumns(bin.Left, targetTable, usedColumns);
-          CollectUsedColumns(bin.Right, targetTable, usedColumns);
+          CollectUsedColumns(bin.Left, bucketByTable, collectVisited);
+          CollectUsedColumns(bin.Right, bucketByTable, collectVisited);
           break;
         case SqlUnary un:
-          CollectUsedColumns(un.Operand, targetTable, usedColumns);
+          CollectUsedColumns(un.Operand, bucketByTable, collectVisited);
           break;
         case SqlCase cas:
-          CollectUsedColumns(cas.Value, targetTable, usedColumns);
-          CollectUsedColumns(cas.Else, targetTable, usedColumns);
+          CollectUsedColumns(cas.Value, bucketByTable, collectVisited);
+          CollectUsedColumns(cas.Else, bucketByTable, collectVisited);
           foreach (var pair in (IEnumerable<KeyValuePair<SqlExpression, SqlExpression>>) cas) {
-            CollectUsedColumns(pair.Key, targetTable, usedColumns);
-            CollectUsedColumns(pair.Value, targetTable, usedColumns);
+            CollectUsedColumns(pair.Key, bucketByTable, collectVisited);
+            CollectUsedColumns(pair.Value, bucketByTable, collectVisited);
           }
           break;
         case SqlCast cast:
-          CollectUsedColumns(cast.Operand, targetTable, usedColumns);
+          CollectUsedColumns(cast.Operand, bucketByTable, collectVisited);
           break;
         case SqlFunctionCallBase func:
-          foreach (var arg in func.Arguments) {
-            CollectUsedColumns(arg, targetTable, usedColumns);
+          var args = func.Arguments;
+          for (int i = 0, n = args.Count; i < n; i++) {
+            CollectUsedColumns(args[i], bucketByTable, collectVisited);
           }
           break;
         case SqlAggregate agg:
-          CollectUsedColumns(agg.Expression, targetTable, usedColumns);
+          CollectUsedColumns(agg.Expression, bucketByTable, collectVisited);
           break;
         case SqlLike like:
-          CollectUsedColumns(like.Expression, targetTable, usedColumns);
-          CollectUsedColumns(like.Pattern, targetTable, usedColumns);
-          CollectUsedColumns(like.Escape, targetTable, usedColumns);
+          CollectUsedColumns(like.Expression, bucketByTable, collectVisited);
+          CollectUsedColumns(like.Pattern, bucketByTable, collectVisited);
+          CollectUsedColumns(like.Escape, bucketByTable, collectVisited);
           break;
         case SqlBetween between:
-          CollectUsedColumns(between.Expression, targetTable, usedColumns);
-          CollectUsedColumns(between.Left, targetTable, usedColumns);
-          CollectUsedColumns(between.Right, targetTable, usedColumns);
+          CollectUsedColumns(between.Expression, bucketByTable, collectVisited);
+          CollectUsedColumns(between.Left, bucketByTable, collectVisited);
+          CollectUsedColumns(between.Right, bucketByTable, collectVisited);
           break;
         case SqlSubQuery sub:
-          if (sub.Query is SqlSelect innerSelect) {
-            CollectUsedColumnsFromSelect(innerSelect, targetTable, usedColumns);
-            if (innerSelect.From != null) {
-              CollectUsedColumnsFromCorrelatedJoinSides(innerSelect.From, targetTable, usedColumns);
-            }
+          // SqlSubQuery.Query is ISqlQueryExpression — both SqlSelect and
+          // SqlQueryExpression (UNION / INTERSECT / EXCEPT) are valid bodies.
+          // Missing the SqlQueryExpression arm meant correlated references
+          // inside set-operation subqueries were invisible to the collector,
+          // causing the parent query-ref to be incorrectly pruned. Mirror
+          // the symmetric dispatch already used by CollectUsedColumnsFromQuerySubtree.
+          switch (sub.Query) {
+            case SqlSelect innerSelect:
+              RecurseIntoSelect(innerSelect, bucketByTable, collectVisited);
+              break;
+            case SqlQueryExpression queryExpr:
+              CollectUsedColumnsFromQueryExpression(queryExpr, bucketByTable, collectVisited);
+              break;
           }
           break;
         case SqlExpressionList list:
           for (int i = 0; i < list.Count; i++) {
-            CollectUsedColumns(list[i], targetTable, usedColumns);
+            CollectUsedColumns(list[i], bucketByTable, collectVisited);
           }
           break;
         case SqlTrim trim:
-          CollectUsedColumns(trim.Expression, targetTable, usedColumns);
+          CollectUsedColumns(trim.Expression, bucketByTable, collectVisited);
           break;
         case SqlExtract extract:
-          CollectUsedColumns(extract.Operand, targetTable, usedColumns);
+          CollectUsedColumns(extract.Operand, bucketByTable, collectVisited);
           break;
         case SqlRound round:
-          CollectUsedColumns(round.Argument, targetTable, usedColumns);
-          CollectUsedColumns(round.Length, targetTable, usedColumns);
+          CollectUsedColumns(round.Argument, bucketByTable, collectVisited);
+          CollectUsedColumns(round.Length, bucketByTable, collectVisited);
           break;
         case SqlCollate collate:
-          CollectUsedColumns(collate.Operand, targetTable, usedColumns);
+          CollectUsedColumns(collate.Operand, bucketByTable, collectVisited);
           break;
         case SqlMatch match:
-          CollectUsedColumns(match.Value, targetTable, usedColumns);
-          CollectUsedColumns(match.SubQuery, targetTable, usedColumns);
+          CollectUsedColumns(match.Value, bucketByTable, collectVisited);
+          CollectUsedColumns(match.SubQuery, bucketByTable, collectVisited);
           break;
         case SqlVariant variant:
-          CollectUsedColumns(variant.Main, targetTable, usedColumns);
-          CollectUsedColumns(variant.Alternative, targetTable, usedColumns);
+          CollectUsedColumns(variant.Main, bucketByTable, collectVisited);
+          CollectUsedColumns(variant.Alternative, bucketByTable, collectVisited);
           break;
         case SqlDynamicFilter filter:
-          foreach (var e in filter.Expressions) {
-            CollectUsedColumns(e, targetTable, usedColumns);
+          var filterExprs = filter.Expressions;
+          for (int i = 0, n = filterExprs.Count; i < n; i++) {
+            CollectUsedColumns(filterExprs[i], bucketByTable, collectVisited);
           }
           break;
         case SqlRowNumber rn:
-          foreach (var order in rn.OrderBy) {
-            if (order.Expression != null) {
-              CollectUsedColumns(order.Expression, targetTable, usedColumns);
+          var rnOrderBy = rn.OrderBy;
+          for (int i = 0, n = rnOrderBy.Count; i < n; i++) {
+            var rnOrderExpr = rnOrderBy[i].Expression;
+            if (rnOrderExpr != null) {
+              CollectUsedColumns(rnOrderExpr, bucketByTable, collectVisited);
             }
           }
           break;
-
         case SqlMetadata metadata:
-          CollectUsedColumns(metadata.Expression, targetTable, usedColumns);
+          CollectUsedColumns(metadata.Expression, bucketByTable, collectVisited);
           break;
 
-        // Leaf nodes — no column references to collect
+        // Leaf nodes — no column references to collect.
         case SqlNull:
         case SqlLiteral:
         case SqlParameterRef:
@@ -477,14 +426,58 @@ namespace Xtensive.Orm.Providers
           break;
 
         default:
-          // Unknown expression type — conservatively mark all target columns as used
-          // to prevent incorrect pruning when new expression types are introduced.
-          var targetColumns = targetTable.Columns;
-          for (int i = 0; i < targetColumns.Count; i++) {
-            usedColumns.Add(targetColumns[i]);
-          }
+          // Unknown expression type — almost certainly a new SqlExpression
+          // subclass added without updating this switch. Surface the omission
+          // loudly in DEBUG, then conservatively mark every candidate target
+          // as fully used so pruning becomes a no-op rather than incorrect.
+          Debug.Fail(
+            $"SqlColumnPruner: unhandled SqlExpression type '{expr.GetType().FullName}'. " +
+            "Pruning is conservatively disabled across this node. " +
+            "Add a case to CollectUsedColumns to enable pruning through this expression type.");
+          MarkAllTargetsFullyUsed(bucketByTable);
           break;
       }
+    }
+
+    private static void MarkAllTargetsFullyUsed(Dictionary<SqlTable, ColumnBucket> bucketByTable)
+    {
+      // Saturate every bucket, then drop them all from the active routing dict
+      // in a single Clear() call. Iterating + a tail Clear avoids the need to
+      // mutate the dictionary mid-walk, so no key snapshot is required.
+      // Dictionary<,>.Enumerator is a struct, so the foreach is allocation-free.
+      if (bucketByTable.Count == 0) {
+        return;
+      }
+      foreach (var bucket in bucketByTable.Values) {
+        var cols = bucket.QueryRef.Columns;
+        var used = bucket.UsedColumns;
+        for (int i = 0, n = cols.Count; i < n; i++) {
+          used.Add(cols[i]);
+        }
+      }
+      bucketByTable.Clear();
+    }
+
+    /// <summary>
+    /// Per-target accumulator. Declared as a <c>readonly struct</c> so the
+    /// three fields (a <see cref="SqlQueryRef"/> reference, an int, and a
+    /// <see cref="HashSet{T}"/> reference) live inline inside the dictionary
+    /// entry and list element slots — no per-bucket heap allocation. Mutations
+    /// to the accumulated column set still propagate across every struct copy
+    /// (dictionary entry, list entry, <c>out var</c> locals) because
+    /// <see cref="UsedColumns"/> is a reference to a shared heap object.
+    /// </summary>
+    private readonly struct ColumnBucket(SqlQueryRef queryRef, int columnCount)
+    {
+      public readonly SqlQueryRef QueryRef = queryRef;
+      public readonly int ColumnCount = columnCount;
+      // UsedColumns is bounded above by ColumnCount (we never add a column
+      // not already in QueryRef.Columns). Pre-sizing eliminates the entire
+      // HashSet 4/8/16/... resize-and-rehash chain, which matters for wide
+      // entity-table buckets where ColumnCount is routinely 20+.
+      public readonly HashSet<SqlTableColumn> UsedColumns = new(columnCount);
+
+      public bool IsSaturated => UsedColumns.Count >= ColumnCount;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlColumnPruner.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlColumnPruner.cs
@@ -416,6 +416,9 @@ namespace Xtensive.Orm.Providers
         case SqlSubQuery sub:
           if (sub.Query is SqlSelect innerSelect) {
             CollectUsedColumnsFromSelect(innerSelect, targetTable, usedColumns);
+            if (innerSelect.From != null) {
+              CollectUsedColumnsFromCorrelatedJoinSides(innerSelect.From, targetTable, usedColumns);
+            }
           }
           break;
         case SqlExpressionList list:

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlColumnPruner.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlColumnPruner.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using Xtensive.Sql;
 using Xtensive.Sql.Dml;
 
 namespace Xtensive.Orm.Providers
@@ -29,8 +30,13 @@ namespace Xtensive.Orm.Providers
       // Prune this level's FROM source first (top-down enables cascading
       // through multiple nesting levels — the inner select sees the
       // already-reduced column set).
-      if (select.From is SqlQueryRef queryRef && queryRef.Query is SqlSelect) {
+      if (select.From is SqlQueryRef queryRef) {
         TryPruneQueryRef(select, queryRef);
+      }
+
+      // When FROM is a join, prune each side that is a SqlQueryRef
+      if (select.From is SqlJoinedTable) {
+        TryPruneJoinSides(select);
       }
 
       // Then recurse into FROM sources to prune deeper levels
@@ -45,13 +51,34 @@ namespace Xtensive.Orm.Providers
     private void RecurseIntoTable(SqlTable table)
     {
       switch (table) {
-        case SqlQueryRef queryRef when queryRef.Query is SqlSelect innerSelect:
-          PruneSelect(innerSelect);
+        case SqlQueryRef queryRef:
+          if (queryRef.Query is SqlSelect innerSelect) {
+            PruneSelect(innerSelect);
+          }
+          else if (queryRef.Query is SqlQueryExpression queryExpr) {
+            RecurseIntoQueryExpression(queryExpr);
+          }
           break;
         case SqlJoinedTable joined:
           RecurseIntoTable(joined.JoinExpression.Left);
           RecurseIntoTable(joined.JoinExpression.Right);
           break;
+      }
+    }
+
+    private void RecurseIntoQueryExpression(SqlQueryExpression expr)
+    {
+      RecurseIntoQueryExpressionSide(expr.Left);
+      RecurseIntoQueryExpressionSide(expr.Right);
+    }
+
+    private void RecurseIntoQueryExpressionSide(ISqlQueryExpression side)
+    {
+      if (side is SqlSelect select) {
+        PruneSelect(select);
+      }
+      else if (side is SqlQueryExpression nested) {
+        RecurseIntoQueryExpression(nested);
       }
     }
 
@@ -193,6 +220,61 @@ namespace Xtensive.Orm.Providers
       }
 
       queryRef.PruneColumns(indicesToKeep);
+    }
+
+    private void TryPruneJoinSides(SqlSelect select)
+    {
+      var joinQueryRefs = new List<SqlQueryRef>();
+      CollectQueryRefsFromJoinTree(select.From, joinQueryRefs);
+
+      foreach (var sideRef in joinQueryRefs) {
+        var columnCount = sideRef.Columns.Count;
+        if (columnCount == 0) {
+          continue;
+        }
+
+        var usedColumns = new HashSet<SqlTableColumn>(ReferenceEqualityComparer.Instance);
+        CollectUsedColumnsFromSelect(select, sideRef, usedColumns);
+        CollectUsedColumnsFromJoinConditions(select.From, sideRef, usedColumns);
+
+        if (usedColumns.Count >= columnCount) {
+          continue;
+        }
+
+        var indicesToKeep = new List<int>(usedColumns.Count);
+        for (int i = 0; i < columnCount; i++) {
+          if (usedColumns.Contains(sideRef.Columns[i])) {
+            indicesToKeep.Add(i);
+          }
+        }
+
+        if (indicesToKeep.Count == 0 || indicesToKeep.Count >= columnCount) {
+          continue;
+        }
+
+        sideRef.PruneColumns(indicesToKeep);
+      }
+    }
+
+    private static void CollectQueryRefsFromJoinTree(SqlTable table, List<SqlQueryRef> result)
+    {
+      if (table is SqlQueryRef qr) {
+        result.Add(qr);
+      }
+      else if (table is SqlJoinedTable jt) {
+        CollectQueryRefsFromJoinTree(jt.JoinExpression.Left, result);
+        CollectQueryRefsFromJoinTree(jt.JoinExpression.Right, result);
+      }
+    }
+
+    private void CollectUsedColumnsFromJoinConditions(
+      SqlTable table, SqlTable targetTable, HashSet<SqlTableColumn> usedColumns)
+    {
+      if (table is SqlJoinedTable jt) {
+        CollectUsedColumns(jt.JoinExpression.Expression, targetTable, usedColumns);
+        CollectUsedColumnsFromJoinConditions(jt.JoinExpression.Left, targetTable, usedColumns);
+        CollectUsedColumnsFromJoinConditions(jt.JoinExpression.Right, targetTable, usedColumns);
+      }
     }
 
     private void CollectUsedColumnsFromSelect(

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlSelectCorrector.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlSelectCorrector.cs
@@ -6,6 +6,7 @@
 
 using Xtensive.Orm.Rse.Compilation;
 using Xtensive.Orm.Rse.Providers;
+using Xtensive.Sql.Dml;
 
 namespace Xtensive.Orm.Providers
 {
@@ -15,14 +16,24 @@ namespace Xtensive.Orm.Providers
 
     public ExecutableProvider Process(ExecutableProvider rootProvider)
     {
-      var sqlProvider = rootProvider as SqlProvider;
-      if (sqlProvider!=null) {
-        var statement = sqlProvider.Request.Statement;
-        SqlSelectProcessor.Process(statement, providerInfo);
-        SqlColumnPruner.Process(statement);
+      if (rootProvider is SqlProvider sqlProvider) {
+        Process(sqlProvider.Request.Statement);
       }
       return rootProvider;
     }
+
+    /// <summary>
+    /// Runs the post-compilation pipeline on a bare <see cref="SqlSelect"/>
+    /// statement. This is the same pipeline applied to production
+    /// <see cref="SqlProvider"/>s by the <see cref="IPostCompiler"/> entry point
+    /// above, factored out so that callers (notably unit tests) can drive the
+    /// corrector without constructing an entire <see cref="ExecutableProvider"/>
+    /// graph. Internal mechanics (column pruning, comment hoisting, paging
+    /// fixups, etc.) are intentionally encapsulated here so tests do not pin
+    /// the choice of inner class.
+    /// </summary>
+    internal void Process(SqlSelect statement) =>
+      SqlSelectProcessor.Process(statement, providerInfo);
 
     // Constructors
     

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlSelectCorrector.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlSelectCorrector.cs
@@ -16,8 +16,11 @@ namespace Xtensive.Orm.Providers
     public ExecutableProvider Process(ExecutableProvider rootProvider)
     {
       var sqlProvider = rootProvider as SqlProvider;
-      if (sqlProvider!=null)
-        SqlSelectProcessor.Process(sqlProvider.Request.Statement, providerInfo);
+      if (sqlProvider!=null) {
+        var statement = sqlProvider.Request.Statement;
+        SqlSelectProcessor.Process(statement, providerInfo);
+        SqlColumnPruner.Process(statement);
+      }
       return rootProvider;
     }
 

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlSelectProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlSelectProcessor.cs
@@ -79,6 +79,10 @@ namespace Xtensive.Orm.Providers
     {
       VisitNullable(node.Value);
       VisitNullable(node.Else);
+      foreach (var pair in (IEnumerable<KeyValuePair<SqlExpression, SqlExpression>>) node) {
+        VisitNullable(pair.Key);
+        VisitNullable(pair.Value);
+      }
     }
 
     public void Visit(SqlCast node)
@@ -437,6 +441,13 @@ namespace Xtensive.Orm.Providers
 
     public void Visit(SqlSelect node)
     {
+      // Prune unused columns from the immediate FROM clause before recursing
+      // into it. Doing this at the start of every Visit(SqlSelect) cascades
+      // top-down through nested selects via the visitor's own recursion —
+      // the inner SqlSelect's pruning sees the already-reduced parent column
+      // set when its own Visit(SqlSelect) runs.
+      SqlColumnPruner.PruneFromClause(node);
+
       foreach (var column in node.Columns)
         Visit(column);
       foreach (var column in node.GroupByReadOnly)
@@ -525,6 +536,8 @@ namespace Xtensive.Orm.Providers
 
     public void Visit(SqlVariant node)
     {
+      VisitNullable(node.Main);
+      VisitNullable(node.Alternative);
     }
 
     public void Visit(SqlWhile node)

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlQueryRef.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlQueryRef.cs
@@ -35,7 +35,7 @@ namespace Xtensive.Sql.Dml
 
     internal void PruneColumns(List<int> indicesToKeep)
     {
-      if (query is SqlSelect innerSelect) {
+      if (query is SqlSelect innerSelect && !innerSelect.Distinct) {
         PruneSelectColumns(innerSelect.Columns, indicesToKeep);
       }
       else if (query is SqlQueryExpression queryExpression && IsUnionAllTree(queryExpression)) {

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlQueryRef.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlQueryRef.cs
@@ -33,6 +33,26 @@ namespace Xtensive.Sql.Dml
       visitor.Visit(this);
     }
 
+    internal void PruneColumns(List<int> indicesToKeep)
+    {
+      if (query is not SqlSelect innerSelect) {
+        return;
+      }
+
+      var selectColumns = innerSelect.Columns;
+      var newQueryColumns = new List<SqlTableColumn>(indicesToKeep.Count);
+      var keptSelectColumns = new List<SqlColumn>(indicesToKeep.Count);
+
+      foreach (var idx in indicesToKeep) {
+        newQueryColumns.Add(columns[idx]);
+        keptSelectColumns.Add(selectColumns[idx]);
+      }
+
+      selectColumns.Clear();
+      selectColumns.AddRange(keptSelectColumns);
+      columns = new SqlTableColumnCollection(newQueryColumns);
+    }
+
     internal SqlQueryRef(ISqlQueryExpression query)
       : this(query, string.Empty)
     {

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlQueryRef.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlQueryRef.cs
@@ -38,7 +38,7 @@ namespace Xtensive.Sql.Dml
       if (query is SqlSelect innerSelect) {
         PruneSelectColumns(innerSelect.Columns, indicesToKeep);
       }
-      else if (query is SqlQueryExpression queryExpression) {
+      else if (query is SqlQueryExpression queryExpression && IsUnionAllTree(queryExpression)) {
         PruneQueryExpressionColumns(queryExpression, indicesToKeep);
       }
       else {
@@ -60,6 +60,20 @@ namespace Xtensive.Sql.Dml
       }
       selectColumns.Clear();
       selectColumns.AddRange(keptColumns);
+    }
+
+    private static bool IsUnionAllTree(SqlQueryExpression expr)
+    {
+      if (expr.NodeType != SqlNodeType.Union || !expr.All) {
+        return false;
+      }
+      if (expr.Left is SqlQueryExpression leftExpr && !IsUnionAllTree(leftExpr)) {
+        return false;
+      }
+      if (expr.Right is SqlQueryExpression rightExpr && !IsUnionAllTree(rightExpr)) {
+        return false;
+      }
+      return true;
     }
 
     private static void PruneQueryExpressionColumns(SqlQueryExpression expr, List<int> indicesToKeep)

--- a/Orm/Xtensive.Orm/Sql/Dml/SqlQueryRef.cs
+++ b/Orm/Xtensive.Orm/Sql/Dml/SqlQueryRef.cs
@@ -35,22 +35,47 @@ namespace Xtensive.Sql.Dml
 
     internal void PruneColumns(List<int> indicesToKeep)
     {
-      if (query is not SqlSelect innerSelect) {
+      if (query is SqlSelect innerSelect) {
+        PruneSelectColumns(innerSelect.Columns, indicesToKeep);
+      }
+      else if (query is SqlQueryExpression queryExpression) {
+        PruneQueryExpressionColumns(queryExpression, indicesToKeep);
+      }
+      else {
         return;
       }
 
-      var selectColumns = innerSelect.Columns;
       var newQueryColumns = new List<SqlTableColumn>(indicesToKeep.Count);
-      var keptSelectColumns = new List<SqlColumn>(indicesToKeep.Count);
-
       foreach (var idx in indicesToKeep) {
         newQueryColumns.Add(columns[idx]);
-        keptSelectColumns.Add(selectColumns[idx]);
       }
-
-      selectColumns.Clear();
-      selectColumns.AddRange(keptSelectColumns);
       columns = new SqlTableColumnCollection(newQueryColumns);
+    }
+
+    private static void PruneSelectColumns(SqlColumnCollection selectColumns, List<int> indicesToKeep)
+    {
+      var keptColumns = new List<SqlColumn>(indicesToKeep.Count);
+      foreach (var idx in indicesToKeep) {
+        keptColumns.Add(selectColumns[idx]);
+      }
+      selectColumns.Clear();
+      selectColumns.AddRange(keptColumns);
+    }
+
+    private static void PruneQueryExpressionColumns(SqlQueryExpression expr, List<int> indicesToKeep)
+    {
+      PruneQueryExpressionSide(expr.Left, indicesToKeep);
+      PruneQueryExpressionSide(expr.Right, indicesToKeep);
+    }
+
+    private static void PruneQueryExpressionSide(ISqlQueryExpression side, List<int> indicesToKeep)
+    {
+      if (side is SqlSelect select) {
+        PruneSelectColumns(select.Columns, indicesToKeep);
+      }
+      else if (side is SqlQueryExpression nested) {
+        PruneQueryExpressionColumns(nested, indicesToKeep);
+      }
     }
 
     internal SqlQueryRef(ISqlQueryExpression query)

--- a/Version.props
+++ b/Version.props
@@ -2,8 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.3.14</DoVersion>
-    <DoVersionSuffix>servicetitan</DoVersionSuffix>
+    <DoVersion>7.3.15</DoVersion>
+    <DoVersionSuffix>servicetitan-test-pruner</DoVersionSuffix>
 </PropertyGroup>
 
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -3,7 +3,7 @@
 
 <PropertyGroup>
     <DoVersion>7.3.15</DoVersion>
-    <DoVersionSuffix>servicetitan-test-pruner</DoVersionSuffix>
+    <DoVersionSuffix>servicetitan-test-pruner2</DoVersionSuffix>
 </PropertyGroup>
 
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -3,7 +3,7 @@
 
 <PropertyGroup>
     <DoVersion>7.3.15</DoVersion>
-    <DoVersionSuffix>servicetitan-test-pruner2</DoVersionSuffix>
+    <DoVersionSuffix>servicetitan-test-pruner3</DoVersionSuffix>
 </PropertyGroup>
 
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -3,7 +3,7 @@
 
 <PropertyGroup>
     <DoVersion>7.3.15</DoVersion>
-    <DoVersionSuffix>servicetitan-test-pruner3</DoVersionSuffix>
+    <DoVersionSuffix>servicetitan-test-pruner4</DoVersionSuffix>
 </PropertyGroup>
 
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -3,7 +3,7 @@
 
 <PropertyGroup>
     <DoVersion>7.3.15</DoVersion>
-    <DoVersionSuffix>servicetitan-test-pruner4</DoVersionSuffix>
+    <DoVersionSuffix>servicetitan</DoVersionSuffix>
 </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
### Rationale
The current ORM implementation often generates large SQL queries that include all columns in intermediate subqueries, even when those columns are not needed in the final result. This leads to unnecessarily large query text across many parts of the application, which has two direct performance consequences: queries exceeding 8KB cannot be cached by SQL Server, and query compilation — which is a CPU-intensive operation.
The goal of this workstream is to rework the ORM layer to generate more compact SQL, resulting in smaller query text, more effective use of the SQL Server query cache, and reduced CPU consumption from compilation overhead.

### Implementation
This pull request introduces column pruning functionality to the SQL query processing pipeline, ensuring that only the necessary columns are retained in SQL statements. The main changes add a new pruning step to the post-compilation process and implement logic to prune columns from various SQL query representations.

SQL query processing improvements:

* Added a call to `SqlColumnPruner.Process` in the `SqlSelectCorrector.Process` method to prune unnecessary columns from SQL statements after processing them, improving query efficiency.

Column pruning implementation:

* Introduced the `PruneColumns` method and supporting helpers in `SqlQueryRef`, enabling selective retention of columns in `SqlSelect`, `SqlQueryExpression`, and their nested forms. This method updates both the underlying query and the exposed columns collection to match the pruned set.

### Also
Add `--fix-missing` to `apt-get update` and `install` commands so the build tolerates partially downloaded package indices caused by CDN mirror sync in progress, instead of failing with exit code 100.