### PR TITLE
extend session events to cover raw connections and commands

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Storage/DbConnectionInitializingEventTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/DbConnectionInitializingEventTest.cs
@@ -1,0 +1,144 @@
+// Copyright (C) 2026 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Xtensive.Orm.Configuration;
+using Xtensive.Orm.Services;
+using Xtensive.Orm.Tests.Storage.DbConnectionInitializingEventTestModel;
+
+namespace Xtensive.Orm.Tests.Storage.DbConnectionInitializingEventTestModel
+{
+  [HierarchyRoot]
+  public class TestEntity : Entity
+  {
+    [Key, Field]
+    public int Id { get; set; }
+
+    [Field]
+    public string Text { get; set; }
+  }
+}
+
+namespace Xtensive.Orm.Tests.Storage
+{
+  public class DbConnectionInitializingEventTest : AutoBuildTest
+  {
+    protected override DomainConfiguration BuildConfiguration()
+    {
+      var configuration = base.BuildConfiguration();
+      configuration.Types.Register(typeof(TestEntity));
+      configuration.UpgradeMode = DomainUpgradeMode.Recreate;
+      return configuration;
+    }
+
+    [Test]
+    public void FiresOnceBeforeFirstCommandTest()
+    {
+      using (var session = Domain.OpenSession()) {
+        var initCount = 0;
+        var commandCount = 0;
+        var commandRanBeforeInit = false;
+        session.Events.DbCommandExecuting += (_, _) => commandCount++;
+        session.Events.DbConnectionInitializing += (_, _) => {
+          if (commandCount > 0) {
+            commandRanBeforeInit = true;
+          }
+          initCount++;
+        };
+
+        using (var transaction = session.OpenTransaction()) {
+          _ = new TestEntity { Text = "abc" };
+          session.SaveChanges();
+          transaction.Complete();
+        }
+
+        Assert.That(initCount, Is.EqualTo(1));
+        Assert.That(commandRanBeforeInit, Is.False);
+      }
+    }
+
+    [Test]
+    public void DoesNotFireAgainOnAlreadyOpenConnectionTest()
+    {
+      using (var session = Domain.OpenSession()) {
+        var initCount = 0;
+        session.Events.DbConnectionInitializing += (_, _) => initCount++;
+
+        using (var transaction = session.OpenTransaction()) {
+          _ = new TestEntity { Text = "abc" };
+          session.SaveChanges();
+          _ = new TestEntity { Text = "def" };
+          session.SaveChanges();
+          transaction.Complete();
+        }
+
+        Assert.That(initCount, Is.EqualTo(1));
+      }
+    }
+
+    [Test]
+    public void FiresAgainOnReopenAfterCloseTest()
+    {
+      using (var session = Domain.OpenSession()) {
+        var initCount = 0;
+        session.Events.DbConnectionInitializing += (_, _) => initCount++;
+
+        using (var transaction = session.OpenTransaction()) {
+          _ = new TestEntity { Text = "abc" };
+          session.SaveChanges();
+          transaction.Complete();
+        }
+
+        using (var transaction = session.OpenTransaction()) {
+          _ = new TestEntity { Text = "def" };
+          session.SaveChanges();
+          transaction.Complete();
+        }
+
+        Assert.That(initCount, Is.EqualTo(2));
+      }
+    }
+
+    [Test]
+    public async Task FiresOnceOnGenuineOpenAsyncTest()
+    {
+      // Domain.OpenSession() defers the connection open lazily, unlike OpenSessionAsync() which opens
+      // eagerly as part of session creation, before a caller has a chance to subscribe.
+      using (var session = Domain.OpenSession()) {
+        var initCount = 0;
+        session.Events.DbConnectionInitializing += (_, _) => initCount++;
+
+        await using (var transaction = await session.OpenTransactionAsync()) {
+          _ = new TestEntity { Text = "abc" };
+          await session.SaveChangesAsync();
+          transaction.Complete();
+        }
+
+        Assert.That(initCount, Is.EqualTo(1));
+      }
+    }
+
+    [Test]
+    public void AppendedSqlRunsInTheInitBatchTest()
+    {
+      Require.ProviderIs(StorageProvider.SqlServer, "SET CONTEXT_INFO is SQL Server-specific");
+
+      using (var session = Domain.OpenSession()) {
+        session.Events.DbConnectionInitializing += (_, e) => e.AppendInitializationSql("SET CONTEXT_INFO 0xDECAFBAD");
+
+        using (var transaction = session.OpenTransaction()) {
+          using var command = session.Services.Demand<DirectSqlAccessor>().CreateCommand();
+          command.CommandText = "SELECT CONTEXT_INFO()";
+          var contextInfo = (byte[]) command.ExecuteScalar();
+
+          Assert.That(contextInfo, Is.Not.Null);
+          Assert.That(new[] { contextInfo[0], contextInfo[1], contextInfo[2], contextInfo[3] },
+            Is.EqualTo(new byte[] { 0xDE, 0xCA, 0xFB, 0xAD }));
+          transaction.Complete();
+        }
+      }
+    }
+  }
+}

