### PR TITLE
Optimization: Use `ValueTuple<>` instead of `Tuple<>` in `ToDictionaryAsync()`

### DIFF
--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
@@ -1655,6 +1655,26 @@ namespace Xtensive.Orm
       return dictionary;
     }
 
+    private static IQueryable<(TKey, TSource)> ComposeQuery<TKey, TSource>(IQueryable<TSource> source, Expression<Func<TSource, TKey>> keySelector)
+    {
+      var itemParam = ParameterTraits<TSource>.ItemParam;
+      var body = Expression.Call(Traits<TKey, TSource>.TupleFactoryMethod,
+        ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
+        itemParam[0]);
+      return source.Select(FastExpression.Lambda<Func<TSource, ValueTuple<TKey, TSource>>>(body, itemParam));
+    }
+
+    private static IQueryable<(TKey, TValue)> ComposeQuery<TKey, TValue, TSource>(IQueryable<TSource> source,
+        Expression<Func<TSource, TKey>> keySelector,
+        Expression<Func<TSource, TValue>> valueSelector)
+    {
+      var itemParam = ParameterTraits<TSource>.ItemParam;
+      var body = Expression.Call(Traits<TKey, TValue>.TupleFactoryMethod,
+        ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
+        ExpressionReplacer.ReplaceAll(valueSelector.Body, valueSelector.Parameters, itemParam));
+      return source.Select(FastExpression.Lambda<Func<TSource, ValueTuple<TKey, TValue>>>(body, itemParam));
+    }
+
     /// <summary>
     /// Creates a <see cref="Dictionary{TKey, TSource}"/> from an <see cref="IQueryable{TSource}"/>
     /// by enumerating it asynchronously according to a specified key selector function.
@@ -1675,16 +1695,9 @@ namespace Xtensive.Orm
     /// <see cref="Dictionary{TKey, TValue}"/> that contains values of type <typeparamref name="TSource"/>
     /// selected from the input sequence.</returns>
     public static Task<Dictionary<TKey, TSource>> ToDictionaryAsync<TKey, TSource>(
-      this IQueryable<TSource> source,
-      Expression<Func<TSource, TKey>> keySelector, CancellationToken cancellationToken = default)
-    {
-      var itemParam = ParameterTraits<TSource>.ItemParam;
-      var body = Expression.Call(Traits<TKey, TSource>.TupleFactoryMethod,
-        ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
-        itemParam[0]);
-      var query = source.Select(FastExpression.Lambda<Func<TSource, ValueTuple<TKey, TSource>>>(body, itemParam));
-      return ToDictionaryAsync(query, cancellationToken);
-    }
+        this IQueryable<TSource> source,
+        Expression<Func<TSource, TKey>> keySelector, CancellationToken cancellationToken = default) =>
+      ToDictionaryAsync(ComposeQuery(source, keySelector), cancellationToken);
 
     /// <summary>
     /// Creates a <see cref="Dictionary{TKey, TValue}"/> from an <see cref="IQueryable{TSource}"/>
@@ -1708,18 +1721,11 @@ namespace Xtensive.Orm
     /// <see cref="Dictionary{TKey, TValue}"/> that contains values of type <typeparamref name="TValue"/>
     /// selected from the input sequence.</returns>
     public static Task<Dictionary<TKey, TValue>> ToDictionaryAsync<TKey, TValue, TSource>(
-      this IQueryable<TSource> source,
-      Expression<Func<TSource, TKey>> keySelector,
-      Expression<Func<TSource, TValue>> valueSelector,
-      CancellationToken cancellationToken = default)
-    {
-      var itemParam = ParameterTraits<TSource>.ItemParam;
-      var body = Expression.Call(Traits<TKey, TValue>.TupleFactoryMethod,
-        ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
-        ExpressionReplacer.ReplaceAll(valueSelector.Body, valueSelector.Parameters, itemParam));
-      var query = source.Select(FastExpression.Lambda<Func<TSource, ValueTuple<TKey, TValue>>>(body, itemParam));
-      return ToDictionaryAsync(query, cancellationToken);
-    }
+        this IQueryable<TSource> source,
+        Expression<Func<TSource, TKey>> keySelector,
+        Expression<Func<TSource, TValue>> valueSelector,
+        CancellationToken cancellationToken = default) =>
+      ToDictionaryAsync(ComposeQuery(source, keySelector, valueSelector), cancellationToken);
 
     /// <summary>
     /// Asynchronously creates a <see cref="HashSet{TSource}"/> from an <see cref="IQueryable{TSource}"/>
