### PR TITLE
Cache some `MethodInfo` by static `Traits<>` instead of global `ConcurrentDictionary`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Linq/QueryHelper.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/QueryHelper.cs
@@ -96,13 +96,13 @@ namespace Xtensive.Orm.Linq
       var indexerGetter = ownerType.GetMethod(Reflection.WellKnown.IndexerPropertyGetterName, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
       if (indexerGetter.Attributes.HasFlag(MethodAttributes.SpecialName)
           && (indexerGetter.DeclaringType == WellKnownOrmTypes.Persistent || indexerGetter.DeclaringType == WellKnownOrmTypes.Entity))
-        return Expression.Convert(Expression.Call(Expression.Constant(owner), indexerGetter, new[] { Expression.Constant(entitySet.Field.Name) }), entitySet.Field.ValueType);
+        return Expression.Convert(Expression.Call(Expression.Constant(owner), indexerGetter, Expression.Constant(entitySet.Field.Name)), entitySet.Field.ValueType);
 
       // old-fashion slow way, if something went wrong
       var indexers = ownerType.GetProperties(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
         .Where(p => p.GetIndexParameters().Any())
         .Select(p => p.GetGetMethod());
-      return Expression.Convert(Expression.Call(Expression.Constant(owner),indexers.Single(), new []{Expression.Constant(entitySet.Field.Name)}), entitySet.Field.ValueType);
+      return Expression.Convert(Expression.Call(Expression.Constant(owner),indexers.Single(), Expression.Constant(entitySet.Field.Name)), entitySet.Field.ValueType);
     }
 
     public static Expression CreateEntitySetQuery(Expression ownerEntity, FieldInfo field, Domain domain)

--- a/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
+++ b/Orm/Xtensive.Orm/Orm/Linq/Translator.Expressions.cs
@@ -1018,7 +1018,7 @@ namespace Xtensive.Orm.Linq
         Expression.Call(
           objectExpression,
           objectExpression.Type.GetProperty(Reflection.WellKnown.IndexerPropertyName).GetGetMethod(),
-          new[] {Expression.Constant(evaluatedArgument)}),
+          Expression.Constant(evaluatedArgument)),
         fieldInfo.ValueType);
     }
 

--- a/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryEndpoint.cs
@@ -137,7 +137,7 @@ namespace Xtensive.Orm
     {
       ArgumentNullException.ThrowIfNull(searchCriteria);
       var method = WellKnownMembers.Query.FreeTextExpression.CachedMakeGenericMethod(typeof(T));
-      var expression = Expression.Call(null, method, [searchCriteria]);
+      var expression = Expression.Call(method, searchCriteria);
       return Provider.CreateQuery<FullTextMatch<T>>(expression);
     }
 
@@ -158,7 +158,7 @@ namespace Xtensive.Orm
       ArgumentNullException.ThrowIfNull(searchCriteria);
       ArgumentOutOfRangeException.ThrowIfNegativeOrZero(topNByRank);
       var method = WellKnownMembers.Query.FreeTextExpressionTopNByRank.CachedMakeGenericMethod(typeof (T));
-      var expression = Expression.Call(null, method, searchCriteria, Expr.Constant(topNByRank));
+      var expression = Expression.Call(method, searchCriteria, Expr.Constant(topNByRank));
       return Provider.CreateQuery<FullTextMatch<T>>(expression);
     }
 
@@ -198,7 +198,7 @@ namespace Xtensive.Orm
       ArgumentNullException.ThrowIfNull(searchCriteria);
       ArgumentNullException.ThrowIfNull(targetFields);
       var method = WellKnownMembers.Query.ContainsTableExprWithColumns.CachedMakeGenericMethod(typeof(T));
-      var expression = Expression.Call(null, method, searchCriteria, Expression.Constant(targetFields));
+      var expression = Expression.Call(method, searchCriteria, Expression.Constant(targetFields));
       return Provider.CreateQuery<FullTextMatch<T>>(expression);
     }
 
@@ -221,7 +221,7 @@ namespace Xtensive.Orm
       ArgumentNullException.ThrowIfNull(searchCriteria);
       ArgumentOutOfRangeException.ThrowIfNegativeOrZero(topNByRank);
       var method = WellKnownMembers.Query.ContainsTableExprTopNByRank.CachedMakeGenericMethod(typeof(T));
-      var expression = Expression.Call(null, method, searchCriteria, Expr.Constant(topNByRank));
+      var expression = Expression.Call(method, searchCriteria, Expr.Constant(topNByRank));
       return Provider.CreateQuery<FullTextMatch<T>>(expression);
     }
 
@@ -249,7 +249,7 @@ namespace Xtensive.Orm
       ArgumentNullException.ThrowIfNull(targetFields);
       ArgumentOutOfRangeException.ThrowIfNegativeOrZero(topNByRank);
       var method = WellKnownMembers.Query.ContainsTableExprTopNByRank.CachedMakeGenericMethod(typeof(T));
-      var expression = Expression.Call(null, method, searchCriteria, Expression.Constant(targetFields), Expr.Constant(topNByRank));
+      var expression = Expression.Call(method, searchCriteria, Expression.Constant(targetFields), Expr.Constant(topNByRank));
       return Provider.CreateQuery<FullTextMatch<T>>(expression);
     }
 

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
@@ -72,7 +72,7 @@ namespace Xtensive.Orm
     /// if every element of the source sequence passes the test in the specified predicate;
     /// otherwise, false. </returns>
     public static Task<bool> AllAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, bool>(AllTraits<TSource>.Method, source, predicate, cancellationToken);