--- a/Orm/Xtensive.Orm.Tests/Storage/DbConnectionOpenedEventTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/DbConnectionOpenedEventTest.cs
@@ -1,0 +1,130 @@
+using System.Data.Common;
+using System.Linq;
+using NUnit.Framework;
+using Xtensive.Orm.Configuration;
+using Xtensive.Orm.Tests.Storage.DbConnectionOpenedEventTestModel;
+
+namespace Xtensive.Orm.Tests.Storage.DbConnectionOpenedEventTestModel
+{
+  [HierarchyRoot]
+  public class TestEntity : Entity
+  {
+    [Key, Field]
+    public int Id { get; set; }
+
+    [Field]
+    public string Text { get; set; }
+  }
+}
+
+namespace Xtensive.Orm.Tests.Storage
+{
+  public class DbConnectionOpenedEventTest : AutoBuildTest
+  {
+    protected override DomainConfiguration BuildConfiguration()
+    {
+      var configuration = base.BuildConfiguration();
+      configuration.Types.Register(typeof(TestEntity));
+      configuration.UpgradeMode = DomainUpgradeMode.Recreate;
+      return configuration;
+    }
+
+    [Test]
+    public void FiresOnceOnGenuineOpenTest()
+    {
+      using (var session = Domain.OpenSession()) {
+        var openedCount = 0;
+        DbConnection openedConnection = null;
+        session.Events.DbConnectionOpened += (_, args) => {
+          openedCount++;
+          openedConnection = args.Connection;
+        };
+
+        using (var transaction = session.OpenTransaction()) {
+          _ = new TestEntity { Text = "abc" };
+          session.SaveChanges();
+          transaction.Complete();
+        }
+
+        Assert.That(openedCount, Is.EqualTo(1));
+        Assert.That(openedConnection, Is.Not.Null);
+      }
+    }
+
+    [Test]
+    public void DoesNotFireAgainOnAlreadyOpenConnectionTest()
+    {
+      using (var session = Domain.OpenSession()) {
+        var openedCount = 0;
+        session.Events.DbConnectionOpened += (_, _) => openedCount++;
+
+        using (var transaction = session.OpenTransaction()) {
+          _ = new TestEntity { Text = "abc" };
+          session.SaveChanges();
+          _ = new TestEntity { Text = "def" };
+          session.SaveChanges();
+          transaction.Complete();
+        }
+
+        Assert.That(openedCount, Is.EqualTo(1));
+      }
+    }
+
+    [Test]
+    public void FiresAgainOnReopenAfterCloseTest()
+    {
+      using (var session = Domain.OpenSession()) {
+        var openedCount = 0;
+        session.Events.DbConnectionOpened += (_, _) => openedCount++;
+
+        using (var transaction = session.OpenTransaction()) {
+          _ = new TestEntity { Text = "abc" };
+          session.SaveChanges();
+          transaction.Complete();
+        }
+
+        using (var transaction = session.OpenTransaction()) {
+          _ = new TestEntity { Text = "def" };
+          session.SaveChanges();
+          transaction.Complete();
+        }
+
+        Assert.That(openedCount, Is.EqualTo(2));
+      }
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task FiresOnceOnGenuineOpenAsyncTest()
+    {
+      // Domain.OpenSession() defers the connection open lazily, unlike OpenSessionAsync() which opens
+      // eagerly as part of session creation, before a caller has a chance to subscribe.
+      using (var session = Domain.OpenSession()) {
+        var openedCount = 0;
+        session.Events.DbConnectionOpened += (_, _) => openedCount++;
+
+        await using (var transaction = await session.OpenTransactionAsync()) {
+          _ = new TestEntity { Text = "abc" };
+          await session.SaveChangesAsync();
+          transaction.Complete();
+        }
+
+        Assert.That(openedCount, Is.EqualTo(1));
+      }
+    }
+
+    [Test]
+    public void FiresForNonTransactionalReadsSessionTest()
+    {
+      var sessionConfiguration = new SessionConfiguration(SessionOptions.ServerProfile | SessionOptions.NonTransactionalReads);
+
+      using (var session = Domain.OpenSession(sessionConfiguration)) {
+        var openedCount = 0;
+        session.Events.DbConnectionOpened += (_, _) => openedCount++;
+
+        _ = session.Query.All<TestEntity>().Any();
+
+        Assert.That(openedCount, Is.EqualTo(1));
+      }
+    }
+  }
+}

--- a/Orm/Xtensive.Orm.Tests/Storage/DbConnectionOpenedEventTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/DbConnectionOpenedEventTest.cs
@@ -1,5 +1,4 @@
 using System.Data.Common;
-using System.Linq;
 using NUnit.Framework;
 using Xtensive.Orm.Configuration;
 using Xtensive.Orm.Tests.Storage.DbConnectionOpenedEventTestModel;

--- a/Orm/Xtensive.Orm.Tests/Storage/DirectSqlConnectionAccessedTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/DirectSqlConnectionAccessedTest.cs
@@ -74,7 +74,7 @@ namespace Xtensive.Orm.Tests.Storage
     {
       using (var session = Domain.OpenSession())
       using (var transaction = session.OpenTransaction()) {
-        var callOrder = new System.Collections.Generic.List<int>();
+        var callOrder = new List<int>();
         session.Events.RawConnectionAccessed += (_, _) => callOrder.Add(1);
         session.Events.RawConnectionAccessed += (_, _) => callOrder.Add(2);
 

--- a/Orm/Xtensive.Orm.Tests/Storage/DirectSqlConnectionAccessedTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/DirectSqlConnectionAccessedTest.cs
@@ -1,0 +1,90 @@
+using System.Data.Common;
+using NUnit.Framework;
+using Xtensive.Orm.Configuration;
+using Xtensive.Orm.Services;
+using Xtensive.Orm.Tests.Storage.DirectSqlConnectionAccessedTestModel;
+
+namespace Xtensive.Orm.Tests.Storage.DirectSqlConnectionAccessedTestModel
+{
+  [HierarchyRoot]
+  public class TestEntity : Entity
+  {
+    [Key, Field]
+    public int Id { get; set; }
+
+    [Field]
+    public string Text { get; set; }
+  }
+}
+
+namespace Xtensive.Orm.Tests.Storage
+{
+  public class DirectSqlConnectionAccessedTest : AutoBuildTest
+  {
+    protected override DomainConfiguration BuildConfiguration()
+    {
+      var configuration = base.BuildConfiguration();
+      configuration.Types.Register(typeof(TestEntity));
+      configuration.UpgradeMode = DomainUpgradeMode.Recreate;
+      return configuration;
+    }
+
+    [Test]
+    public void AccessingConnectionFiresTheHookTest()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        var hookCallCount = 0;
+        DbConnection hookConnection = null;
+        session.Events.RawConnectionAccessed += (_, args) => {
+          hookCallCount++;
+          hookConnection = args.Connection;
+        };
+
+        var directSql = session.Services.Demand<DirectSqlAccessor>();
+        var connection = directSql.Connection;
+
+        Assert.That(hookCallCount, Is.EqualTo(1));
+        Assert.That(hookConnection, Is.SameAs(connection));
+
+        transaction.Complete();
+      }
+    }
+
+    [Test]
+    public void EachAccessFiresTheHookAgainTest()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        var hookCallCount = 0;
+        session.Events.RawConnectionAccessed += (_, _) => hookCallCount++;
+
+        var directSql = session.Services.Demand<DirectSqlAccessor>();
+        _ = directSql.Connection;
+        _ = directSql.Connection;
+
+        Assert.That(hookCallCount, Is.EqualTo(2));
+
+        transaction.Complete();
+      }
+    }
+
+    [Test]
+    public void InvokesEachSubscriberTest()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        var callOrder = new System.Collections.Generic.List<int>();
+        session.Events.RawConnectionAccessed += (_, _) => callOrder.Add(1);
+        session.Events.RawConnectionAccessed += (_, _) => callOrder.Add(2);
+
+        var directSql = session.Services.Demand<DirectSqlAccessor>();
+        _ = directSql.Connection;
+
+        Assert.That(callOrder, Is.EqualTo(new[] { 1, 2 }));
+
+        transaction.Complete();
+      }
+    }
+  }
+}

