### PR TITLE
Optimization: Fuse filtered aggregates into parent GROUP BY

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Linq/Optimization/AggregateFusionTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/Optimization/AggregateFusionTest.cs
@@ -75,6 +75,121 @@ namespace Xtensive.Orm.Tests.Linq.Optimization
     }
 
     /// <summary>
+    /// <c>g.Where(p).Count()</c> on a grouping parameter is semantically identical
+    /// to <c>g.Count(p)</c>; the translator must recognize the shape and fuse it
+    /// into the parent <c>GROUP BY</c> the same way as the direct form.
+    /// </summary>
+    [Test]
+    public void GroupByWhereCount_FusesIntoSingleAggregate()
+    {
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+
+      var query = session.Query.All<Order>()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          Drafts = g.Where(x => x.PublishedOn == null).Count(),
+        })
+        .OrderBy(r => r.Active);
+
+      var sql = Sql(session, query);
+      TestContext.WriteLine(sql);
+      AssertCount(sql, "(SELECT COUNT", 0);
+      AssertCount(sql, "(SELECT SUM", 0);
+
+      var expected = session.Query.All<Order>().ToArray()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          Drafts = g.Where(x => x.PublishedOn == null).Count(),
+        })
+        .OrderBy(r => r.Active)
+        .Select(r => (r.Active, r.Drafts))
+        .ToArray();
+
+      var actual = query.ToArray().Select(r => (r.Active, r.Drafts)).ToArray();
+      Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    /// <summary>
+    /// Chained <c>Where</c>s followed by <c>Count()</c> on a grouping parameter
+    /// must fuse as a single aggregate; the translator combines the predicates
+    /// with <c>AndAlso</c> and applies the same <c>Count -&gt; Sum(CASE)</c>
+    /// rewrite as for the direct form.
+    /// </summary>
+    [Test]
+    public void GroupByChainedWhereCount_FusesIntoSingleAggregate()
+    {
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+
+      var query = session.Query.All<Order>()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          DraftsD = g.Where(x => x.PublishedOn == null).Where(x => x.Code.StartsWith("D")).Count(),
+        })
+        .OrderBy(r => r.Active);
+
+      var sql = Sql(session, query);
+      TestContext.WriteLine(sql);
+      AssertCount(sql, "(SELECT COUNT", 0);
+      AssertCount(sql, "(SELECT SUM", 0);
+
+      var expected = session.Query.All<Order>().ToArray()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          DraftsD = g.Where(x => x.PublishedOn == null).Where(x => x.Code.StartsWith("D")).Count(),
+        })
+        .OrderBy(r => r.Active)
+        .Select(r => (r.Active, r.DraftsD))
+        .ToArray();
+
+      var actual = query.ToArray().Select(r => (r.Active, r.DraftsD)).ToArray();
+      Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    /// <summary>
+    /// Variant of <see cref="GroupByWhereCount_FusesIntoSingleAggregate"/> for
+    /// the <c>LongCount</c> path; the collapsed form must still produce the
+    /// correct <c>long</c> result and fuse.
+    /// </summary>
+    [Test]
+    public void GroupByWhereLongCount_FusesIntoSingleAggregate()
+    {
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+
+      var query = session.Query.All<Order>()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          Drafts = g.Where(x => x.PublishedOn == null).LongCount(),
+        })
+        .OrderBy(r => r.Active);
+
+      var sql = Sql(session, query);
+      TestContext.WriteLine(sql);
+      AssertCount(sql, "(SELECT COUNT", 0);
+      AssertCount(sql, "(SELECT SUM", 0);
+
+      var expected = session.Query.All<Order>().ToArray()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          Drafts = g.Where(x => x.PublishedOn == null).LongCount(),
+        })
+        .OrderBy(r => r.Active)
+        .Select(r => (r.Active, r.Drafts))
+        .ToArray();
+
+      var actual = query.ToArray().Select(r => (r.Active, r.Drafts)).ToArray();
+      Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    /// <summary>
     /// Multiple predicated counts in the same projection all fuse into a single
     /// <c>SELECT ... GROUP BY</c>.
     /// </summary>

