### PR TITLE
Optimize `LambdaExpressionFactory`

### DIFF
--- a/Orm/Xtensive.Orm.Tests.Core/Linq/LambdaExpressionFactoryTests.cs
+++ b/Orm/Xtensive.Orm.Tests.Core/Linq/LambdaExpressionFactoryTests.cs
@@ -43,8 +43,7 @@ namespace Xtensive.Orm.Tests.Core.Linq
     [Test]
     public void ShouldCreateLambda()
     {
-      var lambda = (Func<int, int>) LambdaExpressionFactory.Instance
-        .CreateLambda(delegateType, plusOne.Body, plusOne.Parameters)
+      var lambda = (Func<int, int>) LambdaExpressionFactory.CreateLambda(delegateType, plusOne.Body, plusOne.Parameters)
         .Compile();
 
       Assert.That(lambda.Invoke(1), Is.EqualTo(2));

--- a/Orm/Xtensive.Orm/Linq/ExpressionVisitor.cs
+++ b/Orm/Xtensive.Orm/Linq/ExpressionVisitor.cs
@@ -145,7 +145,7 @@ namespace Xtensive.Linq
 
     /// <inheritdoc/>
     protected override Expression VisitLambda<T>(Expression<T> l) =>
-      Visit((LambdaExpression)l, l.Body, static (l, body) => FastExpression.Lambda(l.Type, body, l.Parameters));
+      Visit((LambdaExpression)l, l.Body, static (l, body) => FastExpression.Lambda<T>(body, l.Parameters));
 
     protected Expression VisitLambda(LambdaExpression lambda) => base.Visit(lambda);
 

--- a/Orm/Xtensive.Orm/Linq/FastExpression.cs
+++ b/Orm/Xtensive.Orm/Linq/FastExpression.cs
@@ -24,7 +24,7 @@ namespace Xtensive.Linq
     /// <param name="parameters">The parameters of lambda expression.</param>
     /// <returns>Constructed lambda expression.</returns>
     public static LambdaExpression Lambda(Type delegateType, Expression body, params ParameterExpression[] parameters) =>
-      LambdaExpressionFactory.Instance.CreateLambda(delegateType, body, parameters ?? Array.Empty<ParameterExpression>());
+      LambdaExpressionFactory.CreateLambda(delegateType, body, parameters ?? []);
 
     /// <summary>
     /// Generates <see cref="LambdaExpression"/> faster than <see cref="Expression.Lambda(Type,Expression,ParameterExpression[])"/>.
@@ -34,10 +34,10 @@ namespace Xtensive.Linq
     /// <param name="parameters">The parameters of lambda expression.</param>
     /// <returns>Constructed lambda expression.</returns>
     public static Expression<TDelegate> Lambda<TDelegate>(Expression body, params ParameterExpression[] parameters) =>
-      (Expression<TDelegate>) LambdaExpressionFactory.Instance.CreateLambda(typeof(TDelegate), body, parameters ?? Array.Empty<ParameterExpression>());
+      LambdaExpressionFactory.CreateLambda<TDelegate>(body, parameters ?? []);
 
     public static Expression<TDelegate> Lambda<TDelegate>(Expression body, IReadOnlyList<ParameterExpression> parameters) =>
-      (Expression<TDelegate>) LambdaExpressionFactory.Instance.CreateLambda(typeof(TDelegate), body, parameters);
+      LambdaExpressionFactory.CreateLambda<TDelegate>(body, parameters);
 
     /// <summary>
     /// Generates <see cref="LambdaExpression"/> faster than <see cref="Expression.Lambda(Type,Expression,IEnumerable{ParameterExpression})"/>.
@@ -47,7 +47,7 @@ namespace Xtensive.Linq
     /// <param name="parameters">The parameters of lambda expression.</param>
     /// <returns>Constructed lambda expression.</returns>
     public static LambdaExpression Lambda(Type delegateType, Expression body, IReadOnlyList<ParameterExpression> parameters) =>
-      LambdaExpressionFactory.Instance.CreateLambda(delegateType, body, parameters);
+      LambdaExpressionFactory.CreateLambda(delegateType, body, parameters);
 
     /// <summary>
     /// Generates <see cref="LambdaExpression"/> faster than <see cref="Expression.Lambda(Expression,ParameterExpression[])"/>.
@@ -56,7 +56,7 @@ namespace Xtensive.Linq
     /// <param name="parameters">The parameters of lambda expression.</param>
     /// <returns>Constructed lambda expression.</returns>
     public static LambdaExpression Lambda(Expression body, params ParameterExpression[] parameters) =>
-      LambdaExpressionFactory.Instance.CreateLambda(body, parameters ?? Array.Empty<ParameterExpression>());
+      LambdaExpressionFactory.CreateLambda(body, parameters ?? []);
 
     /// <summary>
     /// Generates <see cref="LambdaExpression"/> faster than <see cref="Expression.Lambda(Expression,ParameterExpression[])"/>.
@@ -65,6 +65,6 @@ namespace Xtensive.Linq
     /// <param name="parameters">The parameters of lambda expression.</param>
     /// <returns>Constructed lambda expression.</returns>
     public static LambdaExpression Lambda(Expression body, IReadOnlyList<ParameterExpression> parameters) =>
-      LambdaExpressionFactory.Instance.CreateLambda(body, parameters);
+      LambdaExpressionFactory.CreateLambda(body, parameters);
   }
 }

