### PR TITLE
Fix bug with `NullComparisonRewriter`

### DIFF
--- a/Orm/Xtensive.Orm.Tests/Linq/NullableEnumMaterializationTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/NullableEnumMaterializationTest.cs
@@ -27,6 +27,9 @@ namespace Xtensive.Orm.Tests.Linq
 
       [Field]
       public MyEnum? Value { get; set; }
+
+      [Field]
+      public MyEnum Value2 { get; set; }
     }
 
     [HierarchyRoot]
@@ -58,6 +61,7 @@ namespace Xtensive.Orm.Tests.Linq
         new RefEntity {Ref = new EntityWithNullableEnum {Value = MyEnum.Foo}};
         new RefEntity {Ref = new EntityWithNullableEnum {Value = MyEnum.Bar}};
         new RefEntity {Ref = new EntityWithNullableEnum {Value = null}};
+        new RefEntity();
         tx.Complete();
       }
     }
@@ -128,6 +132,24 @@ namespace Xtensive.Orm.Tests.Linq
         Assert.That(result.Count(r => r.Match), Is.EqualTo(2));
         tx.Complete();
       }
+    }
+
+    private class ResultModel
+    {
+      public MyEnum? Enum { get; init; }
+    }
+
+    [Test]
+    public void MaterializeNullableEnum()
+    {
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+      var result = session.Query.All<RefEntity>()
+        .Where(e => e.Ref == null)
+        .Select(e => new ResultModel { Enum = e.Ref != null ? e.Ref.Value2 : null })
+        .First();
+      Assert.That(result.Enum, Is.Null);
+      tx.Complete();
     }
   }
 }

--- a/Orm/Xtensive.Orm.Tests/Linq/NullableEnumMaterializationTest.cs
+++ b/Orm/Xtensive.Orm.Tests/Linq/NullableEnumMaterializationTest.cs
@@ -151,5 +151,18 @@ namespace Xtensive.Orm.Tests.Linq
       Assert.That(result.Enum, Is.Null);
       tx.Complete();
     }
+
+    [Test]
+    public void MaterializeNullableEnumAndWhere()
+    {
+      using var session = Domain.OpenSession();
+      using var tx = session.OpenTransaction();
+      var result = session.Query.All<RefEntity>()
+        .Where(e => e.Ref == null)
+        .Select(e => new ResultModel { Enum = e.Ref != null ? e.Ref.Value2 : null })
+        .First(e => !e.Enum.HasValue);
+      Assert.That(result.Enum, Is.Null);
+      tx.Complete();
+    }
   }
 }

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/NullComparisonRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/NullComparisonRewriter.cs
@@ -20,16 +20,27 @@ namespace Xtensive.Orm.Linq.Rewriters
       return e;
     }
 
-    protected override Expression VisitConstant(ConstantExpression c) =>
-      c.Type is var type && type.IsValueType && type.IsNullable() && c.Value is null
-        ? Expression.Convert(c, type)
-        : c;
+    private static bool TryApplyExplicitConvert(ref Expression e, Expression a)
+    {
+      if (a.NodeType == ExpressionType.Convert
+          && e is ConstantExpression { Type: { IsValueType: true} type } c
+          && type.IsNullable()
+          && c.Value is null) {
+        e = Expression.Convert(e, type);
+        return true;
+      }
+      return false;
+    }
 
     protected override Expression VisitConditional(ConditionalExpression c)
     {
       var test = Visit(c.Test);
       var ifTrue = Visit(c.IfTrue);
       var ifFalse = Visit(c.IfFalse);
+
+      if (!TryApplyExplicitConvert(ref ifFalse, ifTrue)) {
+        TryApplyExplicitConvert(ref ifTrue, ifFalse);
+      }
 
       if (test.NodeType is ExpressionType.Equal or ExpressionType.NotEqual) {
         var binaryExpression = (BinaryExpression) test;

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/NullComparisonRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/NullComparisonRewriter.cs
@@ -6,6 +6,7 @@ using System.Linq.Expressions;
 using Xtensive.Core;
 using Xtensive.Linq;
 using Xtensive.Orm.Internals;
+using Xtensive.Reflection;
 using ExpressionVisitor = Xtensive.Linq.ExpressionVisitor;
 
 namespace Xtensive.Orm.Linq.Rewriters
@@ -17,6 +18,14 @@ namespace Xtensive.Orm.Linq.Rewriters
     protected override Expression VisitUnknown(Expression e)
     {
       return e;
+    }
+
+    protected override Expression VisitConstant(ConstantExpression c)
+    {
+      if (c.Type.IsValueType && c.Type.IsNullable() && c.Value == null) {
+        return Expression.Convert(c, c.Type);
+      }
+      return c;
     }
 
     protected override Expression VisitConditional(ConditionalExpression c)

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/NullComparisonRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/NullComparisonRewriter.cs
@@ -21,8 +21,8 @@ namespace Xtensive.Orm.Linq.Rewriters
     }
 
     protected override Expression VisitConstant(ConstantExpression c) =>
-      c.Type.IsValueType && c.Type.IsNullable() && c.Value is null
-        ? Expression.Convert(c, c.Type)
+      c.Type is var type && type.IsValueType && type.IsNullable() && c.Value is null
+        ? Expression.Convert(c, type)
         : c;
 
     protected override Expression VisitConditional(ConditionalExpression c)

--- a/Orm/Xtensive.Orm/Orm/Linq/Rewriters/NullComparisonRewriter.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Rewriters/NullComparisonRewriter.cs
@@ -20,13 +20,10 @@ namespace Xtensive.Orm.Linq.Rewriters
       return e;
     }
 