--- a/Orm/Xtensive.Orm.Tests/Storage/DirectSqlGetConnectionAsyncTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/DirectSqlGetConnectionAsyncTest.cs
@@ -1,0 +1,119 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Xtensive.Orm.Configuration;
+using Xtensive.Orm.Services;
+using Xtensive.Orm.Tests.Storage.DirectSqlGetConnectionAsyncTestModel;
+
+namespace Xtensive.Orm.Tests.Storage.DirectSqlGetConnectionAsyncTestModel
+{
+  [HierarchyRoot]
+  public class TestEntity : Entity
+  {
+    [Key, Field]
+    public int Id { get; set; }
+
+    [Field]
+    public string Text { get; set; }
+  }
+}
+
+namespace Xtensive.Orm.Tests.Storage
+{
+  public class DirectSqlGetConnectionAsyncTest : AutoBuildTest
+  {
+    protected override DomainConfiguration BuildConfiguration()
+    {
+      var configuration = base.BuildConfiguration();
+      configuration.Types.Register(typeof(TestEntity));
+      configuration.UpgradeMode = DomainUpgradeMode.Recreate;
+      return configuration;
+    }
+
+    [Test]
+    public async Task OpensConnectionAndFiresHookOnceTest()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        var hookCallCount = 0;
+        DbConnection hookConnection = null;
+        session.Events.RawConnectionAccessedAsync += (connection, _) => {
+          hookCallCount++;
+          hookConnection = connection;
+          return Task.CompletedTask;
+        };
+
+        var directSql = session.Services.Demand<DirectSqlAccessor>();
+        var connection = await directSql.GetConnectionAsync();
+
+        Assert.That(connection, Is.Not.Null);
+        Assert.That(connection.State, Is.EqualTo(ConnectionState.Open));
+        Assert.That(hookCallCount, Is.EqualTo(1));
+        Assert.That(hookConnection, Is.SameAs(connection));
+
+        transaction.Complete();
+      }
+    }
+
+    [Test]
+    public async Task HookAwaitsItsWorkTest()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        var hookCompleted = false;
+        session.Events.RawConnectionAccessedAsync += async (_, cancellationToken) => {
+          await Task.Delay(10, cancellationToken);
+          hookCompleted = true;
+        };
+
+        var directSql = session.Services.Demand<DirectSqlAccessor>();
+        _ = await directSql.GetConnectionAsync();
+
+        // GetConnectionAsync must not return until the hook's own await completes.
+        Assert.That(hookCompleted, Is.True);
+
+        transaction.Complete();
+      }
+    }
+
+    [Test]
+    public async Task TransactionReadAfterIsCheapNoOpTest()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        var directSql = session.Services.Demand<DirectSqlAccessor>();
+        _ = await directSql.GetConnectionAsync();
+
+        Assert.That(directSql.Transaction, Is.Not.Null);
+
+        transaction.Complete();
+      }
+    }
+
+    [Test]
+    public async Task InvokesEachSubscriberSequentiallyTest()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        var callOrder = new List<int>();
+        session.Events.RawConnectionAccessedAsync += async (_, _) => {
+          await Task.Delay(20);
+          callOrder.Add(1);
+        };
+        session.Events.RawConnectionAccessedAsync += async (_, _) => {
+          await Task.Delay(1);
+          callOrder.Add(2);
+        };
+
+        var directSql = session.Services.Demand<DirectSqlAccessor>();
+        _ = await directSql.GetConnectionAsync();
+
+        Assert.That(callOrder, Is.EqualTo(new[] { 1, 2 }));
+
+        transaction.Complete();
+      }
+    }
+  }
+}

