### PR TITLE
fix CI build workflows to reference Orm.slnx

### DIFF
--- a/.github/workflows/autobuild-on-push-and-pr.yml
+++ b/.github/workflows/autobuild-on-push-and-pr.yml
@@ -67,5 +67,5 @@ jobs:
 
       - name: Build Orm
         if: ${{ success() }}
-        run: dotnet build Orm.sln --configuration $BUILD_CONFIG
+        run: dotnet build Orm.slnx --configuration $BUILD_CONFIG
 

--- a/.github/workflows/build_on_tag_push.yml
+++ b/.github/workflows/build_on_tag_push.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Build Orm
         if: ${{ success() }}
-        run: dotnet build Orm.sln --configuration Release
+        run: dotnet build Orm.slnx --configuration Release
         
       #check that nuget packages are built, last chance to abort
       - name: Check package exist

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Bump
-        run: gawk -i inplace '{match($0,/(^.+DoVersion>[0-9]+.[0-9]+.[0-9]+.)([0-9]+)/,a);if(a[2]>0){print a[1]a[2]+1"</DoVersion>"}else{print $0}}' Version.props
+        run: gawk -i inplace '{match($0,/(^.+DoVersion>[0-9]+\.[0-9]+\.)([0-9]+)(<\/DoVersion>)/,a);if(a[2]>0){print a[1]a[2]+1a[3]}else{print $0}}' Version.props
       - name: Commit
         run: git config user.email 'spavlov@servicetitan.com' && git config user.name 'Bump-Version GitHub Action' && git commit -a -m 'Bump version' && git push

--- a/.github/workflows/dispatched-build.yml
+++ b/.github/workflows/dispatched-build.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Build Orm
         if: ${{ success() }}
-        run: dotnet build Orm.sln --configuration $BUILD_CONFIG -v ${{ inputs.verbosity }}
+        run: dotnet build Orm.slnx --configuration $BUILD_CONFIG -v ${{ inputs.verbosity }}
 
       - name: Organize files
         if: ${{ success() && inputs.buildConfiguration == 'Release' && inputs.publish_artifacts }}

--- a/.github/workflows/reusable-storage-dependant-tests.yml
+++ b/.github/workflows/reusable-storage-dependant-tests.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Build Orm
         if: ${{ success() }}
         timeout-minutes: 5
-        run: dotnet build Orm.sln -c ${{ inputs.build_config }}
+        run: dotnet build Orm.slnx -c ${{ inputs.build_config }}
 
       
 

--- a/.github/workflows/reusable-storage-independant-tests.yml
+++ b/.github/workflows/reusable-storage-independant-tests.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Build Orm
         if: ${{ success() }}
         timeout-minutes: 5
-        run: dotnet build Orm.sln -c ${{ inputs.build_config }}
+        run: dotnet build Orm.slnx -c ${{ inputs.build_config }}
 
       - name: Run tests
         id: complex_tests

--- a/Version.props
+++ b/Version.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.3.24</DoVersion>
+    <DoVersion>7.3.25</DoVersion>
     <DoVersionSuffix>servicetitan</DoVersionSuffix>
 </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- Five workflows still built `Orm.sln`, which was removed by the `.slnx` migration (#386), so every push to `master-servicetitan` has been failing CI with `MSB1009: Project file does not exist`.
- Points all of them at `Orm.slnx` instead: `autobuild-on-push-and-pr.yml`, `build_on_tag_push.yml`, `dispatched-build.yml`, `reusable-storage-dependant-tests.yml`, `reusable-storage-independant-tests.yml`.

## Test plan
- [ ] Confirm the auto-build workflow run on this PR/branch succeeds instead of failing with MSB1009