### PR TITLE
Optimization: use Span iteration in materialization hot path

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Internals/EntityDataReader.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/EntityDataReader.cs
@@ -29,7 +29,7 @@ namespace Xtensive.Orm.Internals
     private readonly record struct CacheItem
     (
       RecordSetHeader Header,
-      IReadOnlyList<RecordPartMapping> Mappings
+      RecordPartMapping[] Mappings
     );
 
     private readonly ICache<RecordSetHeader, CacheItem> cache;
@@ -68,15 +68,17 @@ namespace Xtensive.Orm.Internals
       return source.Select(tuple => ParseRow(tuple, context, cacheItem.Mappings));
     }
 
-    private Record ParseRow(Tuple tuple, MaterializationContext context, IReadOnlyList<RecordPartMapping> recordPartMappings)
+    private Record ParseRow(Tuple tuple, MaterializationContext context, RecordPartMapping[] recordPartMappings)
     {
-      var count = recordPartMappings.Count;
+      var mappingsSpan = recordPartMappings.AsSpan();
+      var count = mappingsSpan.Length;
       if (count == 1) {
-        return new Record(tuple, ParseColumnGroup(tuple, context, 0, recordPartMappings[0]));
+        return new Record(tuple, ParseColumnGroup(tuple, context, 0, mappingsSpan[0]));
       }
       var pairs = new (Key, Tuple)[count];
-      for (var i = 0; i < count; i++) {
-        pairs[i] = ParseColumnGroup(tuple, context, i, recordPartMappings[i]);
+      var pairsSpan = pairs.AsSpan();
+      for (var i = 0; i < pairsSpan.Length; i++) {
+        pairsSpan[i] = ParseColumnGroup(tuple, context, i, mappingsSpan[i]);
       }
       return new Record(tuple, pairs);
     }

--- a/Orm/Xtensive.Orm/Orm/Internals/EntityDataReader.cs
+++ b/Orm/Xtensive.Orm/Orm/Internals/EntityDataReader.cs
@@ -75,7 +75,7 @@ namespace Xtensive.Orm.Internals
       if (count == 1) {
         return new Record(tuple, ParseColumnGroup(tuple, context, 0, mappingsSpan[0]));
       }
-      var pairs = new (Key, Tuple)[count];
+      var pairs = GC.AllocateUninitializedArray<(Key, Tuple)>(count);
       var pairsSpan = pairs.AsSpan();
       for (var i = 0; i < pairsSpan.Length; i++) {
         pairsSpan[i] = ParseColumnGroup(tuple, context, i, mappingsSpan[i]);

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
@@ -609,9 +609,10 @@ namespace Xtensive.Orm.Linq.Materialization
       var keyDescriptor = entityType.Key.TupleDescriptor;
       var length = mapping.Length;
       var map = new ColNum[length];
+      var mapSpan = map.AsSpan();
       var offset = mapping.Offset;
-      for (var i = 0; i < length; i++) {
-        map[i] = (ColNum)(offset + i);
+      for (var i = 0; i < mapSpan.Length; i++) {
+        mapSpan[i] = (ColNum)(offset + i);
       }
       return new MapTransform(true, keyDescriptor, map);
     }


### PR DESCRIPTION
Addresses review concerns of https://github.com/servicetitan/dataobjects-net/pull/473

- EntityDataReader: narrow CacheItem.Mappings from IReadOnlyList to RecordPartMapping[] (the backing type is always an array) and iterate ParseRow via ReadOnlySpan/Span to remove interface-indexer virtual calls and per-iteration bounds checks when building the (Key, Tuple) pair array.
- ExpressionMaterializer.CreateKeySegmentTransform: fill the key segment map through Span<ColNum> so the JIT can elide bounds checks on the sequential write loop.

Made-with: Cursor