### PR TITLE
Simplify TranslateQuery()

### DIFF
--- a/Orm/Xtensive.Orm/Orm/Providers/Interfaces/IQueryRequest.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Interfaces/IQueryRequest.cs
@@ -4,14 +4,13 @@
 // Created by: Denis Krjuchkov
 // Created:    2012.02.25
 
-using System.Collections.Generic;
 using Xtensive.Sql.Compiler;
 
 namespace Xtensive.Orm.Providers
 {
   public interface IQueryRequest
   {
-    IEnumerable<QueryParameterBinding> ParameterBindings { get; }
+    IReadOnlyCollection<QueryParameterBinding> ParameterBindings { get; }
 
     SqlCompilationResult GetCompiledStatement();
   }

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/QueryRequest.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/QueryRequest.cs
@@ -24,7 +24,7 @@ namespace Xtensive.Orm.Providers
     private SqlCompilationResult compiledStatement;
 
     public SqlSelect Statement { get; private set; }
-    public IEnumerable<QueryParameterBinding> ParameterBindings { get; }
+    public IReadOnlyCollection<QueryParameterBinding> ParameterBindings { get; }
 
     public TupleDescriptor TupleDescriptor { get; }
     public QueryRequestOptions Options { get; }

--- a/Orm/Xtensive.Orm/Orm/Providers/Requests/UserQueryRequest.cs
+++ b/Orm/Xtensive.Orm/Orm/Providers/Requests/UserQueryRequest.cs
@@ -17,7 +17,7 @@ namespace Xtensive.Orm.Providers
       return compiledStatement;
     }
 
-    public IEnumerable<QueryParameterBinding> ParameterBindings { get; }
+    public IReadOnlyCollection<QueryParameterBinding> ParameterBindings { get; }
 
     // Constructors
 

--- a/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryBuilder.cs
+++ b/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryBuilder.cs
@@ -38,22 +38,13 @@ namespace Xtensive.Orm.Services
       ArgumentNullException.ThrowIfNull(query);
 
       var configuration = Session.CompilationService.CreateConfiguration(Session) with { PrepareRequest = false };
-      var translated = queryProvider.Translate(query.Expression, configuration);
 
-      var sqlProvider = translated.DataSource as SqlProvider;
-      if (sqlProvider==null)
-        throw new InvalidOperationException("Query was not translated to SqlProvider");
+      var request = (queryProvider.Translate(query.Expression, configuration).DataSource as SqlProvider
+                     ?? throw new InvalidOperationException("Query was not translated to SqlProvider")
+        ).Request;
 
-      var request = sqlProvider.Request;
-
-      if (request.ParameterBindings is ICollection<Providers.QueryParameterBinding> bindingCollection) {
-        return new QueryTranslationResult(
-          request.Statement,
-          bindingCollection.Select(b => new QueryParameterBinding(b)).ToArray());
-      }
-      else
-        return new QueryTranslationResult(request.Statement,
-          request.ParameterBindings.Select(b => new QueryParameterBinding(b)).ToList());
+      return new(request.Statement,
+        request.ParameterBindings.Select(b => new QueryParameterBinding(b)).ToArray());
     }
 
     /// <summary>

--- a/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryTranslationResult.cs
+++ b/Orm/Xtensive.Orm/Orm/Services/QueryBuilding/QueryTranslationResult.cs
@@ -4,34 +4,8 @@
 // Created by: Denis Krjuchkov
 // Created:    2012.02.27
 
-using System.Collections.Generic;
-using System.Linq;
-using Xtensive.Sql;
 using Xtensive.Sql.Dml;
 
-namespace Xtensive.Orm.Services
-{
-  /// <summary>
-  /// Result of LINQ query translation.
-  /// </summary>
-  public readonly struct QueryTranslationResult
-  {
-    /// <summary>
-    /// Gets <see cref="SqlSelect"/> query.
-    /// </summary>
-    public SqlSelect Query { get; }
+namespace Xtensive.Orm.Services;
 
-    /// <summary>
-    /// Gets parameter bindings for translated query.
-    /// </summary>
-    public IReadOnlyList<QueryParameterBinding> ParameterBindings { get; }
-
-    // Constructors
-
-    internal QueryTranslationResult(SqlSelect query, IReadOnlyList<QueryParameterBinding> bindings)
-    {
-      Query = query;
-      ParameterBindings = bindings;
-    }
-  }
-}
+public readonly record struct QueryTranslationResult(SqlSelect Query, IReadOnlyList<QueryParameterBinding> ParameterBindings);


### PR DESCRIPTION
`.ToArray()` extenstion is smart to determine `.Count` availability
We need to try `ICollection<>` casting as an optimization

Also:
* Refactor `QueryTranslationResult` to one-liner