+      ExecuteScalarAsync<bool>(AllTraits<TSource>.Method, source, predicate, cancellationToken);
 
     private static class AnyTraits<TSource>
     {
@@ -95,7 +95,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains true
     /// if the source sequence contains any elements; otherwise, false.</returns>
     public static Task<bool> AnyAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, bool>(AnyTraits<TSource>.Method, source, cancellationToken);
+      ExecuteScalarAsync<bool>(AnyTraits<TSource>.Method, source, cancellationToken);
 
     private static class AnyWithPredicateTraits<TSource>
     {
@@ -120,7 +120,7 @@ namespace Xtensive.Orm
     /// if any elements in the source sequence pass the test in the specified predicate;
     /// otherwise, false.</returns>
     public static Task<bool> AnyAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, bool>(AnyWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
+      ExecuteScalarAsync<bool>(AnyWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
 
     #region AverageAsync
 
@@ -143,7 +143,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the sequence of values.</returns>
     public static Task<double> AverageAsync(this IQueryable<int> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<int, double>(AverageIntDoubleMethod, source, cancellationToken);
+      ExecuteScalarAsync<double>(AverageIntDoubleMethod, source, cancellationToken);
 
     private static readonly MethodInfo AverageNullableIntDoubleMethod = NormalizeOperation<int?, double?>(WellKnownMembers.Queryable.AverageNullableInt32);
 
@@ -162,7 +162,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the sequence of values.</returns>
     public static Task<double?> AverageAsync(this IQueryable<int?> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<int?, double?>(AverageNullableIntDoubleMethod, source, cancellationToken);
+      ExecuteScalarAsync<double?>(AverageNullableIntDoubleMethod, source, cancellationToken);
 
     private static class AverageWithSelectorInt32Traits<TSource>
     {
@@ -187,7 +187,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the projected values.</returns>
     public static Task<double> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, double>(AverageWithSelectorInt32Traits<TSource>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<double>(AverageWithSelectorInt32Traits<TSource>.Method, source, selector, cancellationToken);
 
     private static class AverageWithSelectorNullableInt32Traits<TSource>
     {
@@ -212,7 +212,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the projected values.</returns>
     public static Task<double?> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int?>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, double?>(AverageWithSelectorNullableInt32Traits<TSource>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<double?>(AverageWithSelectorNullableInt32Traits<TSource>.Method, source, selector, cancellationToken);
 
     // Average<long>
 
@@ -233,7 +233,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the sequence of values.</returns>
     public static Task<double> AverageAsync(this IQueryable<long> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<long, double>(AverageLongDoubleMethod, source, cancellationToken);
+      ExecuteScalarAsync<double>(AverageLongDoubleMethod, source, cancellationToken);
 
     private static readonly MethodInfo AverageNullableLongDoubleMethod = NormalizeOperation<long?, double?>(WellKnownMembers.Queryable.AverageNullableInt64);
 
@@ -252,7 +252,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the sequence of values.</returns>
     public static Task<double?> AverageAsync(this IQueryable<long?> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<long?, double?>(AverageNullableLongDoubleMethod, source, cancellationToken);
+      ExecuteScalarAsync<double?>(AverageNullableLongDoubleMethod, source, cancellationToken);
 
     private static class AverageWithSelectorInt64Traits<TSource>
     {
@@ -277,7 +277,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the projected values.</returns>
     public static Task<double> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, long>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, double>(AverageWithSelectorInt64Traits<TSource>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<double>(AverageWithSelectorInt64Traits<TSource>.Method, source, selector, cancellationToken);
 
     private static class AverageWithSelectorNullableInt64Traits<TSource>
     {
@@ -302,7 +302,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the projected values.</returns>
     public static Task<double?> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, long?>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, double?>(AverageWithSelectorNullableInt64Traits<TSource>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<double?>(AverageWithSelectorNullableInt64Traits<TSource>.Method, source, selector, cancellationToken);
 
     // Average<double>
 
@@ -323,7 +323,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the sequence of values.</returns>
     public static Task<double> AverageAsync(this IQueryable<double> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<double, double>(AverageDoubleMethod, source, cancellationToken);
+      ExecuteScalarAsync<double>(AverageDoubleMethod, source, cancellationToken);
 
     private static readonly MethodInfo AverageNullableDoubleMethod = NormalizeOperation<double?, double?>(WellKnownMembers.Queryable.AverageNullableDouble);
 
@@ -342,7 +342,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the sequence of values.</returns>
     public static Task<double?> AverageAsync(this IQueryable<double?> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<double?, double?>(AverageNullableDoubleMethod, source, cancellationToken);
+      ExecuteScalarAsync<double?>(AverageNullableDoubleMethod, source, cancellationToken);
 
     private static class AverageWithSelectorDoubleTraits<TSource>
     {
@@ -367,7 +367,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the projected values.</returns>
     public static Task<double> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, double>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, double>(AverageWithSelectorDoubleTraits<TSource>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<double>(AverageWithSelectorDoubleTraits<TSource>.Method, source, selector, cancellationToken);
 
     private static class AverageWithSelectorNullableDoubleTraits<TSource>
     {
@@ -392,7 +392,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the projected values.</returns>
     public static Task<double?> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, double?>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, double?>(AverageWithSelectorNullableDoubleTraits<TSource>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<double?>(AverageWithSelectorNullableDoubleTraits<TSource>.Method, source, selector, cancellationToken);
 
     // Average<float>
 
@@ -413,7 +413,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the sequence of values.</returns>
     public static Task<float> AverageAsync(this IQueryable<float> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<float, float>(AverageSingleMethod, source, cancellationToken);
+      ExecuteScalarAsync<float>(AverageSingleMethod, source, cancellationToken);
 
     private static readonly MethodInfo AverageNullableSingleMethod = NormalizeOperation<float?, float?>(WellKnownMembers.Queryable.AverageNullableSingle);
 
@@ -432,7 +432,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the sequence of values.</returns>
     public static Task<float?> AverageAsync(this IQueryable<float?> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<float?, float?>(AverageNullableSingleMethod, source, cancellationToken);
+      ExecuteScalarAsync<float?>(AverageNullableSingleMethod, source, cancellationToken);
 
     private static class AverageWithSelectorSingleTraits<TSource>
     {
@@ -457,7 +457,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the projected values.</returns>
     public static Task<float> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, float>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, float>(AverageWithSelectorSingleTraits<TSource>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<float>(AverageWithSelectorSingleTraits<TSource>.Method, source, selector, cancellationToken);
 
     private static class AverageWithSelectorNullableSingleTraits<TSource>
     {
@@ -482,7 +482,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the projected values.</returns>
     public static Task<float?> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, float?>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, float?>(AverageWithSelectorNullableSingleTraits<TSource>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<float?>(AverageWithSelectorNullableSingleTraits<TSource>.Method, source, selector, cancellationToken);
 
     // Average<decimal>
 
@@ -503,7 +503,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the sequence of values.</returns>
     public static Task<decimal> AverageAsync(this IQueryable<decimal> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<decimal, decimal>(AverageDecimalMethod, source, cancellationToken);
+      ExecuteScalarAsync<decimal>(AverageDecimalMethod, source, cancellationToken);
 
     private static readonly MethodInfo AverageNullableDecimalMethod = NormalizeOperation<decimal?, decimal?>(WellKnownMembers.Queryable.AverageNullableDecimal);
 
@@ -522,7 +522,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the sequence of values.</returns>
     public static Task<decimal?> AverageAsync(this IQueryable<decimal?> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<decimal?, decimal?>(AverageNullableDecimalMethod, source, cancellationToken);
+      ExecuteScalarAsync<decimal?>(AverageNullableDecimalMethod, source, cancellationToken);
 
     private static class AverageWithSelectorDecimalTraits<TSource>
     {
@@ -547,7 +547,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the projected values.</returns>
     public static Task<decimal> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, decimal>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, decimal>(AverageWithSelectorDecimalTraits<TSource>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<decimal>(AverageWithSelectorDecimalTraits<TSource>.Method, source, selector, cancellationToken);
 
     private static class AverageWithSelectorNullableDecimalTraits<TSource>
     {
@@ -572,7 +572,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the projected values.</returns>
     public static Task<decimal?> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, decimal?>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, decimal?>(AverageWithSelectorNullableDecimalTraits<TSource>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<decimal?>(AverageWithSelectorNullableDecimalTraits<TSource>.Method, source, selector, cancellationToken);
 
     #endregion
 
@@ -600,7 +600,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains true
     /// if the input sequence contains the specified value; otherwise, false.</returns>
     public static Task<bool> ContainsAsync<TSource>(this IQueryable<TSource> source, TSource item, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, bool>(ContainsTraits<TSource>.Method, source, Expression.Constant(item, typeof(TSource)), cancellationToken);
+      ExecuteScalarAsync<bool>(ContainsTraits<TSource>.Method, source, Expression.Constant(item, typeof(TSource)), cancellationToken);
 
     #region Count
 
@@ -625,7 +625,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// number of elements in the input sequence.</returns>
     public static Task<int> CountAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, int>(CountTraits<TSource>.Method, source, cancellationToken);
+      ExecuteScalarAsync<int>(CountTraits<TSource>.Method, source, cancellationToken);
 
     private static class CountWithPredicateTraits<TSource>
     {
@@ -649,7 +649,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// number of elements in the sequence that satisfy the condition in the predicate function.</returns>
     public static Task<int> CountAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, int>(CountWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
+      ExecuteScalarAsync<int>(CountWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
 
     #endregion
 
@@ -678,7 +678,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     ///  first element in source.</returns>
     public static Task<TSource> FirstAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(FirstTraits<TSource>.Method, source, cancellationToken);
+      ExecuteScalarAsync<TSource>(FirstTraits<TSource>.Method, source, cancellationToken);
 
     private static class FirstWithPredicateTraits<TSource>
     {
@@ -702,7 +702,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     ///  first element in source that passes the test in predicate.</returns>
     public static Task<TSource> FirstAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(FirstWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
+      ExecuteScalarAsync<TSource>(FirstWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
 
     // FirstOrDefault
 
@@ -728,7 +728,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains default
     /// (TSource) if source is empty; otherwise, the first element in source.</returns>
     public static Task<TSource> FirstOrDefaultAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(FirstOrDefaultTraits<TSource>.Method, source, cancellationToken);
+      ExecuteScalarAsync<TSource>(FirstOrDefaultTraits<TSource>.Method, source, cancellationToken);
 
     private static class FirstOrDefaultWithPredicateTraits<TSource>
     {
@@ -754,7 +754,7 @@ namespace Xtensive.Orm
     /// (TSource) if source is empty or if no element passes the test specified by predicate;
     /// otherwise, the first element in source that passes the test specified by predicate.</returns>
     public static Task<TSource> FirstOrDefaultAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(FirstOrDefaultWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
+      ExecuteScalarAsync<TSource>(FirstOrDefaultWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
 
     #endregion
 
@@ -782,7 +782,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// last element in source.</returns>
     public static Task<TSource> LastAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(LastTraits<TSource>.Method, source, cancellationToken);
+      ExecuteScalarAsync<TSource>(LastTraits<TSource>.Method, source, cancellationToken);
 
     private static class LastWithPredicateTraits<TSource>
     {
@@ -806,7 +806,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// last element in source.</returns>
     public static Task<TSource> LastAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(LastWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
+      ExecuteScalarAsync<TSource>(LastWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
 
     // LastOrDefault
 
@@ -832,7 +832,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains default
     /// (TSource) if source is empty; otherwise, the last element in source.</returns>
     public static Task<TSource> LastOrDefaultAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(LastOrDefaultTraits<TSource>.Method, source, cancellationToken);
+      ExecuteScalarAsync<TSource>(LastOrDefaultTraits<TSource>.Method, source, cancellationToken);
 
     private static class LastOrDefaultWithPredicateTraits<TSource>
     {
@@ -858,7 +858,7 @@ namespace Xtensive.Orm
     /// (TSource) if source is empty or if no element passes the test specified by predicate;
     /// otherwise, the last element in source that passes the test specified by predicate.</returns>
     public static Task<TSource> LastOrDefaultAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(LastOrDefaultWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
+      ExecuteScalarAsync<TSource>(LastOrDefaultWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
 
     #endregion
 
@@ -886,7 +886,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// number of elements in the input sequence.</returns>
     public static Task<long> LongCountAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, long>(LongCountTraits<TSource>.Method, source, cancellationToken);
+      ExecuteScalarAsync<long>(LongCountTraits<TSource>.Method, source, cancellationToken);
 
     private static class LongCountWithPredicateTraits<TSource>
     {
@@ -912,7 +912,7 @@ namespace Xtensive.Orm
     /// number of elements in the sequence that satisfy the condition in the predicate
     /// function.</returns>
     public static Task<long> LongCountAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, long>(LongCountWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
+      ExecuteScalarAsync<long>(LongCountWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
 
     #endregion
 
@@ -941,7 +941,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// maximum value in the sequence.</returns>
     public static Task<TSource> MaxAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(MaxTraits<TSource>.Method, source, cancellationToken);
+      ExecuteScalarAsync<TSource>(MaxTraits<TSource>.Method, source, cancellationToken);
 
     private static class MaxWithSelectorTraits<TSource, TResult>
     {
@@ -967,7 +967,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// maximum value in the sequence.</returns>
     public static Task<TResult> MaxAsync<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TResult>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TResult>(MaxWithSelectorTraits<TSource, TResult>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<TResult>(MaxWithSelectorTraits<TSource, TResult>.Method, source, selector, cancellationToken);
 
     // Min
 
@@ -991,7 +991,7 @@ namespace Xtensive.Orm
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     public static Task<TSource> MinAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(MinTraits<TSource>.Method, source, cancellationToken);
+      ExecuteScalarAsync<TSource>(MinTraits<TSource>.Method, source, cancellationToken);
 
     private static class MinWithSelectorTraits<TSource, TResult>
     {
@@ -1016,7 +1016,7 @@ namespace Xtensive.Orm
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     public static Task<TResult> MinAsync<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TResult>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TResult>(MinWithSelectorTraits<TSource, TResult>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<TResult>(MinWithSelectorTraits<TSource, TResult>.Method, source, selector, cancellationToken);
 
     #endregion
 
@@ -1046,7 +1046,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// single element of the input sequence that satisfies the condition in predicate.</returns>
     public static Task<TSource> SingleAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(SingleTraits<TSource>.Method, source, cancellationToken);
+      ExecuteScalarAsync<TSource>(SingleTraits<TSource>.Method, source, cancellationToken);
 
     private static class SingleWithPredicateTraits<TSource>
     {
@@ -1071,7 +1071,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// single element of the input sequence that satisfies the condition in predicate.</returns>
     public static Task<TSource> SingleAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(SingleWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
+      ExecuteScalarAsync<TSource>(SingleWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
 
     // SingleOrDefault
 
@@ -1099,7 +1099,7 @@ namespace Xtensive.Orm
     /// single element of the input sequence, or default (TSource) if the sequence contains
     /// no elements.</returns>
     public static Task<TSource> SingleOrDefaultAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(SingleOrDefaultTraits<TSource>.Method, source, cancellationToken);
+      ExecuteScalarAsync<TSource>(SingleOrDefaultTraits<TSource>.Method, source, cancellationToken);
 
     private static class SingleOrDefaultWithPredicateTraits<TSource>
     {
@@ -1126,7 +1126,7 @@ namespace Xtensive.Orm
     /// single element of the input sequence that satisfies the condition in predicate,
     /// or default (TSource) if no such element is found.</returns>
     public static Task<TSource> SingleOrDefaultAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(SingleOrDefaultWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
+      ExecuteScalarAsync<TSource>(SingleOrDefaultWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
 
     #endregion
 
@@ -1151,7 +1151,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the values in the sequence.</returns>
     public static Task<int> SumAsync(this IQueryable<int> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<int, int>(IntSumMethod, source, cancellationToken);
+      ExecuteScalarAsync<int>(IntSumMethod, source, cancellationToken);
 
     private static readonly MethodInfo NullableIntSumMethod = NormalizeOperation<int?, int?>(WellKnownMembers.Queryable.SumNullableInt32);
 
@@ -1170,7 +1170,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the values in the sequence.</returns>
     public static Task<int?> SumAsync(this IQueryable<int?> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<int?, int?>(NullableIntSumMethod, source, cancellationToken);
+      ExecuteScalarAsync<int?>(NullableIntSumMethod, source, cancellationToken);
 
     private static class SumWithSelectorInt32Traits<TSource>
     {
@@ -1196,7 +1196,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the projected values.</returns>
     public static Task<int> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, int>(SumWithSelectorInt32Traits<TSource>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<int>(SumWithSelectorInt32Traits<TSource>.Method, source, selector, cancellationToken);
 
     private static class SumWithSelectorNullableInt32Traits<TSource>
     {
@@ -1221,7 +1221,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the projected values.</returns>
     public static Task<int?> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int?>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, int?>(SumWithSelectorNullableInt32Traits<TSource>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<int?>(SumWithSelectorNullableInt32Traits<TSource>.Method, source, selector, cancellationToken);
 
     // Sum<long>
 
@@ -1242,7 +1242,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the values in the sequence.</returns>
     public static Task<long> SumAsync(this IQueryable<long> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<long, long>(LongSumMethod, source, cancellationToken);
+      ExecuteScalarAsync<long>(LongSumMethod, source, cancellationToken);
 
     private static readonly MethodInfo NullableLongSumMethod = NormalizeOperation<long?, long?>(WellKnownMembers.Queryable.SumNullableInt64);
 
@@ -1261,7 +1261,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the values in the sequence.</returns>
     public static Task<long?> SumAsync(this IQueryable<long?> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<long?, long?>(NullableLongSumMethod, source, cancellationToken);
+      ExecuteScalarAsync<long?>(NullableLongSumMethod, source, cancellationToken);
 
     private static class SumWithSelectorInt64Traits<TSource>
     {
@@ -1286,7 +1286,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the projected values.</returns>
     public static Task<long> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, long>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, long>(SumWithSelectorInt64Traits<TSource>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<long>(SumWithSelectorInt64Traits<TSource>.Method, source, selector, cancellationToken);
 
     private static class SumWithSelectorNullableInt64Traits<TSource>
     {
@@ -1311,7 +1311,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the projected values.</returns>
     public static Task<long?> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, long?>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, long?>(SumWithSelectorNullableInt64Traits<TSource>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<long?>(SumWithSelectorNullableInt64Traits<TSource>.Method, source, selector, cancellationToken);
 
     // Sum<double>
 
@@ -1332,7 +1332,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the values in the sequence.</returns>
     public static Task<double> SumAsync(this IQueryable<double> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<double, double>(SumDoubleMethod, source, cancellationToken);
+      ExecuteScalarAsync<double>(SumDoubleMethod, source, cancellationToken);
 
     private static readonly MethodInfo NullableDoubleSumMethod = NormalizeOperation<double?, double?>(WellKnownMembers.Queryable.SumNullableDouble);
 
@@ -1351,7 +1351,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the values in the sequence.</returns>
     public static Task<double?> SumAsync(this IQueryable<double?> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<double?, double?>(NullableDoubleSumMethod, source, cancellationToken);
+      ExecuteScalarAsync<double?>(NullableDoubleSumMethod, source, cancellationToken);
 
     private static class SumWithSelectorDoubleTraits<TSource>
     {
@@ -1376,7 +1376,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the projected values.</returns>
     public static Task<double> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, double>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, double>(SumWithSelectorDoubleTraits<TSource>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<double>(SumWithSelectorDoubleTraits<TSource>.Method, source, selector, cancellationToken);
 
     private static class SumWithSelectorNullableDoubleTraits<TSource>
     {
@@ -1401,7 +1401,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the projected values.</returns>
     public static Task<double?> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, double?>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, double?>(SumWithSelectorNullableDoubleTraits<TSource>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<double?>(SumWithSelectorNullableDoubleTraits<TSource>.Method, source, selector, cancellationToken);
 
     // Sum<float>
 
@@ -1422,7 +1422,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the values in the sequence.</returns>
     public static Task<float> SumAsync(this IQueryable<float> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<float, float>(SumSingleMethod, source, cancellationToken);
+      ExecuteScalarAsync<float>(SumSingleMethod, source, cancellationToken);
 
     private static readonly MethodInfo SumNullableSingleMethod = NormalizeOperation<float?, float?>(WellKnownMembers.Queryable.SumNullableSingle);
 
@@ -1441,7 +1441,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the values in the sequence.</returns>
     public static Task<float?> SumAsync(this IQueryable<float?> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<float?, float?>(SumNullableSingleMethod, source, cancellationToken);
+      ExecuteScalarAsync<float?>(SumNullableSingleMethod, source, cancellationToken);
 
     private static class SumWithSelectorSingleTraits<TSource>
     {
@@ -1466,7 +1466,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the projected values.</returns>
     public static Task<float> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, float>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, float>(SumWithSelectorSingleTraits<TSource>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<float>(SumWithSelectorSingleTraits<TSource>.Method, source, selector, cancellationToken);
 
     private static class SumWithSelectorNullableSingleTraits<TSource>
     {
@@ -1491,7 +1491,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the projected values.</returns>
     public static Task<float?> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, float?>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, float?>(SumWithSelectorNullableSingleTraits<TSource>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<float?>(SumWithSelectorNullableSingleTraits<TSource>.Method, source, selector, cancellationToken);
 
     // Sum<decimal>
 
@@ -1512,7 +1512,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the values in the sequence.</returns>
     public static Task<decimal> SumAsync(this IQueryable<decimal> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<decimal, decimal>(SumDecimalMethod, source, cancellationToken);
+      ExecuteScalarAsync<decimal>(SumDecimalMethod, source, cancellationToken);
 
     private static readonly MethodInfo SumNullableDecimalMethod = NormalizeOperation<decimal?, decimal?>(WellKnownMembers.Queryable.SumNullableDecimal);
 
@@ -1531,7 +1531,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the values in the sequence.</returns>
     public static Task<decimal?> SumAsync(this IQueryable<decimal?> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<decimal?, decimal?>(SumNullableDecimalMethod, source, cancellationToken);
+      ExecuteScalarAsync<decimal?>(SumNullableDecimalMethod, source, cancellationToken);
 
     private static class SumWithSelectorDecimalTraits<TSource>
     {
@@ -1556,7 +1556,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the projected values.</returns>
     public static Task<decimal> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, decimal>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, decimal>(SumWithSelectorDecimalTraits<TSource>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<decimal>(SumWithSelectorDecimalTraits<TSource>.Method, source, selector, cancellationToken);
 
     private static class SumWithSelectorNullableDecimalTraits<TSource>
     {
@@ -1581,7 +1581,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the projected values.</returns>
     public static Task<decimal?> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, decimal?>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, decimal?>(SumWithSelectorNullableDecimalTraits<TSource>.Method, source, selector, cancellationToken);
+      ExecuteScalarAsync<decimal?>(SumWithSelectorNullableDecimalTraits<TSource>.Method, source, selector, cancellationToken);
 
     #endregion
 
@@ -1853,8 +1853,8 @@ namespace Xtensive.Orm
         : operation.GetGenericArguments().Length == 2 ? operation.CachedMakeGenericMethod(typeof(TSource), typeof(TResult))
         : operation.CachedMakeGenericMethod(typeof(TSource));
 
-    private static async Task<TResult> ExecuteScalarAsync<TSource, TResult>(MethodInfo operation,
-      IQueryable<TSource> source, CancellationToken cancellationToken)
+    private static async Task<TResult> ExecuteScalarAsync<TResult>(MethodInfo operation,
+      IQueryable source, CancellationToken cancellationToken)
     {
       ArgumentNullException.ThrowIfNull(source);
       return source.Provider is QueryProvider provider
@@ -1862,8 +1862,8 @@ namespace Xtensive.Orm
         : (TResult) operation.Invoke(BoxedZero, [source]);
     }
 
-    private static async Task<TResult> ExecuteScalarAsync<TSource, TResult>(MethodInfo operation,
-      IQueryable<TSource> source,
+    private static async Task<TResult> ExecuteScalarAsync<TResult>(MethodInfo operation,
+      IQueryable source,
       Expression expression,
       CancellationToken cancellationToken = default)
     {

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
@@ -49,6 +49,11 @@ namespace Xtensive.Orm
       }
     }
 
+    private static class AllTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, bool>(WellKnownMembers.Queryable.All);
+    }
+
     /// <summary>
     /// Asynchronously determines whether all the elements of a sequence satisfy a condition.
     /// </summary>
@@ -67,7 +72,12 @@ namespace Xtensive.Orm
     /// if every element of the source sequence passes the test in the specified predicate;
     /// otherwise, false. </returns>
     public static Task<bool> AllAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, bool>(WellKnownMembers.Queryable.All, source, predicate, cancellationToken);
+      ExecuteScalarAsync<TSource, bool>(AllTraits<TSource>.Method, source, predicate, cancellationToken);
+
+    private static class AnyTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, bool>(WellKnownMembers.Queryable.Any);
+    }
 
     /// <summary>
     /// Asynchronously determines whether a sequence contains any elements.
@@ -85,7 +95,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains true
     /// if the source sequence contains any elements; otherwise, false.</returns>
     public static Task<bool> AnyAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, bool>(WellKnownMembers.Queryable.Any, source, cancellationToken);
+      ExecuteScalarAsync<TSource, bool>(AnyTraits<TSource>.Method, source, cancellationToken);
+
+    private static class AnyWithPredicateTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, bool>(WellKnownMembers.Queryable.AnyWithPredicate);
+    }
 
     /// <summary>
     /// Asynchronously determines whether any element of a sequence satisfies a condition.
@@ -105,11 +120,13 @@ namespace Xtensive.Orm
     /// if any elements in the source sequence pass the test in the specified predicate;
     /// otherwise, false.</returns>
     public static Task<bool> AnyAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, bool>(WellKnownMembers.Queryable.AnyWithPredicate, source, predicate, cancellationToken);
+      ExecuteScalarAsync<TSource, bool>(AnyWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
 
     #region AverageAsync
 
     // Average<int>
+
+    private static readonly MethodInfo AverageIntDoubleMethod = NormalizeOperation<int, double>(WellKnownMembers.Queryable.AverageInt32);
 
     /// <summary>
     /// Asynchronously computes the average of a sequence of values.
@@ -126,7 +143,9 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the sequence of values.</returns>
     public static Task<double> AverageAsync(this IQueryable<int> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<int, double>(WellKnownMembers.Queryable.AverageInt32, source, cancellationToken);
+      ExecuteScalarAsync<int, double>(AverageIntDoubleMethod, source, cancellationToken);
+
+    private static readonly MethodInfo AverageNullableIntDoubleMethod = NormalizeOperation<int?, double?>(WellKnownMembers.Queryable.AverageNullableInt32);
 
     /// <summary>
     /// Asynchronously computes the average of a sequence of values.
@@ -143,7 +162,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the sequence of values.</returns>
     public static Task<double?> AverageAsync(this IQueryable<int?> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<int?, double?>(WellKnownMembers.Queryable.AverageNullableInt32, source, cancellationToken);
+      ExecuteScalarAsync<int?, double?>(AverageNullableIntDoubleMethod, source, cancellationToken);
+
+    private static class AverageWithSelectorInt32Traits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, double>(WellKnownMembers.Queryable.AverageWithSelectorInt32);
+    }
 
     /// <summary>
     /// Asynchronously computes the average of a sequence of values that is obtained
@@ -163,7 +187,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the projected values.</returns>
     public static Task<double> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, double>(WellKnownMembers.Queryable.AverageWithSelectorInt32, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, double>(AverageWithSelectorInt32Traits<TSource>.Method, source, selector, cancellationToken);
+
+    private static class AverageWithSelectorNullableInt32Traits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, double?>(WellKnownMembers.Queryable.AverageWithSelectorNullableInt32);
+    }
 
     /// <summary>
     /// Asynchronously computes the average of a sequence of values that is obtained
@@ -183,9 +212,11 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the projected values.</returns>
     public static Task<double?> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int?>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, double?>(WellKnownMembers.Queryable.AverageWithSelectorNullableInt32, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, double?>(AverageWithSelectorNullableInt32Traits<TSource>.Method, source, selector, cancellationToken);
 
     // Average<long>
+
+    private static readonly MethodInfo AverageLongDoubleMethod = NormalizeOperation<long, double>(WellKnownMembers.Queryable.AverageInt64);
 
     /// <summary>
     /// Asynchronously computes the average of a sequence of values.
@@ -202,7 +233,9 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the sequence of values.</returns>
     public static Task<double> AverageAsync(this IQueryable<long> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<long, double>(WellKnownMembers.Queryable.AverageInt64, source, cancellationToken);
+      ExecuteScalarAsync<long, double>(AverageLongDoubleMethod, source, cancellationToken);
+
+    private static readonly MethodInfo AverageNullableLongDoubleMethod = NormalizeOperation<long?, double?>(WellKnownMembers.Queryable.AverageNullableInt64);
 
     /// <summary>
     /// Asynchronously computes the average of a sequence of values.
@@ -219,7 +252,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the sequence of values.</returns>
     public static Task<double?> AverageAsync(this IQueryable<long?> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<long?, double?>(WellKnownMembers.Queryable.AverageNullableInt64, source, cancellationToken);
+      ExecuteScalarAsync<long?, double?>(AverageNullableLongDoubleMethod, source, cancellationToken);
+
+    private static class AverageWithSelectorInt64Traits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, double>(WellKnownMembers.Queryable.AverageWithSelectorInt64);
+    }
 
     /// <summary>
     /// Asynchronously computes the average of a sequence of values that is obtained
@@ -239,7 +277,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the projected values.</returns>
     public static Task<double> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, long>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, double>(WellKnownMembers.Queryable.AverageWithSelectorInt64, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, double>(AverageWithSelectorInt64Traits<TSource>.Method, source, selector, cancellationToken);
+
+    private static class AverageWithSelectorNullableInt64Traits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, double?>(WellKnownMembers.Queryable.AverageWithSelectorNullableInt64);
+    }
 
     /// <summary>
     /// Asynchronously computes the average of a sequence of values that is obtained
@@ -259,9 +302,11 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the projected values.</returns>
     public static Task<double?> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, long?>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, double?>(WellKnownMembers.Queryable.AverageWithSelectorNullableInt64, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, double?>(AverageWithSelectorNullableInt64Traits<TSource>.Method, source, selector, cancellationToken);
 
     // Average<double>
+
+    private static readonly MethodInfo AverageDoubleMethod = NormalizeOperation<double, double>(WellKnownMembers.Queryable.AverageDouble);
 
     /// <summary>
     /// Asynchronously computes the average of a sequence of values.
@@ -278,7 +323,9 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the sequence of values.</returns>
     public static Task<double> AverageAsync(this IQueryable<double> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<double, double>(WellKnownMembers.Queryable.AverageDouble, source, cancellationToken);
+      ExecuteScalarAsync<double, double>(AverageDoubleMethod, source, cancellationToken);
+
+    private static readonly MethodInfo AverageNullableDoubleMethod = NormalizeOperation<double?, double?>(WellKnownMembers.Queryable.AverageNullableDouble);
 
     /// <summary>
     /// Asynchronously computes the average of a sequence of values.
@@ -295,7 +342,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the sequence of values.</returns>
     public static Task<double?> AverageAsync(this IQueryable<double?> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<double?, double?>(WellKnownMembers.Queryable.AverageNullableDouble, source, cancellationToken);
+      ExecuteScalarAsync<double?, double?>(AverageNullableDoubleMethod, source, cancellationToken);
+
+    private static class AverageWithSelectorDoubleTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, double>(WellKnownMembers.Queryable.AverageWithSelectorDouble);
+    }
 
     /// <summary>
     /// Asynchronously computes the average of a sequence of values that is obtained
@@ -315,7 +367,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the projected values.</returns>
     public static Task<double> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, double>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, double>(WellKnownMembers.Queryable.AverageWithSelectorDouble, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, double>(AverageWithSelectorDoubleTraits<TSource>.Method, source, selector, cancellationToken);
+
+    private static class AverageWithSelectorNullableDoubleTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, double?>(WellKnownMembers.Queryable.AverageWithSelectorNullableDouble);
+    }
 
     /// <summary>
     /// Asynchronously computes the average of a sequence of values that is obtained
@@ -335,9 +392,11 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the projected values.</returns>
     public static Task<double?> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, double?>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, double?>(WellKnownMembers.Queryable.AverageWithSelectorNullableDouble, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, double?>(AverageWithSelectorNullableDoubleTraits<TSource>.Method, source, selector, cancellationToken);
 
     // Average<float>
+
+    private static readonly MethodInfo AverageSingleMethod = NormalizeOperation<float, float>(WellKnownMembers.Queryable.AverageSingle);
 
     /// <summary>
     /// Asynchronously computes the average of a sequence of values.
@@ -354,7 +413,9 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the sequence of values.</returns>
     public static Task<float> AverageAsync(this IQueryable<float> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<float, float>(WellKnownMembers.Queryable.AverageSingle, source, cancellationToken);
+      ExecuteScalarAsync<float, float>(AverageSingleMethod, source, cancellationToken);
+
+    private static readonly MethodInfo AverageNullableSingleMethod = NormalizeOperation<float?, float?>(WellKnownMembers.Queryable.AverageNullableSingle);
 
     /// <summary>
     /// Asynchronously computes the average of a sequence of values.
@@ -371,7 +432,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the sequence of values.</returns>
     public static Task<float?> AverageAsync(this IQueryable<float?> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<float?, float?>(WellKnownMembers.Queryable.AverageNullableSingle, source, cancellationToken);
+      ExecuteScalarAsync<float?, float?>(AverageNullableSingleMethod, source, cancellationToken);
+
+    private static class AverageWithSelectorSingleTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, float>(WellKnownMembers.Queryable.AverageWithSelectorSingle);
+    }
 
     /// <summary>
     /// Asynchronously computes the average of a sequence of values that is obtained
@@ -391,7 +457,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the projected values.</returns>
     public static Task<float> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, float>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, float>(WellKnownMembers.Queryable.AverageWithSelectorSingle, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, float>(AverageWithSelectorSingleTraits<TSource>.Method, source, selector, cancellationToken);
+
+    private static class AverageWithSelectorNullableSingleTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, float?>(WellKnownMembers.Queryable.AverageWithSelectorNullableSingle);
+    }
 
     /// <summary>
     /// Asynchronously computes the average of a sequence of values that is obtained
@@ -411,9 +482,11 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the projected values.</returns>
     public static Task<float?> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, float?>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, float?>(WellKnownMembers.Queryable.AverageWithSelectorNullableSingle, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, float?>(AverageWithSelectorNullableSingleTraits<TSource>.Method, source, selector, cancellationToken);
 
     // Average<decimal>
+
+    private static readonly MethodInfo AverageDecimalMethod = NormalizeOperation<decimal, decimal>(WellKnownMembers.Queryable.AverageDecimal);
 
     /// <summary>
     /// Asynchronously computes the average of a sequence of values.
@@ -430,7 +503,9 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the sequence of values.</returns>
     public static Task<decimal> AverageAsync(this IQueryable<decimal> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<decimal, decimal>(WellKnownMembers.Queryable.AverageDecimal, source, cancellationToken);
+      ExecuteScalarAsync<decimal, decimal>(AverageDecimalMethod, source, cancellationToken);
+
+    private static readonly MethodInfo AverageNullableDecimalMethod = NormalizeOperation<decimal?, decimal?>(WellKnownMembers.Queryable.AverageNullableDecimal);
 
     /// <summary>
     /// Asynchronously computes the average of a sequence of values.
@@ -447,7 +522,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the sequence of values.</returns>
     public static Task<decimal?> AverageAsync(this IQueryable<decimal?> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<decimal?, decimal?>(WellKnownMembers.Queryable.AverageNullableDecimal, source, cancellationToken);
+      ExecuteScalarAsync<decimal?, decimal?>(AverageNullableDecimalMethod, source, cancellationToken);
+
+    private static class AverageWithSelectorDecimalTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, decimal>(WellKnownMembers.Queryable.AverageWithSelectorDecimal);
+    }
 
     /// <summary>
     /// Asynchronously computes the average of a sequence of values that is obtained
@@ -467,7 +547,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the projected values.</returns>
     public static Task<decimal> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, decimal>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, decimal>(WellKnownMembers.Queryable.AverageWithSelectorDecimal, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, decimal>(AverageWithSelectorDecimalTraits<TSource>.Method, source, selector, cancellationToken);
+
+    private static class AverageWithSelectorNullableDecimalTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, decimal?>(WellKnownMembers.Queryable.AverageWithSelectorNullableDecimal);
+    }
 
     /// <summary>
     /// Asynchronously computes the average of a sequence of values that is obtained
@@ -487,11 +572,16 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// average of the projected values.</returns>
     public static Task<decimal?> AverageAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, decimal?>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, decimal?>(WellKnownMembers.Queryable.AverageWithSelectorNullableDecimal, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, decimal?>(AverageWithSelectorNullableDecimalTraits<TSource>.Method, source, selector, cancellationToken);
 
     #endregion
 
     // Contains
+
+    private static class ContainsTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, bool>(WellKnownMembers.Queryable.Contains);
+    }
 
     /// <summary>
     /// Asynchronously determines whether a sequence contains a specified element.
@@ -510,9 +600,14 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains true
     /// if the input sequence contains the specified value; otherwise, false.</returns>
     public static Task<bool> ContainsAsync<TSource>(this IQueryable<TSource> source, TSource item, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, bool>(WellKnownMembers.Queryable.Contains, source, Expression.Constant(item, typeof(TSource)), cancellationToken);
+      ExecuteScalarAsync<TSource, bool>(ContainsTraits<TSource>.Method, source, Expression.Constant(item, typeof(TSource)), cancellationToken);
 
     #region Count
+
+    private static class CountTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, int>(WellKnownMembers.Queryable.Count);
+    }
 
     /// <summary>
     /// Asynchronously returns the number of elements in a sequence.
@@ -530,7 +625,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// number of elements in the input sequence.</returns>
     public static Task<int> CountAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, int>(WellKnownMembers.Queryable.Count, source, cancellationToken);
+      ExecuteScalarAsync<TSource, int>(CountTraits<TSource>.Method, source, cancellationToken);
+
+    private static class CountWithPredicateTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, int>(WellKnownMembers.Queryable.CountWithPredicate);
+    }
 
     /// <summary>
     /// Asynchronously returns the number of elements in a sequence that satisfy a condition.
@@ -549,13 +649,18 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// number of elements in the sequence that satisfy the condition in the predicate function.</returns>
     public static Task<int> CountAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, int>(WellKnownMembers.Queryable.CountWithPredicate, source, predicate, cancellationToken);
+      ExecuteScalarAsync<TSource, int>(CountWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
 
     #endregion
 
     #region First, FirstOrDefault
 
     // First
+
+    private static class FirstTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, TSource>(WellKnownMembers.Queryable.First);
+    }
 
     /// <summary>
     /// Asynchronously returns the first element of a sequence
@@ -573,7 +678,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     ///  first element in source.</returns>
     public static Task<TSource> FirstAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(WellKnownMembers.Queryable.First, source, cancellationToken);
+      ExecuteScalarAsync<TSource, TSource>(FirstTraits<TSource>.Method, source, cancellationToken);
+
+    private static class FirstWithPredicateTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, TSource>(WellKnownMembers.Queryable.FirstWithPredicate);
+    }
 
     /// <summary>
     /// Asynchronously returns the first element of a sequence that satisfies a specified condition.
@@ -592,9 +702,14 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     ///  first element in source that passes the test in predicate.</returns>
     public static Task<TSource> FirstAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(WellKnownMembers.Queryable.FirstWithPredicate, source, predicate, cancellationToken);
+      ExecuteScalarAsync<TSource, TSource>(FirstWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
 
     // FirstOrDefault
+
+    private static class FirstOrDefaultTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, TSource>(WellKnownMembers.Queryable.FirstOrDefault);
+    }
 
     /// <summary>
     /// Asynchronously returns the first element of a sequence, or a default value if
@@ -613,7 +728,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains default
     /// (TSource) if source is empty; otherwise, the first element in source.</returns>
     public static Task<TSource> FirstOrDefaultAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(WellKnownMembers.Queryable.FirstOrDefault, source, cancellationToken);
+      ExecuteScalarAsync<TSource, TSource>(FirstOrDefaultTraits<TSource>.Method, source, cancellationToken);
+
+    private static class FirstOrDefaultWithPredicateTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, TSource>(WellKnownMembers.Queryable.FirstOrDefaultWithPredicate);
+    }
 
     /// <summary>
     /// Asynchronously returns the first element of a sequence that satisfies a specified
@@ -634,12 +754,17 @@ namespace Xtensive.Orm
     /// (TSource) if source is empty or if no element passes the test specified by predicate;
     /// otherwise, the first element in source that passes the test specified by predicate.</returns>
     public static Task<TSource> FirstOrDefaultAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(WellKnownMembers.Queryable.FirstOrDefaultWithPredicate, source, predicate, cancellationToken);
+      ExecuteScalarAsync<TSource, TSource>(FirstOrDefaultWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
 
     #endregion
 
     #region Last, LastOrDefault
     // Last
+
+    private static class LastTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, TSource>(WellKnownMembers.Queryable.Last);
+    }
 
     /// <summary>
     /// Asynchronously returns the last element of a sequence.
@@ -657,7 +782,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// last element in source.</returns>
     public static Task<TSource> LastAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(WellKnownMembers.Queryable.Last, source, cancellationToken);
+      ExecuteScalarAsync<TSource, TSource>(LastTraits<TSource>.Method, source, cancellationToken);
+
+    private static class LastWithPredicateTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, TSource>(WellKnownMembers.Queryable.LastWithPredicate);
+    }
 
     /// <summary>
     /// Asynchronously returns the last element of a sequence.
@@ -676,9 +806,14 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// last element in source.</returns>
     public static Task<TSource> LastAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(WellKnownMembers.Queryable.LastWithPredicate, source, predicate, cancellationToken);
+      ExecuteScalarAsync<TSource, TSource>(LastWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
 
     // LastOrDefault
+
+    private static class LastOrDefaultTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, TSource>(WellKnownMembers.Queryable.LastOrDefault);
+    }
 
     /// <summary>
     /// Asynchronously returns the last element of a sequence, or a default value if
@@ -697,7 +832,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains default
     /// (TSource) if source is empty; otherwise, the last element in source.</returns>
     public static Task<TSource> LastOrDefaultAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(WellKnownMembers.Queryable.LastOrDefault, source, cancellationToken);
+      ExecuteScalarAsync<TSource, TSource>(LastOrDefaultTraits<TSource>.Method, source, cancellationToken);
+
+    private static class LastOrDefaultWithPredicateTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, TSource>(WellKnownMembers.Queryable.LastOrDefaultWithPredicate);
+    }
 
     /// <summary>
     /// Asynchronously returns the last element of a sequence that satisfies a specified
@@ -718,11 +858,16 @@ namespace Xtensive.Orm
     /// (TSource) if source is empty or if no element passes the test specified by predicate;
     /// otherwise, the last element in source that passes the test specified by predicate.</returns>
     public static Task<TSource> LastOrDefaultAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(WellKnownMembers.Queryable.LastOrDefaultWithPredicate, source, predicate, cancellationToken);
+      ExecuteScalarAsync<TSource, TSource>(LastOrDefaultWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
 
     #endregion
 
     #region LongCount
+
+    private static class LongCountTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, long>(WellKnownMembers.Queryable.LongCount);
+    }
 
     /// <summary>
     /// Asynchronously returns an System.Int64 that represents the number of elements
@@ -741,7 +886,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// number of elements in the input sequence.</returns>
     public static Task<long> LongCountAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, long>(WellKnownMembers.Queryable.LongCount, source, cancellationToken);
+      ExecuteScalarAsync<TSource, long>(LongCountTraits<TSource>.Method, source, cancellationToken);
+
+    private static class LongCountWithPredicateTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, long>(WellKnownMembers.Queryable.LongCountWithPredicate);
+    }
 
     /// <summary>
     /// Asynchronously returns an System.Int64 that represents the number of elements
@@ -762,13 +912,18 @@ namespace Xtensive.Orm
     /// number of elements in the sequence that satisfy the condition in the predicate
     /// function.</returns>
     public static Task<long> LongCountAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, long>(WellKnownMembers.Queryable.LongCountWithPredicate, source, predicate, cancellationToken);
+      ExecuteScalarAsync<TSource, long>(LongCountWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
 
     #endregion
 
     #region Min, Max
 
     // Max
+
+    private static class MaxTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, TSource>(WellKnownMembers.Queryable.Max);
+    }
 
     /// <summary>
     /// Asynchronously returns the maximum value of a sequence.
@@ -786,7 +941,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// maximum value in the sequence.</returns>
     public static Task<TSource> MaxAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(WellKnownMembers.Queryable.Max, source, cancellationToken);
+      ExecuteScalarAsync<TSource, TSource>(MaxTraits<TSource>.Method, source, cancellationToken);
+
+    private static class MaxWithSelectorTraits<TSource, TResult>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, TResult>(WellKnownMembers.Queryable.MaxWithSelector);
+    }
 
     /// <summary>
     /// Asynchronously invokes a projection function on each element of a sequence and
@@ -807,9 +967,14 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// maximum value in the sequence.</returns>
     public static Task<TResult> MaxAsync<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TResult>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TResult>(WellKnownMembers.Queryable.MaxWithSelector, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, TResult>(MaxWithSelectorTraits<TSource, TResult>.Method, source, selector, cancellationToken);
 
     // Min
+
+    private static class MinTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, TSource>(WellKnownMembers.Queryable.Min);
+    }
 
     /// <summary>
     /// Asynchronously returns the minimum value of a sequence.
@@ -826,7 +991,12 @@ namespace Xtensive.Orm
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     public static Task<TSource> MinAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(WellKnownMembers.Queryable.Min, source, cancellationToken);
+      ExecuteScalarAsync<TSource, TSource>(MinTraits<TSource>.Method, source, cancellationToken);
+
+    private static class MinWithSelectorTraits<TSource, TResult>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, TResult>(WellKnownMembers.Queryable.MinWithSelector);
+    }
 
     /// <summary>
     /// Asynchronously invokes a projection function on each element of a sequence and
@@ -846,13 +1016,18 @@ namespace Xtensive.Orm
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     public static Task<TResult> MinAsync<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TResult>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TResult>(WellKnownMembers.Queryable.MinWithSelector, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, TResult>(MinWithSelectorTraits<TSource, TResult>.Method, source, selector, cancellationToken);
 
     #endregion
 
     #region Single, SingleOrDefault
 
     // Single
+
+    private static class SingleTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, TSource>(WellKnownMembers.Queryable.Single);
+    }
 
     /// <summary>
     /// Asynchronously returns the only element of a sequence that satisfies a specified
@@ -871,7 +1046,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// single element of the input sequence that satisfies the condition in predicate.</returns>
     public static Task<TSource> SingleAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(WellKnownMembers.Queryable.Single, source, cancellationToken);
+      ExecuteScalarAsync<TSource, TSource>(SingleTraits<TSource>.Method, source, cancellationToken);
+
+    private static class SingleWithPredicateTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, TSource>(WellKnownMembers.Queryable.SingleWithPredicate);
+    }
 
     /// <summary>
     /// Asynchronously returns the only element of a sequence that satisfies a specified
@@ -891,9 +1071,14 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// single element of the input sequence that satisfies the condition in predicate.</returns>
     public static Task<TSource> SingleAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(WellKnownMembers.Queryable.SingleWithPredicate, source, predicate, cancellationToken);
+      ExecuteScalarAsync<TSource, TSource>(SingleWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
 
     // SingleOrDefault
+
+    private static class SingleOrDefaultTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, TSource>(WellKnownMembers.Queryable.SingleOrDefault);
+    }
 
     /// <summary>
     /// Asynchronously returns the only element of a sequence, or a default value if
@@ -914,7 +1099,12 @@ namespace Xtensive.Orm
     /// single element of the input sequence, or default (TSource) if the sequence contains
     /// no elements.</returns>
     public static Task<TSource> SingleOrDefaultAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(WellKnownMembers.Queryable.SingleOrDefault, source, cancellationToken);
+      ExecuteScalarAsync<TSource, TSource>(SingleOrDefaultTraits<TSource>.Method, source, cancellationToken);
+
+    private static class SingleOrDefaultWithPredicateTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, TSource>(WellKnownMembers.Queryable.SingleOrDefaultWithPredicate);
+    }
 
     /// <summary>
     /// Asynchronously returns the only element of a sequence, or a default value if
@@ -936,13 +1126,15 @@ namespace Xtensive.Orm
     /// single element of the input sequence that satisfies the condition in predicate,
     /// or default (TSource) if no such element is found.</returns>
     public static Task<TSource> SingleOrDefaultAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, TSource>(WellKnownMembers.Queryable.SingleOrDefaultWithPredicate, source, predicate, cancellationToken);
+      ExecuteScalarAsync<TSource, TSource>(SingleOrDefaultWithPredicateTraits<TSource>.Method, source, predicate, cancellationToken);
 
     #endregion
 
     #region Sum
 
     // Sum<int>
+
+    private static readonly MethodInfo IntSumMethod = NormalizeOperation<int, int>(WellKnownMembers.Queryable.SumInt32);
 
     /// <summary>
     /// Asynchronously computes the sum of a sequence of values.
@@ -959,7 +1151,9 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the values in the sequence.</returns>
     public static Task<int> SumAsync(this IQueryable<int> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<int, int>(WellKnownMembers.Queryable.SumInt32, source, cancellationToken);
+      ExecuteScalarAsync<int, int>(IntSumMethod, source, cancellationToken);
+
+    private static readonly MethodInfo NullableIntSumMethod = NormalizeOperation<int?, int?>(WellKnownMembers.Queryable.SumNullableInt32);
 
     /// <summary>
     /// Asynchronously computes the sum of a sequence of values.
@@ -976,7 +1170,13 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the values in the sequence.</returns>
     public static Task<int?> SumAsync(this IQueryable<int?> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<int?, int?>(WellKnownMembers.Queryable.SumNullableInt32, source, cancellationToken);
+      ExecuteScalarAsync<int?, int?>(NullableIntSumMethod, source, cancellationToken);
+
+    private static class SumWithSelectorInt32Traits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, int>(WellKnownMembers.Queryable.SumWithSelectorInt32);
+    }
+
 
     /// <summary>
     /// Asynchronously computes the sum of the sequence of values that is obtained by
@@ -996,7 +1196,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the projected values.</returns>
     public static Task<int> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, int>(WellKnownMembers.Queryable.SumWithSelectorInt32, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, int>(SumWithSelectorInt32Traits<TSource>.Method, source, selector, cancellationToken);
+
+    private static class SumWithSelectorNullableInt32Traits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, int?>(WellKnownMembers.Queryable.SumWithSelectorNullableInt32);
+    }
 
     /// <summary>
     /// Asynchronously computes the sum of the sequence of values that is obtained by
@@ -1016,9 +1221,11 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the projected values.</returns>
     public static Task<int?> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int?>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, int?>(WellKnownMembers.Queryable.SumWithSelectorNullableInt32, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, int?>(SumWithSelectorNullableInt32Traits<TSource>.Method, source, selector, cancellationToken);
 
     // Sum<long>
+
+    private static readonly MethodInfo LongSumMethod = NormalizeOperation<long, long>(WellKnownMembers.Queryable.SumInt64);
 
     /// <summary>
     /// Asynchronously computes the sum of a sequence of values.
@@ -1035,7 +1242,9 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the values in the sequence.</returns>
     public static Task<long> SumAsync(this IQueryable<long> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<long, long>(WellKnownMembers.Queryable.SumInt64, source, cancellationToken);
+      ExecuteScalarAsync<long, long>(LongSumMethod, source, cancellationToken);
+
+    private static readonly MethodInfo NullableLongSumMethod = NormalizeOperation<long?, long?>(WellKnownMembers.Queryable.SumNullableInt64);
 
     /// <summary>
     /// Asynchronously computes the sum of a sequence of values.
@@ -1052,7 +1261,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the values in the sequence.</returns>
     public static Task<long?> SumAsync(this IQueryable<long?> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<long?, long?>(WellKnownMembers.Queryable.SumNullableInt64, source, cancellationToken);
+      ExecuteScalarAsync<long?, long?>(NullableLongSumMethod, source, cancellationToken);
+
+    private static class SumWithSelectorInt64Traits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, long>(WellKnownMembers.Queryable.SumWithSelectorInt64);
+    }
 
     /// <summary>
     /// Asynchronously computes the sum of the sequence of values that is obtained by
@@ -1072,7 +1286,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the projected values.</returns>
     public static Task<long> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, long>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, long>(WellKnownMembers.Queryable.SumWithSelectorInt64, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, long>(SumWithSelectorInt64Traits<TSource>.Method, source, selector, cancellationToken);
+
+    private static class SumWithSelectorNullableInt64Traits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, long?>(WellKnownMembers.Queryable.SumWithSelectorNullableInt64);
+    }
 
     /// <summary>
     /// Asynchronously computes the sum of the sequence of values that is obtained by
@@ -1092,9 +1311,11 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the projected values.</returns>
     public static Task<long?> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, long?>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, long?>(WellKnownMembers.Queryable.SumWithSelectorNullableInt64, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, long?>(SumWithSelectorNullableInt64Traits<TSource>.Method, source, selector, cancellationToken);
 
     // Sum<double>
+
+    private static readonly MethodInfo SumDoubleMethod = NormalizeOperation<double, double>(WellKnownMembers.Queryable.SumDouble);
 
     /// <summary>
     /// Asynchronously computes the sum of a sequence of values.
@@ -1111,7 +1332,9 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the values in the sequence.</returns>
     public static Task<double> SumAsync(this IQueryable<double> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<double, double>(WellKnownMembers.Queryable.SumDouble, source, cancellationToken);
+      ExecuteScalarAsync<double, double>(SumDoubleMethod, source, cancellationToken);
+
+    private static readonly MethodInfo NullableDoubleSumMethod = NormalizeOperation<double?, double?>(WellKnownMembers.Queryable.SumNullableDouble);
 
     /// <summary>
     /// Asynchronously computes the sum of a sequence of values.
@@ -1128,7 +1351,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the values in the sequence.</returns>
     public static Task<double?> SumAsync(this IQueryable<double?> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<double?, double?>(WellKnownMembers.Queryable.SumNullableDouble, source, cancellationToken);
+      ExecuteScalarAsync<double?, double?>(NullableDoubleSumMethod, source, cancellationToken);
+
+    private static class SumWithSelectorDoubleTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, double>(WellKnownMembers.Queryable.SumWithSelectorDouble);
+    }
 
     /// <summary>
     /// Asynchronously computes the sum of the sequence of values that is obtained by
@@ -1148,7 +1376,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the projected values.</returns>
     public static Task<double> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, double>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, double>(WellKnownMembers.Queryable.SumWithSelectorDouble, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, double>(SumWithSelectorDoubleTraits<TSource>.Method, source, selector, cancellationToken);
+
+    private static class SumWithSelectorNullableDoubleTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, double?>(WellKnownMembers.Queryable.SumWithSelectorNullableDouble);
+    }
 
     /// <summary>
     /// Asynchronously computes the sum of the sequence of values that is obtained by
@@ -1168,9 +1401,11 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the projected values.</returns>
     public static Task<double?> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, double?>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, double?>(WellKnownMembers.Queryable.SumWithSelectorNullableDouble, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, double?>(SumWithSelectorNullableDoubleTraits<TSource>.Method, source, selector, cancellationToken);
 
     // Sum<float>
+
+    private static readonly MethodInfo SumSingleMethod = NormalizeOperation<float, float>(WellKnownMembers.Queryable.SumSingle);
 
     /// <summary>
     /// Asynchronously computes the sum of a sequence of values.
@@ -1187,7 +1422,9 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the values in the sequence.</returns>
     public static Task<float> SumAsync(this IQueryable<float> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<float, float>(WellKnownMembers.Queryable.SumSingle, source, cancellationToken);
+      ExecuteScalarAsync<float, float>(SumSingleMethod, source, cancellationToken);
+
+    private static readonly MethodInfo SumNullableSingleMethod = NormalizeOperation<float?, float?>(WellKnownMembers.Queryable.SumNullableSingle);
 
     /// <summary>
     /// Asynchronously computes the sum of a sequence of values.
@@ -1204,7 +1441,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the values in the sequence.</returns>
     public static Task<float?> SumAsync(this IQueryable<float?> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<float?, float?>(WellKnownMembers.Queryable.SumNullableSingle, source, cancellationToken);
+      ExecuteScalarAsync<float?, float?>(SumNullableSingleMethod, source, cancellationToken);
+
+    private static class SumWithSelectorSingleTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, float>(WellKnownMembers.Queryable.SumWithSelectorSingle);
+    }
 
     /// <summary>
     /// Asynchronously computes the sum of the sequence of values that is obtained by
@@ -1224,7 +1466,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the projected values.</returns>
     public static Task<float> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, float>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, float>(WellKnownMembers.Queryable.SumWithSelectorSingle, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, float>(SumWithSelectorSingleTraits<TSource>.Method, source, selector, cancellationToken);
+
+    private static class SumWithSelectorNullableSingleTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, float?>(WellKnownMembers.Queryable.SumWithSelectorNullableSingle);
+    }
 
     /// <summary>
     /// Asynchronously computes the sum of the sequence of values that is obtained by
@@ -1244,9 +1491,11 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the projected values.</returns>
     public static Task<float?> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, float?>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, float?>(WellKnownMembers.Queryable.SumWithSelectorNullableSingle, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, float?>(SumWithSelectorNullableSingleTraits<TSource>.Method, source, selector, cancellationToken);
 
     // Sum<decimal>
+
+    private static readonly MethodInfo SumDecimalMethod = NormalizeOperation<decimal, decimal>(WellKnownMembers.Queryable.SumDecimal);
 
     /// <summary>
     /// Asynchronously computes the sum of a sequence of values.
@@ -1263,7 +1512,9 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the values in the sequence.</returns>
     public static Task<decimal> SumAsync(this IQueryable<decimal> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<decimal, decimal>(WellKnownMembers.Queryable.SumDecimal, source, cancellationToken);
+      ExecuteScalarAsync<decimal, decimal>(SumDecimalMethod, source, cancellationToken);
+
+    private static readonly MethodInfo SumNullableDecimalMethod = NormalizeOperation<decimal?, decimal?>(WellKnownMembers.Queryable.SumNullableDecimal);
 
     /// <summary>
     /// Asynchronously computes the sum of a sequence of values.
@@ -1280,7 +1531,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the values in the sequence.</returns>
     public static Task<decimal?> SumAsync(this IQueryable<decimal?> source, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<decimal?, decimal?>(WellKnownMembers.Queryable.SumNullableDecimal, source, cancellationToken);
+      ExecuteScalarAsync<decimal?, decimal?>(SumNullableDecimalMethod, source, cancellationToken);
+
+    private static class SumWithSelectorDecimalTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, decimal>(WellKnownMembers.Queryable.SumWithSelectorDecimal);
+    }
 
     /// <summary>
     /// Asynchronously computes the sum of the sequence of values that is obtained by
@@ -1300,7 +1556,12 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the projected values.</returns>
     public static Task<decimal> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, decimal>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, decimal>(WellKnownMembers.Queryable.SumWithSelectorDecimal, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, decimal>(SumWithSelectorDecimalTraits<TSource>.Method, source, selector, cancellationToken);
+
+    private static class SumWithSelectorNullableDecimalTraits<TSource>
+    {
+      public static readonly MethodInfo Method = NormalizeOperation<TSource, decimal?>(WellKnownMembers.Queryable.SumWithSelectorNullableDecimal);
+    }
 
     /// <summary>
     /// Asynchronously computes the sum of the sequence of values that is obtained by
@@ -1320,7 +1581,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains the
     /// sum of the projected values.</returns>
     public static Task<decimal?> SumAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, decimal?>> selector, CancellationToken cancellationToken = default) =>
-      ExecuteScalarAsync<TSource, decimal?>(WellKnownMembers.Queryable.SumWithSelectorNullableDecimal, source, selector, cancellationToken);
+      ExecuteScalarAsync<TSource, decimal?>(SumWithSelectorNullableDecimalTraits<TSource>.Method, source, selector, cancellationToken);
 
     #endregion
 
@@ -1596,7 +1857,6 @@ namespace Xtensive.Orm
       IQueryable<TSource> source, CancellationToken cancellationToken)
     {
       ArgumentNullException.ThrowIfNull(source);
-      operation = NormalizeOperation<TSource, TResult>(operation);
       return source.Provider is QueryProvider provider
         ? await provider.ExecuteScalarAsync<TResult>(Expression.Call(null, operation, [source.Expression]), cancellationToken)
         : (TResult) operation.Invoke(BoxedZero, [source]);
@@ -1610,7 +1870,6 @@ namespace Xtensive.Orm
       ArgumentNullException.ThrowIfNull(source);
       ArgumentNullException.ThrowIfNull(expression);
 
-      operation = NormalizeOperation<TSource, TResult>(operation);
       return source.Provider is QueryProvider provider
         ? await provider.ExecuteScalarAsync<TResult>(Expression.Call(null, operation, [source.Expression, expression]), cancellationToken)
         : (TResult) operation.Invoke(BoxedZero, [source, expression]);

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
@@ -1330,6 +1330,11 @@ namespace Xtensive.Orm
       typeof(Tuple).GetMethods(BindingFlags.Public | BindingFlags.Static)
         .Single(mi => mi.Name == nameof(Tuple.Create) && mi.GetGenericArguments().Length == 2);
 
+    private static class Traits<TKey, TSource>
+    {
+      public static readonly MethodInfo TupleFactoryMethod = TupleCreateMethod.CachedMakeGenericMethod(typeof(TKey), typeof(TSource));
+    }
+
     /// <summary>
     /// Asynchronously creates a <see cref="List{TSource}"/> from an <see cref="IQueryable{TSource}"/>
     /// by enumerating it asynchronously.
@@ -1403,9 +1408,8 @@ namespace Xtensive.Orm
       this IQueryable<TSource> source,
       Expression<Func<TSource, TKey>> keySelector, CancellationToken cancellationToken = default)
     {
-      var tupleFactoryMethod = TupleCreateMethod.CachedMakeGenericMethod(typeof(TKey), typeof(TSource));
       var itemParam = ParameterTraits<TSource>.ItemParam;
-      var body = Expression.Call(null, tupleFactoryMethod,
+      var body = Expression.Call(null, Traits<TKey, TSource>.TupleFactoryMethod,
         ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
         itemParam[0]);
       var query = source.Select(FastExpression.Lambda<Func<TSource, Tuple<TKey, TSource>>>(body, itemParam));
@@ -1445,9 +1449,8 @@ namespace Xtensive.Orm
       Expression<Func<TSource, TValue>> valueSelector,
       CancellationToken cancellationToken = default)
     {
-      var tupleFactoryMethod = TupleCreateMethod.CachedMakeGenericMethod(typeof(TKey), typeof(TValue));
       var itemParam = ParameterTraits<TSource>.ItemParam;
-      var body = Expression.Call(null, tupleFactoryMethod,
+      var body = Expression.Call(null, Traits<TKey, TValue>.TupleFactoryMethod,
         ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
         ExpressionReplacer.ReplaceAll(valueSelector.Body, valueSelector.Parameters, itemParam));
       var query = source.Select(FastExpression.Lambda<Func<TSource, Tuple<TKey, TValue>>>(body, itemParam));
@@ -1510,9 +1513,8 @@ namespace Xtensive.Orm
     public static async Task<ILookup<TKey, TSource>> ToLookupAsync<TKey, TSource>(this IQueryable<TSource> source,
       Expression<Func<TSource, TKey>> keySelector, CancellationToken cancellationToken = default)
     {
-      var tupleFactoryMethod = TupleCreateMethod.CachedMakeGenericMethod(typeof(TKey), typeof(TSource));
       var itemParam = ParameterTraits<TSource>.ItemParam;
-      var body = Expression.Call(null, tupleFactoryMethod,
+      var body = Expression.Call(null, Traits<TKey, TSource>.TupleFactoryMethod,
         ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
         itemParam[0]);
       var query = source.Select(FastExpression.Lambda<Func<TSource, Tuple<TKey, TSource>>>(body, itemParam));
@@ -1547,9 +1549,8 @@ namespace Xtensive.Orm
       Expression<Func<TSource, TValue>> valueSelector,
       CancellationToken cancellationToken = default)
     {
-      var tupleFactoryMethod = TupleCreateMethod.CachedMakeGenericMethod(typeof(TKey), typeof(TValue));
       var itemParam = ParameterTraits<TSource>.ItemParam;
-      var body = Expression.Call(null, tupleFactoryMethod,
+      var body = Expression.Call(null, Traits<TKey, TValue>.TupleFactoryMethod,
         ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
         ExpressionReplacer.ReplaceAll(valueSelector.Body, valueSelector.Parameters, itemParam));
       var query = source.Select(FastExpression.Lambda<Func<TSource, Tuple<TKey, TValue>>>(body, itemParam));

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
@@ -1711,7 +1711,7 @@ namespace Xtensive.Orm
       CancellationToken cancellationToken = default)
     {
       var itemParam = ParameterTraits<TSource>.ItemParam;
-      var body = Expression.Call(null, Traits<TKey, TValue>.TupleFactoryMethod,
+      var body = Expression.Call(Traits<TKey, TValue>.TupleFactoryMethod,
         ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
         ExpressionReplacer.ReplaceAll(valueSelector.Body, valueSelector.Parameters, itemParam));
       var query = source.Select(FastExpression.Lambda<Func<TSource, Tuple<TKey, TValue>>>(body, itemParam));
@@ -1775,7 +1775,7 @@ namespace Xtensive.Orm
       Expression<Func<TSource, TKey>> keySelector, CancellationToken cancellationToken = default)
     {
       var itemParam = ParameterTraits<TSource>.ItemParam;
-      var body = Expression.Call(null, Traits<TKey, TSource>.TupleFactoryMethod,
+      var body = Expression.Call(Traits<TKey, TSource>.TupleFactoryMethod,
         ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
         itemParam[0]);
       var query = source.Select(FastExpression.Lambda<Func<TSource, Tuple<TKey, TSource>>>(body, itemParam));
@@ -1811,7 +1811,7 @@ namespace Xtensive.Orm
       CancellationToken cancellationToken = default)
     {
       var itemParam = ParameterTraits<TSource>.ItemParam;
-      var body = Expression.Call(null, Traits<TKey, TValue>.TupleFactoryMethod,
+      var body = Expression.Call(Traits<TKey, TValue>.TupleFactoryMethod,
         ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
         ExpressionReplacer.ReplaceAll(valueSelector.Body, valueSelector.Parameters, itemParam));
       var query = source.Select(FastExpression.Lambda<Func<TSource, Tuple<TKey, TValue>>>(body, itemParam));
@@ -1858,7 +1858,7 @@ namespace Xtensive.Orm
     {
       ArgumentNullException.ThrowIfNull(source);
       return source.Provider is QueryProvider provider
-        ? await provider.ExecuteScalarAsync<TResult>(Expression.Call(null, operation, [source.Expression]), cancellationToken)
+        ? await provider.ExecuteScalarAsync<TResult>(Expression.Call(operation, source.Expression), cancellationToken)
         : (TResult) operation.Invoke(BoxedZero, [source]);
     }
 
@@ -1871,7 +1871,7 @@ namespace Xtensive.Orm
       ArgumentNullException.ThrowIfNull(expression);
 
       return source.Provider is QueryProvider provider
-        ? await provider.ExecuteScalarAsync<TResult>(Expression.Call(null, operation, [source.Expression, expression]), cancellationToken)
+        ? await provider.ExecuteScalarAsync<TResult>(Expression.Call(operation, source.Expression, expression), cancellationToken)
         : (TResult) operation.Invoke(BoxedZero, [source, expression]);
     }
   }

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
@@ -50,7 +50,7 @@ namespace Xtensive.Orm
         throw new NotSupportedException(string.Format(errorMessage, providerType));
       }
 
-      var expression = Expression.Call(null, Traits<TSource>.ExtensionTagMethodInfo, new[] { source.Expression, Expression.Constant(tag)});
+      var expression = Expression.Call(Traits<TSource>.ExtensionTagMethodInfo, source.Expression, Expression.Constant(tag));
       return source.Provider.CreateQuery<TSource>(expression);
     }
 
@@ -73,8 +73,8 @@ namespace Xtensive.Orm
         throw new NotSupportedException(string.Format(errorMessage, providerType));
       }
 
-      var genericMethod = WellKnownMembers.Queryable.ExtensionTag.MakeGenericMethod(new[] { source.ElementType });
-      var expression = Expression.Call(null, genericMethod, new[] { source.Expression, Expression.Constant(tag) });
+      var genericMethod = WellKnownMembers.Queryable.ExtensionTag.CachedMakeGenericMethod(source.ElementType);
+      var expression = Expression.Call(genericMethod, source.Expression, Expression.Constant(tag));
       return source.Provider.CreateQuery(expression);
     }
     
@@ -97,8 +97,8 @@ namespace Xtensive.Orm
         throw new NotSupportedException(string.Format(errorMessage, providerType));
       }
 
-      var genericMethod = WellKnownMembers.Queryable.ExtensionWithIndexHint.MakeGenericMethod(typeof(TSource), typeof(TEntity));
-      var expression = Expression.Call(null, genericMethod, new[] { source.Expression, Expression.Constant(indexName)});
+      var genericMethod = WellKnownMembers.Queryable.ExtensionWithIndexHint.CachedMakeGenericMethod(typeof(TSource), typeof(TEntity));
+      var expression = Expression.Call(genericMethod, source.Expression, Expression.Constant(indexName));
       return source.Provider.CreateQuery<TSource>(expression);
     }  
     
@@ -128,8 +128,8 @@ namespace Xtensive.Orm
         throw new NotSupportedException(string.Format(errorMessage, providerType));
       }
 
-      var genericMethod = WellKnownMembers.Queryable.ExtensionWithIndexHint.MakeGenericMethod(new[] { source.ElementType, source.ElementType });
-      var expression = Expression.Call(null, genericMethod, new[] { source.Expression, Expression.Constant(indexName)});
+      var genericMethod = WellKnownMembers.Queryable.ExtensionWithIndexHint.CachedMakeGenericMethod(source.ElementType, source.ElementType);
+      var expression = Expression.Call(genericMethod, source.Expression, Expression.Constant(indexName));
       return source.Provider.CreateQuery(expression);
     } 
 
@@ -170,7 +170,7 @@ namespace Xtensive.Orm
         throw new NotSupportedException(string.Format(errorMessage, providerType));
       }
 
-      var expression = Expression.Call(null, TakeTraits<TSource>.Method, [source.Expression, count]);
+      var expression = Expression.Call(TakeTraits<TSource>.Method, source.Expression, count);
       return source.Provider.CreateQuery<TSource>(expression);
     }
 
@@ -198,7 +198,7 @@ namespace Xtensive.Orm
         throw new NotSupportedException(string.Format(errorMessage, providerType));
       }
 
-      var expression = Expression.Call(null, SkipTraits<TSource>.Method, [source.Expression, count]);
+      var expression = Expression.Call(SkipTraits<TSource>.Method, source.Expression, count);
       return source.Provider.CreateQuery<TSource>(expression);
     }
 
@@ -226,7 +226,7 @@ namespace Xtensive.Orm
         throw new NotSupportedException(string.Format(errorMessage, providerType));
       }
 
-      var expression = Expression.Call(null, ElementAtTraits<TSource>.Method, [source.Expression, index]);
+      var expression = Expression.Call(ElementAtTraits<TSource>.Method, source.Expression, index);
       return source.Provider.Execute<TSource>(expression);
     }
 
@@ -254,7 +254,7 @@ namespace Xtensive.Orm
         throw new NotSupportedException(string.Format(errorMessage, providerType));
       }
 
-      var expression = Expression.Call(null, ElementAtOrDefaultTraits<TSource>.Method, [source.Expression, index]);
+      var expression = Expression.Call(ElementAtOrDefaultTraits<TSource>.Method, source.Expression, index);
       return source.Provider.Execute<TSource>(expression);
     }
 
@@ -281,7 +281,7 @@ namespace Xtensive.Orm
         throw new NotSupportedException(string.Format(errorMessage, providerType));
       }
 
-      var expression = Expression.Call(null, LockTraits<TSource>.Method, [source.Expression, Expression.Constant(lockMode), Expression.Constant(lockBehavior)]);
+      var expression = Expression.Call(LockTraits<TSource>.Method, source.Expression, Expression.Constant(lockMode), Expression.Constant(lockBehavior));
       return source.Provider.CreateQuery<TSource>(expression);
     }
 
@@ -404,7 +404,7 @@ namespace Xtensive.Orm
       }
 
       var genericMethod = WellKnownMembers.Queryable.ExtensionLeftJoinEx.MakeGenericMethod(new[] { typeof(TOuter), typeof(TInner), typeof(TKey), typeof(TResult) });
-      var expression = Expression.Call(null, genericMethod, new[] { outer.Expression, GetSourceExpression(inner), outerKeySelector, innerKeySelector, resultSelector });
+      var expression = Expression.Call(genericMethod, outer.Expression, GetSourceExpression(inner), outerKeySelector, innerKeySelector, resultSelector);
       return outer.Provider.CreateQuery<TResult>(expression);
     }
 

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.cs
@@ -146,6 +146,11 @@ namespace Xtensive.Orm
           new[] {source.ElementType}, source.Expression));
     }
 
+    private static class TakeTraits<TSource>
+    {
+      public static readonly MethodInfo Method = WellKnownMembers.Queryable.ExtensionTake.CachedMakeGenericMethod(typeof(TSource));
+    }
+
     /// <summary>
     /// Version of <see cref="Queryable.Take{TSource}(IQueryable{TSource}, int)"/>, where <paramref name="count"/>
     /// is specified as <see cref="Expression"/>.
@@ -165,9 +170,13 @@ namespace Xtensive.Orm
         throw new NotSupportedException(string.Format(errorMessage, providerType));
       }
 
-      var genericMethod = WellKnownMembers.Queryable.ExtensionTake.CachedMakeGenericMethod(typeof(TSource));
-      var expression = Expression.Call(null, genericMethod, new[] {source.Expression, count});
+      var expression = Expression.Call(null, TakeTraits<TSource>.Method, [source.Expression, count]);
       return source.Provider.CreateQuery<TSource>(expression);
+    }
+
+    private static class SkipTraits<TSource>
+    {
+      public static readonly MethodInfo Method = WellKnownMembers.Queryable.ExtensionSkip.CachedMakeGenericMethod(typeof(TSource));
     }
 
     /// <summary>
@@ -189,9 +198,13 @@ namespace Xtensive.Orm
         throw new NotSupportedException(string.Format(errorMessage, providerType));
       }
 
-      var genericMethod = WellKnownMembers.Queryable.ExtensionSkip.CachedMakeGenericMethod(typeof(TSource));
-      var expression = Expression.Call(null, genericMethod, new[] {source.Expression, count});
+      var expression = Expression.Call(null, SkipTraits<TSource>.Method, [source.Expression, count]);
       return source.Provider.CreateQuery<TSource>(expression);
+    }
+
+    private static class ElementAtTraits<TSource>
+    {
+      public static readonly MethodInfo Method = WellKnownMembers.Queryable.ExtensionElementAt.CachedMakeGenericMethod(typeof(TSource));
     }
 
     /// <summary>
@@ -213,9 +226,13 @@ namespace Xtensive.Orm
         throw new NotSupportedException(string.Format(errorMessage, providerType));
       }
 
-      var genericMethod = WellKnownMembers.Queryable.ExtensionElementAt.CachedMakeGenericMethod(typeof(TSource));
-      var expression = Expression.Call(null, genericMethod, new[] {source.Expression, index});
+      var expression = Expression.Call(null, ElementAtTraits<TSource>.Method, [source.Expression, index]);
       return source.Provider.Execute<TSource>(expression);
+    }
+
+    private static class ElementAtOrDefaultTraits<TSource>
+    {
+      public static readonly MethodInfo Method = WellKnownMembers.Queryable.ExtensionElementAtOrDefault.CachedMakeGenericMethod(typeof(TSource));
     }
 
     /// <summary>
@@ -237,9 +254,13 @@ namespace Xtensive.Orm
         throw new NotSupportedException(string.Format(errorMessage, providerType));
       }
 
-      var genericMethod = WellKnownMembers.Queryable.ExtensionElementAtOrDefault.CachedMakeGenericMethod(typeof(TSource));
-      var expression = Expression.Call(null, genericMethod, new[] {source.Expression, index});
+      var expression = Expression.Call(null, ElementAtOrDefaultTraits<TSource>.Method, [source.Expression, index]);
       return source.Provider.Execute<TSource>(expression);
+    }
+
+    private static class LockTraits<TSource>
+    {
+      public static readonly MethodInfo Method = WellKnownMembers.Queryable.ExtensionLock.CachedMakeGenericMethod(typeof(TSource));
     }
 
     /// <summary>
@@ -260,8 +281,7 @@ namespace Xtensive.Orm
         throw new NotSupportedException(string.Format(errorMessage, providerType));
       }
 
-      var genericMethod = WellKnownMembers.Queryable.ExtensionLock.CachedMakeGenericMethod(typeof(TSource));
-      var expression = Expression.Call(null, genericMethod, new[] {source.Expression, Expression.Constant(lockMode), Expression.Constant(lockBehavior)});
+      var expression = Expression.Call(null, LockTraits<TSource>.Method, [source.Expression, Expression.Constant(lockMode), Expression.Constant(lockBehavior)]);
       return source.Provider.CreateQuery<TSource>(expression);
     }
 


### PR DESCRIPTION
Also:
* Use specialized `Expression.Call()` overloads to reduce argument allocations