### PR TITLE
Fix bug with inner `.Count(predicate)` translation

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Issues/IssueGithub0114_QueryRootReuseCauseNoRefJoin.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/IssueGithub0114_QueryRootReuseCauseNoRefJoin.cs
@@ -121,7 +121,7 @@ namespace Xtensive.Orm.Tests.Issues.IssueGithub0114_QueryRootReuseCauseNoRefJoin
 namespace Xtensive.Orm.Tests.Issues
 {
   [TestFixture]
-  public sealed class IssueGithub0114_QueryRootReuseCauseNoRefJoin : AutoBuildTest
+  public sealed partial class IssueGithub0114_QueryRootReuseCauseNoRefJoin : AutoBuildTest
   {
     protected override DomainConfiguration BuildConfiguration()
     {

--- a/Orm/Xtensive.Orm.Tests/Issues/Issue_Count.cs
+++ b/Orm/Xtensive.Orm.Tests/Issues/Issue_Count.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+using Xtensive.Orm.Tests.Issues.IssueGithub0114_QueryRootReuseCauseNoRefJoinModel;
+
+namespace Xtensive.Orm.Tests.Issues;
+
+[TestFixture]
+public sealed partial class IssueGithub0114_QueryRootReuseCauseNoRefJoin : AutoBuildTest
+{
+  [Test]
+  public void InnerWhere()
+  {
+    using var session = Domain.OpenSession();
+    using var tx = session.OpenTransaction();
+    _ = session.Query.All<Promotion>().GroupBy(p => p.Id).Select(g =>
+      g.Where(x => x.CampainName == null).Count()
+    ).ToArray();
+  }
+
+  [Test]
+  public void InnerCount()
+  {
+    using var session = Domain.OpenSession();
+    using var tx = session.OpenTransaction();
+    _ = session.Query.All<Promotion>().GroupBy(p => p.Id).Select(g =>
+      g.Count(x => x.CampainName == null)
+    ).ToArray();
+  }
+}
+

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -191,6 +191,12 @@ namespace Xtensive.Orm.Linq
             break;
           case QueryableMethodKind.LongCount:
           case QueryableMethodKind.Count:
+            var src = mcArguments[0];
+            if (argsCount == 2) {
+              using var _ = CreateScope(new TranslatorState(State) { BuildingProjection = false });
+              src = VisitWhere(mcArguments[0], mcArguments[1].StripQuotes());
+            }
+            return VisitAggregate(src, mc.Method, null, context.IsRoot(mc), mc);
           case QueryableMethodKind.Max:
           case QueryableMethodKind.Min:
           case QueryableMethodKind.Sum:

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -194,7 +194,7 @@ namespace Xtensive.Orm.Linq
             var src = mcArguments[0];
             if (argsCount == 2) {
               using var _ = CreateScope(new TranslatorState(State) { BuildingProjection = false });
-              src = VisitWhere(mcArguments[0], mcArguments[1].StripQuotes());
+              src = VisitWhere(src, mcArguments[1].StripQuotes());
             }
             return VisitAggregate(src, mc.Method, null, context.IsRoot(mc), mc);
           case QueryableMethodKind.Max:


### PR DESCRIPTION
The new DataObjects from Xtensive (starting `7.3.12` in our version numbering)
cannot translate inner `.Count(predicate)` expressions like following:
```
session.Query.All<Promotion>().GroupBy(p => p.Id).Select(g =>
      g.Count(x => x.CampainName == null)
    )
```

See the discussion: https://servicetitan.slack.com/archives/CLM7XAVLK/p1776720202265489?thread_ts=1776709176.616779&cid=CLM7XAVLK

This PR fixes it, translating as an equivalent sequence `.Where(predicate).Count()`

Also:
* Add a test