--- a/Orm/Xtensive.Orm/Linq/Internals/LambdaExpressionFactory.cs
+++ b/Orm/Xtensive.Orm/Linq/Internals/LambdaExpressionFactory.cs
@@ -50,7 +50,7 @@ namespace Xtensive.Linq
 
     private static readonly Func<Type, Factory> CreateHandler = CanUseFastFactory() ? CreateFactoryFast : CreateFactorySlow;
 
-    private static readonly ConcurrentDictionary<Type, Factory> cache = new();
+    private static readonly ConcurrentDictionary<Type, Factory> cache = [];
 
     private static class Traits<TDelegate>
     {

--- a/Orm/Xtensive.Orm/Linq/Internals/LambdaExpressionFactory.cs
+++ b/Orm/Xtensive.Orm/Linq/Internals/LambdaExpressionFactory.cs
@@ -34,7 +34,7 @@ using FastFactory = System.Func<
 
 namespace Xtensive.Linq
 {
-  internal sealed class LambdaExpressionFactory
+  internal static class LambdaExpressionFactory
   {
     private static readonly Type[] internalFactorySignature = new[] {
       WellKnownTypes.Expression, WellKnownTypes.String, WellKnownTypes.Bool, typeof(IReadOnlyList<ParameterExpression>)
@@ -50,14 +50,20 @@ namespace Xtensive.Linq
 
     private static readonly Func<Type, Factory> CreateHandler = CanUseFastFactory() ? CreateFactoryFast : CreateFactorySlow;
 
-    public static LambdaExpressionFactory Instance { get; } = new();
+    private static readonly ConcurrentDictionary<Type, Factory> cache = new();
 
-    private readonly ConcurrentDictionary<Type, Factory> cache = new();
+    private static class Traits<TDelegate>
+    {
+      public static readonly Factory Factory = CreateHandler(typeof(TDelegate));
+    }
 
-    public LambdaExpression CreateLambda(Type delegateType, Expression body, IReadOnlyList<ParameterExpression> parameters) =>
+    public static Expression<TDelegate> CreateLambda<TDelegate>(Expression body, IReadOnlyList<ParameterExpression> parameters) =>
+      (Expression<TDelegate>) Traits<TDelegate>.Factory(body, parameters);
+
+    public static LambdaExpression CreateLambda(Type delegateType, Expression body, IReadOnlyList<ParameterExpression> parameters) =>
       cache.GetOrAdd(delegateType, CreateHandler).Invoke(body, parameters);
 
-    public LambdaExpression CreateLambda(Expression body, IReadOnlyList<ParameterExpression> parameters)
+    public static LambdaExpression CreateLambda(Expression body, IReadOnlyList<ParameterExpression> parameters)
     {
       var delegateType = DelegateHelper.MakeDelegateType(body.Type, parameters.Select(p => p.Type), parameters.Count);
       return CreateLambda(delegateType, body, parameters);


### PR DESCRIPTION
Make `LambdaExpressionFactory` static to skip dereference of `LambdaExpressionFactory.Instance`

Cache lambda factories in static `Traits<TDelegate>.Factory`instead of `ConcurrentDictionary` by `typeof(TDelegate)` key  when the `TDelegate` is known statically