### PR TITLE
Fix regression after upstream merge

### DIFF
--- a/Extensions/Xtensive.Orm.BulkOperations.Tests/ContainsTest.cs
+++ b/Extensions/Xtensive.Orm.BulkOperations.Tests/ContainsTest.cs
@@ -164,5 +164,40 @@ namespace Xtensive.Orm.BulkOperations.Tests
         Assert.That(session.Query.All<TagType>().Count(t => t.ProjectedValueAdjustment == -1 && t.Id > 700), Is.EqualTo(1));
       }
     }
+
+    // Regression: large collections in Bulk Update Contains used to trip the SQL
+    // Server 2100-parameter limit because SqlDml.Variant branches did not share
+    // their TVP binding. Both branches must reuse the same QueryRowFilterParameterBinding.
+    [Test]
+    public void TestManyIdsContains()
+    {
+      using (var session = Domain.OpenSession())
+      using (var tx = session.OpenTransaction()) {
+        var ids = tagIds.Concat(Enumerable.Range(4000, 2200).Select(o => (long) o)).ToArray();
+        var updatedRows = session.Query.All<TagType>()
+          .Where(t => ids.Contains(t.Id))
+          .Set(t => t.ProjectedValueAdjustment, 2)
+          .Update();
+        Assert.That(updatedRows, Is.EqualTo(100));
+        Assert.That(session.Query.All<TagType>().Count(t => t.ProjectedValueAdjustment == 2 && t.Id <= 200), Is.EqualTo(100));
+        Assert.That(session.Query.All<TagType>().Count(t => t.ProjectedValueAdjustment == -1 && t.Id > 700), Is.EqualTo(1));
+      }
+    }
+
+    [Test]
+    public void TestManyGuidsContains()
+    {
+      using (var session = Domain.OpenSession())
+      using (var tx = session.OpenTransaction()) {
+        var ids = guids.Concat(Enumerable.Range(4000, 2200).Select(IntToGuid)).ToArray();
+        var updatedRows = session.Query.All<TagType>()
+          .Where(t => ids.Contains(t.Guid))
+          .Set(t => t.ProjectedValueAdjustment, 2)
+          .Update();
+        Assert.That(updatedRows, Is.EqualTo(100));
+        Assert.That(session.Query.All<TagType>().Count(t => t.ProjectedValueAdjustment == 2 && t.Id <= 200), Is.EqualTo(100));
+        Assert.That(session.Query.All<TagType>().Count(t => t.ProjectedValueAdjustment == -1 && t.Id > 700), Is.EqualTo(1));
+      }
+    }
   }
 }

