### PR TITLE
Optimization: Reduce per-row allocations in materialization hot path

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Internals/EntityDataReader.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/EntityDataReader.cs
@@ -68,12 +68,18 @@ namespace Xtensive.Orm.Internals
       return source.Select(tuple => ParseRow(tuple, context, cacheItem.Mappings));
     }
 
-    private Record ParseRow(Tuple tuple, MaterializationContext context, IReadOnlyList<RecordPartMapping> recordPartMappings) =>
-      recordPartMappings.Count == 1
-        ? new Record(tuple, ParseColumnGroup(tuple, context, 0, recordPartMappings[0]))
-        : new Record(tuple, recordPartMappings.Select(
-            (recordPartMapping, i) => ParseColumnGroup(tuple, context, i, recordPartMapping))
-          );
+    private Record ParseRow(Tuple tuple, MaterializationContext context, IReadOnlyList<RecordPartMapping> recordPartMappings)
+    {
+      var count = recordPartMappings.Count;
+      if (count == 1) {
+        return new Record(tuple, ParseColumnGroup(tuple, context, 0, recordPartMappings[0]));
+      }
+      var pairs = new (Key, Tuple)[count];
+      for (var i = 0; i < count; i++) {
+        pairs[i] = ParseColumnGroup(tuple, context, i, recordPartMappings[i]);
+      }
+      return new Record(tuple, pairs);
+    }
 
     private (Key, Tuple) ParseColumnGroup(Tuple tuple, MaterializationContext context, int groupIndex, in RecordPartMapping mapping)
     {

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
@@ -15,6 +15,7 @@ using Xtensive.Orm.Linq.Rewriters;
 using Xtensive.Orm.Rse;
 using Xtensive.Reflection;
 using Xtensive.Tuples;
+using Xtensive.Tuples.Transform;
 using Tuple = Xtensive.Tuples.Tuple;
 
 namespace Xtensive.Orm.Linq.Materialization
@@ -28,13 +29,11 @@ namespace Xtensive.Orm.Linq.Materialization
 
     private const int NumberOfItemsOnStack = 64;
     private static readonly MethodInfo BuildPersistentTupleMethod = typeof(ExpressionMaterializer).GetMethod(nameof(BuildPersistentTuple), BindingFlags.NonPublic | BindingFlags.Static);
-    private static readonly MethodInfo GetTupleSegmentMethod = typeof(ExpressionMaterializer).GetMethod(nameof(GetTupleSegment), BindingFlags.NonPublic | BindingFlags.Static);
+    private static readonly MethodInfo ApplyKeySegmentTransformMethod = typeof(ExpressionMaterializer).GetMethod(nameof(ApplyKeySegmentTransform), BindingFlags.NonPublic | BindingFlags.Static);
     private static readonly MethodInfo GetParameterValueMethod = WellKnownOrmTypes.ParameterContext.GetMethod(nameof(ParameterContext.GetValue));
     private static readonly PropertyInfo ParameterContextProperty = WellKnownOrmTypes.ItemMaterializationContext.GetProperty(nameof(ItemMaterializationContext.ParameterContext));
     private static readonly MethodInfo GetTupleParameterValueMethod = GetParameterValueMethod.CachedMakeGenericMethod(WellKnownOrmTypes.Tuple);
-    private static readonly IReadOnlyList<ParameterExpression> TupleParameters = [QueryHelper.TupleParameter];
     private static readonly ParameterExpression MaterializationContextParameter = Expression.Parameter(WellKnownOrmTypes.ItemMaterializationContext, "mc");
-    private static readonly IReadOnlyList<ParameterExpression> TupleAndMaterializationContextParameters = [QueryHelper.TupleParameter, MaterializationContextParameter];
     private static readonly ConstantExpression TypeReferenceAccuracyConstantExpression = Expression.Constant(TypeReferenceAccuracy.BaseType);
     private static readonly MethodInfo GetTypeInfoMethod = typeof(ItemMaterializationContext).GetMethod(nameof(ItemMaterializationContext.GetTypeInfo));
 
@@ -357,10 +356,14 @@ namespace Xtensive.Orm.Linq.Materialization
     internal protected override Expression VisitKeyExpression(KeyExpression expression)
     {
       // TODO: http://code.google.com/p/dataobjectsdotnet/issues/detail?id=336
+      // Precompute a MapTransform for the key segment once at materializer compile time
+      // so that at runtime we avoid allocating a SegmentTransformTuple wrapper and an
+      // intermediate regular tuple for every materialized row.
+      var keyTransform = CreateKeySegmentTransform(expression.EntityType, expression.Mapping);
       Expression tupleExpression = Expression.Call(
-        GetTupleSegmentMethod,
+        ApplyKeySegmentTransformMethod,
         GetTupleExpression(expression),
-        Expression.Constant(expression.Mapping));
+        Expression.Constant(keyTransform));
       return Expression.Call(
         WellKnownMembers.Key.Create,
         Expression.Constant(context.Domain),
@@ -598,7 +601,20 @@ namespace Xtensive.Orm.Linq.Materialization
       return result;
     }
 
-    private static Tuple GetTupleSegment(Tuple tuple, in Segment<ColNum> segment) => tuple.GetSegment(segment).ToRegular();
+    private static Tuple ApplyKeySegmentTransform(Tuple tuple, MapTransform transform) =>
+      transform.Apply(TupleTransformType.Tuple, tuple);
+
+    private static MapTransform CreateKeySegmentTransform(Orm.Model.TypeInfo entityType, in Segment<ColNum> mapping)
+    {
+      var keyDescriptor = entityType.Key.TupleDescriptor;
+      var length = mapping.Length;
+      var map = new ColNum[length];
+      var offset = mapping.Offset;
+      for (var i = 0; i < length; i++) {
+        map[i] = (ColNum)(offset + i);
+      }
+      return new MapTransform(true, keyDescriptor, map);
+    }
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ItemMaterializationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ItemMaterializationContext.cs
@@ -2,6 +2,7 @@
 // This code is distributed under MIT license terms.
 // See the License.txt file in the project root for more information.
 
+using System;
 using System.Reflection;
 using Xtensive.Core;
 using Xtensive.Orm.Internals;
@@ -74,7 +75,9 @@ namespace Xtensive.Orm.Linq.Materialization
       ParameterContext = parameterContext;
       MaterializationContext = materializationContext;
 
-      entities = new Entity[materializationContext.EntitiesInRow];
+      // Reuse the MaterializationContext-owned buffer across rows instead of allocating a new array per row.
+      entities = materializationContext.EntitiesBuffer;
+      Array.Clear(entities, 0, entities.Length);
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs
@@ -17,6 +17,14 @@ namespace Xtensive.Orm.Linq.Materialization
     private readonly EntityMappingCache[] entityMappings = new EntityMappingCache[entityCount];
 
     /// <summary>
+    /// Shared per-row buffer reused by <see cref="ItemMaterializationContext"/> across rows
+    /// of the same query to avoid a per-row <see cref="Entity"/>[] allocation.
+    /// Safe because <see cref="ItemMaterializationContext"/> is constructed and fully consumed
+    /// on a single logical row before the next row begins.
+    /// </summary>
+    internal readonly Entity[] EntitiesBuffer = new Entity[entityCount];
+
+    /// <summary>
     /// Gets the session in which materialization is executing.
     /// </summary>
     public Session Session => session;
@@ -65,7 +73,9 @@ namespace Xtensive.Orm.Linq.Materialization
       }
 
       var allIndexes = MaterializationHelper.CreateSingleSourceMap(descriptor.Count, typeColumnMap);
