### PR TITLE
clear initialization SQL after running it on the async prepare path

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Storage/AsyncSessionInitializationSqlTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/AsyncSessionInitializationSqlTest.cs
@@ -1,0 +1,69 @@
+// Copyright (C) 2024 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Xtensive.Orm.Services;
+using Xtensive.Orm.Tests.Storage.AsyncSessionInitializationSqlTestModel;
+
+namespace Xtensive.Orm.Tests.Storage
+{
+  namespace AsyncSessionInitializationSqlTestModel
+  {
+    [HierarchyRoot]
+    public class TestEntity : Entity
+    {
+      [Key, Field]
+      public long Id { get; private set; }
+    }
+  }
+
+  [TestFixture]
+  public class AsyncSessionInitializationSqlTest : AutoBuildTest
+  {
+    private const string InitializationSql = "SET CONTEXT_INFO 0xDECAFBAD";
+    private const int OuterTransactionCount = 3;
+
+    protected override Xtensive.Orm.Configuration.DomainConfiguration BuildConfiguration()
+    {
+      var configuration = base.BuildConfiguration();
+      configuration.Types.Register(typeof(TestEntity));
+      return configuration;
+    }
+
+    [Test]
+    public async Task InitializationSqlRunsOncePerOuterTransaction()
+    {
+      Require.ProviderIs(StorageProvider.SqlServer, "SET CONTEXT_INFO is SQL Server-specific");
+
+      await using var session = await Domain.OpenSessionAsync();
+
+      var initializationSqlExecutions = 0;
+      session.Events.DbCommandExecuting += (_, e) => {
+        if (e.Command.CommandText == InitializationSql) {
+          initializationSqlExecutions++;
+        }
+      };
+
+      // Re-registering the same script each outer transaction reproduces the monolith's tagging pattern
+      // and is what the async prepare must drain rather than accumulate.
+      session.Events.TransactionOpened += (_, e) => {
+        if (!e.Transaction.IsNested) {
+          session.Services.Demand<DirectSqlAccessor>().RegisterInitializationSql(InitializationSql);
+        }
+      };
+
+      for (var i = 0; i < OuterTransactionCount; i++) {
+        await using var tx = await session.OpenTransactionAsync();
+        // Forces the deferred connection open, running the queued script on the async prepare path.
+        _ = await session.Query.All<TestEntity>().CountAsync();
+        tx.Complete();
+      }
+
+      // An un-drained queue re-runs every prior script, costing 1+2+3 executions instead of one each.
+      Assert.That(initializationSqlExecutions, Is.EqualTo(OuterTransactionCount));
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.cs
@@ -248,6 +248,8 @@ namespace Xtensive.Orm.Providers
         throw;
       }
 
+      initializationSqlScripts.Clear();
+
       if (pendingTransaction == null) {
         return;
       }


### PR DESCRIPTION
PrepareAsync executed the queued initialization scripts but never drained
the queue, so every later transaction in the same session re-ran all
previously registered scripts. Add initializationSqlScripts.Clear() to
match the existing Prepare() method.

Adds an async regression test that registers the same script each outer
transaction and asserts it executes exactly once per transaction.