--- a/Orm/Xtensive.Orm.Tests.Core/Rse/RecordSetHeaderTest.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Rse/RecordSetHeaderTest.cs
@@ -1,0 +1,89 @@
+// Copyright (C) 2026 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xtensive.Orm.Rse;
+using Xtensive.Tuples;
+
+namespace Xtensive.Orm.Tests.Core.Rse
+{
+  /// <summary>
+  /// Regression tests for <see cref="RecordSetHeader"/> ensuring that intermediate
+  /// header construction during query translation does not eagerly trip the
+  /// <c>DO_MAX_1000_COLUMNS</c> guard in <see cref="TupleDescriptor.LazyData"/>.
+  /// The guard must still fire if/when the resulting descriptor's lazy data
+  /// is actually accessed (e.g. at materialization).
+  /// </summary>
+  [TestFixture]
+  public class RecordSetHeaderTest
+  {
+    private static RecordSetHeader CreateHeader(int columnCount, string prefix = "c")
+    {
+      var fieldTypes = new Type[columnCount];
+      var columns = new Column[columnCount];
+      for (var i = 0; i < columnCount; i++) {
+        fieldTypes[i] = typeof(int);
+        columns[i] = new SystemColumn(prefix + i, (ColNum) i, typeof(int));
+      }
+      return new RecordSetHeader(TupleDescriptor.CreateFromNormalized(fieldTypes), columns);
+    }
+
+    [Test]
+    public void Add_DoesNotEagerlyValidateColumnCount()
+    {
+      var header = CreateHeader(1000);
+
+      // Adding a single column would push the resulting descriptor over the
+      // 1000-column threshold. Header construction must succeed lazily.
+      var extended = header.Add(new SystemColumn("extra", 1000, typeof(int)));
+
+      Assert.That(extended.Columns.Count, Is.EqualTo(1001));
+      Assert.That(extended.TupleDescriptor.Count, Is.EqualTo(1001));
+    }
+
+    [Test]
+    public void AddRange_DoesNotEagerlyValidateColumnCount()
+    {
+      var header = CreateHeader(800);
+      var extra = new List<Column>(300);
+      for (var i = 0; i < 300; i++) {
+        extra.Add(new SystemColumn("extra" + i, (ColNum) (800 + i), typeof(int)));
+      }
+
+      var extended = header.Add(extra);
+
+      Assert.That(extended.Columns.Count, Is.EqualTo(1100));
+      Assert.That(extended.TupleDescriptor.Count, Is.EqualTo(1100));
+    }
+
+    [Test]
+    public void Join_DoesNotEagerlyValidateColumnCount()
+    {
+      var left = CreateHeader(700, "l");
+      var right = CreateHeader(700, "r");
+
+      var joined = left.Join(right);
+
+      Assert.That(joined.Columns.Count, Is.EqualTo(1400));
+      Assert.That(joined.TupleDescriptor.Count, Is.EqualTo(1400));
+    }
+
+    [Test]
+    public void OversizedDescriptor_StillThrowsOnLazyDataAccess()
+    {
+      // Building a descriptor with > 1000 fields via the lazy path must succeed,
+      // but accessing the lazy data (e.g. ValuesLength) must surface the guard.
+      var fieldTypes = new Type[1500];
+      for (var i = 0; i < fieldTypes.Length; i++) {
+        fieldTypes[i] = typeof(int);
+      }
+      var descriptor = TupleDescriptor.CreateFromNormalized(fieldTypes);
+
+      Assert.That(descriptor.Count, Is.EqualTo(1500));
+      Assert.Throws<NotSupportedException>(() => _ = descriptor.ValuesLength);
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Include.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Include.cs
@@ -91,8 +91,9 @@ namespace Xtensive.Orm.Providers
       IncludeProvider provider, IReadOnlyList<TypeMapping> mappings, Func<ParameterContext, object> valueAccessor,
       IReadOnlyList<SqlExpression> sourceColumns, QueryParameterBinding binding = null)
     {
-      var filterTupleDescriptor = provider.FilteredTupleDescriptor;
-      binding = new QueryRowFilterParameterBinding(mappings, valueAccessor, null, false);
+      // In the Auto+TVP path both SqlDml.Variant branches must share the TVP binding
+      // so CommandFactory can switch to a single table-valued parameter at runtime.
+      binding ??= new QueryRowFilterParameterBinding(mappings, valueAccessor, null, false);
       return (SqlDml.DynamicFilter(binding, provider.FilteredColumns.Select(index => sourceColumns[index]).ToArray()), binding);
     }
 

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -132,8 +132,6 @@ namespace Xtensive.Orm.Rse
         newColumns[j++] = c.Clone((ColNum) (columnCount + c.Index));
       }
 
-      var newTupleDescriptor = CreateTupleDescriptor(newColumns);
-
       var columnGroupCount = ColumnGroups.Count;
       var groups = new ColumnGroup[columnGroupCount + joined.ColumnGroups.Count];
       j = 0;

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -267,7 +267,7 @@ namespace Xtensive.Orm.Rse
       for (var i = 0; i < n; i++) {
         newFieldTypes[i] = newColumns[i].Type;
       }
-      return TupleDescriptor.Create(newFieldTypes);
+      return TupleDescriptor.CreateFromNormalized(newFieldTypes);
     }
 
     /// <inheritdoc/>

--- a/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
+++ b/Orm/Xtensive.Orm/Orm/Rse/RecordSetHeader.cs
@@ -267,7 +267,7 @@ namespace Xtensive.Orm.Rse
       for (var i = 0; i < n; i++) {
         newFieldTypes[i] = newColumns[i].Type;
       }
-      return TupleDescriptor.CreateFromNormalized(newFieldTypes);
+      return TupleDescriptor.Create(newFieldTypes);
     }
 
     /// <inheritdoc/>