@@ -1773,15 +1779,8 @@ namespace Xtensive.Orm
     /// <see cref="ILookup{TKey, TSource}"/> that contains values of type <typeparamref name="TSource"/>
     /// selected from the input sequence.</returns>
     public static Task<ILookup<TKey, TSource>> ToLookupAsync<TKey, TSource>(this IQueryable<TSource> source,
-      Expression<Func<TSource, TKey>> keySelector, CancellationToken cancellationToken = default)
-    {
-      var itemParam = ParameterTraits<TSource>.ItemParam;
-      var body = Expression.Call(Traits<TKey, TSource>.TupleFactoryMethod,
-        ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
-        itemParam[0]);
-      var query = source.Select(FastExpression.Lambda<Func<TSource, ValueTuple<TKey, TSource>>>(body, itemParam));
-      return ToLookupAsync(query, cancellationToken);
-    }
+      Expression<Func<TSource, TKey>> keySelector, CancellationToken cancellationToken = default) =>
+      ToLookupAsync(ComposeQuery(source, keySelector), cancellationToken);
 
     /// <summary>
     /// Asynchronously creates a <see cref="ILookup{TKey, TValue}"/> from an <see cref="IQueryable{T}"/>
@@ -1806,17 +1805,10 @@ namespace Xtensive.Orm
     /// <see cref="ILookup{TKey, TElement}"/> that contains values of type <typeparamref name="TValue"/>
     /// selected from the input sequence.</returns>
     public static Task<ILookup<TKey, TValue>> ToLookupAsync<TKey, TValue, TSource>(this IQueryable<TSource> source,
-      Expression<Func<TSource, TKey>> keySelector,
-      Expression<Func<TSource, TValue>> valueSelector,
-      CancellationToken cancellationToken = default)
-    {
-      var itemParam = ParameterTraits<TSource>.ItemParam;
-      var body = Expression.Call(Traits<TKey, TValue>.TupleFactoryMethod,
-        ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
-        ExpressionReplacer.ReplaceAll(valueSelector.Body, valueSelector.Parameters, itemParam));
-      var query = source.Select(FastExpression.Lambda<Func<TSource, ValueTuple<TKey, TValue>>>(body, itemParam));
-      return ToLookupAsync(query, cancellationToken);
-    }
+        Expression<Func<TSource, TKey>> keySelector,
+        Expression<Func<TSource, TValue>> valueSelector,
+        CancellationToken cancellationToken = default) =>
+      ToLookupAsync(ComposeQuery(source, keySelector, valueSelector), cancellationToken);
 
     #endregion
 

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
@@ -1674,7 +1674,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains a
     /// <see cref="Dictionary{TKey, TValue}"/> that contains values of type <typeparamref name="TSource"/>
     /// selected from the input sequence.</returns>
-    public static async Task<Dictionary<TKey, TSource>> ToDictionaryAsync<TKey, TSource>(
+    public static Task<Dictionary<TKey, TSource>> ToDictionaryAsync<TKey, TSource>(
       this IQueryable<TSource> source,
       Expression<Func<TSource, TKey>> keySelector, CancellationToken cancellationToken = default)
     {
@@ -1683,7 +1683,7 @@ namespace Xtensive.Orm
         ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
         itemParam[0]);
       var query = source.Select(FastExpression.Lambda<Func<TSource, ValueTuple<TKey, TSource>>>(body, itemParam));
-      return await ToDictionaryAsync(query, cancellationToken);
+      return ToDictionaryAsync(query, cancellationToken);
     }
 
     /// <summary>
@@ -1707,7 +1707,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains a
     /// <see cref="Dictionary{TKey, TValue}"/> that contains values of type <typeparamref name="TValue"/>
     /// selected from the input sequence.</returns>
-    public static async Task<Dictionary<TKey, TValue>> ToDictionaryAsync<TKey, TValue, TSource>(
+    public static Task<Dictionary<TKey, TValue>> ToDictionaryAsync<TKey, TValue, TSource>(
       this IQueryable<TSource> source,
       Expression<Func<TSource, TKey>> keySelector,
       Expression<Func<TSource, TValue>> valueSelector,
@@ -1718,7 +1718,7 @@ namespace Xtensive.Orm
         ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
         ExpressionReplacer.ReplaceAll(valueSelector.Body, valueSelector.Parameters, itemParam));
       var query = source.Select(FastExpression.Lambda<Func<TSource, ValueTuple<TKey, TValue>>>(body, itemParam));
-      return await ToDictionaryAsync(query, cancellationToken);
+      return ToDictionaryAsync(query, cancellationToken);
     }
 
     /// <summary>
