### PR TITLE
Optimize `ExpressionMaterializer.CreateEntity()`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
@@ -6,6 +6,7 @@
 
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using Xtensive.Core;
 using Xtensive.Linq;
 using Xtensive.Orm.Internals;
@@ -384,9 +385,9 @@ namespace Xtensive.Orm.Linq.Materialization
     /// <exception cref="InvalidOperationException">Unable to materialize Entity.</exception>
     private Expression CreateEntity(IEntityExpression expression, Expression tupleExpression)
     {
-      if (!entityRegistry.TryGetValue(expression, out var index)) {
-        index = entityRegistry.Count;
-        entityRegistry.Add(expression, index);
+      ref var index = ref CollectionsMarshal.GetValueRefOrAddDefault(entityRegistry, expression, out var exists);
+      if (!exists) {
+        index = entityRegistry.Count - 1;
       }
 
       if (itemMaterializationContextParameter==null)

--- a/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Materialization/ExpressionMaterializer.cs
@@ -385,10 +385,8 @@ namespace Xtensive.Orm.Linq.Materialization
     /// <exception cref="InvalidOperationException">Unable to materialize Entity.</exception>
     private Expression CreateEntity(IEntityExpression expression, Expression tupleExpression)
     {
-      ref var index = ref CollectionsMarshal.GetValueRefOrAddDefault(entityRegistry, expression, out var exists);
-      if (!exists) {
-        index = entityRegistry.Count - 1;
-      }
+      ref var indexRef = ref CollectionsMarshal.GetValueRefOrAddDefault(entityRegistry, expression, out var exists);
+      var index = exists ? indexRef : (indexRef = entityRegistry.Count - 1);
 
       if (itemMaterializationContextParameter==null)
         throw new InvalidOperationException(


### PR DESCRIPTION
Avoid double Dictionary lookup