--- a/Orm/Xtensive.Orm/Tuples/TupleDescriptor.cs
+++ b/Orm/Xtensive.Orm/Tuples/TupleDescriptor.cs
@@ -337,27 +337,15 @@ namespace Xtensive.Tuples
 
     private TupleDescriptor(Type[] fieldTypes)
     {
-      var fieldCount = fieldTypes.Length;
       FieldTypes = fieldTypes;
-
-      switch (fieldCount) {
-        case 0:
-          Data.ValuesLength = 0;
-          Data.ObjectsLength = 0;
-          return;
-        case 1:
-          TupleLayout.ConfigureLen1(ref FieldTypes[0],
-            ref FieldDescriptors[0],
-            out Data.ValuesLength, out Data.ObjectsLength);
-          break;
-        case 2:
-          TupleLayout.ConfigureLen2(FieldTypes,
-            ref FieldDescriptors[0], ref FieldDescriptors[1],
-            out Data.ValuesLength, out Data.ObjectsLength);
-          break;
-        default:
-          TupleLayout.Configure(FieldTypes, FieldDescriptors, out Data.ValuesLength, out Data.ObjectsLength);
-          break;
+      // Eagerly normalize field types in place (Nullable<T> -> T, enum -> underlying, ...)
+      // so FieldTypes is canonical at construction. Heavy packed-layout configuration
+      // (and the DO_MAX_1000_COLUMNS guard) is deferred to LazyData materialization.
+      for (int i = 0, n = fieldTypes.Length; i < n; ++i) {
+        ref var fieldType = ref fieldTypes[i];
+        if (TupleLayout.ValueFieldAccessorResolver.GetValue(fieldType) is { } valueAccessor) {
+          fieldType = valueAccessor.FieldType;
+        }
       }
     }
 

--- a/Version.props
+++ b/Version.props
@@ -3,7 +3,7 @@
 
 <PropertyGroup>
     <DoVersion>7.3.18</DoVersion>
-    <DoVersionSuffix>servicetitan-upstream-fix-2</DoVersionSuffix>
+    <DoVersionSuffix>servicetitan-upstream-fix-3</DoVersionSuffix>
 </PropertyGroup>
 
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -3,7 +3,7 @@
 
 <PropertyGroup>
     <DoVersion>7.3.18</DoVersion>
-    <DoVersionSuffix>servicetitan</DoVersionSuffix>
+    <DoVersionSuffix>servicetitan-upstream-fix</DoVersionSuffix>
 </PropertyGroup>
 
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -3,7 +3,7 @@
 
 <PropertyGroup>
     <DoVersion>7.3.18</DoVersion>
-    <DoVersionSuffix>servicetitan-upstream-fix</DoVersionSuffix>
+    <DoVersionSuffix>servicetitan-upstream-fix-2</DoVersionSuffix>
 </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
- Fix `QueryTranslationException` from `RecordSetHeader.Join` dead code.
- Fix SQL 2100-parameter limit in Bulk Update with large `Contains`.
- Fix botched merge of TupleDescriptor single-arg ctor in PR #481

Remove an unused `CreateTupleDescriptor(newColumns)` call in `RecordSetHeader.Join`. 

After upstream PR https://github.com/servicetitan/dataobjects-net/pull/248 changed the return statement to use the lazy two-arg `TupleDescriptor(a, b)` constructor, the local `newTupleDescriptor` became dead code. Combined with the later move of the >1000-column guard into `LazyData` (PR https://github.com/servicetitan/dataobjects-net/pull/204), this dead call eagerly tripped `NotSupportedException` during translation of complex queries whose transient joined headers exceed 1000 columns, even when the materialized recordset (after column pruning) would not.

Restore PR #204's lazy normalize-only body. The upstream merge kept the eager switch+Configure block but routed writes through the lazy `Data` property, forcing `LazyData` materialization (and the DO_MAX_1000_COLUMNS guard) at construction time. Deferring layout to `LazyData` removes the eager 1000-column trip during query translation and obviates the `RecordSetHeader.Add` workaround.

Add `Xtensive.Orm.Tests.Core/Rse/RecordSetHeaderTest.cs` with regression tests covering both `Add` overloads, `Join`, and the preserved runtime guard via `LazyData` access.