-      var keyIndexes = allIndexes.Take(keyInfo.TupleDescriptor.Count).ToArray();
+      var keyCount = keyInfo.TupleDescriptor.Count;
+      var keyIndexes = new ColNum[keyCount];
+      Array.Copy(allIndexes, keyIndexes, keyCount);
 
       var transform    = new MapTransform(true, descriptor, allIndexes);
       var keyTransform = new MapTransform(true, keyInfo.TupleDescriptor, keyIndexes);

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationHelper.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationHelper.cs
@@ -55,8 +55,16 @@ namespace Xtensive.Orm.Linq.Materialization
 
     public static T GetDefault<T>() => default;
 
-    public static bool IsNull(Tuple tuple, IReadOnlyList<ColNum> columns) =>
-      columns.All(column => tuple.GetFieldState(column).IsNull());
+    public static bool IsNull(Tuple tuple, IReadOnlyList<ColNum> columns)
+    {
+      var count = columns.Count;
+      for (var i = 0; i < count; i++) {
+        if (!tuple.GetFieldState(columns[i]).IsNull()) {
+          return false;
+        }
+      }
+      return true;
+    }
 
     public static object ThrowEmptySequenceException() =>
       throw new InvalidOperationException(Strings.ExSequenceContainsNoElements);