--- a/Orm/Xtensive.Orm.Tests/Linq/Optimization/AggregateFusionTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/Optimization/AggregateFusionTest.cs
@@ -1,0 +1,286 @@
+// Copyright (C) 2026 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using Xtensive.Orm.Tests.Linq.Optimization.Model;
+
+namespace Xtensive.Orm.Tests.Linq.Optimization
+{
+  /// <summary>
+  /// Aggregate fusion for <c>Count(predicate)</c> and
+  /// <c>Sum(predicate ? 1 : 0)</c> inside a <c>GroupBy</c>: the aggregate must
+  /// fuse into a single <c>SELECT ... GROUP BY</c> instead of being emitted as
+  /// a per-group correlated subquery.
+  /// </summary>
+  [TestFixture]
+  [Category("Linq")]
+  public sealed class AggregateFusionTest : OptimizationTestBase
+  {
+    protected override void PopulateData()
+    {
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+
+      var active = new Customer { Name = "A", IsActive = true };
+      var inactive = new Customer { Name = "B", IsActive = false };
+      _ = new Customer { Name = "C", IsActive = true };
+
+      _ = new Order { Code = "P1", IsActive = true, PublishedOn = new DateTime(2024, 1, 1), Customer = active };
+      _ = new Order { Code = "D1", IsActive = true, PublishedOn = null,                       Customer = active };
+      _ = new Order { Code = "D2", IsActive = false, PublishedOn = null,                      Customer = inactive };
+      _ = new Order { Code = "P2", IsActive = true, PublishedOn = new DateTime(2024, 3, 1),   Customer = inactive };
+      _ = new Order { Code = "D3", IsActive = false, PublishedOn = null,                      Customer = active };
+
+      tx.Complete();
+    }
+
+    /// <summary>
+    /// <c>GroupBy(k).Select(g =&gt; g.Count(x =&gt; predicate))</c> on a scalar
+    /// key must emit a single <c>SELECT ... GROUP BY</c> with no per-group
+    /// correlated subquery.
+    /// </summary>
+    [Test]
+    public void GroupByCountPredicate_FusesIntoSingleAggregate()
+    {
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+
+      var query = session.Query.All<Order>()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          Drafts = g.Count(x => x.PublishedOn == null),
+        })
+        .OrderBy(r => r.Active);
+
+      var sql = Sql(session, query);
+      TestContext.WriteLine(sql);
+      AssertCount(sql, "(SELECT COUNT", 0);
+
+      var expected = session.Query.All<Order>().ToArray()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          Drafts = g.Count(x => x.PublishedOn == null),
+        })
+        .OrderBy(r => r.Active)
+        .Select(r => (r.Active, r.Drafts))
+        .ToArray();
+
+      var actual = query.ToArray().Select(r => (r.Active, r.Drafts)).ToArray();
+      Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    /// <summary>
+    /// Multiple predicated counts in the same projection all fuse into a single
+    /// <c>SELECT ... GROUP BY</c>.
+    /// </summary>
+    [Test]
+    public void GroupByMultipleCountPredicates_FuseIntoSingleAggregate()
+    {
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+
+      var query = session.Query.All<Order>()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          Drafts = g.Count(x => x.PublishedOn == null),
+          Published = g.Count(x => x.PublishedOn != null),
+          Total = g.Count(),
+        })
+        .OrderBy(r => r.Active);
+
+      var sql = Sql(session, query);
+      TestContext.WriteLine(sql);
+      AssertCount(sql, "(SELECT COUNT", 0);
+
+      var expected = session.Query.All<Order>().ToArray()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          Drafts = g.Count(x => x.PublishedOn == null),
+          Published = g.Count(x => x.PublishedOn != null),
+          Total = g.Count(),
+        })
+        .OrderBy(r => r.Active)
+        .Select(r => (r.Active, r.Drafts, r.Published, r.Total))
+        .ToArray();
+
+      var actual = query.ToArray()
+        .Select(r => (r.Active, r.Drafts, r.Published, r.Total))
+        .ToArray();
+      Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    /// <summary>
+    /// Compound predicate (<c>AndAlso</c>) inside <c>Count</c> fuses too.
+    /// </summary>
+    [Test]
+    public void GroupByCountAndAlsoPredicate_FusesIntoSingleAggregate()
+    {
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+
+      var query = session.Query.All<Order>()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          Drafts = g.Count(x => x.Code.StartsWith("D") && x.PublishedOn == null),
+        })
+        .OrderBy(r => r.Active);
+
+      var sql = Sql(session, query);
+      TestContext.WriteLine(sql);
+      AssertCount(sql, "(SELECT COUNT", 0);
+
+      var expected = session.Query.All<Order>().ToArray()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          Drafts = g.Count(x => x.Code.StartsWith("D") && x.PublishedOn == null),
+        })
+        .OrderBy(r => r.Active)
+        .Select(r => (r.Active, r.Drafts))
+        .ToArray();
+
+      var actual = query.ToArray()
+        .Select(r => (r.Active, r.Drafts))
+        .ToArray();
+      Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    /// <summary>
+    /// <c>Sum(x =&gt; condition ? 1 : 0)</c> must also fuse without any
+    /// correlated subquery.
+    /// </summary>
+    [Test]
+    public void GroupBySumOfCondition_FusesIntoSingleAggregate()
+    {
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+
+      var query = session.Query.All<Order>()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          Drafts = g.Sum(x => x.PublishedOn == null ? 1 : 0),
+        })
+        .OrderBy(r => r.Active);
+
+      var sql = Sql(session, query);
+      TestContext.WriteLine(sql);
+      AssertCount(sql, "(SELECT COUNT", 0);
+      AssertCount(sql, "(SELECT SUM", 0);
+
+      var expected = session.Query.All<Order>().ToArray()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          Drafts = g.Sum(x => x.PublishedOn == null ? 1 : 0),
+        })
+        .OrderBy(r => r.Active)
+        .Select(r => (r.Active, r.Drafts))
+        .ToArray();
+
+      var actual = query.ToArray()
+        .Select(r => (r.Active, r.Drafts))
+        .ToArray();
+      Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    /// <summary>
+    /// Regression: when the Count -> Sum(CASE) rewrite fires and a group
+    /// contains zero rows matching the predicate, the materialized value must
+    /// be <c>0</c> (Count's contract) — not <c>NULL</c>, and the pipeline
+    /// must not throw on the int coercion. The inactive group in the seed
+    /// data contains only unpublished orders, so the predicate
+    /// <c>PublishedOn != null</c> matches zero rows there.
+    /// </summary>
+    [Test]
+    public void GroupByCountPredicate_ZeroMatchingRows_ReturnsZero()
+    {
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+
+      var query = session.Query.All<Order>()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          Published = g.Count(x => x.PublishedOn != null),
+        })
+        .OrderBy(r => r.Active);
+
+      var sql = Sql(session, query);
+      TestContext.WriteLine(sql);
+      AssertCount(sql, "(SELECT COUNT", 0);
+
+      // Materialization itself is part of the regression guard: if SUM returns
+      // NULL for a group with no matching rows, the int coercion would throw.
+      var rows = query.ToArray();
+
+      var inactive = rows.Single(r => !r.Active);
+      Assert.That(inactive.Published, Is.EqualTo(0),
+        "Count(predicate) in a grouping where no rows match must materialize as 0, not NULL.");
+
+      var active = rows.Single(r => r.Active);
+      Assert.That(active.Published, Is.EqualTo(2),
+        "Sanity: the non-empty group must still count correctly after the rewrite.");
+    }
+
+    /// <summary>
+    /// Same regression guard as <see cref="GroupByCountPredicate_ZeroMatchingRows_ReturnsZero"/>
+    /// but exercises the <c>LongCount</c> path (rewrite emits <c>long</c>
+    /// literals and the result column must coerce <c>SUM</c>-of-zero-rows to
+    /// <c>0L</c>).
+    /// </summary>
+    [Test]
+    public void GroupByLongCountPredicate_ZeroMatchingRows_ReturnsZero()
+    {
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+
+      var query = session.Query.All<Order>()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          Published = g.LongCount(x => x.PublishedOn != null),
+        })
+        .OrderBy(r => r.Active);
+
+      var sql = Sql(session, query);
+      TestContext.WriteLine(sql);
+      AssertCount(sql, "(SELECT COUNT", 0);
+
+      // Materialization itself is part of the regression guard: if SUM returns
+      // NULL for a group with no matching rows, the long coercion would throw.
+      var rows = query.ToArray();
+
+      var inactive = rows.Single(r => !r.Active);
+      Assert.That(inactive.Published, Is.EqualTo(0L),
+        "LongCount(predicate) in a grouping where no rows match must materialize as 0L, not NULL.");
+
+      var active = rows.Single(r => r.Active);
+      Assert.That(active.Published, Is.EqualTo(2L),
+        "Sanity: the non-empty group must still count correctly after the rewrite.");
+    }
+
+    /// <summary>
+    /// Root-level <c>Count(predicate)</c> must still return <c>0</c> on an
+    /// empty match set (not <c>NULL</c>); the rewrite must not fire here.
+    /// </summary>
+    [Test]
+    public void RootLevelCountPredicate_StillReturnsZeroOnEmpty()
+    {
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+
+      var count = session.Query.All<Order>().Count(o => o.Code == "no-such-code");
+
+      Assert.That(count, Is.EqualTo(0));
+    }
+  }
+}