--- a/Orm/Xtensive.Orm.Tests/Storage/DirectSqlGetConnectionAsyncTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/DirectSqlGetConnectionAsyncTest.cs
@@ -37,9 +37,9 @@ namespace Xtensive.Orm.Tests.Storage
       using (var transaction = session.OpenTransaction()) {
         var hookCallCount = 0;
         DbConnection hookConnection = null;
-        session.Events.RawConnectionAccessedAsync += (connection, _) => {
+        session.Events.RawConnectionAccessedAsync += (args, _) => {
           hookCallCount++;
-          hookConnection = connection;
+          hookConnection = args.Connection;
           return Task.CompletedTask;
         };
 

--- a/Orm/Xtensive.Orm.Tests/Storage/DirectSqlGetConnectionAsyncTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/DirectSqlGetConnectionAsyncTest.cs
@@ -1,7 +1,5 @@
-using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using Xtensive.Orm.Configuration;
 using Xtensive.Orm.Services;

--- a/Orm/Xtensive.Orm.Tests/Storage/EventNotifyingDbCommandTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/EventNotifyingDbCommandTest.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Data;
 using System.Data.Common;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using Xtensive.Orm.Configuration;
 using Xtensive.Orm.Providers;

--- a/Orm/Xtensive.Orm.Tests/Storage/EventNotifyingDbCommandTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Storage/EventNotifyingDbCommandTest.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Xtensive.Orm.Configuration;
+using Xtensive.Orm.Providers;
+using Xtensive.Orm.Services;
+using Xtensive.Orm.Tests.Storage.EventNotifyingDbCommandTestModel;
+
+namespace Xtensive.Orm.Tests.Storage.EventNotifyingDbCommandTestModel
+{
+  [HierarchyRoot]
+  public class TestEntity : Entity
+  {
+    [Key, Field]
+    public int Id { get; set; }
+
+    [Field]
+    public string Text { get; set; }
+  }
+}
+
+namespace Xtensive.Orm.Tests.Storage
+{
+  public class EventNotifyingDbCommandTest : AutoBuildTest
+  {
+    protected override DomainConfiguration BuildConfiguration()
+    {
+      var configuration = base.BuildConfiguration();
+      configuration.Types.Register(typeof(TestEntity));
+      configuration.UpgradeMode = DomainUpgradeMode.Recreate;
+      return configuration;
+    }
+
+    protected override void PopulateData()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        _ = new TestEntity { Text = "abc" };
+        session.SaveChanges();
+        transaction.Complete();
+      }
+    }
+
+    [Test]
+    public void ForwardsMembersFaithfullyTest()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        var directSql = session.Services.Demand<DirectSqlAccessor>();
+        using (var command = directSql.CreateCommand()) {
+          command.CommandText = "SELECT 1";
+          command.CommandType = CommandType.Text;
+          command.CommandTimeout = 42;
+          var parameter = command.CreateParameter();
+          parameter.ParameterName = "@p";
+          parameter.Value = 1;
+          command.Parameters.Add(parameter);
+
+          Assert.That(command.CommandText, Is.EqualTo("SELECT 1"));
+          Assert.That(command.CommandType, Is.EqualTo(CommandType.Text));
+          Assert.That(command.CommandTimeout, Is.EqualTo(42));
+          Assert.That(command.Parameters.Count, Is.EqualTo(1));
+          Assert.That(command.Connection, Is.Not.Null);
+          Assert.That(command.Transaction, Is.Not.Null);
+        }
+        transaction.Complete();
+      }
+    }
+
+    [Test]
+    public void ExecuteNonQueryFiresNotificationsOnceTest()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        var executingCount = 0;
+        var executedCount = 0;
+        session.Events.DbCommandExecuting += (_, _) => executingCount++;
+        session.Events.DbCommandExecuted += (_, _) => executedCount++;
+
+        var directSql = session.Services.Demand<DirectSqlAccessor>();
+        using (var command = directSql.CreateCommand()) {
+          command.CommandText = "SELECT 1";
+          _ = command.ExecuteNonQuery();
+        }
+
+        Assert.That(executingCount, Is.EqualTo(1));
+        Assert.That(executedCount, Is.EqualTo(1));
+        transaction.Complete();
+      }
+    }
+
+    [Test]
+    public async Task ExecuteNonQueryAsyncFiresNotificationsOnceTest()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        var executingCount = 0;
+        var executedCount = 0;
+        session.Events.DbCommandExecuting += (_, _) => executingCount++;
+        session.Events.DbCommandExecuted += (_, _) => executedCount++;
+
+        var directSql = session.Services.Demand<DirectSqlAccessor>();
+        using (var command = directSql.CreateCommand()) {
+          command.CommandText = "SELECT 1";
+          _ = await command.ExecuteNonQueryAsync();
+        }
+
+        Assert.That(executingCount, Is.EqualTo(1));
+        Assert.That(executedCount, Is.EqualTo(1));
+        transaction.Complete();
+      }
+    }
+
+    [Test]
+    public void ExecuteScalarFiresNotificationsOnceTest()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        var executingCount = 0;
+        var executedCount = 0;
+        session.Events.DbCommandExecuting += (_, _) => executingCount++;
+        session.Events.DbCommandExecuted += (_, _) => executedCount++;
+
+        var directSql = session.Services.Demand<DirectSqlAccessor>();
+        using (var command = directSql.CreateCommand()) {
+          command.CommandText = "SELECT 1";
+          var result = command.ExecuteScalar();
+          Assert.That(Convert.ToInt32(result), Is.EqualTo(1));
+        }
+
+        Assert.That(executingCount, Is.EqualTo(1));
+        Assert.That(executedCount, Is.EqualTo(1));
+        transaction.Complete();
+      }
+    }
+
+    [Test]
+    public void ExecuteReaderFiresNotificationsOnceTest()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        var executingCount = 0;
+        var executedCount = 0;
+        session.Events.DbCommandExecuting += (_, _) => executingCount++;
+        session.Events.DbCommandExecuted += (_, _) => executedCount++;
+
+        var directSql = session.Services.Demand<DirectSqlAccessor>();
+        using (var command = directSql.CreateCommand()) {
+          command.CommandText = "SELECT 1";
+          using (var reader = command.ExecuteReader()) {
+            while (reader.Read()) {
+            }
+          }
+        }
+
+        Assert.That(executingCount, Is.EqualTo(1));
+        Assert.That(executedCount, Is.EqualTo(1));
+        transaction.Complete();
+      }
+    }
+
+    [Test]
+    public void FailingCommandPropagatesExceptionUnwrappedTest()
+    {
+      using (var session = Domain.OpenSession())
+      using (var transaction = session.OpenTransaction()) {
+        Exception notifiedException = null;
+        session.Events.DbCommandExecuted += (_, args) => notifiedException = args.Exception;
+
+        var directSql = session.Services.Demand<DirectSqlAccessor>();
+        using (var command = directSql.CreateCommand()) {
+          command.CommandText = "SELECT * FROM [NoSuchTable_EventNotifyingDbCommandTest]";
+          var thrown = Assert.Catch(() => command.ExecuteNonQuery());
+
+          Assert.That(thrown, Is.Not.InstanceOf<StorageException>());
+          Assert.That(notifiedException, Is.SameAs(thrown));
+        }
+      }
+    }
+
+    [Test]
+    public void CancelForwardsToInnerCommandTest()
+    {
+      var inner = new FakeDbCommand();
+      var wrapper = new EventNotifyingDbCommand(null, inner);
+
+      wrapper.Cancel();
+
+      Assert.That(inner.CancelCalled, Is.True);
+    }
+
+    [Test]
+    public void DisposeForwardsToInnerCommandTest()
+    {
+      var inner = new FakeDbCommand();
+      var wrapper = new EventNotifyingDbCommand(null, inner);
+
+      wrapper.Dispose();
+
+      Assert.That(inner.DisposeCalled, Is.True);
+    }
+
+    private sealed class FakeDbCommand : DbCommand
+    {
+      public bool CancelCalled;
+      public bool DisposeCalled;
+
+      public override string CommandText { get; set; }
+      public override int CommandTimeout { get; set; }
+      public override CommandType CommandType { get; set; }
+      public override UpdateRowSource UpdatedRowSource { get; set; }
+      public override bool DesignTimeVisible { get; set; }
+      protected override DbConnection DbConnection { get; set; }
+      protected override DbParameterCollection DbParameterCollection => throw new NotImplementedException();
+      protected override DbTransaction DbTransaction { get; set; }
+
+      public override void Cancel() => CancelCalled = true;
+
+      protected override DbParameter CreateDbParameter() => throw new NotImplementedException();
+
+      public override void Prepare()
+      {
+      }
+
+      public override int ExecuteNonQuery() => throw new NotImplementedException();
+
+      public override object ExecuteScalar() => throw new NotImplementedException();
+
+      protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior) => throw new NotImplementedException();
+
+      protected override void Dispose(bool disposing)
+      {
+        if (disposing) {
+          DisposeCalled = true;
+        }
+        base.Dispose(disposing);
+      }
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/DbConnectionEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/DbConnectionEventArgs.cs
@@ -3,22 +3,9 @@ using System.Data.Common;
 namespace Xtensive.Orm
 {
   /// <summary>
-  /// Event args for <see cref="SessionEventAccessor.DbConnectionOpened"/>.
+  /// Event args carrying a <see cref="DbConnection"/>, used by <see cref="SessionEventAccessor.DbConnectionOpened"/>
+  /// and <see cref="SessionEventAccessor.RawConnectionAccessed"/>.
   /// </summary>
-  public readonly struct DbConnectionEventArgs
-  {
-    /// <summary>
-    /// Gets the connection that transitioned from closed to open.
-    /// </summary>
-    public DbConnection Connection { get; }
-
-    /// <summary>
-    /// Initializes a new instance of this class.
-    /// </summary>
-    /// <param name="connection">The connection that transitioned from closed to open.</param>
-    public DbConnectionEventArgs(DbConnection connection)
-    {
-      Connection = connection;
-    }
-  }
+  /// <param name="Connection">The connection the event concerns.</param>
+  public readonly record struct DbConnectionEventArgs(DbConnection Connection);
 }