@@ -1772,7 +1772,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains a
     /// <see cref="ILookup{TKey, TSource}"/> that contains values of type <typeparamref name="TSource"/>
     /// selected from the input sequence.</returns>
-    public static async Task<ILookup<TKey, TSource>> ToLookupAsync<TKey, TSource>(this IQueryable<TSource> source,
+    public static Task<ILookup<TKey, TSource>> ToLookupAsync<TKey, TSource>(this IQueryable<TSource> source,
       Expression<Func<TSource, TKey>> keySelector, CancellationToken cancellationToken = default)
     {
       var itemParam = ParameterTraits<TSource>.ItemParam;
@@ -1780,7 +1780,7 @@ namespace Xtensive.Orm
         ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
         itemParam[0]);
       var query = source.Select(FastExpression.Lambda<Func<TSource, ValueTuple<TKey, TSource>>>(body, itemParam));
-      return await ToLookupAsync(query, cancellationToken);
+      return ToLookupAsync(query, cancellationToken);
     }
 
     /// <summary>
@@ -1805,7 +1805,7 @@ namespace Xtensive.Orm
     /// <returns>A task that represents the asynchronous operation. The task result contains a
     /// <see cref="ILookup{TKey, TElement}"/> that contains values of type <typeparamref name="TValue"/>
     /// selected from the input sequence.</returns>
-    public static async Task<ILookup<TKey, TValue>> ToLookupAsync<TKey, TValue, TSource>(this IQueryable<TSource> source,
+    public static Task<ILookup<TKey, TValue>> ToLookupAsync<TKey, TValue, TSource>(this IQueryable<TSource> source,
       Expression<Func<TSource, TKey>> keySelector,
       Expression<Func<TSource, TValue>> valueSelector,
       CancellationToken cancellationToken = default)
@@ -1815,7 +1815,7 @@ namespace Xtensive.Orm
         ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
         ExpressionReplacer.ReplaceAll(valueSelector.Body, valueSelector.Parameters, itemParam));
       var query = source.Select(FastExpression.Lambda<Func<TSource, ValueTuple<TKey, TValue>>>(body, itemParam));
-      return await ToLookupAsync(query, cancellationToken);
+      return ToLookupAsync(query, cancellationToken);
     }
 
     #endregion

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
@@ -1588,8 +1588,8 @@ namespace Xtensive.Orm
     #region Collection methods
 
     private static readonly MethodInfo TupleCreateMethod =
-      typeof(Tuple).GetMethods(BindingFlags.Public | BindingFlags.Static)
-        .Single(mi => mi.Name == nameof(Tuple.Create) && mi.GetGenericArguments().Length == 2);
+      typeof(ValueTuple).GetMethods(BindingFlags.Public | BindingFlags.Static)
+        .Single(mi => mi.Name == nameof(ValueTuple.Create) && mi.GetGenericArguments().Length == 2);
 
     private static class Traits<TKey, TSource>
     {
@@ -1646,6 +1646,15 @@ namespace Xtensive.Orm
       CancellationToken cancellationToken = default) =>
       (await source.ToListAsync(cancellationToken).ConfigureAwaitFalse()).ToArray();
 
+    private static async Task<Dictionary<TKey, TValue>> ToDictionaryAsync<TKey, TValue>(this IQueryable<(TKey, TValue)> query, CancellationToken cancellationToken)
+    {
+      Dictionary<TKey, TValue> dictionary = [];
+      await foreach (var (k, v) in query.AsAsyncEnumerable().WithCancellation(cancellationToken).ConfigureAwaitFalse()) {
+        dictionary.Add(k, v);
+      }
+      return dictionary;
+    }
+
     /// <summary>
     /// Creates a <see cref="Dictionary{TKey, TSource}"/> from an <see cref="IQueryable{TSource}"/>
     /// by enumerating it asynchronously according to a specified key selector function.
@@ -1673,14 +1682,8 @@ namespace Xtensive.Orm
       var body = Expression.Call(null, Traits<TKey, TSource>.TupleFactoryMethod,
         ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
         itemParam[0]);
-      var query = source.Select(FastExpression.Lambda<Func<TSource, Tuple<TKey, TSource>>>(body, itemParam));
-      var dictionary = new Dictionary<TKey, TSource>();
-      var asyncSource = query.AsAsyncEnumerable().WithCancellation(cancellationToken).ConfigureAwaitFalse();
-      await foreach (var tuple in asyncSource) {
-        dictionary.Add(tuple.Item1, tuple.Item2);
-      }
-
-      return dictionary;
+      var query = source.Select(FastExpression.Lambda<Func<TSource, ValueTuple<TKey, TSource>>>(body, itemParam));
+      return await ToDictionaryAsync(query, cancellationToken);
     }
 
     /// <summary>