--- a/Orm/Xtensive.Orm/Orm/Record.cs
+++ b/Orm/Xtensive.Orm/Orm/Record.cs
@@ -60,11 +60,11 @@ namespace Xtensive.Orm
 
     // Constructors
 
-    internal Record(Tuple tuple, IEnumerable<(Key, Tuple)> keyTuplePairs)
+    internal Record(Tuple tuple, (Key, Tuple)[] keyTuplePairs)
     {
       Source = tuple;
-      this.keyTuplePairs = keyTuplePairs.ToArray();
-      keyTuplePair = this.keyTuplePairs[0];
+      this.keyTuplePairs = keyTuplePairs;
+      keyTuplePair = keyTuplePairs[0];
     }
 
     internal Record(Tuple tuple, (Key, Tuple) keyTuplePair)

--- a/Orm/Xtensive.Orm/Tuples/Transform/MapTransform.cs
+++ b/Orm/Xtensive.Orm/Tuples/Transform/MapTransform.cs
@@ -164,7 +164,7 @@ namespace Xtensive.Tuples.Transform
     /// <returns>Transformation result - 
     /// either <see cref="TransformedTuple"/> or <see cref="Tuple"/> descendant,
     /// dependently on specified <paramref name="transformType"/>.</returns>
-    protected Tuple Apply(TupleTransformType transformType, Tuple source)
+    protected internal Tuple Apply(TupleTransformType transformType, Tuple source)
     {
       if (sourceCount>1)
         throw new InvalidOperationException(string.Format(Strings.ExTheNumberOfSourcesIsTooSmallExpected, sourceCount));
@@ -193,7 +193,7 @@ namespace Xtensive.Tuples.Transform
     /// <returns>Transformation result - 
     /// either <see cref="TransformedTuple"/> or <see cref="Tuple"/> descendant,
     /// dependently on specified <paramref name="transformType"/>.</returns>
-    protected Tuple Apply(TupleTransformType transformType, Tuple source1, Tuple source2)
+    protected internal Tuple Apply(TupleTransformType transformType, Tuple source1, Tuple source2)
     {
       if (sourceCount>2)
         throw new InvalidOperationException(string.Format(Strings.ExTheNumberOfSourcesIsTooSmallExpected, sourceCount));


### PR DESCRIPTION
### Tl;DR;
- MaterializationContext: introduce shared EntitiesBuffer reused by ItemMaterializationContext across rows instead of allocating a new Entity[] per row; replace LINQ Take+ToArray with Array.Copy for key indexes on type mapping cache miss.
- ItemMaterializationContext: reuse shared buffer and clear it per row.
- Record: accept (Key, Tuple)[] directly, dropping IEnumerable.ToArray.
- EntityDataReader.ParseRow: build the pair array via a for loop instead of recordPartMappings.Select(...) to avoid the enumerator and closure allocation.
- MaterializationHelper.IsNull: replace LINQ All(...) with a for loop.
- MapTransform: widen single- and two-source Apply overloads to protected internal so hot-path callers can invoke them directly, bypassing the params Tuple[] overload.
- ExpressionMaterializer.VisitKeyExpression: precompute a MapTransform for the key segment once at materializer compile time and emit a direct MapTransform.Apply(Tuple) call, replacing the per-row tuple.GetSegment(segment).ToRegular() path which allocated a SegmentTransformTuple wrapper and an intermediate tuple.

---

## Context

When a LINQ query is executed, each returned row is driven through the same materialization pipeline:

1. The compiled item-materializer lambda runs for the row.
2. That lambda builds keys, materializes entities, checks for NULL parts, and assembles the projection shape.
3. `EntityDataReader.ParseRow` (where applicable) splits the row into column groups.

Everything inside this pipeline runs **once per row**. Any LINQ call, boxed enumerator, closure, `Select/ToArray`, `.All(...)`, or throw-away transform **multiplies by N rows**. On wide result sets (tens to hundreds of thousands of rows) this is where you see the biggest allocation and CPU win in a profiler.

The pre-existing code in the five hot spots below accumulated the "convenient, LINQ-ish" style that's fine in cold paths but expensive in the per-row loop.

## What changes in this PR

### 1. Reuse the entity buffer across rows (was: one allocation per row)

**Files:** `Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationContext.cs`, `ItemMaterializationContext.cs`

`ItemMaterializationContext` is a *per-row* object: `ItemMaterializer.Materialize` constructs a fresh one for every row. Its constructor used to allocate the per-row cache of already-materialized entities:

```csharp
// Before
entities = new Entity[materializationContext.EntitiesInRow];
```

For a query returning 100k rows, that's 100k `Entity[]` allocations — all the same size, all thrown away milliseconds later.

**Change:** the buffer now lives on `MaterializationContext` (which exists once per enumeration) and `ItemMaterializationContext` reuses it, clearing it per row:

```csharp
// After
entities = materializationContext.EntitiesBuffer;
Array.Clear(entities, 0, entities.Length);
```

**Safety argument:**
- Materialization on a single `MaterializingReader` is strictly sequential (single `IEnumerator`/`IAsyncEnumerator`).
- Subqueries (`SubQuery.cs`) enqueue themselves on `MaterializationContext.MaterializationQueue` and run via `DelayedQuery`, which builds its **own** `MaterializationContext` — they never alias the outer buffer.
- Repeated `Current` reads for the same row stay correct: each re-enters `Materialize`, reclears the buffer, and re-materializes — identical semantics to the old fresh-per-call buffer.

**Expected benefit:** N allocations → 1 allocation per query for this buffer. Directly visible in Gen 0 pressure and materialization throughput on result-heavy queries.

### 2. Avoid LINQ `Select` + `ToArray` in `EntityDataReader.ParseRow`

**Files:** `Orm/Xtensive.Orm/Orm/Internals/EntityDataReader.cs`, `Orm/Xtensive.Orm/Orm/Record.cs`

Queries that project joined entities (the common case for `EntityDataReader`) have `recordPartCount > 1`, and every row went through:

```csharp
// Before
private Record ParseRow(...) =>
  recordPartMappings.Length == 1
    ? new Record(tuple, ParseColumnGroup(...))
    : new Record(tuple, recordPartMappings.Select(
        (recordPartMapping, i) => ParseColumnGroup(tuple, context, i, recordPartMapping))
      );
```

combined with

```csharp
// Record ctor — Before
internal Record(Tuple tuple, IEnumerable<Pair<Key, Tuple>> keyTuplePairs)
{
  ...
  this.keyTuplePairs = keyTuplePairs.ToArray();
```

Per row this produces: a `Select` iterator + a captured closure + a `ToArray` growable internal buffer + the final array — all to produce an array whose size is already known at compile time.

**Change:** fill a pre-sized array with a `for` loop and hand it directly to a new `Record` ctor that stores it by reference:

```csharp
// After
private Record ParseRow(Tuple tuple, MaterializationContext context, RecordPartMapping[] recordPartMappings)
{
  if (recordPartMappings.Length == 1) {
    return new Record(tuple, ParseColumnGroup(tuple, context, 0, recordPartMappings[0]));
  }
  var pairs = new Pair<Key, Tuple>[recordPartMappings.Length];
  for (int i = 0; i < recordPartMappings.Length; i++) {
    pairs[i] = ParseColumnGroup(tuple, context, i, recordPartMappings[i]);
  }
  return new Record(tuple, pairs);
}
```

`Record`'s old `IEnumerable` ctor was the only user of `keyTuplePairs.ToArray()` — replaced with an array-taking ctor. No API breakage: `Record` is a `readonly struct` with only `internal` ctors.

**Expected benefit on multi-entity projections:** the `Select` iterator, the closure that captures `tuple`/`context`, and the `ToArray` internal doubling buffer all vanish. Per-row allocation drops to exactly one `Pair<Key, Tuple>[N]` — the minimum `Record` actually needs.

### 3. Precompute the key segment `MapTransform` (was: full rebuild per row)

**Files:** `Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs`, `Orm/Xtensive.Orm/Tuples/Transform/MapTransform.cs`

This is the change with the largest per-row footprint. Every `KeyExpression` in the projection emitted a call to:

```csharp
// Before
private static Tuple GetTupleSegment(Tuple tuple, in Segment<int> segment) =>
  tuple.GetSegment(segment).ToRegular();
```

with the `Segment<int>` baked in as a compile-time `Expression.Constant`. Even though offset and length are constant for that key across the whole query, `GetSegment` was rebuilding all its infrastructure **per row**:

1. `new int[length]` — source index map
2. `new Type[length]` — field types
3. `TupleDescriptor.Create(fieldTypes)` — interning lookup
4. `new MapTransform(...)` — plus an internal `Pair<int,int>[]` allocated inside `SetSingleSourceMap`
5. `new MapTransformTuple1(...)` — the `TransformedTuple` view returned
6. `ToRegular()` — `new RegularTuple` + a field-by-field copy going through the `MapTransformTuple1` indirection

**Change (two parts):**

**3a. Precompute the `MapTransform` at materializer compile time.** `VisitKeyExpression` runs once per `KeyExpression` during `MakeMaterialization` (not per row), so we build the transform there and bake it into the expression tree as a constant:

```csharp
// At compile time (inside VisitKeyExpression)
var keyTransform = CreateKeySegmentTransform(expression.EntityType, expression.Mapping);
Expression tupleExpression = Expression.Call(
  ApplyKeySegmentTransformMethod,
  GetTupleExpression(expression),
  Expression.Constant(keyTransform));

private static MapTransform CreateKeySegmentTransform(TypeInfo entityType, in Segment<int> mapping)
{
  var keyDescriptor = entityType.Key.TupleDescriptor;
  var map = new int[mapping.Length];
  var offset = mapping.Offset;
  for (int i = 0; i < map.Length; i++) {
    map[i] = offset + i;
  }
  return new MapTransform(true, keyDescriptor, map);
}
```

`KeyExpression.Create` guarantees `mapping.Length == entityType.Key.TupleDescriptor.Count`, and both `KeyExpression.Remap` overloads preserve that length while only adjusting the offset — so the precomputed descriptor is always the right shape.

**3b. Call the single-source `Apply` overload directly.** `MapTransform`'s single-source and two-source `Apply(TupleTransformType, Tuple ...)` overloads were widened from `protected` to `protected internal`:

```csharp
// MapTransform.cs — was protected, now protected internal
protected internal Tuple Apply(TupleTransformType transformType, Tuple source) { ... }
protected internal Tuple Apply(TupleTransformType transformType, Tuple source1, Tuple source2) { ... }
```

This is a **strictly additive** access-level change:
- External assemblies see no new API (they still cannot call these overloads).
- Only code inside `Xtensive.Orm` — where `ExpressionMaterializer` lives — gains direct access.
- The three-source overload remains `protected`; no behavioral or inheritance contract changes.

With the widened access, C# overload resolution at the per-row call site picks the single-`Tuple` overload directly instead of funneling through the public `Apply(TupleTransformType, params Tuple[])`. That removes the `Tuple[1]` params array that the params-based dispatch would otherwise allocate on every row:

```csharp
// After — per-row helper
private static Tuple ApplyKeySegmentTransform(Tuple tuple, MapTransform transform) =>
  transform.Apply(TupleTransformType.Tuple, tuple); // binds to Apply(TupleTransformType, Tuple)
```

The selected overload does the minimal work required:

```csharp
case TupleTransformType.Tuple:
  Tuple result = Tuple.Create(Descriptor);
  source.CopyTo(result, singleSourceMap);
  return result;
```

**Per key per row, summarized:**

| Step                                               | Before | After |
| -------------------------------------------------- | :----: | :---: |
| `new int[length]` map                              |   yes  |  **no** (precomputed) |
| `new Type[length]` field types                     |   yes  |  **no** |
| `TupleDescriptor.Create(fieldTypes)`               |   yes  |  **no** |
| `new MapTransform(...)` + internal `Pair<int,int>[]` | yes |  **no** |
| `MapTransformTuple1` view wrapper                  |   yes  |  **no** |
| `Tuple[1]` params array                            |   no   |  **no** (direct overload) |
| `new RegularTuple` + `CopyTo(result, map)`         |   yes  |  yes |

Net: **~5 allocations + an indirected copy → 1 allocation + a direct map-driven copy** per key per row. Multiplied by every row that materializes entities (every result row containing a managed entity reference), this is the single largest improvement in the PR.

**Correctness note on `LongKey`:** `KeyFactory.Materialize` hands the tuple by reference to `LongKey` when the key has more than `WellKnown.MaxGenericKeyLength` columns. We deliberately keep the `RegularTuple` copy (rather than aliasing the source row via a `TransformedTuple` view) to avoid extending the lifetime of the full source tuple through every long-keyed entity reference. The optimization only removes redundant intermediate objects; the minimum-safe materialization for `LongKey` is preserved.

### 4. `MaterializationHelper.IsNull` — replace `.All(...)` with an indexed loop

**File:** `Orm/Xtensive.Orm/Orm/Linq/Materialization/MaterializationHelper.cs`

```csharp
// Before
public static bool IsNull(Tuple tuple, int[] columns) =>
  columns.All(column => tuple.GetFieldState(column).IsNull());
```

`IsNull` is called from inside the emitted materializer lambda whenever an `EntityExpression` needs an "all null → produce null entity" guard (left joins, default-if-empty, nullable structures). `.All` on `int[]` boxes the enumerator, and because the lambda captures `tuple`, also allocates a closure — **per call, per row**.

```csharp
// After
public static bool IsNull(Tuple tuple, int[] columns)
{
  for (int i = 0; i < columns.Length; i++) {
    if (!tuple.GetFieldState(columns[i]).IsNull()) {
      return false;
    }
  }
  return true;
}
```

**Expected benefit:** zero allocations on this path, early-exit on the first non-null column, identical semantics. On queries with several nullable entity parts (outer joins, conditional projections) the closure alone was being allocated multiple times per row.

## Overall expected impact

All changes sit on the "cost × N rows" path. For a query materializing entities:

- **Fewer allocations per row:** the key-materialization helper goes from ~5 allocations to **1** per key; `IsNull` goes from closure + boxed enumerator to **zero**; multi-part `ParseRow` goes from iterator + closure + doubling buffer to **one** pre-sized array.
- **Fewer allocations per query:** one `Entity[EntitiesInRow]` instead of one per row.
- **Less CPU:** `for` loops with direct indexing instead of `IEnumerable` dispatch; direct `CopyTo(result, map)` instead of a `TransformedTuple` indirection layer; no params-array dispatch for the hot `MapTransform.Apply` call.

Where to look for the effect in benchmarks / profiles:

- Gen 0 collection rate on result-heavy LINQ queries.
- Allocated bytes per materialized row (BenchmarkDotNet `MemoryDiagnoser`), especially on queries with multiple `KeyExpression`s in the projection.
- CPU samples in `MapTransform` / `TupleDescriptor.Create` / `Enumerable.All` under the materializer lambda — expected to largely disappear.

## Risk & correctness notes for reviewers

- **Entity buffer reuse** relies on sequential access to a single `MaterializationContext`. Verified against every `new MaterializationContext(...)` site (`EntityDataReader.Read`, `Translator.Materialization.cs`) and the delayed-subquery path (`SubQuery.cs`) — no aliasing between concurrent materializations, no buffer sharing across delayed queries.
- **`Record` ctor change:** the old `IEnumerable<Pair<Key, Tuple>>` ctor had exactly one caller; changing the parameter type is safe. `Record` exposes no public ctors.
- **`KeyExpression` descriptor precompute** relies on `mapping.Length == entityType.Key.TupleDescriptor.Count`, guaranteed by `KeyExpression.Create` and preserved by both `Remap` overloads. Documented in code comments so future changes to `KeyExpression` don't silently break the assumption.
- **`MapTransform.Apply` visibility widening (`protected` → `protected internal`) for 1-source and 2-source overloads.** Purely additive — no external caller can see a new API, no inheritance contract changes, no behavioral change. The 3-source overload remains `protected` (not used on the hot path). Reviewers concerned about API surface should note: these methods were already reachable externally via the public `params` overloads that forward to them; widening to `internal` just lets the same-assembly callers skip the forwarding array.
- **`IsNull`** is a pure behavioral equivalent; called on `int[]` (not `IEnumerable`), so no semantic risk from losing the `.All` contract.

---
Made-with: Cursor