--- a/Orm/Xtensive.Orm/Orm/DbConnectionEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/DbConnectionEventArgs.cs
@@ -7,5 +7,6 @@ namespace Xtensive.Orm
   /// and <see cref="SessionEventAccessor.RawConnectionAccessed"/>.
   /// </summary>
   /// <param name="Connection">The connection the event concerns.</param>
-  public readonly record struct DbConnectionEventArgs(DbConnection Connection);
+  /// <param name="Transaction">The connection's active transaction, or <see langword="null"/> if none.</param>
+  public readonly record struct DbConnectionEventArgs(DbConnection Connection, DbTransaction Transaction = null);
 }

--- a/Orm/Xtensive.Orm/Orm/DbConnectionEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/DbConnectionEventArgs.cs
@@ -1,0 +1,24 @@
+using System.Data.Common;
+
+namespace Xtensive.Orm
+{
+  /// <summary>
+  /// Event args for <see cref="SessionEventAccessor.DbConnectionOpened"/>.
+  /// </summary>
+  public readonly struct DbConnectionEventArgs
+  {
+    /// <summary>
+    /// Gets the connection that transitioned from closed to open.
+    /// </summary>
+    public DbConnection Connection { get; }
+
+    /// <summary>
+    /// Initializes a new instance of this class.
+    /// </summary>
+    /// <param name="connection">The connection that transitioned from closed to open.</param>
+    public DbConnectionEventArgs(DbConnection connection)
+    {
+      Connection = connection;
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/DbConnectionInitializingEventArgs.cs
+++ b/Orm/Xtensive.Orm/Orm/DbConnectionInitializingEventArgs.cs
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 Xtensive LLC.
+// This code is distributed under MIT license terms.
+// See the License.txt file in the project root for more information.
+
+using System;
+
+namespace Xtensive.Orm
+{
+  /// <summary>
+  /// Event args for <see cref="SessionEventAccessor.DbConnectionInitializing"/>, raised before a connection's
+  /// initialization SQL runs. Subscribers may append SQL to the initialization batch, which then executes as a
+  /// single batch when the connection opens. The connection is not yet open and the seeded SQL (for example
+  /// <c>USE [db]</c>) has not yet run, so a subscriber may only append to the batch, not issue its own commands.
+  /// </summary>
+  public class DbConnectionInitializingEventArgs
+  {
+    /// <summary>
+    /// Gets the session whose connection is being initialized.
+    /// </summary>
+    public Session Session { get; }
+
+    /// <summary>
+    /// Gets the initialization SQL that will run when the connection opens, including any appended by
+    /// subscribers.
+    /// </summary>
+    public string InitializationScript { get; private set; }
+
+    /// <summary>
+    /// Appends <paramref name="sql"/> to the initialization batch, after any SQL already present.
+    /// </summary>
+    public void AppendInitializationSql(string sql)
+    {
+      if (string.IsNullOrEmpty(sql)) {
+        return;
+      }
+      if (string.IsNullOrEmpty(InitializationScript)) {
+        InitializationScript = sql;
+        return;
+      }
+      InitializationScript = $"{InitializationScript.TrimEnd().TrimEnd(';')}; {sql}";
+    }
+
+    // Constructors
+
+    internal DbConnectionInitializingEventArgs(Session session, string initializationScript)
+    {
+      Session = session;
+      InitializationScript = initializationScript;
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Providers/EventNotifyingDbCommand.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/EventNotifyingDbCommand.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Xtensive.Core;
+
+namespace Xtensive.Orm.Providers
+{
+  /// <summary>
+  /// Wraps a raw <see cref="DbCommand"/> handed out by <see cref="IDirectSqlService.CreateCommand"/>,
+  /// raising the same <see cref="SessionEventAccessor.DbCommandExecuting"/>/
+  /// <see cref="SessionEventAccessor.DbCommandExecuted"/> events around execution that the ORM's own
+  /// commands raise, without translating any exception the inner command throws.
+  /// </summary>
+  internal sealed class EventNotifyingDbCommand : DbCommand
+  {
+    private readonly Session session;
+    private readonly DbCommand innerCommand;
+
+    public override string CommandText
+    {
+      get => innerCommand.CommandText;
+      set => innerCommand.CommandText = value;
+    }
+
+    public override int CommandTimeout
+    {
+      get => innerCommand.CommandTimeout;
+      set => innerCommand.CommandTimeout = value;
+    }
+
+    public override CommandType CommandType
+    {
+      get => innerCommand.CommandType;
+      set => innerCommand.CommandType = value;
+    }
+
+    public override UpdateRowSource UpdatedRowSource
+    {
+      get => innerCommand.UpdatedRowSource;
+      set => innerCommand.UpdatedRowSource = value;
+    }
+
+    public override bool DesignTimeVisible
+    {
+      get => innerCommand.DesignTimeVisible;
+      set => innerCommand.DesignTimeVisible = value;
+    }
+
+    protected override DbConnection DbConnection
+    {
+      get => innerCommand.Connection;
+      set => innerCommand.Connection = value;
+    }
+
+    protected override DbParameterCollection DbParameterCollection => innerCommand.Parameters;
+
+    protected override DbTransaction DbTransaction
+    {
+      get => innerCommand.Transaction;
+      set => innerCommand.Transaction = value;
+    }
+
+    public override void Cancel() => innerCommand.Cancel();
+
+    protected override DbParameter CreateDbParameter() => innerCommand.CreateParameter();
+
+    public override void Prepare() => innerCommand.Prepare();
+
+    public override Task PrepareAsync(CancellationToken cancellationToken = default) =>
+      innerCommand.PrepareAsync(cancellationToken);
+
+    public override int ExecuteNonQuery()
+    {
+      session.Events.NotifyDbCommandExecuting(this);
+      try {
+        var result = innerCommand.ExecuteNonQuery();
+        session.Events.NotifyDbCommandExecuted(this);
+        return result;
+      }
+      catch (Exception exception) {
+        session.Events.NotifyDbCommandExecuted(this, exception);
+        throw;
+      }
+    }
+
+    public override async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
+    {
+      session.Events.NotifyDbCommandExecuting(this);
+      try {
+        var result = await innerCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwaitFalse();
+        session.Events.NotifyDbCommandExecuted(this);
+        return result;
+      }
+      catch (Exception exception) {
+        session.Events.NotifyDbCommandExecuted(this, exception);
+        throw;
+      }
+    }
+
+    public override object ExecuteScalar()
+    {
+      session.Events.NotifyDbCommandExecuting(this);
+      try {
+        var result = innerCommand.ExecuteScalar();
+        session.Events.NotifyDbCommandExecuted(this);
+        return result;
+      }
+      catch (Exception exception) {
+        session.Events.NotifyDbCommandExecuted(this, exception);
+        throw;
+      }
+    }
+
+    public override async Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
+    {
+      session.Events.NotifyDbCommandExecuting(this);
+      try {
+        var result = await innerCommand.ExecuteScalarAsync(cancellationToken).ConfigureAwaitFalse();
+        session.Events.NotifyDbCommandExecuted(this);
+        return result;
+      }
+      catch (Exception exception) {
+        session.Events.NotifyDbCommandExecuted(this, exception);
+        throw;
+      }
+    }
+
+    protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+    {
+      session.Events.NotifyDbCommandExecuting(this);
+      try {
+        var result = innerCommand.ExecuteReader(behavior);
+        session.Events.NotifyDbCommandExecuted(this);
+        return result;
+      }
+      catch (Exception exception) {
+        session.Events.NotifyDbCommandExecuted(this, exception);
+        throw;
+      }
+    }
+
+    protected override async Task<DbDataReader> ExecuteDbDataReaderAsync(
+      CommandBehavior behavior, CancellationToken cancellationToken)
+    {
+      session.Events.NotifyDbCommandExecuting(this);
+      try {
+        var result = await innerCommand.ExecuteReaderAsync(behavior, cancellationToken).ConfigureAwaitFalse();
+        session.Events.NotifyDbCommandExecuted(this);
+        return result;
+      }
+      catch (Exception exception) {
+        session.Events.NotifyDbCommandExecuted(this, exception);
+        throw;
+      }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+      if (disposing) {
+        innerCommand.Dispose();
+      }
+      base.Dispose(disposing);
+    }
+
+    public override ValueTask DisposeAsync() => innerCommand.DisposeAsync();
+
+    public EventNotifyingDbCommand(Session session, DbCommand innerCommand)
+    {
+      this.session = session;
+      this.innerCommand = innerCommand;
+    }
+  }
+}

--- a/Orm/Xtensive.Orm/Orm/Providers/EventNotifyingDbCommand.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/EventNotifyingDbCommand.cs
@@ -1,8 +1,5 @@
-using System;
 using System.Data;
 using System.Data.Common;
-using System.Threading;
-using System.Threading.Tasks;
 using Xtensive.Core;
 
 namespace Xtensive.Orm.Providers
@@ -13,11 +10,8 @@ namespace Xtensive.Orm.Providers
   /// <see cref="SessionEventAccessor.DbCommandExecuted"/> events around execution that the ORM's own
   /// commands raise, without translating any exception the inner command throws.
   /// </summary>
-  internal sealed class EventNotifyingDbCommand : DbCommand
+  internal sealed class EventNotifyingDbCommand(Session session, DbCommand innerCommand) : DbCommand
   {
-    private readonly Session session;
-    private readonly DbCommand innerCommand;
-
     public override string CommandText
     {
       get => innerCommand.CommandText;
@@ -165,11 +159,5 @@ namespace Xtensive.Orm.Providers
     }
 
     public override ValueTask DisposeAsync() => innerCommand.DisposeAsync();
-
-    public EventNotifyingDbCommand(Session session, DbCommand innerCommand)
-    {
-      this.session = session;
-      this.innerCommand = innerCommand;
-    }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/Interfaces/IDirectSqlService.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Interfaces/IDirectSqlService.cs
@@ -6,6 +6,8 @@
 
 using System;
 using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
 using Xtensive.Orm.Services;
 
 namespace Xtensive.Orm.Providers
@@ -46,5 +48,14 @@ namespace Xtensive.Orm.Providers
     /// <returns>Newly created <see cref="DbCommand"/> object.</returns>
     /// <exception cref="InvalidOperationException">Connection is not open.</exception>
     DbCommand CreateCommand();
+
+    /// <summary>
+    /// Asynchronously ensures the underlying <see cref="Connection"/> is open and returns it, without
+    /// creating a <see cref="DbCommand"/>. Intended for consumers, such as <c>SqlBulkCopy</c>, that need
+    /// the raw connection itself and can await the open behind a real asynchronous call.
+    /// </summary>
+    /// <param name="cancellationToken">The token to cancel the operation.</param>
+    /// <returns>The underlying, open <see cref="DbConnection"/>.</returns>
+    Task<DbConnection> GetConnectionAsync(CancellationToken cancellationToken = default);
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.IDirectSqlService.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.IDirectSqlService.cs
@@ -6,6 +6,8 @@
 
 using System;
 using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
 using Xtensive.Core;
 
 namespace Xtensive.Orm.Providers
@@ -24,7 +26,9 @@ namespace Xtensive.Orm.Providers
     DbConnection IDirectSqlService.Connection {
       get {
         Prepare();
-        return connection.UnderlyingConnection;
+        var underlyingConnection = connection.UnderlyingConnection;
+        Session.Events.NotifyRawConnectionAccessed(underlyingConnection);
+        return underlyingConnection;
       }
     }
 
@@ -48,7 +52,16 @@ namespace Xtensive.Orm.Providers
     DbCommand IDirectSqlService.CreateCommand()
     {
       Prepare();
-      return connection.CreateCommand();
+      return new EventNotifyingDbCommand(Session, connection.CreateCommand());
+    }
+
+    /// <inheritdoc/>
+    async Task<DbConnection> IDirectSqlService.GetConnectionAsync(CancellationToken cancellationToken)
+    {
+      await PrepareAsync(cancellationToken).ConfigureAwaitFalse();
+      var underlyingConnection = connection.UnderlyingConnection;
+      await Session.Events.NotifyRawConnectionAccessedAsync(underlyingConnection, cancellationToken).ConfigureAwaitFalse();
+      return underlyingConnection;
     }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.IDirectSqlService.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.IDirectSqlService.cs
@@ -6,8 +6,6 @@
 
 using System;
 using System.Data.Common;
-using System.Threading;
-using System.Threading.Tasks;
 using Xtensive.Core;
 
 namespace Xtensive.Orm.Providers

--- a/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.IDirectSqlService.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/SqlSessionHandler.IDirectSqlService.cs
@@ -25,7 +25,7 @@ namespace Xtensive.Orm.Providers
       get {
         Prepare();
         var underlyingConnection = connection.UnderlyingConnection;
-        Session.Events.NotifyRawConnectionAccessed(underlyingConnection);
+        Session.Events.NotifyRawConnectionAccessed(underlyingConnection, connection.ActiveTransaction);
         return underlyingConnection;
       }
     }
@@ -58,7 +58,7 @@ namespace Xtensive.Orm.Providers
     {
       await PrepareAsync(cancellationToken).ConfigureAwaitFalse();
       var underlyingConnection = connection.UnderlyingConnection;
-      await Session.Events.NotifyRawConnectionAccessedAsync(underlyingConnection, cancellationToken).ConfigureAwaitFalse();
+      await Session.Events.NotifyRawConnectionAccessedAsync(underlyingConnection, connection.ActiveTransaction, cancellationToken).ConfigureAwaitFalse();
       return underlyingConnection;
     }
   }

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
@@ -78,6 +78,9 @@ namespace Xtensive.Orm.Providers
       }
 
       var script = connection.Extensions.Get<InitializationSqlExtension>()?.Script;
+      if (session != null) {
+        script = session.Events.NotifyDbConnectionInitializing(script);
+      }
 
       try {
         if (!string.IsNullOrEmpty(script)) {
@@ -105,6 +108,9 @@ namespace Xtensive.Orm.Providers
       }
 
       var script = connection.Extensions.Get<InitializationSqlExtension>()?.Script;
+      if (session != null) {
+        script = session.Events.NotifyDbConnectionInitializing(script);
+      }
 
       try {
         if (!string.IsNullOrEmpty(script)) {

--- a/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/StorageDriver.Operations.cs
@@ -90,6 +90,8 @@ namespace Xtensive.Orm.Providers
       catch (Exception exception) {
         throw ExceptionBuilder.BuildException(exception);
       }
+
+      session?.Events.NotifyDbConnectionOpened(connection.UnderlyingConnection);
     }
 
     public Task OpenConnectionAsync(Session session, SqlConnection connection) =>
@@ -118,6 +120,8 @@ namespace Xtensive.Orm.Providers
       catch (Exception exception) {
         throw ExceptionBuilder.BuildException(exception);
       }
+
+      session?.Events.NotifyDbConnectionOpened(connection.UnderlyingConnection);
     }
 
     public void EnsureConnectionIsOpen(Session session, SqlConnection connection)

--- a/Orm/Xtensive.Orm/Orm/Services/DirectSqlAccessor.cs
+++ b/Orm/Xtensive.Orm/Orm/Services/DirectSqlAccessor.cs
@@ -5,6 +5,8 @@
 // Created:    2010.02.08
 
 using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
 using Xtensive.Core;
 
 using Xtensive.IoC;
@@ -47,6 +49,12 @@ namespace Xtensive.Orm.Services
     public DbCommand CreateCommand()
     {
       return service.CreateCommand();
+    }
+
+    /// <see cref="IDirectSqlService.GetConnectionAsync" copy="true" />
+    public Task<DbConnection> GetConnectionAsync(CancellationToken cancellationToken = default)
+    {
+      return service.GetConnectionAsync(cancellationToken);
     }
 
 

--- a/Orm/Xtensive.Orm/Orm/SessionEventAccessor.cs
+++ b/Orm/Xtensive.Orm/Orm/SessionEventAccessor.cs
@@ -10,6 +10,8 @@ using System.ComponentModel;
 using System.Data.Common;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
 using Xtensive.Core;
 using Xtensive.Orm.Model;
 using Xtensive.Orm.Providers;
@@ -47,6 +49,24 @@ namespace Xtensive.Orm
     /// Occurs when <see cref="DbCommand"/> is canceled.
     /// </summary>
     public event EventHandler<DbCommandEventArgs> DbCommandCanceled;
+
+    /// <summary>
+    /// Occurs when the underlying <see cref="DbConnection"/> transitions from closed to open.
+    /// Does not occur when an already-open connection is reused.
+    /// </summary>
+    public event EventHandler<DbConnectionEventArgs> DbConnectionOpened;
+
+    /// <summary>
+    /// Occurs when a raw connection is handed out by <see cref="Xtensive.Orm.Services.DirectSqlAccessor.Connection"/>.
+    /// </summary>
+    public event EventHandler<DbConnectionEventArgs> RawConnectionAccessed;
+
+    /// <summary>
+    /// Occurs when a raw connection is handed out by <see cref="Xtensive.Orm.Services.DirectSqlAccessor.GetConnectionAsync"/>,
+    /// before it is returned to the caller. Unlike the other events on this type, subscribers run behind
+    /// a genuine <see langword="await"/> instead of firing synchronously.
+    /// </summary>
+    public event Func<DbConnection, CancellationToken, Task> RawConnectionAccessedAsync;
 
     /// <summary>
     /// Occurs when LINQ query is about to execute.
@@ -271,6 +291,24 @@ namespace Xtensive.Orm
 
     internal void NotifyDbCommandCanceled(DbCommand command) =>
       DbCommandCanceled?.Invoke(this, new DbCommandEventArgs(command));
+
+    internal void NotifyDbConnectionOpened(DbConnection connection) =>
+      DbConnectionOpened?.Invoke(this, new DbConnectionEventArgs(connection));
+
+    internal void NotifyRawConnectionAccessed(DbConnection connection) =>
+      RawConnectionAccessed?.Invoke(this, new DbConnectionEventArgs(connection));
+
+    internal async Task NotifyRawConnectionAccessedAsync(DbConnection connection, CancellationToken cancellationToken)
+    {
+      var handler = RawConnectionAccessedAsync;
+      if (handler == null) {
+        return;
+      }
+      foreach (var subscriber in handler.GetInvocationList()) {
+        await ((Func<DbConnection, CancellationToken, Task>) subscriber)
+          .Invoke(connection, cancellationToken).ConfigureAwaitFalse();
+      }
+    }
 
     internal Expression NotifyQueryExecuting(Expression expression)
     {

--- a/Orm/Xtensive.Orm/Orm/SessionEventAccessor.cs
+++ b/Orm/Xtensive.Orm/Orm/SessionEventAccessor.cs
@@ -66,7 +66,7 @@ namespace Xtensive.Orm
     /// before it is returned to the caller. Unlike the other events on this type, subscribers run behind
     /// a genuine <see langword="await"/> instead of firing synchronously.
     /// </summary>
-    public event Func<DbConnection, CancellationToken, Task> RawConnectionAccessedAsync;
+    public event Func<DbConnectionEventArgs, CancellationToken, Task> RawConnectionAccessedAsync;
 
     /// <summary>
     /// Occurs when LINQ query is about to execute.
@@ -295,18 +295,19 @@ namespace Xtensive.Orm
     internal void NotifyDbConnectionOpened(DbConnection connection) =>
       DbConnectionOpened?.Invoke(this, new DbConnectionEventArgs(connection));
 
-    internal void NotifyRawConnectionAccessed(DbConnection connection) =>
-      RawConnectionAccessed?.Invoke(this, new DbConnectionEventArgs(connection));
+    internal void NotifyRawConnectionAccessed(DbConnection connection, DbTransaction transaction) =>
+      RawConnectionAccessed?.Invoke(this, new DbConnectionEventArgs(connection, transaction));
 
-    internal async Task NotifyRawConnectionAccessedAsync(DbConnection connection, CancellationToken cancellationToken)
+    internal async Task NotifyRawConnectionAccessedAsync(DbConnection connection, DbTransaction transaction, CancellationToken cancellationToken)
     {
       var handler = RawConnectionAccessedAsync;
       if (handler == null) {
         return;
       }
+      var args = new DbConnectionEventArgs(connection, transaction);
       foreach (var subscriber in handler.GetInvocationList()) {
-        await ((Func<DbConnection, CancellationToken, Task>) subscriber)
-          .Invoke(connection, cancellationToken).ConfigureAwaitFalse();
+        await ((Func<DbConnectionEventArgs, CancellationToken, Task>) subscriber)
+          .Invoke(args, cancellationToken).ConfigureAwaitFalse();
       }
     }
 

--- a/Orm/Xtensive.Orm/Orm/SessionEventAccessor.cs
+++ b/Orm/Xtensive.Orm/Orm/SessionEventAccessor.cs
@@ -51,6 +51,13 @@ namespace Xtensive.Orm
     public event EventHandler<DbCommandEventArgs> DbCommandCanceled;
 
     /// <summary>
+    /// Occurs before a connection's initialization SQL runs, on the same closed-to-open transition as
+    /// <see cref="DbConnectionOpened"/> but before the connection opens. Subscribers may append SQL to the
+    /// initialization batch via <see cref="DbConnectionInitializingEventArgs.AppendInitializationSql"/>.
+    /// </summary>
+    public event EventHandler<DbConnectionInitializingEventArgs> DbConnectionInitializing;
+
+    /// <summary>
     /// Occurs when the underlying <see cref="DbConnection"/> transitions from closed to open.
     /// Does not occur when an already-open connection is reused.
     /// </summary>
@@ -291,6 +298,16 @@ namespace Xtensive.Orm
 
     internal void NotifyDbCommandCanceled(DbCommand command) =>
       DbCommandCanceled?.Invoke(this, new DbCommandEventArgs(command));
+
+    internal string NotifyDbConnectionInitializing(string initializationScript)
+    {
+      if (DbConnectionInitializing == null) {
+        return initializationScript;
+      }
+      var args = new DbConnectionInitializingEventArgs(Session, initializationScript);
+      DbConnectionInitializing.Invoke(this, args);
+      return args.InitializationScript;
+    }
 
     internal void NotifyDbConnectionOpened(DbConnection connection) =>
       DbConnectionOpened?.Invoke(this, new DbConnectionEventArgs(connection));

--- a/Version.props
+++ b/Version.props
@@ -3,7 +3,7 @@
 
 <PropertyGroup>
     <DoVersion>7.3.24</DoVersion>
-    <DoVersionSuffix>connection-init-test</DoVersionSuffix>
+    <DoVersionSuffix>servicetitan</DoVersionSuffix>
 </PropertyGroup>
 
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -3,7 +3,7 @@
 
 <PropertyGroup>
     <DoVersion>7.3.24</DoVersion>
-    <DoVersionSuffix>servicetitan</DoVersionSuffix>
+    <DoVersionSuffix>connection-init-test</DoVersionSuffix>
 </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Recreating of https://github.com/servicetitan/dataobjects-net/pull/493
@dagreen-st  Please dont merge it until testing with the Monolith

## Summary
- Adds a `DbConnectionOpened` event on `SessionEventAccessor`, fired once per genuine Closed→Open connection transition
- Adds an internal `EventNotifyingDbCommand` wrapper so `DirectSqlAccessor.CreateCommand()` raises the same `DbCommandExecuting`/`DbCommandExecuted` events the ORM's own commands do
- Adds `GetConnectionAsync` on `IDirectSqlService`/`DirectSqlAccessor`, backed by the existing async prepare path, plus an awaitable raw-connection-accessed hook

### Related:

* design: https://github.com/servicetitan/load-shedder/pull/80
* usage: https://github.com/servicetitan/app/pull/139725 

## Test plan
- [x] `dotnet build` on `Xtensive.Orm` and `Xtensive.Orm.Tests`
- [x] New tests (`DbConnectionOpenedEventTest`, `EventNotifyingDbCommandTest`, `DirectSqlGetConnectionAsyncTest`) pass against a local SQL Server container
- [x] Full `Xtensive.Orm.Tests.Storage` suite run before/after: identical pre-existing failures, no regressions

Reapplies servicetitan/dataobjects-net#493, which was reverted after merge (commits 8e9144db8 and 1f127aa9f). 

Discussion: https://servicetitan.enterprise.slack.com/archives/C0BP3S50BGQ and on the original PR #493