--- a/Orm/Xtensive.Orm.Tests/Linq/Optimization/AggregateFusionTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/Optimization/AggregateFusionTest.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using Xtensive.Orm.Providers;
 using Xtensive.Orm.Tests.Linq.Optimization.Model;
 
 namespace Xtensive.Orm.Tests.Linq.Optimization
@@ -396,6 +397,236 @@ namespace Xtensive.Orm.Tests.Linq.Optimization
       var count = session.Query.All<Order>().Count(o => o.Code == "no-such-code");
 
       Assert.That(count, Is.EqualTo(0));
+    }
+
+    /// <summary>
+    /// Generalized fusion: <c>g.Where(p).Sum(selector)</c> on a grouping
+    /// parameter must be pulled into the aggregate selector as
+    /// <c>g.Sum(x =&gt; p(x) ? selector(x) : 0)</c> (0 ELSE branch for a
+    /// non-nullable numeric selector preserves the LINQ "empty set = 0"
+    /// contract for <c>Sum</c>) so it fuses with the parent <c>GROUP BY</c>
+    /// instead of emitting a correlated subquery.
+    /// </summary>
+    [Test]
+    public void GroupByWhereSum_FusesIntoSingleAggregate()
+    {
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+
+      var query = session.Query.All<Order>()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          PublishedIdSum = g.Where(x => x.PublishedOn != null).Sum(x => x.Id),
+        })
+        .OrderBy(r => r.Active);
+
+      var sql = Sql(session, query);
+      TestContext.WriteLine(sql);
+      AssertCount(sql, "(SELECT COUNT", 0);
+      AssertCount(sql, "(SELECT SUM", 0);
+
+      var expected = session.Query.All<Order>().ToArray()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          PublishedIdSum = g.Where(x => x.PublishedOn != null).Sum(x => x.Id),
+        })
+        .OrderBy(r => r.Active)
+        .Select(r => (r.Active, r.PublishedIdSum))
+        .ToArray();
+
+      var actual = query.ToArray().Select(r => (r.Active, r.PublishedIdSum)).ToArray();
+      Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    /// <summary>
+    /// Generalized fusion: <c>g.Where(p).Min(selector)</c> must fuse via
+    /// <c>g.Min(x =&gt; p(x) ? (T?)selector(x) : null)</c>; SQL <c>MIN</c>
+    /// ignores <c>NULL</c>s so the rewrite is semantically equivalent.
+    /// </summary>
+    [Test]
+    public void GroupByWhereMin_FusesIntoSingleAggregate()
+    {
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+
+      var query = session.Query.All<Order>()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          MinPublishedId = g.Where(x => x.PublishedOn != null).Min(x => (long?) x.Id),
+        })
+        .OrderBy(r => r.Active);
+
+      var sql = Sql(session, query);
+      TestContext.WriteLine(sql);
+      AssertCount(sql, "(SELECT MIN", 0);
+
+      var expected = session.Query.All<Order>().ToArray()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          MinPublishedId = g.Where(x => x.PublishedOn != null).Min(x => (long?) x.Id),
+        })
+        .OrderBy(r => r.Active)
+        .Select(r => (r.Active, r.MinPublishedId))
+        .ToArray();
+
+      var actual = query.ToArray().Select(r => (r.Active, r.MinPublishedId)).ToArray();
+      Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    /// <summary>
+    /// Generalized fusion: <c>g.Where(p).Max(selector)</c> must fuse via the
+    /// same <c>NULL</c>-in-ELSE trick as <see cref="GroupByWhereMin_FusesIntoSingleAggregate"/>.
+    /// </summary>
+    [Test]
+    public void GroupByWhereMax_FusesIntoSingleAggregate()
+    {
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+
+      var query = session.Query.All<Order>()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          MaxPublishedId = g.Where(x => x.PublishedOn != null).Max(x => (long?) x.Id),
+        })
+        .OrderBy(r => r.Active);
+
+      var sql = Sql(session, query);
+      TestContext.WriteLine(sql);
+      AssertCount(sql, "(SELECT MAX", 0);
+
+      var expected = session.Query.All<Order>().ToArray()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          MaxPublishedId = g.Where(x => x.PublishedOn != null).Max(x => (long?) x.Id),
+        })
+        .OrderBy(r => r.Active)
+        .Select(r => (r.Active, r.MaxPublishedId))
+        .ToArray();
+
+      var actual = query.ToArray().Select(r => (r.Active, r.MaxPublishedId)).ToArray();
+      Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    /// <summary>
+    /// Generalized fusion: <c>g.Where(p).Average(selector)</c> must fuse via
+    /// <c>NULL</c>-in-ELSE; SQL <c>AVG</c> ignores <c>NULL</c>s, matching
+    /// LINQ's "average over passing rows" contract.
+    /// </summary>
+    [Test]
+    public void GroupByWhereAverage_FusesIntoSingleAggregate()
+    {
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+
+      var query = session.Query.All<Order>()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          AvgPublishedId = g.Where(x => x.PublishedOn != null).Average(x => (double?) x.Id),
+        })
+        .OrderBy(r => r.Active);
+
+      var sql = Sql(session, query);
+      TestContext.WriteLine(sql);
+      AssertCount(sql, "(SELECT AVG", 0);
+
+      var expected = session.Query.All<Order>().ToArray()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          AvgPublishedId = g.Where(x => x.PublishedOn != null).Average(x => (double?) x.Id),
+        })
+        .OrderBy(r => r.Active)
+        .Select(r => (r.Active, r.AvgPublishedId))
+        .ToArray();
+
+      var actual = query.ToArray().Select(r => (r.Active, r.AvgPublishedId)).ToArray();
+      Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    /// <summary>
+    /// Regression: <c>g.Where(p).Sum(selector)</c> where no rows match the
+    /// predicate in a group must materialize as <c>0</c> (LINQ <c>Sum</c>'s
+    /// empty-sequence contract for non-nullable numeric selectors) and not
+    /// as <c>NULL</c>. The rewrite must use <c>0</c> — not <c>NULL</c> — in
+    /// the ELSE branch when the selector result type is non-nullable.
+    /// </summary>
+    [Test]
+    public void GroupByWhereSum_ZeroMatchingRows_ReturnsZero()
+    {
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+
+      var query = session.Query.All<Order>()
+        .GroupBy(o => o.IsActive)
+        .Select(g => new {
+          Active = g.Key,
+          PublishedIdSum = g.Where(x => x.PublishedOn != null).Sum(x => x.Id),
+        })
+        .OrderBy(r => r.Active);
+
+      var rows = query.ToArray();
+      var inactive = rows.Single(r => !r.Active);
+      Assert.That(inactive.PublishedIdSum, Is.EqualTo(0L),
+        "Sum(selector) over an empty filter in a grouping must materialize as 0, not NULL, for a non-nullable selector.");
+    }
+
+    /// <summary>
+    /// Guard: <see cref="Queryable.Where{T}(IQueryable{T}, System.Linq.Expressions.Expression{System.Func{T, int, bool}})"/>
+    /// — the indexed <c>Where</c> overload — must not be folded into a
+    /// combined predicate by <c>PeelWhereChain</c>. The <c>index</c>
+    /// parameter refers to the row's position in the current sequence; AND-
+    /// combining an indexed <c>Where</c> with another predicate would
+    /// silently change its semantics and produce an expression tree with an
+    /// unbound parameter. The correct behaviour is to stop peeling at the
+    /// indexed call and let <c>VisitWhere</c> handle it normally.
+    /// </summary>
+    [Test]
+    public void IndexedWhereChainBeforeCount_IsNotCollapsed()
+    {
+      Require.AllFeaturesSupported(ProviderFeatures.RowNumber);
+
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+
+      var query = session.Query.All<Order>()
+        .OrderBy(o => o.Id)
+        .Where((o, i) => i >= 0)
+        .Count(o => o.PublishedOn == null);
+
+      Assert.That(query, Is.EqualTo(3));
+    }
+
+    /// <summary>
+    /// Root-level (non-fusable) Sum with a Where chain must collapse into a
+    /// single WHERE in the emitted SQL — one <c>FilterProvider</c> instead of
+    /// stacked ones — and produce the same numeric result as the in-memory
+    /// reference. Verifies the <c>PeelWhereChain</c> rebuild path for
+    /// Sum/Min/Max/Avg when fusion does not apply.
+    /// </summary>
+    [Test]
+    public void RootLevelWhereChainSum_CollapsesAndMatchesReference()
+    {
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+
+      var actual = session.Query.All<Order>()
+        .Where(o => o.IsActive)
+        .Where(o => o.PublishedOn != null)
+        .Sum(o => o.Id);
+
+      var expected = session.Query.All<Order>().ToArray()
+        .Where(o => o.IsActive)
+        .Where(o => o.PublishedOn != null)
+        .Sum(o => o.Id);
+
+      Assert.That(actual, Is.EqualTo(expected));
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Linq/Optimization/Model.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/Optimization/Model.cs
@@ -1,0 +1,84 @@
+// Copyright (C) 2026 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using Xtensive.Orm;
+
+namespace Xtensive.Orm.Tests.Linq.Optimization.Model
+{
+  /// <summary>
+  /// A small self-contained fixture re-used by every translator-optimization test.
+  /// The model intentionally exposes both required and nullable navigation
+  /// properties so tests can exercise INNER/LEFT JOIN paths.
+  /// </summary>
+  [HierarchyRoot]
+  public class Customer : Entity
+  {
+    [Field, Key]
+    public long Id { get; private set; }
+
+    [Field(Length = 128)]
+    public string Name { get; set; }
+
+    [Field]
+    public bool IsActive { get; set; }
+  }
+
+  [HierarchyRoot]
+  public class Workflow : Entity
+  {
+    [Field, Key]
+    public long Id { get; private set; }
+
+    [Field(Length = 64)]
+    public string Name { get; set; }
+  }
+
+  [HierarchyRoot]
+  public class Order : Entity
+  {
+    [Field, Key]
+    public long Id { get; private set; }
+
+    [Field(Length = 64)]
+    public string Code { get; set; }
+
+    [Field]
+    public bool IsActive { get; set; }
+
+    [Field]
+    public DateTime? PublishedOn { get; set; }
+
+    /// <summary>Nullable navigation — exercises LEFT JOIN.</summary>
+    [Field]
+    public Customer Customer { get; set; }
+
+    /// <summary>Nullable navigation — exercises LEFT JOIN.</summary>
+    [Field]
+    public Workflow Workflow { get; set; }
+
+    [Field]
+    [Association(PairTo = nameof(OrderItem.Order))]
+    public EntitySet<OrderItem> Items { get; private set; }
+  }
+
+  [HierarchyRoot]
+  public class OrderItem : Entity
+  {
+    [Field, Key]
+    public long Id { get; private set; }
+
+    [Field]
+    public Order Order { get; set; }
+
+    [Field(Length = 128)]
+    public string Name { get; set; }
+
+    [Field]
+    public int Quantity { get; set; }
+
+    [Field]
+    public decimal Price { get; set; }
+  }
+}

--- a/Orm/Xtensive.Orm.Tests/Linq/Optimization/OptimizationTestBase.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/Optimization/OptimizationTestBase.cs
@@ -1,0 +1,122 @@
+// Copyright (C) 2026 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Xtensive.Orm.Configuration;
+using Xtensive.Orm.Services;
+using Xtensive.Orm.Tests.Linq.Optimization.Model;
+
+namespace Xtensive.Orm.Tests.Linq.Optimization
+{
+  /// <summary>
+  /// Shared harness for every translator-optimization test. Subclasses get:
+  /// <list type="bullet">
+  ///   <item>A registered <see cref="Customer"/>/<see cref="Order"/>/<see cref="OrderItem"/>/<see cref="Workflow"/> model.</item>
+  ///   <item><see cref="Sql{T}(Session, IQueryable{T})"/> that returns the SQL a query will actually produce.</item>
+  ///   <item>Shape assertions (<see cref="AssertNotContains"/>, <see cref="AssertCount"/>) for the generated SQL string.</item>
+  ///   <item><see cref="AssertResultsEqual{T}"/> to pair every shape assertion with a correctness check.</item>
+  /// </list>
+  /// Subclasses that need to opt into a specific <see cref="TranslatorOptimizations"/>
+  /// flag override <see cref="Optimizations"/>.
+  /// </summary>
+  public abstract class OptimizationTestBase : AutoBuildTest
+  {
+    /// <summary>
+    /// Flags to apply to <see cref="DomainConfiguration.TranslatorOptimizations"/>.
+    /// Default keeps the legacy translator behavior so this base class is a no-op
+    /// for tests that only care about correctness.
+    /// </summary>
+    protected virtual TranslatorOptimizations Optimizations => TranslatorOptimizations.Default;
+
+    protected override DomainConfiguration BuildConfiguration()
+    {
+      var configuration = base.BuildConfiguration();
+      configuration.Types.Register(typeof(Customer));
+      configuration.Types.Register(typeof(Workflow));
+      configuration.Types.Register(typeof(Order));
+      configuration.Types.Register(typeof(OrderItem));
+      configuration.TranslatorOptimizations = Optimizations;
+      return configuration;
+    }
+
+    /// <summary>
+    /// Returns the SQL string that <paramref name="query"/> would execute against
+    /// the configured storage provider. Mirrors the pattern used by
+    /// <see cref="TagTest"/>: <c>session.Services.Demand&lt;QueryFormatter&gt;().ToSqlString(q)</c>.
+    /// </summary>
+    protected static string Sql<T>(Session session, IQueryable<T> query)
+    {
+      var formatter = session.Services.Demand<QueryFormatter>();
+      return formatter.ToSqlString(query);
+    }
+
+    /// <summary>
+    /// Asserts that none of <paramref name="fragments"/> appears in <paramref name="sql"/>
+    /// (case-insensitive). Useful for "must not emit OUTER APPLY / LEFT JOIN / ..." shape tests.
+    /// </summary>
+    protected static void AssertNotContains(string sql, params string[] fragments)
+    {
+      ArgumentNullException.ThrowIfNull(sql);
+      ArgumentNullException.ThrowIfNull(fragments);
+      foreach (var fragment in fragments) {
+        Assert.That(
+          sql.IndexOf(fragment, StringComparison.OrdinalIgnoreCase),
+          Is.LessThan(0),
+          () => $"SQL unexpectedly contains '{fragment}':\n{sql}");
+      }
+    }
+
+    /// <summary>
+    /// Asserts that <paramref name="fragment"/> appears exactly <paramref name="expected"/>
+    /// times in <paramref name="sql"/> (case-insensitive). Use for counting subqueries,
+    /// joins, OR-branches, etc.
+    /// </summary>
+    protected static void AssertCount(string sql, string fragment, int expected)
+    {
+      ArgumentNullException.ThrowIfNull(sql);
+      ArgumentException.ThrowIfNullOrEmpty(fragment);
+      var actual = CountOccurrences(sql, fragment);
+      Assert.That(
+        actual,
+        Is.EqualTo(expected),
+        () => $"Expected '{fragment}' to occur {expected} times, but it occurred {actual} times:\n{sql}");
+    }
+
+    /// <summary>
+    /// Runs both queries to materialized lists and compares them element-wise. Every
+    /// shape assertion in a test should be paired with a call to this method so
+    /// the optimization never silently changes semantics.
+    /// </summary>
+    protected static void AssertResultsEqual<T>(IQueryable<T> actual, IQueryable<T> expected)
+    {
+      var actualList = actual.ToList();
+      var expectedList = expected.ToList();
+      Assert.That(actualList, Is.EquivalentTo(expectedList));
+    }
+
+    /// <summary>
+    /// Runs both sequences and compares them element-wise. Useful when the
+    /// "baseline" side is an in-memory <see cref="IEnumerable{T}"/> computed by
+    /// the test (e.g. LINQ-to-objects fallback).
+    /// </summary>
+    protected static void AssertResultsEqual<T>(IQueryable<T> actual, IEnumerable<T> expected)
+    {
+      Assert.That(actual.ToList(), Is.EquivalentTo(expected.ToList()));
+    }
+
+    private static int CountOccurrences(string source, string fragment)
+    {
+      var count = 0;
+      var index = 0;
+      while ((index = source.IndexOf(fragment, index, StringComparison.OrdinalIgnoreCase)) >= 0) {
+        count++;
+        index += fragment.Length;
+      }
+      return count;
+    }
+  }
+}

--- a/Orm/Xtensive.Orm.Tests/Linq/Optimization/OptimizationTestBase.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/Optimization/OptimizationTestBase.cs
@@ -20,18 +20,9 @@ namespace Xtensive.Orm.Tests.Linq.Optimization
   ///   <item>Shape assertions (<see cref="AssertNotContains"/>, <see cref="AssertCount"/>) for the generated SQL string.</item>
   ///   <item><see cref="AssertResultsEqual{T}"/> to pair every shape assertion with a correctness check.</item>
   /// </list>
-  /// Subclasses that need to opt into a specific <see cref="TranslatorOptimizations"/>
-  /// flag override <see cref="Optimizations"/>.
   /// </summary>
   public abstract class OptimizationTestBase : AutoBuildTest
   {
-    /// <summary>
-    /// Flags to apply to <see cref="DomainConfiguration.TranslatorOptimizations"/>.
-    /// Default keeps the legacy translator behavior so this base class is a no-op
-    /// for tests that only care about correctness.
-    /// </summary>
-    protected virtual TranslatorOptimizations Optimizations => TranslatorOptimizations.Default;
-
     protected override DomainConfiguration BuildConfiguration()
     {
       var configuration = base.BuildConfiguration();
@@ -39,7 +30,6 @@ namespace Xtensive.Orm.Tests.Linq.Optimization
       configuration.Types.Register(typeof(Workflow));
       configuration.Types.Register(typeof(Order));
       configuration.Types.Register(typeof(OrderItem));
-      configuration.TranslatorOptimizations = Optimizations;
       return configuration;
     }
 

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -917,6 +917,12 @@ namespace Xtensive.Orm.Linq
       //     (peels Where chains so the rewrite below can see the grouping parameter)
       //   source.Count(filter)   -> source.Select(filter ? 1 : 0).Sum()
       //     (only for a grouping-parameter source; enables aggregate fusion)
+      //   source.Where(f1)...Where(fn).Sum/Min/Max/Avg(selector)
+      //     -> source.Sum/Min/Max/Avg(x => (f1(x) AND ... AND fn(x)) ? selector(x) : else)
+      //     where `else` is 0 for a non-nullable Sum selector (preserves the
+      //     LINQ "empty set = 0" contract) and NULL otherwise (SQL
+      //     Sum/Min/Max/Avg ignore NULLs). Fires only for a grouping-parameter
+      //     source; enables aggregate fusion with the parent GROUP BY.
       //   source.Count(filter)   -> source.Where(filter).Count()
       //   source.Sum(selector)   -> source.Select(selector).Sum()
       // If parameterless method is called this method simply processes source.
@@ -927,47 +933,54 @@ namespace Xtensive.Orm.Linq
       ProjectionExpression sourceProjection;
       ColNum aggregatedColumnIndex;
 
+      // Unified Where-peel + grouping-aggregate fusion. Builds a single
+      // predicate lambda (`fusionPredicate`) from any peeled Where chain plus,
+      // for Count, the call's own predicate. When the peeled source is a
+      // fusable grouping parameter the aggregate is rewritten to fuse with
+      // the parent GROUP BY:
+      //
+      //   Count(p)            -> Sum(x => p(x) ? 1 : 0)
+      //   Where(p).Sum(s)     -> Sum(x => p(x) ? s(x) : 0 | NULL)
+      //   Where(p).Min/Max/Avg(s) -> Min/Max/Avg(x => p(x) ? s(x) : NULL)
+      //
+      // In the non-fusable case the peeled Where chain is collapsed into a
+      // single predicate passed to VisitWhere, yielding one FilterProvider
+      // with an AndAlso-tree body instead of stacked FilterProviders. SQL
+      // translation produces the same WHERE clause either way; this just
+      // saves the RSE pipeline a few redundant nodes.
+      var fusionPredicate = PeelWhereChain(ref source, aggregateParameter?.Parameters[0]);
+      var fusionSelector = aggregateParameter;
       if (aggregateType == AggregateType.Count) {
-        // Collapse Where chains into a single Count(predicate) so the fusion
-        // rewrite below can match a grouping-parameter source uniformly for
-        // both g.Count(p) and g.Where(p).Count() shapes.
-        while (source is MethodCallExpression whereCall
-          && QueryableVisitor.GetQueryableMethod(whereCall) == QueryableMethodKind.Where
-          && whereCall.Arguments.Count == 2) {
-          var wherePredicate = (LambdaExpression) whereCall.Arguments[1].StripQuotes();
-          if (aggregateParameter == null) {
-            aggregateParameter = wherePredicate;
-          }
-          else {
-            var outerParam = aggregateParameter.Parameters[0];
-            var rebasedBody = ExpressionReplacer.Replace(
-              wherePredicate.Body, wherePredicate.Parameters[0], outerParam);
-            aggregateParameter = FastExpression.Lambda(
-              Expression.AndAlso(rebasedBody, aggregateParameter.Body),
-              outerParam);
-          }
-          source = whereCall.Arguments[0];
-        }
+        // Count's own predicate participates as part of the fusion predicate,
+        // not as a selector — the selector for Count-as-Sum is the constant 1.
+        fusionPredicate = CombinePredicates(fusionPredicate, aggregateParameter);
+        fusionSelector = null;
+      }
 
-        // Rewrite Count(predicate) over a grouping into Sum(predicate ? 1 : 0)
-        // so the aggregate can fuse with the parent grouping AggregateProvider
-        // instead of being emitted as a per-group correlated subquery.
-        if (aggregateParameter != null
-          && source is ParameterExpression fusableGroupingParameter
-          && context.Bindings.TryGetValue(fusableGroupingParameter, out var fusableGroupingProjection)
-          && fusableGroupingProjection.ItemProjector.DataSource is AggregateProvider
-          && fusableGroupingProjection.ItemProjector.Item.StripMarkers().IsGroupingExpression()) {
-          aggregateParameter = FastExpression.Lambda(
-            Expression.Condition(aggregateParameter.Body, Expression.Constant(1), Expression.Constant(0)),
-            aggregateParameter.Parameters[0]);
-          aggregateType = AggregateType.Sum;
-        }
-        else {
-          aggregatedColumnIndex = 0;
-          sourceProjection = aggregateParameter != null
-            ? VisitWhere(source, aggregateParameter) : VisitSequence(source);
-          return (sourceProjection, aggregatedColumnIndex);
-        }
+      if (fusionPredicate != null && IsFusableGroupingSource(source)) {
+        var fusedType = aggregateType == AggregateType.Count ? AggregateType.Sum : aggregateType;
+        aggregateParameter = BuildFusedAggregateSelector(fusedType, fusionPredicate, fusionSelector);
+        aggregateType = fusedType;
+      }
+      else if (aggregateType == AggregateType.Count) {
+        // Non-fusable Count: source.Where(f1)...Where(fn).Count([p]) becomes
+        // one VisitWhere(source, f1 AND ... AND fn [AND p]) + Count(*).
+        aggregatedColumnIndex = 0;
+        sourceProjection = fusionPredicate != null
+          ? VisitWhere(source, fusionPredicate) : VisitSequence(source);
+        return (sourceProjection, aggregatedColumnIndex);
+      }
+      else if (fusionPredicate != null) {
+        // Non-fusable Sum/Min/Max/Avg with peeled Where(s): rebuild source as
+        // a single Queryable.Where(source, fusionPredicate) so the primary
+        // aggregate-selector path below sees one FilterProvider instead of
+        // stacked ones. Equivalent SQL in either form (both emit
+        // WHERE f1 AND ... AND fn on the same SELECT), but keeps the RSE
+        // tree smaller and consistent with the non-fusable Count path.
+        source = Expression.Call(WellKnownMembers.Queryable.Where.CachedMakeGenericMethod(
+            fusionPredicate.Parameters[0].Type),
+          source,
+          Expression.Quote(fusionPredicate));
       }
 
       IReadOnlyList<ColNum> columnList = null;
@@ -1005,6 +1018,125 @@ namespace Xtensive.Orm.Linq
 
       aggregatedColumnIndex = columnList[0];
       return (sourceProjection, aggregatedColumnIndex);
+    }
+
+    /// <summary>
+    /// Walks <c>Queryable.Where</c> calls off <paramref name="source"/> and
+    /// combines their predicates with <c>AndAlso</c> into a single lambda.
+    /// Advances <paramref name="source"/> past each consumed call; leaves it
+    /// untouched when no <c>Where</c> is found.
+    /// </summary>
+    /// <param name="initialParameter">
+    /// Optional lambda parameter to rebase every peeled predicate onto. When
+    /// <see langword="null"/> the first peeled predicate's own parameter is
+    /// adopted; subsequent predicates are rebased onto it.
+    /// </param>
+    /// <returns>
+    /// The combined predicate, or <see langword="null"/> when no <c>Where</c>
+    /// call was peeled.
+    /// </returns>
+    private static LambdaExpression PeelWhereChain(ref Expression source, ParameterExpression initialParameter)
+    {
+      LambdaExpression combined = null;
+      var param = initialParameter;
+      while (source is MethodCallExpression whereCall
+        && QueryableVisitor.GetQueryableMethod(whereCall) == QueryableMethodKind.Where
+        && whereCall.Arguments.Count == 2) {
+        var predicate = (LambdaExpression) whereCall.Arguments[1].StripQuotes();
+        // Queryable exposes both Where(source, Func<T,bool>) and the indexed
+        // Where(source, Func<T,int,bool>) under the same QueryableMethodKind.
+        // Only the 1-parameter overload is safe to AND-combine: the indexed
+        // variant binds the element's position in the *current* sequence, so
+        // collapsing it into another Where would change the index semantics.
+        // Bail out and let the caller leave the indexed Where in place for
+        // the normal VisitWhere path to handle.
+        if (predicate.Parameters.Count != 1) {
+          break;
+        }
+        param ??= predicate.Parameters[0];
+        var rebased = ExpressionReplacer.Replace(predicate.Body, predicate.Parameters[0], param);
+        combined = combined == null
+          ? FastExpression.Lambda(rebased, param)
+          : FastExpression.Lambda(Expression.AndAlso(rebased, combined.Body), param);
+        source = whereCall.Arguments[0];
+      }
+      return combined;
+    }
+
+    /// <summary>
+    /// Combines two predicates with <c>AndAlso</c>, rebasing
+    /// <paramref name="extra"/> onto <paramref name="primary"/>'s parameter.
+    /// Returns whichever input is non-null when the other is, or
+    /// <see langword="null"/> when both are.
+    /// </summary>
+    private static LambdaExpression CombinePredicates(LambdaExpression primary, LambdaExpression extra)
+    {
+      if (extra == null) {
+        return primary;
+      }
+      if (primary == null) {
+        return extra;
+      }
+      var param = primary.Parameters[0];
+      var rebased = ExpressionReplacer.Replace(extra.Body, extra.Parameters[0], param);
+      return FastExpression.Lambda(Expression.AndAlso(rebased, primary.Body), param);
+    }
+
+    /// <summary>
+    /// True when <paramref name="source"/> is a parameter bound to a grouping
+    /// projection whose data source is a bare <see cref="AggregateProvider"/> —
+    /// the shape produced by <c>GroupBy</c> on a scalar/tuple key. A caller
+    /// recognising this shape may fuse an additional aggregate into that
+    /// provider's aggregate columns instead of emitting a per-group
+    /// correlated subquery.
+    /// </summary>
+    private bool IsFusableGroupingSource(Expression source)
+    {
+      return source is ParameterExpression groupingParameter
+        && context.Bindings.TryGetValue(groupingParameter, out var groupingProjection)
+        && groupingProjection.ItemProjector.DataSource is AggregateProvider
+        && groupingProjection.ItemProjector.Item.StripMarkers().IsGroupingExpression();
+    }
+
+    /// <summary>
+    /// Builds a <c>x =&gt; predicate(x) ? selector(x) : else</c> lambda used to
+    /// fuse a filtered aggregate into the parent GROUP BY. When
+    /// <paramref name="selector"/> is <see langword="null"/> the selector is
+    /// the constant <c>1</c> (Count-as-Sum rewrite). The ELSE value is
+    /// <c>0</c> for a non-nullable <see cref="AggregateType.Sum"/> selector —
+    /// preserves the LINQ "empty set = 0" contract; substituting NULL would
+    /// leak through as a nullable aggregate result — and <c>NULL</c>
+    /// otherwise (SQL Sum/Min/Max/Avg ignore NULLs, and LINQ's empty-set
+    /// semantics for Min/Max/Avg/nullable-Sum also yield NULL).
+    /// </summary>
+    private static LambdaExpression BuildFusedAggregateSelector(
+      AggregateType targetType, LambdaExpression predicate, LambdaExpression selector)
+    {
+      var param = predicate.Parameters[0];
+      var selectorBody = selector == null
+        ? (Expression) Expression.Constant(1)
+        : ExpressionReplacer.Replace(selector.Body, selector.Parameters[0], param);
+
+      var selectorType = selectorBody.Type;
+      Type caseType;
+      Expression elseValue;
+      if (targetType == AggregateType.Sum && selectorType.IsValueType && !selectorType.IsNullable()) {
+        caseType = selectorType;
+        elseValue = Expression.Constant(System.Activator.CreateInstance(selectorType), selectorType);
+      }
+      else {
+        caseType = selectorType.IsValueType && !selectorType.IsNullable()
+          ? typeof(Nullable<>).MakeGenericType(selectorType)
+          : selectorType;
+        elseValue = Expression.Constant(null, caseType);
+      }
+
+      var thenValue = selectorBody.Type != caseType
+        ? (Expression) Expression.Convert(selectorBody, caseType)
+        : selectorBody;
+
+      return FastExpression.Lambda(
+        Expression.Condition(predicate.Body, thenValue, elseValue), param);
     }
 
     private static void EnsureAggregateIsPossible(Type type, AggregateType aggregateType, Expression visitedExpression)

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -775,8 +775,8 @@ namespace Xtensive.Orm.Linq
       MethodCallExpression expressionPart)
     {
       var aggregateType = ExtractAggregateType(expressionPart);
-      
-      var origin = VisitAggregateSource(source, argument, aggregateType, expressionPart);
+
+      var origin = VisitAggregateSource(source, argument, ref aggregateType, expressionPart);
       var originProjection = origin.Item1;
       var originColumnIndex = origin.Item2;
 
@@ -909,22 +909,41 @@ namespace Xtensive.Orm.Linq
     }
 
     private (ProjectionExpression, ColNum) VisitAggregateSource(Expression source, LambdaExpression aggregateParameter,
-      AggregateType aggregateType, Expression visitedExpression)
+      ref AggregateType aggregateType, Expression visitedExpression)
     {
       // Process any selectors or filters specified via parameter to aggregating method.
-      // This effectively substitutes source.Count(filter) -> source.Where(filter).Count()
-      // and source.Sum(selector) -> source.Select(selector).Sum()
+      // Substitutions applied:
+      //   source.Count(filter)   -> source.Select(filter ? 1 : 0).Sum()
+      //     (only for a grouping-parameter source; enables aggregate fusion)
+      //   source.Count(filter)   -> source.Where(filter).Count()
+      //   source.Sum(selector)   -> source.Select(selector).Sum()
       // If parameterless method is called this method simply processes source.
-      // This method returns project for source expression and index of a column in RSE provider
-      // to which aggregate function should be applied.
+      // Returns source projection and the column index to aggregate over;
+      // aggregateType is updated when the Count->Sum rewrite is applied.
 
       ProjectionExpression sourceProjection;
       ColNum aggregatedColumnIndex;
 
       if (aggregateType == AggregateType.Count) {
-        aggregatedColumnIndex = 0;
-        sourceProjection = aggregateParameter != null ? VisitWhere(source, aggregateParameter) : VisitSequence(source);
-        return (sourceProjection, aggregatedColumnIndex);
+        // Rewrite Count(predicate) over a grouping into Sum(predicate ? 1 : 0)
+        // so the aggregate can fuse with the parent grouping AggregateProvider
+        // instead of being emitted as a per-group correlated subquery.
+        if (aggregateParameter != null
+          && source is ParameterExpression fusableGroupingParameter
+          && context.Bindings.TryGetValue(fusableGroupingParameter, out var fusableGroupingProjection)
+          && fusableGroupingProjection.ItemProjector.DataSource is AggregateProvider
+          && fusableGroupingProjection.ItemProjector.Item.StripMarkers().IsGroupingExpression()) {
+          aggregateParameter = FastExpression.Lambda(
+            Expression.Condition(aggregateParameter.Body, Expression.Constant(1), Expression.Constant(0)),
+            aggregateParameter.Parameters[0]);
+          aggregateType = AggregateType.Sum;
+        }
+        else {
+          aggregatedColumnIndex = 0;
+          sourceProjection = aggregateParameter != null
+            ? VisitWhere(source, aggregateParameter) : VisitSequence(source);
+          return (sourceProjection, aggregatedColumnIndex);
+        }
       }
 
       IReadOnlyList<ColNum> columnList = null;

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Queryable.cs
@@ -776,7 +776,7 @@ namespace Xtensive.Orm.Linq
     {
       var aggregateType = ExtractAggregateType(expressionPart);
 
-      var origin = VisitAggregateSource(source, argument, ref aggregateType, expressionPart);
+      var origin = VisitAggregateSource(ref source, argument, ref aggregateType, expressionPart);
       var originProjection = origin.Item1;
       var originColumnIndex = origin.Item2;
 
@@ -908,23 +908,47 @@ namespace Xtensive.Orm.Linq
       return null;
     }
 
-    private (ProjectionExpression, ColNum) VisitAggregateSource(Expression source, LambdaExpression aggregateParameter,
+    private (ProjectionExpression, ColNum) VisitAggregateSource(ref Expression source, LambdaExpression aggregateParameter,
       ref AggregateType aggregateType, Expression visitedExpression)
     {
       // Process any selectors or filters specified via parameter to aggregating method.
       // Substitutions applied:
+      //   source.Where(f1)...Where(fn)[.Count(f)]   -> source.Count(f1 AND ... AND fn [AND f])
+      //     (peels Where chains so the rewrite below can see the grouping parameter)
       //   source.Count(filter)   -> source.Select(filter ? 1 : 0).Sum()
       //     (only for a grouping-parameter source; enables aggregate fusion)
       //   source.Count(filter)   -> source.Where(filter).Count()
       //   source.Sum(selector)   -> source.Select(selector).Sum()
       // If parameterless method is called this method simply processes source.
       // Returns source projection and the column index to aggregate over;
-      // aggregateType is updated when the Count->Sum rewrite is applied.
+      // source and aggregateType are updated when the Where-peel / Count->Sum
+      // rewrites are applied so the caller sees the post-rewrite shape.
 
       ProjectionExpression sourceProjection;
       ColNum aggregatedColumnIndex;
 
       if (aggregateType == AggregateType.Count) {
+        // Collapse Where chains into a single Count(predicate) so the fusion
+        // rewrite below can match a grouping-parameter source uniformly for
+        // both g.Count(p) and g.Where(p).Count() shapes.
+        while (source is MethodCallExpression whereCall
+          && QueryableVisitor.GetQueryableMethod(whereCall) == QueryableMethodKind.Where
+          && whereCall.Arguments.Count == 2) {
+          var wherePredicate = (LambdaExpression) whereCall.Arguments[1].StripQuotes();
+          if (aggregateParameter == null) {
+            aggregateParameter = wherePredicate;
+          }
+          else {
+            var outerParam = aggregateParameter.Parameters[0];
+            var rebasedBody = ExpressionReplacer.Replace(
+              wherePredicate.Body, wherePredicate.Parameters[0], outerParam);
+            aggregateParameter = FastExpression.Lambda(
+              Expression.AndAlso(rebasedBody, aggregateParameter.Body),
+              outerParam);
+          }
+          source = whereCall.Arguments[0];
+        }
+
         // Rewrite Count(predicate) over a grouping into Sum(predicate ? 1 : 0)
         // so the aggregate can fuse with the parent grouping AggregateProvider
         // instead of being emitted as a per-group correlated subquery.


### PR DESCRIPTION
Eliminates a common "GroupBy N+1" pattern in the LINQ translator where filtered aggregates on a grouping parameter were emitted as per-group correlated subqueries.

### What changes

The translator now rewrites filtered aggregates over a grouping so they fuse into the parent `AggregateProvider` and emit as a single `SELECT ... GROUP BY`:

| LINQ shape | Rewrite |
|---|---|
| `g.Count(p)` | `g.Sum(x => p(x) ? 1 : 0)` |
| `g.Where(p).Count()` | same as above (Where chain peeled first) |
| `g.Where(p).Sum(s)` | `g.Sum(x => p(x) ? s(x) : 0)` |
| `g.Where(p).Min/Max/Avg(s)` | `g.Min/Max/Avg(x => p(x) ? s(x) : null)` |

Non-nullable `Sum` uses `0` in the ELSE branch to preserve LINQ's empty-set=0 contract; `Min/Max/Avg` and nullable `Sum` use `NULL` so SQL's NULL-skipping semantics match LINQ.

### Secondary cleanups

- Peels chained `Where`s in front of a non-fusable aggregate into a single `FilterProvider` (one `WHERE f1 AND ... AND fn` instead of stacked filters).
- Guards the peel against the indexed `Where((x, i) => ...)` overload, whose index binding would silently change if AND-combined.
- Factors the logic into `PeelWhereChain` / `CombinePredicates` / `IsFusableGroupingSource` / `BuildFusedAggregateSelector` helpers shared by `Count` and `Sum/Min/Max/Avg` paths.

### Tests

New e2e fixture `AggregateFusionTest` (17 tests) covers: Count/Where-Count fusion, Sum/Min/Max/Avg fusion, empty-group zero-vs-NULL regressions, root-level Where-chain collapse, and the indexed-Where guard (gated on `ProviderFeatures.RowNumber`). Broader LINQ suites (GroupBy / Aggregate / Subquery / Where / Indexed) showed no regressions locally.