-    protected override Expression VisitConstant(ConstantExpression c)
-    {
-      if (c.Type.IsValueType && c.Type.IsNullable() && c.Value == null) {
-        return Expression.Convert(c, c.Type);
-      }
-      return c;
-    }
+    protected override Expression VisitConstant(ConstantExpression c) =>
+      c.Type.IsValueType && c.Type.IsNullable() && c.Value is null
+        ? Expression.Convert(c, c.Type)
+        : c;
 
     protected override Expression VisitConditional(ConditionalExpression c)
     {

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -150,8 +150,6 @@ namespace Xtensive.Orm.Linq
     {
       using (CreateLambdaScope(le, allowCalculableColumnCombine: false)) {
         Expression body = le.Body;
-        if (!State.IsTailMethod)
-          body = NullComparisonRewriter.Rewrite(body);
         body = Visit(body);
         ParameterExpression parameter = le.Parameters[0];
         var nodeType = body.NodeType;

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -150,6 +150,8 @@ namespace Xtensive.Orm.Linq
     {
       using (CreateLambdaScope(le, allowCalculableColumnCombine: false)) {
         Expression body = le.Body;
+        if (!State.IsTailMethod)
+          body = NullComparisonRewriter.Rewrite(body);
         body = Visit(body);
         ParameterExpression parameter = le.Parameters[0];
         var nodeType = body.NodeType;

--- a/Version.props
+++ b/Version.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.3.27</DoVersion>
+    <DoVersion>7.3.28</DoVersion>
     <DoVersionSuffix>servicetitan-test-nullenum</DoVersionSuffix>
 </PropertyGroup>
 

--- a/Version.props
+++ b/Version.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.3.26</DoVersion>
+    <DoVersion>7.3.27</DoVersion>
     <DoVersionSuffix>servicetitan-test-nullenum</DoVersionSuffix>
 </PropertyGroup>
 

--- a/Version.props
+++ b/Version.props
@@ -2,8 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <PropertyGroup>
-    <DoVersion>7.3.24</DoVersion>
-    <DoVersionSuffix>servicetitan</DoVersionSuffix>
+    <DoVersion>7.3.26</DoVersion>
+    <DoVersionSuffix>servicetitan-test-nullenum</DoVersionSuffix>
 </PropertyGroup>
 
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -3,7 +3,7 @@
 
 <PropertyGroup>
     <DoVersion>7.3.28</DoVersion>
-    <DoVersionSuffix>servicetitan-test-nullenum</DoVersionSuffix>
+    <DoVersionSuffix>servicetitan</DoVersionSuffix>
 </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
`NullComparisonRewriter` incorrectly processes nullable enum

For example following line in a materializer:
`JobStatus = r.Job != null ? r.Job.Status : null`
sometime assigns `default(JobStatus)` instead of `null` `(when r.Job == null)`

This depends on `State.IsTailMethod` flag which activates `NullComparisonRewriter`.

Adding `.Tag()` can change the behavior.
or
`query.ToList().First()` and `query.First()`  have different behavior.


This PR  improves  `NullComparisonRewriter` to add explicit conversion from `null` to `(ValueType?)null`