@@ -1714,14 +1717,8 @@ namespace Xtensive.Orm
       var body = Expression.Call(Traits<TKey, TValue>.TupleFactoryMethod,
         ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
         ExpressionReplacer.ReplaceAll(valueSelector.Body, valueSelector.Parameters, itemParam));
-      var query = source.Select(FastExpression.Lambda<Func<TSource, Tuple<TKey, TValue>>>(body, itemParam));
-      var dictionary = new Dictionary<TKey, TValue>();
-      var asyncSource = query.AsAsyncEnumerable().WithCancellation(cancellationToken).ConfigureAwaitFalse();
-      await foreach (var tuple in asyncSource) {
-        dictionary.Add(tuple.Item1, tuple.Item2);
-      }
-
-      return dictionary;
+      var query = source.Select(FastExpression.Lambda<Func<TSource, ValueTuple<TKey, TValue>>>(body, itemParam));
+      return await ToDictionaryAsync(query, cancellationToken);
     }
 
     /// <summary>
@@ -1752,6 +1749,10 @@ namespace Xtensive.Orm
       return hashSet;
     }
 
+    private static async Task<ILookup<TKey, TValue>> ToLookupAsync<TKey, TValue>(this IQueryable<(TKey, TValue)> query, CancellationToken cancellationToken) =>
+      (await query.ExecuteAsync(cancellationToken).ConfigureAwaitFalse())
+      .ToLookup(tuple => tuple.Item1, tuple => tuple.Item2);
+
     /// <summary>
     /// Asynchronously creates a <see cref="ILookup{TKey, TSource}"/> from an <see cref="IQueryable{T}"/>
     /// by enumerating it asynchronously according to a specified key selector function.
@@ -1778,9 +1779,8 @@ namespace Xtensive.Orm
       var body = Expression.Call(Traits<TKey, TSource>.TupleFactoryMethod,
         ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
         itemParam[0]);
-      var query = source.Select(FastExpression.Lambda<Func<TSource, Tuple<TKey, TSource>>>(body, itemParam));
-      var queryResult = await query.ExecuteAsync(cancellationToken).ConfigureAwaitFalse();
-      return queryResult.ToLookup(tuple => tuple.Item1, tuple => tuple.Item2);
+      var query = source.Select(FastExpression.Lambda<Func<TSource, ValueTuple<TKey, TSource>>>(body, itemParam));
+      return await ToLookupAsync(query, cancellationToken);
     }
 
     /// <summary>
@@ -1814,9 +1814,8 @@ namespace Xtensive.Orm
       var body = Expression.Call(Traits<TKey, TValue>.TupleFactoryMethod,
         ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
         ExpressionReplacer.ReplaceAll(valueSelector.Body, valueSelector.Parameters, itemParam));
-      var query = source.Select(FastExpression.Lambda<Func<TSource, Tuple<TKey, TValue>>>(body, itemParam));
-      var queryResult = await query.ExecuteAsync(cancellationToken).ConfigureAwaitFalse();
-      return queryResult.ToLookup(tuple => tuple.Item1, tuple => tuple.Item2);
+      var query = source.Select(FastExpression.Lambda<Func<TSource, ValueTuple<TKey, TValue>>>(body, itemParam));
+      return await ToLookupAsync(query, cancellationToken);
     }
 
     #endregion

--- a/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
+++ b/Orm/Xtensive.Orm/Orm/QueryableExtensions.Async.cs
@@ -1679,7 +1679,7 @@ namespace Xtensive.Orm
       Expression<Func<TSource, TKey>> keySelector, CancellationToken cancellationToken = default)
     {
       var itemParam = ParameterTraits<TSource>.ItemParam;
-      var body = Expression.Call(null, Traits<TKey, TSource>.TupleFactoryMethod,
+      var body = Expression.Call(Traits<TKey, TSource>.TupleFactoryMethod,
         ExpressionReplacer.ReplaceAll(keySelector.Body, keySelector.Parameters, itemParam),
         itemParam[0]);
       var query = source.Select(FastExpression.Lambda<Func<TSource, ValueTuple<TKey, TSource>>>(body, itemParam));


### PR DESCRIPTION
To save allocations

Also:
* The same for `.ToLookupAsync()`
* Extract common parts of these extensions into separate method