### PR TITLE
Deduplicate SQL query parameters across expression processors

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Storage/QueryParameterDeduplicationTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/QueryParameterDeduplicationTest.cs
@@ -1,0 +1,355 @@
+// Copyright (C) 2026 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using Xtensive.Orm.Configuration;
+using Xtensive.Orm.Providers;
+using Xtensive.Orm.Tests.Storage.ClosureParametersCachingTestModel;
+
+namespace Xtensive.Orm.Tests.Storage
+{
+  [TestFixture]
+  public class QueryParameterDeduplicationTest : AutoBuildTest
+  {
+    protected override DomainConfiguration BuildConfiguration()
+    {
+      var configuration = base.BuildConfiguration();
+      configuration.Types.RegisterCaching(typeof(Invoice).Assembly, typeof(Invoice).Namespace);
+      configuration.UpgradeMode = DomainUpgradeMode.Recreate;
+      return configuration;
+    }
+
+    protected override void PopulateData()
+    {
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+      _ = new PaymentSplit {
+        Active = true,
+        Payment = new Payment { Active = true },
+        Invoice = new Invoice(),
+        Order = 5,
+        Amount = 10m
+      };
+      tx.Complete();
+    }
+
+    [Test]
+    public void ClosureParameterReferencedMultipleTimesInQueryIsBoundOnce()
+    {
+      // `threshold` is referenced in two separate Where clauses, each compiled by its own ExpressionProcessor.
+      // Without cross-processor dedup the same int value would appear as two DB parameters.
+      var threshold = 1;
+      AssertNoDuplicateParameterValues(session => {
+        _ = session.Query.All<PaymentSplit>()
+          .Where(split => split.Order > threshold)
+          .Where(split => split.Order >= threshold)
+          .ToList();
+      }, parameter => parameter.Value is int intValue && intValue == threshold, minSqlReferences: 2);
+    }
+
+    [Test]
+    public void TypeIdReferencedInBothUnionBranchesIsBoundOnce()
+    {
+      // Each branch filters PaymentSplit independently; TypeId should still be a single binding.
+      AssertNoDuplicateParameterValues(session => {
+        _ = session.Query.All<PaymentSplit>()
+          .Where(split => split.Order > 10)
+          .Union(session.Query.All<PaymentSplit>().Where(split => split.Order < 0))
+          .ToList();
+      }, parameter => parameter.Value is int intValue && intValue == GetPaymentSplitTypeId(), minSqlReferences: 2);
+    }
+
+    [Test]
+    public void SmallRowFilterArrayReferencedInFilterAndProjectionIsBoundOncePerValue()
+    {
+      // `orders` is used in Where and again in Select; each distinct order value must appear once.
+      var orders = new[] { 5, 7, 9 };
+      AssertNoDuplicateParameterValues(session => {
+        _ = session.Query.All<PaymentSplit>()
+          .Where(split => orders.Contains(split.Order))
+          .Select(split => new {
+            split.Id,
+            InFilter = orders.Contains(split.Order),
+            StillInFilter = orders.Contains(split.Order)
+          })
+          .ToList();
+      }, parameter => parameter.Value is int intValue && orders.Contains(intValue), minSqlReferences: 2);
+    }
+
+    [Test]
+    public void SmallRowFilterArrayReferencedInBothUnionBranchesIsBoundOncePerValue()
+    {
+      // The same `orders` closure is evaluated in both sides of Union.
+      var orders = new[] { 5, 7 };
+      AssertNoDuplicateParameterValues(session => {
+        _ = session.Query.All<PaymentSplit>()
+          .Where(split => orders.Contains(split.Order))
+          .Union(session.Query.All<PaymentSplit>().Where(split => orders.Contains(split.Order)))
+          .ToList();
+      }, parameter => parameter.Value is int intValue && orders.Contains(intValue), minSqlReferences: 2);
+    }
+
+    [Test]
+    public void LargeRowFilterCollectionReferencedMultipleTimesUsesDistinctParameterValues()
+    {
+      Require.AllFeaturesSupported(ProviderFeatures.TableValuedParameters);
+
+      // One large Contains list used in two Where clauses. With TVP dedup a single @tvp parameter is
+      // created and referenced twice in the SQL. Without dedup two separate TVP parameters appear,
+      // each referenced once. ParameterValueComparer cannot compare DataTable/SqlDataRecord values
+      // reliably, so we instead verify that some parameter is referenced more than once in the SQL text.
+      var orders = Enumerable.Range(1, Domain.Configuration.MaxNumberOfConditions + 50).ToArray();
+      ExecuteQuery(session => {
+        _ = session.Query.All<PaymentSplit>()
+          .Where(split => orders.Contains(split.Order))
+          .Where(split => orders.Contains(split.Order))
+          .ToList();
+      }, (_, command) => AssertSomeParameterReferencedMoreThanOnce(command));
+    }
+
+    [Test]
+    public void ExplicitTvpAlgorithmReferencedMultipleTimesUsesDistinctParameterValues()
+    {
+      Require.AllFeaturesSupported(ProviderFeatures.TableValuedParameters);
+
+      // Same dedup check via SQL reference count (see LargeRowFilter test above).
+      var orders = new[] { 5, 7, 9 };
+      ExecuteQuery(session => {
+        _ = session.Query.All<PaymentSplit>()
+          .Where(split => split.Order.In(IncludeAlgorithm.TableValuedParameter, orders))
+          .Where(split => split.Order.In(IncludeAlgorithm.TableValuedParameter, orders))
+          .ToList();
+      }, (_, command) => AssertSomeParameterReferencedMoreThanOnce(command));
+    }
+
+    [Test]
+    public void BooleanClosureReferencedMultipleTimesIsNotBoundAsDbParameter()
+    {
+      // BooleanConstant bindings are expanded in SQL; the bool value must not appear in Parameters at all.
+      var isActive = true;
+      var boolParameterCount = 0;
+
+      ExecuteQuery(session => {
+        _ = session.Query.All<PaymentSplit>()
+          .Where(split => split.Active == isActive && split.Payment.Active == isActive)
+          .Select(split => new {
+            split.Id,
+            Flag = split.Active == isActive,
+            PaymentFlag = split.Payment.Active == isActive
+          })
+          .ToList();
+      }, (_, command) => {
+        foreach (DbParameter parameter in command.Parameters) {
+          if (parameter.Value is bool) {
+            boolParameterCount++;
+          }
+        }
+
+        AssertEachParameterValueAppearsOnce(command);
+      });
+
+      Assert.That(boolParameterCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void DecimalClosureReferencedInFilterAndProjectionIsBoundOnce()
+    {
+      // `amountFilter` is referenced in two separate Where clauses compiled by distinct ExpressionProcessors.
+      // Both use >= so they produce the same Regular binding type and are genuinely deduplicable.
+      // (== would produce SmartNull bindings which are intentionally kept separate from Regular ones.)
+      decimal amountFilter = 10m;
+      AssertNoDuplicateParameterValues(session => {
+        _ = session.Query.All<PaymentSplit>()
+          .Where(split => split.Amount >= amountFilter)
+          .Where(split => split.Amount >= amountFilter)
+          .ToList();
+      }, parameter => parameter.Value is decimal decimalValue && decimalValue == amountFilter, minSqlReferences: 2);
+    }
+
+    [Test]
+    public void TakeClosureReferencedInFilterAndPagingUsesDistinctParameterValues()
+    {
+      // `limit` is a closure in Where (Regular) and in Take (LimitOffset, inlined as a literal).
+      var limit = 10;
+      var limitParameterCount = 0;
+      var literalOccurrences = 0;
+
+      ExecuteQuery(session => {
+        _ = session.Query.All<PaymentSplit>()
+          .Where(split => split.Order < limit)
+          .Where(split => split.Order <= limit)
+          .Take(limit)
+          .ToList();
+      }, (_, command) => {
+        foreach (DbParameter parameter in command.Parameters) {
+          if (parameter.Value is int intValue && intValue == limit) {
+            limitParameterCount++;
+          }
+        }
+
+        literalOccurrences = Regex.Matches(command.CommandText, $@"(?<!\w){limit}(?!\w)").Count;
+        AssertEachParameterValueAppearsOnce(command);
+      });
+
+      Assert.That(limitParameterCount, Is.EqualTo(1));
+      Assert.That(literalOccurrences, Is.GreaterThanOrEqualTo(1));
+    }
+
+    [Test]
+    public void DistinctClosureValuesRemainSeparateParameters()
+    {
+      // Guard against over-deduplication: two different values must stay two parameters.
+      var low = 100001;
+      var high = 200002;
+      ExecuteQuery(session => {
+        _ = session.Query.All<PaymentSplit>()
+          .Where(split => split.Order > low && split.Order < high)
+          .ToList();
+      }, (_, command) => {
+        AssertEachParameterValueAppearsOnce(command);
+
+        var parameters = command.Parameters.Cast<DbParameter>().ToArray();
+        Assert.That(parameters.Count(p => p.Value is int value && value == low), Is.EqualTo(1));
+        Assert.That(parameters.Count(p => p.Value is int value && value == high), Is.EqualTo(1));
+      });
+    }
+
+    private int GetPaymentSplitTypeId() =>
+      Domain.StorageNodeManager
+        .GetNode(WellKnown.DefaultNodeId)
+        .TypeIdRegistry[Domain.Model.Types[typeof(PaymentSplit)]];
+
+    private void AssertNoDuplicateParameterValues(
+      Action<Session> query,
+      Func<DbParameter, bool> relevantParameter = null,
+      int? minSqlReferences = null)
+    {
+      ExecuteQuery(query, (_, command) => {
+        AssertEachParameterValueAppearsOnce(command);
+
+        if (relevantParameter == null || minSqlReferences == null) {
+          return;
+        }
+
+        var matchingParameters = command.Parameters.Cast<DbParameter>().Where(relevantParameter).ToArray();
+        Assert.That(matchingParameters, Is.Not.Empty, "Expected at least one matching parameter.");
+
+        var sqlReferenceCount = matchingParameters
+          .Select(parameter => CountSqlReferences(command, parameter.ParameterName))
+          .Sum();
+
+        Assert.That(sqlReferenceCount, Is.GreaterThanOrEqualTo(minSqlReferences.Value),
+          "Expected the bound parameter to be referenced multiple times in SQL.");
+      });
+    }
+
+    private static void AssertEachParameterValueAppearsOnce(DbCommand command)
+    {
+      var duplicates = command.Parameters
+        .Cast<DbParameter>()
+        .Select(parameter => parameter.Value ?? DBNull.Value)
+        .GroupBy(value => value, ParameterValueComparer.Instance)
+        .Where(group => group.Count() > 1)
+        .Select(group => $"{FormatParameterValue(group.Key)} x{group.Count()}")
+        .ToArray();
+
+      Assert.That(duplicates, Is.Empty,
+        $"Each parameter value must be bound exactly once per query. Duplicates: {string.Join(", ", duplicates)}");
+    }
+
+    private static void AssertSomeParameterReferencedMoreThanOnce(DbCommand command)
+    {
+      var anyShared = command.Parameters
+        .Cast<DbParameter>()
+        .Any(p => CountSqlReferences(command, p.ParameterName) > 1);
+      Assert.That(anyShared, Is.True,
+        "Expected dedup: at least one parameter should be referenced more than once in SQL, "
+        + $"but each of the {command.Parameters.Count} parameter(s) appears exactly once. "
+        + "Command text: " + command.CommandText);
+    }
+
+    private static int CountSqlReferences(DbCommand command, string parameterName)
+    {
+      var reference = parameterName.StartsWith('@') ? parameterName : $"@{parameterName}";
+      return Regex.Matches(command.CommandText, Regex.Escape(reference), RegexOptions.IgnoreCase).Count;
+    }
+
+    private static string FormatParameterValue(object value) =>
+      value switch {
+        DBNull => "<null>",
+        IEnumerable enumerable and not string => $"[{string.Join(", ", enumerable.Cast<object>())}]",
+        _ => value.ToString()
+      };
+
+    private void ExecuteQuery(Action<Session> query, Action<Session, DbCommand> inspectCommand)
+    {
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+
+      void OnDbCommandExecuting(object sender, DbCommandEventArgs args)
+      {
+        inspectCommand(session, args.Command);
+      }
+
+      session.Events.DbCommandExecuting += OnDbCommandExecuting;
+      try {
+        query(session);
+      }
+      finally {
+        session.Events.DbCommandExecuting -= OnDbCommandExecuting;
+      }
+    }
+
+    private sealed class ParameterValueComparer : IEqualityComparer<object>
+    {
+      public static ParameterValueComparer Instance { get; } = new();
+
+      public new bool Equals(object x, object y)
+      {
+        if (ReferenceEquals(x, y)) {
+          return true;
+        }
+
+        if (x is null || y is null || x is DBNull || y is DBNull) {
+          return false;
+        }
+
+        if (x.GetType() != y.GetType()) {
+          return false;
+        }
+
+        if (x is IEnumerable enumerableX && x is not string) {
+          return y is IEnumerable enumerableY
+            && enumerableX.Cast<object>().SequenceEqual(enumerableY.Cast<object>());
+        }
+
+        return x.Equals(y);
+      }
+
+      public int GetHashCode(object obj)
+      {
+        if (obj is null || obj is DBNull) {
+          return 0;
+        }
+
+        if (obj is IEnumerable enumerable && obj is not string) {
+          var hash = new HashCode();
+          foreach (var item in enumerable.Cast<object>()) {
+            hash.Add(item);
+          }
+
+          return hash.ToHashCode();
+        }
+
+        return obj.GetHashCode();
+      }
+    }
+  }
+}

--- a/Orm/Xtensive.Orm.Tests/Storage/TypeIdAsParameterTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/TypeIdAsParameterTest.cs
@@ -198,7 +198,8 @@ namespace Xtensive.Orm.Tests.Storage
           throw new AssertionException("Not all TypeId mentions were replaced");
         }
 
-        Assert.That(command.Parameters.Count, Is.EqualTo(4));
+        // Three implementors share one binding per distinct TypeId (no duplicate parameters).
+        Assert.That(command.Parameters.Count, Is.EqualTo(3));
         Assert.That(
           command.Parameters.Cast<DbParameter>()
             .Select(p => (int) p.Value)

--- a/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/CommandFactory.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/CommandProcessing/CommandFactory.cs
@@ -110,6 +110,8 @@ namespace Xtensive.Orm.Providers
           : new SqlPostCompilerConfiguration();
       ;
       var result = new CommandPart(null, new(), new());
+      var scalarFilterResults = new Dictionary<ScalarFilterKey, string[][]>();
+      var tvpParameterReferences = new Dictionary<TvpParameterKey, string>();
 
       foreach (var binding in request.ParameterBindings) {
         object parameterValue = GetParameterValue(binding, parameterContext);
@@ -152,31 +154,39 @@ namespace Xtensive.Orm.Providers
             }
             else if (rowFilterParameterBinding.TvpTypeMapping != null
                 && (rowFilterParameterBinding.EnforceTvp || filterData.Count > Session.Domain.Configuration.MaxNumberOfConditions)) {
-              configuration.AlternativeBranches.Add(binding);
-              string paramName = GetParameterName(parameterNamePrefix, ref parameterIndex);
-              var parameterReference = Driver.BuildParameterReference(paramName);
+              _ = configuration.AlternativeBranches.Add(binding);
+              var tvpKey = new TvpParameterKey(rowFilterParameterBinding.TvpTypeMapping, filterData);
+              if (!tvpParameterReferences.TryGetValue(tvpKey, out var parameterReference)) {
+                var paramName = GetParameterName(parameterNamePrefix, ref parameterIndex);
+                parameterReference = Driver.BuildParameterReference(paramName);
+                var parameter = Connection.CreateParameter();
+                parameter.ParameterName = paramName;
+                rowFilterParameterBinding.TvpTypeMapping.BindValue(parameter, parameterValue);
+                result.Parameters.Add(parameter);
+                tvpParameterReferences.Add(tvpKey, parameterReference);
+              }
+
               configuration.PlaceholderValues.Add(binding, parameterReference);
-              var parameter = Connection.CreateParameter();
-              parameter.ParameterName = paramName;
-              rowFilterParameterBinding.TvpTypeMapping.BindValue(parameter, parameterValue);
-              result.Parameters.Add(parameter);
               var filterValues = new string[1][] { [parameterReference] };
               configuration.DynamicFilterValues.Add(binding, filterValues);
             }
             else {
-              var commonPrefix = GetParameterName(parameterNamePrefix, ref parameterIndex);
-              var filterValues = new string[filterData.Count][];
-              var rowTypeMapping = rowFilterParameterBinding.RowTypeMapping;
-              for (int tupleIndex = 0; tupleIndex < filterData.Count; tupleIndex++) {
-                var tuple = filterData[tupleIndex];
-                var parameterReferences = new string[tuple.Count];
-                for (int fieldIndex = 0; fieldIndex < tuple.Count; fieldIndex++) {
-                  var name = $"{commonPrefix}_{tupleIndex.ToString("G")}_{fieldIndex.ToString("G")}";
-                  var value = tuple.GetValueOrDefault(fieldIndex);
-                  parameterReferences[fieldIndex] = Driver.BuildParameterReference(name);
-                  AddRegularParameter(result, rowTypeMapping[fieldIndex], name, value);
+              var scalarKey = new ScalarFilterKey(rowFilterParameterBinding.RowTypeMapping, filterData);
+              if (!scalarFilterResults.TryGetValue(scalarKey, out var filterValues)) {
+                var commonPrefix = GetParameterName(parameterNamePrefix, ref parameterIndex);
+                filterValues = new string[filterData.Count][];
+                var rowTypeMapping = rowFilterParameterBinding.RowTypeMapping;
+                for (var tupleIndex = 0; tupleIndex < filterData.Count; tupleIndex++) {
+                  var tuple = filterData[tupleIndex];
+                  var parameterReferences = new string[tuple.Count];
+                  for (var fieldIndex = 0; fieldIndex < tuple.Count; fieldIndex++) {
+                    var name = $"{commonPrefix}_{tupleIndex:G}_{fieldIndex:G}";
+                    AddRegularParameter(result, rowTypeMapping[fieldIndex], name, tuple.GetValueOrDefault(fieldIndex));
+                    parameterReferences[fieldIndex] = Driver.BuildParameterReference(name);
+                  }
+                  filterValues[tupleIndex] = parameterReferences;
                 }
-                filterValues[tupleIndex] = parameterReferences;
+                scalarFilterResults.Add(scalarKey, filterValues);
               }
               configuration.DynamicFilterValues.Add(binding, filterValues);
             }
@@ -297,9 +307,94 @@ namespace Xtensive.Orm.Providers
     
     private string GetParameterName(in string prefix, ref int index)
     {
-      var result = $"{prefix}{index.ToString("G")}"; //leave ToString(). it is faster
+      var result = $"{prefix}{index:G}"; //leave ToString(). it is faster
       index++;
       return result;
+    }
+
+    // Identifies a scalar row-filter parameter set by its field type mappings and the sequence of values,
+    // so two row filters referencing the same local collection share one set of scalar parameters.
+    private sealed class ScalarFilterKey(IReadOnlyList<TypeMapping> rowTypeMapping, List<Tuple> filterData) : IEquatable<ScalarFilterKey>
+    {
+      private readonly IReadOnlyList<TypeMapping> rowTypeMapping = rowTypeMapping;
+      private readonly List<Tuple> filterData = filterData;
+      private int hashCode;
+
+      public bool Equals(ScalarFilterKey other)
+      {
+        if (other == null || filterData.Count != other.filterData.Count
+            || rowTypeMapping.Count != other.rowTypeMapping.Count) {
+          return false;
+        }
+        for (var i = 0; i < rowTypeMapping.Count; i++) {
+          if (!ReferenceEquals(rowTypeMapping[i], other.rowTypeMapping[i])) {
+            return false;
+          }
+        }
+        for (var i = 0; i < filterData.Count; i++) {
+          if (!filterData[i].Equals(other.filterData[i])) {
+            return false;
+          }
+        }
+        return true;
+      }
+
+      public override bool Equals(object obj) => Equals(obj as ScalarFilterKey);
+
+      public override int GetHashCode()
+      {
+        if (hashCode != 0) {
+          return hashCode;
+        }
+        var hash = new HashCode();
+        foreach (var m in rowTypeMapping) {
+          hash.Add(m);
+        }
+        foreach (var tuple in filterData) {
+          hash.Add(tuple.GetHashCode());
+        }
+        return hashCode = hash.ToHashCode();
+      }
+    }
+
+    // Identifies a table-valued parameter by its type mapping and the sequence of values it carries,
+    // so two row filters referencing the same local collection share a single TVP parameter.
+    private sealed class TvpParameterKey(TypeMapping mapping, List<Tuple> filterData) : IEquatable<TvpParameterKey>
+    {
+      private readonly TypeMapping mapping = mapping;
+      private readonly List<Tuple> filterData = filterData;
+      private int hashCode;
+
+      public bool Equals(TvpParameterKey other)
+      {
+        if (other == null || !ReferenceEquals(mapping, other.mapping)
+            || filterData.Count != other.filterData.Count) {
+          return false;
+        }
+
+        for (var i = 0; i < filterData.Count; i++) {
+          if (!filterData[i].Equals(other.filterData[i])) {
+            return false;
+          }
+        }
+
+        return true;
+      }
+
+      public override bool Equals(object obj) => Equals(obj as TvpParameterKey);
+
+      public override int GetHashCode()
+      {
+        if (hashCode != 0) {
+          return hashCode;
+        }
+        var hash = new HashCode();
+        hash.Add(mapping);
+        foreach (var tuple in filterData) {
+          hash.Add(tuple.GetHashCode());
+        }
+        return hashCode = hash.ToHashCode();
+      }
     }
 
     // Constructors

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.Helpers.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.Helpers.cs
@@ -325,20 +325,18 @@ namespace Xtensive.Orm.Providers
     private QueryParameterBinding RegisterParameterBinding(TypeMapping mapping,
       Expression<Func<ParameterContext, object>> accessor, QueryParameterBindingType bindingType)
     {
-      QueryParameterBinding result;
       var identity = GetParameterIdentity(mapping, accessor, bindingType);
 
+      QueryParameterBinding result;
       if (identity == null) {
         result = new QueryParameterBinding(mapping, accessor.CachingCompile(), bindingType);
-        otherBindings.Add(result);
-        return result;
+      }
+      else if (!bindingsWithIdentity.TryGetValue(identity.Value, out result)) {
+        result = new QueryParameterBinding(mapping, accessor.CachingCompile(), bindingType);
+        bindingsWithIdentity.Add(identity.Value, result);
       }
 
-      if (bindingsWithIdentity.TryGetValue(identity.Value, out result))
-        return result;
-
-      result = new QueryParameterBinding(mapping, accessor.CachingCompile(), bindingType);
-      bindingsWithIdentity.Add(identity.Value, result);
+      _ = usedBindings.Add(result);
       return result;
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Expressions/ExpressionProcessor.cs
@@ -50,8 +50,8 @@ namespace Xtensive.Orm.Providers
 
     private readonly List<ParameterExpression> activeParameters = new();
     private readonly Dictionary<ParameterExpression, IReadOnlyList<SqlExpression>> sourceMapping = new();
-    private readonly Dictionary<QueryParameterIdentity, QueryParameterBinding> bindingsWithIdentity = new();
-    private readonly List<QueryParameterBinding> otherBindings = new();
+    private readonly Dictionary<QueryParameterIdentity, QueryParameterBinding> bindingsWithIdentity;
+    private readonly HashSet<QueryParameterBinding> usedBindings = new();
 
     private bool executed;
 
@@ -75,7 +75,7 @@ namespace Xtensive.Orm.Providers
 
     public IEnumerable<QueryParameterBinding> GetBindings()
     {
-      return bindingsWithIdentity.Values.Concat(otherBindings);
+      return usedBindings;
     }
 
     protected override SqlExpression Visit(Expression e)
@@ -530,6 +530,8 @@ namespace Xtensive.Orm.Providers
       this.compiler = compiler; // This might be null, check before use!
       this.lambda = lambda;
       this.sourceColumns = sourceColumns;
+      // Share the dedup table across the whole compilation so equal parameters bind once per query.
+      bindingsWithIdentity = compiler?.BindingsWithIdentity ?? new();
 
       providerInfo = handlers.ProviderInfo;
       driver = handlers.StorageDriver;

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Index.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.Index.cs
@@ -19,6 +19,7 @@ namespace Xtensive.Orm.Providers
     protected record struct QueryAndBindings(SqlSelect Query, List<QueryParameterBinding> Bindings);
 
     private TypeMapping int32TypeMapping;
+    private readonly Dictionary<int, QueryTypeIdentifierParameterBinding> typeIdBindings = new();
 
     /// <inheritdoc/>
     internal protected override SqlProvider VisitIndex(IndexProvider provider)
@@ -330,7 +331,13 @@ namespace Xtensive.Orm.Providers
         : fieldValue;
     }
 
-    private QueryParameterBinding CreateTypeIdentifierBinding(TypeInfo type) =>
-      new QueryTypeIdentifierParameterBinding(type.TypeId, int32TypeMapping ??= Driver.GetTypeMapping(WellKnownTypes.Int32));
+    private QueryParameterBinding CreateTypeIdentifierBinding(TypeInfo type)
+    {
+      if (!typeIdBindings.TryGetValue(type.TypeId, out var binding)) {
+        binding = new QueryTypeIdentifierParameterBinding(type.TypeId, int32TypeMapping ??= Driver.GetTypeMapping(WellKnownTypes.Int32));
+        typeIdBindings.Add(type.TypeId, binding);
+      }
+      return binding;
+    }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlCompiler.cs
@@ -34,6 +34,11 @@ namespace Xtensive.Orm.Providers
     private bool anyTemporaryTablesRequired;
 
     /// <summary>
+    /// Deduplicates closure-based parameter bindings across all expression processors of this compilation.
+    /// </summary>
+    internal Dictionary<QueryParameterIdentity, QueryParameterBinding> BindingsWithIdentity { get; } = new();
+
+    /// <summary>
     /// Gets model mapping.
     /// </summary>
     protected ModelMapping Mapping { get; private set; }

--- a/Version.props
+++ b/Version.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.3.21</DoVersion>
+    <DoVersion>7.3.22</DoVersion>
     <DoVersionSuffix>servicetitan</DoVersionSuffix>
 </PropertyGroup>
 


### PR DESCRIPTION
When the same closure variable or row-filter collection is referenced multiple times in a single query (e.g. two `.Where()` clauses, both sides of a `Union`, or a `Where` + `Select`), the ORM previously emitted one DB parameter per reference. After this change each unique value is bound exactly once per compiled query.

## Summary

- **Scalar/TypeId bindings**: widens the `bindingsWithIdentity` dedup table from per-`ExpressionProcessor` to per-`SqlCompiler`, so all processors in one compilation share it. TypeId bindings are cached by `TypeId` in a new `typeIdBindings` dictionary on `SqlCompiler`.
- **Row-filter scalar bindings** (ComplexCondition / Auto+TempTable path): adds a `ScalarFilterKey(TypeMapping[], List<Tuple>)` dictionary in `CommandFactory.CreateQueryPart` that caches the full `filterValues[][]` result per unique filter list, mirroring the existing TVP dedup pattern.
- **TVP bindings**: adds a `TvpParameterKey(TypeMapping, List<Tuple>)` dictionary in `CommandFactory.CreateQueryPart` so two row filters referencing the same collection share a single TVP parameter.

## Test plan

- [x] `ClosureParameterReferencedMultipleTimesInQueryIsBoundOnce` — same int closure in two `Where` clauses shares one parameter
- [x] `TypeIdReferencedInBothUnionBranchesIsBoundOnce` — TypeId parameter shared across Union branches
- [x] `SmallRowFilterArrayReferencedInFilterAndProjectionIsBoundOncePerValue` — small `Contains` list deduped across `Where` + `Select`
- [x] `SmallRowFilterArrayReferencedInBothUnionBranchesIsBoundOncePerValue` — same array in both Union branches
- [x] `LargeRowFilterCollectionReferencedMultipleTimesUsesDistinctParameterValues` — large list (TVP) referenced twice shares one TVP parameter
- [x] `ExplicitTvpAlgorithmReferencedMultipleTimesUsesDistinctParameterValues` — explicit TVP algorithm shares one parameter
- [x] `BooleanClosureReferencedMultipleTimesIsNotBoundAsDbParameter` — boolean closures expand to SQL constants, not DB params
- [x] `DecimalClosureReferencedInFilterAndProjectionIsBoundOnce` — decimal closure in two `Where` clauses shares one parameter
- [x] `TakeClosureReferencedInFilterAndPagingUsesDistinctParameterValues` — same int used in `Where` (Regular) and `Take` (LimitOffset) stays distinct
- [x] `DistinctClosureValuesRemainSeparateParameters` — guard: different values produce separate parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)